### PR TITLE
Fixes for building on 6.7.2 with clang(LLVM=1), required these change…

### DIFF
--- a/src/driver/amdxdna/amdxdna_devel.c
+++ b/src/driver/amdxdna/amdxdna_devel.c
@@ -21,7 +21,7 @@ MODULE_PARM_DESC(iommu_mode, "0 = w/ PASID (Default), 1 = wo/ PASID, 2 = Bypass"
 
 int amdxdna_iommu_mode_setup(struct amdxdna_dev *xdna)
 {
-	struct iommu_domain *domain = {};
+	struct iommu_domain *domain = NULL;
 
 	switch (iommu_mode) {
 	case AMDXDNA_IOMMU_PASID:

--- a/src/driver/amdxdna/amdxdna_devel.c
+++ b/src/driver/amdxdna/amdxdna_devel.c
@@ -21,12 +21,12 @@ MODULE_PARM_DESC(iommu_mode, "0 = w/ PASID (Default), 1 = wo/ PASID, 2 = Bypass"
 
 int amdxdna_iommu_mode_setup(struct amdxdna_dev *xdna)
 {
+	struct iommu_domain *domain = {};
+
 	switch (iommu_mode) {
 	case AMDXDNA_IOMMU_PASID:
 		break;
 	case AMDXDNA_IOMMU_NO_PASID:
-		struct iommu_domain *domain;
-
 		if (!iommu_present(xdna->pdev->dev.bus)) {
 			XDNA_ERR(xdna, "IOMMU not present");
 			return -ENODEV;

--- a/src/driver/amdxdna/amdxdna_drv.c
+++ b/src/driver/amdxdna/amdxdna_drv.c
@@ -179,7 +179,7 @@ static int amdxdna_drm_get_info_ioctl(struct drm_device *dev, void *data, struct
 {
 	struct amdxdna_drm_get_info *args = data;
 	struct amdxdna_dev *xdna = to_xdna_dev(dev);
-	int ret;
+	int ret = {};
 
 	XDNA_DBG(xdna, "Request parameter %u", args->param);
 	switch (args->param) {

--- a/src/driver/amdxdna/amdxdna_drv.c
+++ b/src/driver/amdxdna/amdxdna_drv.c
@@ -179,7 +179,7 @@ static int amdxdna_drm_get_info_ioctl(struct drm_device *dev, void *data, struct
 {
 	struct amdxdna_drm_get_info *args = data;
 	struct amdxdna_dev *xdna = to_xdna_dev(dev);
-	int ret = {};
+	int ret = -EINVAL;
 
 	XDNA_DBG(xdna, "Request parameter %u", args->param);
 	switch (args->param) {

--- a/src/driver/amdxdna/amdxdna_mailbox.c
+++ b/src/driver/amdxdna/amdxdna_mailbox.c
@@ -591,7 +591,7 @@ xdna_mailbox_create_channel(struct mailbox *mb,
 			    u32 iohub_int_addr,
 			    int mb_irq)
 {
-	struct mailbox_channel *mb_chann = {};
+	struct mailbox_channel *mb_chann = NULL;
 	int ret;
 #if defined(CONFIG_DEBUG_FS)
 	struct mailbox_res_record *record;

--- a/src/driver/amdxdna/amdxdna_mailbox.c
+++ b/src/driver/amdxdna/amdxdna_mailbox.c
@@ -12,7 +12,8 @@
 #if defined(CONFIG_DEBUG_FS)
 #include <linux/seq_file.h>
 #endif
-
+#include <linux/irqreturn.h>
+#include <linux/pci.h>
 #include "amdxdna_mailbox.h"
 
 #define CREATE_TRACE_POINTS
@@ -590,7 +591,7 @@ xdna_mailbox_create_channel(struct mailbox *mb,
 			    u32 iohub_int_addr,
 			    int mb_irq)
 {
-	struct mailbox_channel *mb_chann;
+	struct mailbox_channel *mb_chann = {};
 	int ret;
 #if defined(CONFIG_DEBUG_FS)
 	struct mailbox_res_record *record;


### PR DESCRIPTION
…s for the following (maybe a couple more) warn/error's.

error: label followed by a declaration is a C23 extension [-Werror,-Wc23-extensions
src/driver/amdxdna/amdxdna_drv.c:189:2: error: variable 'ret' is used uninitialized whenever switch default is taken [-Werror,-Wsometimes-uninitialized]
src/driver/amdxdna/amdxdna_mailbox.c:614:10: error: variable 'mb_chann' is uninitialized when used here [-Werror,-Wuninitialized]
src/driver/amdxdna/amdxdna_mailbox.c:692:2: error: call to undeclared function 'free_irq'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
src/driver/amdxdna/amdxdna_mailbox.c:660:8: error: call to undeclared function 'request_irq'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
src/driver/amdxdna/amdxdna_mailbox.c:376:8: error: unknown type name 'irqreturn_t'
src/driver/amdxdna/amdxdna_mailbox.c:386:9: error: use of undeclared identifier 'IRQ_HANDLED
src/driver/amdxdna/amdxdna_mailbox.c:659:8: error: call to undeclared function 'request_irq'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]