### PR TITLE
Requires at least Linux 6.8 to compile

### DIFF
--- a/src/driver/CMake/config/dkms.conf.in
+++ b/src/driver/CMake/config/dkms.conf.in
@@ -1,5 +1,7 @@
 PACKAGE_NAME=@XDNA_DKMS_PKG_NAME@
 PACKAGE_VERSION="@XRT_PLUGIN_VERSION_STRING@"
+# Requires at least Linux 6.8 to compile
+BUILD_EXCLUSIVE_KERNEL_MIN=6.8
 MAKE[0]="cd driver/@XDNA_DRV_DIR@; make KERNEL_SRC=${kernel_source_dir}; cd ../.."
 CLEAN="cd driver/@XDNA_DRV_DIR@; make clean KERNEL_SRC=${kernel_source_dir}; cd ../.."
 BUILT_MODULE_NAME[0]=@XDNA_DRV@


### PR DESCRIPTION
Avoid breaking DKMS with older kernels on a system.