### PR TITLE
Define correct mpnpu_clk/hclk ranges for npu devices

### DIFF
--- a/src/driver/amdxdna/npu1_pci.h
+++ b/src/driver/amdxdna/npu1_pci.h
@@ -59,6 +59,11 @@
 	pci_resource_len(NDEV2PDEV(_ndev), (_ndev)->xdna->dev_info->mbox_bar); \
 })
 
+#define SMU_MPNPUCLK_FREQ_MAX(ndev) \
+	((ndev)->priv->smu_mpnpuclk_freq_max)
+#define SMU_HCLK_FREQ_MAX(ndev) \
+	((ndev)->priv->smu_hclk_freq_max)
+
 enum npu_smu_reg_idx {
 	SMU_CMD_REG = 0,
 	SMU_ARG_REG,
@@ -193,6 +198,8 @@ struct npu_dev_priv {
 	struct npu_bar_off_pair	sram_offs[SRAM_MAX_INDEX];
 	struct npu_bar_off_pair	psp_regs_off[PSP_MAX_REGS];
 	struct npu_bar_off_pair	smu_regs_off[SMU_MAX_REGS];
+	u32			smu_mpnpuclk_freq_max;
+	u32			smu_hclk_freq_max;
 };
 
 /* npu1_pci.c */

--- a/src/driver/amdxdna/npu1_regs.c
+++ b/src/driver/amdxdna/npu1_regs.c
@@ -42,6 +42,9 @@
 
 #define NPU1_RT_CFG_VAL_PDI_LOAD_APP 1
 
+#define NPU1_MPNPUCLK_FREQ_MAX  600
+#define NPU1_HCLK_FREQ_MAX      1024
+
 const struct npu_dev_priv npu1_dev_priv = {
 	.fw_path        = "amdnpu/1502_00/npu.sbin",
 	.protocol_major = 0x5,
@@ -71,6 +74,8 @@ const struct npu_dev_priv npu1_dev_priv = {
 		DEFINE_BAR_OFFSET(SMU_RESP_REG, NPU1_SMU, MPNPU_PUB_SCRATCH6),
 		DEFINE_BAR_OFFSET(SMU_OUT_REG,  NPU1_SMU, MPNPU_PUB_SCRATCH7),
 	},
+	.smu_mpnpuclk_freq_max = NPU1_MPNPUCLK_FREQ_MAX,
+	.smu_hclk_freq_max     = NPU1_HCLK_FREQ_MAX,
 };
 
 const struct amdxdna_dev_info dev_npu1_info = {

--- a/src/driver/amdxdna/npu2_regs.c
+++ b/src/driver/amdxdna/npu2_regs.c
@@ -59,6 +59,9 @@
 
 #define NPU2_RT_CFG_VAL_PDI_LOAD_APP 1
 
+#define NPU2_MPNPUCLK_FREQ_MAX  1267
+#define NPU2_HCLK_FREQ_MAX      1800
+
 const struct npu_dev_priv npu2_dev_priv = {
 	.fw_path        = "amdnpu/17f0_00/npu.sbin",
 	.protocol_major = 0x6,
@@ -88,6 +91,8 @@ const struct npu_dev_priv npu2_dev_priv = {
 		DEFINE_BAR_OFFSET(SMU_RESP_REG, NPU2_SMU, MP1_C2PMSG_61),
 		DEFINE_BAR_OFFSET(SMU_OUT_REG,  NPU2_SMU, MP1_C2PMSG_60),
 	},
+	.smu_mpnpuclk_freq_max = NPU2_MPNPUCLK_FREQ_MAX,
+	.smu_hclk_freq_max     = NPU2_HCLK_FREQ_MAX,
 };
 
 const struct amdxdna_dev_info dev_npu2_info = {

--- a/src/driver/amdxdna/npu4_regs.c
+++ b/src/driver/amdxdna/npu4_regs.c
@@ -59,6 +59,9 @@
 
 #define NPU4_RT_CFG_VAL_PDI_LOAD_APP 1
 
+#define NPU4_MPNPUCLK_FREQ_MAX  1267
+#define NPU4_HCLK_FREQ_MAX      1800
+
 const struct npu_dev_priv npu4_dev_priv = {
 	.fw_path        = "amdnpu/17f0_10/npu.sbin",
 	.protocol_major = 0x6,
@@ -88,6 +91,9 @@ const struct npu_dev_priv npu4_dev_priv = {
 		DEFINE_BAR_OFFSET(SMU_RESP_REG, NPU4_SMU, MP1_C2PMSG_61),
 		DEFINE_BAR_OFFSET(SMU_OUT_REG,  NPU4_SMU, MP1_C2PMSG_60),
 	},
+
+	.smu_mpnpuclk_freq_max = NPU4_MPNPUCLK_FREQ_MAX,
+	.smu_hclk_freq_max     = NPU4_HCLK_FREQ_MAX,
 };
 
 const struct amdxdna_dev_info dev_npu4_info = {


### PR DESCRIPTION
The max mpnpu_clk/hclk ranges are different between npu1 and npu2/npu4, add clock range definitions in const struct npu_dev_priv and use for clock settings

When setting npu clocks, display clock value in dmesg