### PR TITLE
Mailbox sanity check in rx worker

### DIFF
--- a/src/driver/amdxdna/npu1_debugfs.c
+++ b/src/driver/amdxdna/npu1_debugfs.c
@@ -234,11 +234,12 @@ static int test_case01(struct npu_device *ndev)
 	return 0;
 }
 
-static void test_case02_cb(void *handle, const u32 *data, size_t size)
+static int test_case02_cb(void *handle, const u32 *data, size_t size)
 {
 	struct completion *comp = handle;
 
 	complete(comp);
+	return 0;
 }
 
 static int test_case02(struct npu_device *ndev, u32 argc, const u32 *args)

--- a/src/driver/amdxdna/npu1_error.c
+++ b/src/driver/amdxdna/npu1_error.c
@@ -198,7 +198,7 @@ static u32 npu1_error_backtrack(struct npu_device *ndev, void *err_info, u32 num
 	return err_col;
 }
 
-static void npu1_error_async_cb(void *handle, const u32 *data, size_t size)
+static int npu1_error_async_cb(void *handle, const u32 *data, size_t size)
 {
 	struct async_event_msg_resp *resp;
 	struct async_event *e = handle;
@@ -210,6 +210,7 @@ static void npu1_error_async_cb(void *handle, const u32 *data, size_t size)
 		e->resp.status = resp->status;
 	}
 	queue_work(e->wq, &e->work);
+	return 0;
 }
 
 static int npu1_error_event_send(struct async_event *e)

--- a/src/driver/amdxdna/npu1_message.c
+++ b/src/driver/amdxdna/npu1_message.c
@@ -255,13 +255,14 @@ int npu1_destroy_context(struct npu_device *ndev, struct amdxdna_hwctx *hwctx)
 	if (!hwctx->priv->mbox_chan)
 		return 0;
 
+	xdna_mailbox_destroy_channel(hwctx->priv->mbox_chan);
+
 	req.context_id = hwctx->fw_ctx_id;
 	ret = npu_send_mgmt_msg_wait(ndev, &msg);
 	if (ret)
 		XDNA_WARN(xdna, "%s.%d destroy context failed, ret %d",
 			  hwctx->name, hwctx->id, ret);
 
-	xdna_mailbox_destroy_channel(hwctx->priv->mbox_chan);
 	hwctx->priv->mbox_chan = NULL;
 	XDNA_DBG(xdna, "%s.%d destroyed fw ctx %d", hwctx->name,
 		 hwctx->id, hwctx->fw_ctx_id);

--- a/src/driver/amdxdna/npu1_message.c
+++ b/src/driver/amdxdna/npu1_message.c
@@ -368,7 +368,7 @@ fail:
 }
 
 int npu1_register_asyn_event_msg(struct npu_device *ndev, dma_addr_t addr, u32 size,
-				 void *handle, void (*cb)(void*, const u32 *, size_t))
+				 void *handle, int (*cb)(void*, const u32 *, size_t))
 {
 	struct async_event_msg_req req = { 0 };
 	struct xdna_mailbox_msg msg = {
@@ -429,7 +429,7 @@ int npu1_config_cu(struct amdxdna_hwctx *hwctx)
 
 int npu1_execbuf(struct amdxdna_hwctx *hwctx, u32 cu_idx,
 		 u32 *payload, u32 payload_len, void *handle,
-		 void (*notify_cb)(void *, const u32 *, size_t))
+		 int (*notify_cb)(void *, const u32 *, size_t))
 {
 	struct mailbox_channel *chann = hwctx->priv->mbox_chan;
 	struct amdxdna_dev *xdna = hwctx->client->xdna;

--- a/src/driver/amdxdna/npu1_pci.c
+++ b/src/driver/amdxdna/npu1_pci.c
@@ -261,6 +261,7 @@ static void npu1_hw_stop(struct amdxdna_dev *xdna)
 	struct npu_device *ndev = xdna->dev_handle;
 
 	npu1_mgmt_fw_fini(ndev);
+	xdna_mailbox_stop_channel(ndev->mgmt_chann);
 	xdna_mailbox_destroy_channel(ndev->mgmt_chann);
 	npu1_psp_stop(ndev->psp_hdl);
 	npu1_smu_fini(ndev);
@@ -341,6 +342,7 @@ static int npu1_hw_start(struct amdxdna_dev *xdna)
 	return 0;
 
 destroy_mgmt_chann:
+	xdna_mailbox_stop_channel(ndev->mgmt_chann);
 	xdna_mailbox_destroy_channel(ndev->mgmt_chann);
 stop_psp:
 	npu1_psp_stop(ndev->psp_hdl);

--- a/src/driver/amdxdna/npu1_pci.h
+++ b/src/driver/amdxdna/npu1_pci.h
@@ -243,13 +243,13 @@ int npu1_destroy_context(struct npu_device *ndev, struct amdxdna_hwctx *hwctx);
 int npu1_map_host_buf(struct npu_device *ndev, u32 context_id, u64 addr, u64 size);
 int npu1_query_status(struct npu_device *ndev, char *buf, u32 size, u32 *cols_filled);
 int npu1_register_asyn_event_msg(struct npu_device *ndev, dma_addr_t addr, u32 size,
-				 void *handle, void (*cb)(void*, const u32 *, size_t));
+				 void *handle, int (*cb)(void*, const u32 *, size_t));
 int npu1_self_test(struct npu_device *ndev);
 
 int npu1_config_cu(struct amdxdna_hwctx *hwctx);
 int npu1_execbuf(struct amdxdna_hwctx *hwctx, u32 cu_idx,
 		 u32 *payload, u32 payload_len, void *handle,
-		 void (*notify_cb)(void *, const u32 *, size_t));
+		 int (*notify_cb)(void *, const u32 *, size_t));
 
 /* npu1_hwctx.c */
 int npu1_hwctx_init(struct amdxdna_hwctx *hwctx);

--- a/src/driver/amdxdna/npu_common.h
+++ b/src/driver/amdxdna/npu_common.h
@@ -38,7 +38,7 @@ struct npu_notify {
 		.notify_cb = npu_msg_cb,			\
 	}
 
-void npu_msg_cb(void *handle, const u32 *data, size_t size);
+int npu_msg_cb(void *handle, const u32 *data, size_t size);
 int npu_send_msg_wait(struct amdxdna_dev *xdna,
 		      struct mailbox_channel *chann,
 		      struct xdna_mailbox_msg *msg);

--- a/src/driver/amdxdna/npu_mailbox.c
+++ b/src/driver/amdxdna/npu_mailbox.c
@@ -613,6 +613,13 @@ int xdna_mailbox_destroy_channel(struct mailbox_channel *mb_chann)
 	list_del(&mb_chann->chann_entry);
 	mutex_unlock(&mb_chann->mb->mbox_lock);
 
+	/* Disalbe an irq and wait. This might sleep. */
+	disable_irq(mb_chann->msix_irq);
+
+	/* Cancel RX work and wait for it to finish */
+	cancel_work_sync(&mb_chann->rx_work);
+
+	MB_DBG(mb_chann, "IRQ disabled and RX work cancelled");
 	free_irq(mb_chann->msix_irq, mb_chann);
 	destroy_workqueue(mb_chann->work_q);
 	/* We can clean up and release resources */

--- a/src/driver/amdxdna/npu_mailbox.c
+++ b/src/driver/amdxdna/npu_mailbox.c
@@ -422,11 +422,6 @@ int xdna_mailbox_send_msg(struct mailbox_channel *mb_chann,
 		return -EINVAL;
 	}
 
-	if (unlikely(!msg->notify_cb)) {
-		MB_ERR(mb_chann, "Message notify callback missed");
-		return -EINVAL;
-	}
-
 	/* The fist word in payload can NOT be TOMBSTONE */
 	if (unlikely(((u32 *)msg->send_data)[0] == TOMBSTONE)) {
 		MB_ERR(mb_chann, "Tomb stone in data");

--- a/src/driver/amdxdna/npu_mailbox.c
+++ b/src/driver/amdxdna/npu_mailbox.c
@@ -32,6 +32,12 @@
 	dev_dbg((_chann)->mb->dev, "xdna_mailbox.%d: "fmt, \
 		(_chann)->msix_irq, ##args); \
 })
+#define MB_WARN_ONCE(chann, fmt, args...) \
+({ \
+	typeof(chann) _chann = chann; \
+	dev_warn_once((_chann)->mb->dev, "xdna_mailbox.%d: "fmt, \
+		      (_chann)->msix_irq, ##args); \
+})
 
 #define MAGIC_VAL			0x1D000000U
 #define MAGIC_VAL_MASK			0xFF000000
@@ -73,6 +79,7 @@ struct mailbox_channel {
 	struct workqueue_struct		*work_q;
 	struct work_struct		rx_work;
 	u32				i2x_head;
+	bool				bad_state;
 };
 
 struct xdna_msg_header {
@@ -99,7 +106,7 @@ struct mailbox_pkg {
 
 struct mailbox_msg {
 	void			*handle;
-	void			(*notify_cb)(void *handle, const u32 *data, size_t size);
+	int			(*notify_cb)(void *handle, const u32 *data, size_t size);
 	size_t			pkg_size; /* package size in bytes */
 	struct mailbox_pkg	pkg;
 };
@@ -203,8 +210,7 @@ static int mailbox_release_msg(int id, void *p, void *data)
 
 	MB_DBG(mb_chann, "msg_id 0x%x msg opcode 0x%x",
 	       mb_msg->pkg.header.id, mb_msg->pkg.header.opcode);
-	if (mb_msg->notify_cb)
-		mb_msg->notify_cb(mb_msg->handle, NULL, 0);
+	mb_msg->notify_cb(mb_msg->handle, NULL, 0);
 	kfree(mb_msg);
 
 	return 0;
@@ -254,37 +260,40 @@ no_space:
 	return -ENOSPC;
 }
 
-static inline void
+static inline int
 mailbox_get_resp(struct mailbox_channel *mb_chann, struct xdna_msg_header *header,
 		 void *data)
 {
 	struct mailbox_msg *mb_msg;
 	unsigned long flags;
 	int msg_id;
+	int ret;
 
 	msg_id = header->id;
 	if (!mailbox_validate_msgid(msg_id)) {
-		MB_DBG(mb_chann, "Bad message ID 0x%x", msg_id);
-		return;
+		MB_ERR(mb_chann, "Bad message ID 0x%x", msg_id);
+		return -EINVAL;
 	}
 
 	msg_id &= ~MAGIC_VAL_MASK;
 	spin_lock_irqsave(&mb_chann->chan_idr_lock, flags);
 	mb_msg = idr_find(&mb_chann->chan_idr, msg_id);
 	if (!mb_msg) {
-		WARN_ONCE(1, "Cannot find msg 0x%x\n", msg_id);
+		MB_ERR(mb_chann, "Cannot find msg 0x%x", msg_id);
 		spin_unlock_irqrestore(&mb_chann->chan_idr_lock, flags);
-		return;
+		return -EINVAL;
 	}
 	idr_remove(&mb_chann->chan_idr, msg_id);
 	spin_unlock_irqrestore(&mb_chann->chan_idr_lock, flags);
 
 	MB_DBG(mb_chann, "opcode 0x%x size %d id 0x%x",
 	       header->opcode, header->total_size, header->id);
-	if (mb_msg->notify_cb)
-		mb_msg->notify_cb(mb_msg->handle, data, header->size);
+	ret = mb_msg->notify_cb(mb_msg->handle, data, header->total_size);
+	if (unlikely(ret))
+		MB_ERR(mb_chann, "Message callback ret %d", ret);
 
 	kfree(mb_msg);
+	return ret;
 }
 
 static inline int mailbox_get_msg(struct mailbox_channel *mb_chann)
@@ -295,11 +304,17 @@ static inline int mailbox_get_msg(struct mailbox_channel *mb_chann)
 	u32 head, tail;
 	u32 start_addr;
 	u64 read_addr;
+	int ret;
 
 	tail = mailbox_get_tailptr(mb_chann, CHAN_RES_I2X);
 	head = mb_chann->i2x_head;
 	ringbuf_size = mailbox_get_ringbuf_size(mb_chann, CHAN_RES_I2X);
 	start_addr = mb_chann->res[CHAN_RES_I2X].rb_start_addr;
+
+	if (unlikely(tail > ringbuf_size)) {
+		MB_WARN_ONCE(mb_chann, "Invalid tail 0x%x", tail);
+		return -EINVAL;
+	}
 
 	/* ringbuf empty */
 	if ((head & (ringbuf_size - 1)) == (tail & (ringbuf_size - 1)))
@@ -311,32 +326,37 @@ static inline int mailbox_get_msg(struct mailbox_channel *mb_chann)
 	/* Peek size of the message or TOMBSTONE */
 	read_addr = mb_chann->mb->res.ringbuf_base + start_addr + head;
 	header.total_size = ioread32((void *)read_addr);
-	rest = sizeof(header) - sizeof(u32);
-	read_addr += sizeof(u32);
-
 	/* size is TOMBSTONE, set next read from 0 */
 	if (header.total_size == TOMBSTONE) {
 		mailbox_set_headptr(mb_chann, 0);
 		return 0;
 	}
-	msg_size = sizeof(header) + header.total_size;
 
-	if (msg_size > ringbuf_size - head  || msg_size > tail - head) {
-		WARN_ONCE(1, "Invalid message size %d, tail %d, head %d\n",
-			  msg_size, tail, head);
+	if (unlikely(!header.total_size || !IS_ALIGNED(header.total_size, 4))) {
+		MB_WARN_ONCE(mb_chann, "Invalid total size 0x%x", header.total_size);
 		return -EINVAL;
 	}
+	msg_size = sizeof(header) + header.total_size;
+
+	if (msg_size > ringbuf_size - head || msg_size > tail - head) {
+		MB_WARN_ONCE(mb_chann, "Invalid message size %d, tail %d, head %d",
+			     msg_size, tail, head);
+		return -EINVAL;
+	}
+
+	rest = sizeof(header) - sizeof(u32);
+	read_addr += sizeof(u32);
 	memcpy_fromio((u32 *)&header + 1, (void *)read_addr, rest);
 	read_addr += rest;
 
-	mailbox_get_resp(mb_chann, &header, (u32 *)read_addr);
+	ret = mailbox_get_resp(mb_chann, &header, (u32 *)read_addr);
 
 	mailbox_set_headptr(mb_chann, head + msg_size);
 	/* After update head, it can equal to ringbuf_size. This is expected. */
 	trace_mbox_set_head(MAILBOX_NAME, mb_chann->msix_irq,
 			    header.opcode, header.id);
 
-	return 0;
+	return ret;
 }
 
 static irqreturn_t mailbox_irq_handler(int irq, void *p)
@@ -359,14 +379,27 @@ static void mailbox_rx_worker(struct work_struct *rx_work)
 
 	mb_chann = container_of(rx_work, struct mailbox_channel, rx_work);
 
+	if (READ_ONCE(mb_chann->bad_state)) {
+		MB_ERR(mb_chann, "Channel in bad state, work aborted");
+		return;
+	}
+
 	while (1) {
 		/*
 		 * If return is 0, keep consuming next message, until there is
 		 * no messages or an error happened.
 		 */
 		ret = mailbox_get_msg(mb_chann);
-		if (ret)
+		if (ret == -ENOENT)
 			break;
+
+		/* Other error means device doesn't look good, disable irq. */
+		if (unlikely(ret)) {
+			MB_ERR(mb_chann, "Unexpected ret %d, disable irq", ret);
+			WRITE_ONCE(mb_chann->bad_state, true);
+			disable_irq(mb_chann->msix_irq);
+			break;
+		}
 	}
 }
 
@@ -389,8 +422,13 @@ int xdna_mailbox_send_msg(struct mailbox_channel *mb_chann,
 		return -EINVAL;
 	}
 
+	if (unlikely(!msg->notify_cb)) {
+		MB_ERR(mb_chann, "Message notify callback missed");
+		return -EINVAL;
+	}
+
 	/* The fist word in payload can NOT be TOMBSTONE */
-	if  (unlikely(((u32 *)msg->send_data)[0] == TOMBSTONE)) {
+	if (unlikely(((u32 *)msg->send_data)[0] == TOMBSTONE)) {
 		MB_ERR(mb_chann, "Tomb stone in data");
 		return -EINVAL;
 	}
@@ -590,6 +628,7 @@ skip_record:
 		goto destroy_wq;
 	}
 
+	mb_chann->bad_state = false;
 	mutex_lock(&mb->mbox_lock);
 	list_add(&mb_chann->chann_entry, &mb->chann_list);
 	mutex_unlock(&mb->mbox_lock);

--- a/src/driver/amdxdna/npu_mailbox.h
+++ b/src/driver/amdxdna/npu_mailbox.h
@@ -108,6 +108,15 @@ xdna_mailbox_create_channel(struct mailbox *mailbox,
 int xdna_mailbox_destroy_channel(struct mailbox_channel *mailbox_chann);
 
 /*
+ * xdna_mailbox_stop_channel() -- stop mailbox channel
+ *
+ * @mailbox_chann: the handle return from xdna_mailbox_create_channel()
+ *
+ * Return: if success, return 0. otherwise return error code
+ */
+void xdna_mailbox_stop_channel(struct mailbox_channel *mailbox_chann);
+
+/*
  * xdna_mailbox_send_msg() -- Send a message
  *
  * @mailbox_chann: Mailbox channel handle

--- a/src/driver/amdxdna/npu_mailbox.h
+++ b/src/driver/amdxdna/npu_mailbox.h
@@ -25,7 +25,7 @@ struct mailbox_channel;
 struct xdna_mailbox_msg {
 	u32		opcode;
 	void		*handle;
-	void		(*notify_cb)(void *handle, const u32 *data, size_t size);
+	int		(*notify_cb)(void *handle, const u32 *data, size_t size);
 	u8		*send_data;
 	size_t		send_size;
 };


### PR DESCRIPTION
1. When destroy channel, disalbe irq and cancel rx work in front.
2. Check value read from mailbox. Even firmware is untrusted, host driver should not crash.
3. When RX worker read corrupted data from ringbuf. Disable IRQ and mark channel as bad state.