### PR TITLE
add module parameter start_col_index for debug

### DIFF
--- a/src/driver/amdxdna/npu1_ctx.c
+++ b/src/driver/amdxdna/npu1_ctx.c
@@ -11,6 +11,10 @@
 
 #define HWCTX_MAX_TIMEOUT	10000 /* miliseconds */
 
+int start_col_index = -1;
+module_param(start_col_index, int, 0600);
+MODULE_PARM_DESC(start_col_index, "Force start column, default -1 (auto select)");
+
 static inline int
 npu1_hwctx_add_job(struct amdxdna_hwctx *hwctx, struct amdxdna_sched_job *job)
 {
@@ -296,18 +300,35 @@ static int npu1_hwctx_col_list(struct amdxdna_hwctx *hwctx)
 	if (ndev->priv->col_align == COL_ALIGN_NATURE)
 		width = hwctx->num_col;
 
-	/*
-	 * In range [start, end], find out columns that is multiple of width.
-	 *	'first' is the first column,
-	 *	'last' is the last column,
-	 *	'entries' is the total number of columns.
-	 */
-	start =  xdna->dev_info->first_col;
-	end =  ndev->total_col - width;
-	first = start + (width - start % width) % width;
-	last = end - end % width;
-	if (last >= first)
-		entries = (last - first) / width + 1;
+	if (start_col_index == -1) {
+		/*
+		 * In range [start, end], find out columns that is multiple of width.
+		 *	'first' is the first column,
+		 *	'last' is the last column,
+		 *	'entries' is the total number of columns.
+		 */
+		start =  xdna->dev_info->first_col;
+		end =  ndev->total_col - hwctx->num_col;
+		first = start + (width - start % width) % width;
+		last = end - end % width;
+		if (last >= first)
+			entries = (last - first) / width + 1;
+		XDNA_DBG(xdna, "start %d end %d first %d last %d",
+			 start, end, first, last);
+	} else {
+		if (start_col_index < 0) {
+			XDNA_ERR(xdna, "Negative start_col_index");
+			return -EINVAL;
+		}
+
+		if (start_col_index + hwctx->num_col > ndev->total_col) {
+			XDNA_ERR(xdna, "Invalid start_col_index %d, num col %d",
+				 start_col_index, hwctx->num_col);
+			return -EINVAL;
+		}
+		entries = 1;
+		first = start_col_index;
+	}
 
 	if (unlikely(!entries)) {
 		XDNA_ERR(xdna, "Start %d end %d width %d",


### PR DESCRIPTION
Add start_col_index module parameter for debug purpose. System admin can force xdna-driver to use the specified start column.

``` bash
# Usage, for example, user want start column is 3.
sudo modprobe amdxdna start_col_index=3
```