### PR TITLE
Bug fixes

### DIFF
--- a/src/driver/amdxdna/amdxdna_drv.c
+++ b/src/driver/amdxdna/amdxdna_drv.c
@@ -131,7 +131,7 @@ static int amdxdna_flush(struct file *f, fl_owner_t id)
 
 	XDNA_DBG(xdna, "pid %d flushing...", client->pid);
 	mutex_lock(&xdna->dev_lock);
-	list_del(&client->node);
+	list_del_init(&client->node);
 	amdxdna_hwctx_remove_all(client);
 	mutex_unlock(&xdna->dev_lock);
 

--- a/src/driver/amdxdna/npu1_message.c
+++ b/src/driver/amdxdna/npu1_message.c
@@ -418,10 +418,8 @@ int npu1_config_cu(struct amdxdna_hwctx *hwctx)
 	req.num_cus = hwctx->cus->num_cus;
 
 	ret = npu_send_msg_wait(xdna, chann, &msg);
-	if (ret == -ETIME) {
-		xdna_mailbox_stop_channel(chann);
-		xdna_mailbox_destroy_channel(chann);
-	}
+	if (ret == -ETIME)
+		npu1_destroy_context(xdna->dev_handle, hwctx);
 
 	if (resp.status == NPU_STATUS_SUCCESS) {
 		XDNA_DBG(xdna, "Configure %d CUs, ret %d", req.num_cus, ret);

--- a/src/driver/amdxdna/npu1_pci.h
+++ b/src/driver/amdxdna/npu1_pci.h
@@ -137,7 +137,7 @@ struct rt_config {
 #define HWCTX_MAX_CMDS		8
 struct npu_hwctx {
 	struct amdxdna_gem_obj		*heap;
-	void				*mbox_chan;
+	void				*mbox_chann;
 
 	struct drm_gpu_scheduler	sched;
 	struct drm_sched_entity		entity;

--- a/src/driver/amdxdna/npu_common.c
+++ b/src/driver/amdxdna/npu_common.c
@@ -10,6 +10,7 @@
 int npu_msg_cb(void *handle, const u32 *data, size_t size)
 {
 	struct npu_notify *cb_arg = handle;
+	int ret;
 
 	if (unlikely(!data))
 		goto out;
@@ -23,8 +24,9 @@ int npu_msg_cb(void *handle, const u32 *data, size_t size)
 			     16, 4, data, cb_arg->size, true);
 	memcpy(cb_arg->data, data, cb_arg->size);
 out:
+	ret = cb_arg->error;
 	complete(&cb_arg->comp);
-	return cb_arg->error;
+	return ret;
 }
 
 int npu_send_msg_wait(struct amdxdna_dev *xdna,


### PR DESCRIPTION
1. OS can call flush fop multiple times, and list_del() will set poison pointer. This leads to kernel panic. Use list_del_init() instead.
2. If both dev_lock and hwctx_srcu lock need to be held, should acquire dev_lock first. See amdxdna_drm_config_hwctx_ioctl() change.
3. Some minor mailbox related fixes.