### PR TITLE
Support command chaining by issuing commands one at a time

### DIFF
--- a/src/shim/hwq.h
+++ b/src/shim/hwq.h
@@ -18,12 +18,10 @@ public:
   hw_q(const device& device);
 
   void
-  submit_command(xrt_core::buffer_handle *) override
-  { shim_not_supported_err(__func__); }
+  submit_command(xrt_core::buffer_handle *) override;
 
   void
-  submit_command(const std::vector<xrt_core::buffer_handle *>&) override
-  { shim_not_supported_err(__func__); }
+  submit_command(const std::vector<xrt_core::buffer_handle *>&) override;
 
   int
   wait_command(xrt_core::buffer_handle *, uint32_t timeout_ms) const override;
@@ -59,13 +57,21 @@ public:
   get_queue_bo();
 
   virtual void
-  map_doorbell(uint32_t doorbell_offset){}
+  map_doorbell(uint32_t doorbell_offset)
+  {
+    // do nothing by default
+  }
 
 protected:
+  virtual void
+  submit_command_list(const std::vector<xrt_core::buffer_handle *>&) = 0;
 
   const hw_ctx *m_hwctx;
   const pdev& m_pdev;
   uint32_t m_queue_boh;
+
+private:
+  bool m_force_unchained_command;
 };
 
 } // shim_xdna

--- a/src/shim/kmq/hwq.cpp
+++ b/src/shim/kmq/hwq.cpp
@@ -4,8 +4,6 @@
 #include "bo.h"
 #include "hwq.h"
 
-#include "core/common/config_reader.h"
-
 namespace shim_xdna {
 
 hw_q_kmq::
@@ -22,15 +20,7 @@ hw_q_kmq::
 
 void
 hw_q_kmq::
-submit_command(xrt_core::buffer_handle *cmd_bo)
-{
-  std::vector<xrt_core::buffer_handle *> cmd_bos {cmd_bo};
-  return submit_command(cmd_bos);
-}
-
-void
-hw_q_kmq::
-submit_command(const std::vector<xrt_core::buffer_handle *>& cmd_bos)
+submit_command_list(const std::vector<xrt_core::buffer_handle *>& cmd_bos)
 {
   // Assuming 256 max cmds and 256 max args per cmd bo
   const size_t max_cmd_bos = 256;
@@ -43,18 +33,6 @@ submit_command(const std::vector<xrt_core::buffer_handle *>& cmd_bos)
   uint32_t cmd_bo_hdls[max_cmd_bos];
   uint32_t arg_bo_hdls[max_arg_bos];
   size_t arg_cnt = 0;
-
-  if (cmd_bos.size() > 1) {
-    // Default of force_unchained_command should be false once command
-    // chaining is natively supported by driver/firmware.
-    if (xrt_core::config::detail::get_bool_value("Debug.force_unchained_command", true)) {
-      for (auto& cmd : cmd_bos)
-        submit_command(cmd);
-      return;
-    }
-    // Should be removed once command chaining is natively supported by driver/firmware.
-    throw std::runtime_error("Cannot support chaining > 1 commands");
-  }
 
   for (size_t cmd_cnt = 0; cmd_cnt < num_cmd_bos; cmd_cnt++) {
     auto boh = static_cast<bo_kmq*>(cmd_bos[cmd_cnt]);

--- a/src/shim/kmq/hwq.cpp
+++ b/src/shim/kmq/hwq.cpp
@@ -4,6 +4,8 @@
 #include "bo.h"
 #include "hwq.h"
 
+#include "core/common/config_reader.h"
+
 namespace shim_xdna {
 
 hw_q_kmq::
@@ -41,6 +43,18 @@ submit_command(const std::vector<xrt_core::buffer_handle *>& cmd_bos)
   uint32_t cmd_bo_hdls[max_cmd_bos];
   uint32_t arg_bo_hdls[max_arg_bos];
   size_t arg_cnt = 0;
+
+  if (cmd_bos.size() > 1) {
+    // Default of force_unchained_command should be false once command
+    // chaining is natively supported by driver/firmware.
+    if (xrt_core::config::detail::get_bool_value("Debug.force_unchained_command", true)) {
+      for (auto& cmd : cmd_bos)
+        submit_command(cmd);
+      return;
+    }
+    // Should be removed once command chaining is natively supported by driver/firmware.
+    throw std::runtime_error("Cannot support chaining > 1 commands");
+  }
 
   for (size_t cmd_cnt = 0; cmd_cnt < num_cmd_bos; cmd_cnt++) {
     auto boh = static_cast<bo_kmq*>(cmd_bos[cmd_cnt]);

--- a/src/shim/kmq/hwq.h
+++ b/src/shim/kmq/hwq.h
@@ -16,13 +16,11 @@ public:
   ~hw_q_kmq();
 
   void
-  submit_command(xrt_core::buffer_handle *) override;
-
-  void
-  submit_command(const std::vector<xrt_core::buffer_handle *>&) override;
-
-  void
   map_doorbell(uint32_t doorbell_offset);
+
+protected:
+  void
+  submit_command_list(const std::vector<xrt_core::buffer_handle *>&) override;
 };
 
 } // shim_xdna

--- a/src/shim/umq/hwq.cpp
+++ b/src/shim/umq/hwq.cpp
@@ -208,15 +208,7 @@ fill_slot_and_send(volatile host_queue_packet_t *pkt, void *payload, size_t size
 
 void
 hw_q_umq::
-submit_command(xrt_core::buffer_handle *cmd_bo)
-{
-  std::vector<xrt_core::buffer_handle *> cmd_bos {cmd_bo};
-  return submit_command(cmd_bos);
-}
-
-void
-hw_q_umq::
-submit_command(const std::vector<xrt_core::buffer_handle *>& cmd_bos)
+submit_command_list(const std::vector<xrt_core::buffer_handle *>& cmd_bos)
 {
   if (cmd_bos.size() > 1)
     shim_err(EINVAL, "Do not support more than 1 cmd");

--- a/src/shim/umq/hwq.h
+++ b/src/shim/umq/hwq.h
@@ -14,13 +14,6 @@ namespace shim_xdna {
 class hw_q_umq : public hw_q
 {
 public:
-  void
-  submit_command(xrt_core::buffer_handle *) override;
-
-  void
-  submit_command(const std::vector<xrt_core::buffer_handle *>&) override;
-
-public:
   hw_q_umq(const device& device, size_t nslots);
 
   ~hw_q_umq();
@@ -32,10 +25,14 @@ public:
   dump_raw() const;
 
   void
-  map_doorbell(uint32_t doorbell_offset);
+  map_doorbell(uint32_t doorbell_offset) override;
 
   volatile host_queue_header_t *
   get_header_ptr() const;
+
+protected:
+  void
+  submit_command_list(const std::vector<xrt_core::buffer_handle *>& cmd_bos) override;
 
 private:
   std::unique_ptr<xrt_core::buffer_handle> umq_bo;


### PR DESCRIPTION
1. Add support for command chaining by issuing one command at a time for now.
2. Enable command chaining test case.