### PR TITLE
When all columns are used, force to start from col 0

### DIFF
--- a/src/driver/amdxdna/amdxdna_devel.c
+++ b/src/driver/amdxdna/amdxdna_devel.c
@@ -17,6 +17,10 @@ bool priv_load;
 module_param(priv_load, bool, 0644);
 MODULE_PARM_DESC(priv_load, "Privileged loading runtime configure (Default false)");
 
+int start_col_index = -1;
+module_param(start_col_index, int, 0600);
+MODULE_PARM_DESC(start_col_index, "Force start column, default -1 (auto select)");
+
 int amdxdna_iommu_mode_setup(struct amdxdna_dev *xdna)
 {
 	struct iommu_domain *domain = NULL;

--- a/src/driver/amdxdna/amdxdna_devel.h
+++ b/src/driver/amdxdna/amdxdna_devel.h
@@ -16,6 +16,7 @@
 #define AMDXDNA_IOMMU_BYPASS 2
 extern int iommu_mode;
 extern bool priv_load;
+extern int start_col_index;
 
 int amdxdna_iommu_mode_setup(struct amdxdna_dev *aie);
 struct sg_table *amdxdna_alloc_sgt(struct amdxdna_dev *aie, size_t sz,


### PR DESCRIPTION
1. Enable col 0 when all columns are used on NPU1.
2. Move start_col_index module parameter to amdxdna_devel.c.