### PR TITLE
add strix halo support

### DIFF
--- a/src/driver/amdxdna/Makefile
+++ b/src/driver/amdxdna/Makefile
@@ -35,6 +35,7 @@ amdxdna-y := \
 	npu1_regs.o \
 	npu2_regs.o \
 	npu4_regs.o \
+	npu5_regs.o \
 	amdxdna_drv.o
 
 # Helper functions for amdxdna development, but not for upstreaming

--- a/src/driver/amdxdna/amdxdna_drv.c
+++ b/src/driver/amdxdna/amdxdna_drv.c
@@ -39,6 +39,7 @@ static const struct amdxdna_device_id amdxdna_ids[] = {
 	{ 0x1502, 0x0,  &dev_npu1_info },
 	{ 0x17f0, 0x0,  &dev_npu2_info },
 	{ 0x17f0, 0x10, &dev_npu4_info },
+	{ 0x17f0, 0x11, &dev_npu5_info },
 	{0}
 };
 

--- a/src/driver/amdxdna/amdxdna_drv.h
+++ b/src/driver/amdxdna/amdxdna_drv.h
@@ -159,5 +159,6 @@ struct amdxdna_client {
 extern const struct amdxdna_dev_info dev_npu1_info;
 extern const struct amdxdna_dev_info dev_npu2_info;
 extern const struct amdxdna_dev_info dev_npu4_info;
+extern const struct amdxdna_dev_info dev_npu5_info;
 
 #endif /* _AMDXDNA_DRV_H_ */

--- a/src/driver/amdxdna/npu5_regs.c
+++ b/src/driver/amdxdna/npu5_regs.c
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Copyright (C) 2024, Advanced Micro Devices, Inc.
+ */
+
+#include "drm_local/amdxdna_accel.h"
+#include "npu1_pci.h"
+
+/* NPU Public Registers on MpNPUAxiXbar (refer to Diag npu_registers.h) */
+#define MPNPU_PUB_SEC_INTR             0x3010060
+#define MPNPU_PUB_PWRMGMT_INTR         0x3010064
+#define MPNPU_PUB_SCRATCH0             0x301006C
+#define MPNPU_PUB_SCRATCH1             0x3010070
+#define MPNPU_PUB_SCRATCH2             0x3010074
+#define MPNPU_PUB_SCRATCH3             0x3010078
+#define MPNPU_PUB_SCRATCH4             0x301007C
+#define MPNPU_PUB_SCRATCH5             0x3010080
+#define MPNPU_PUB_SCRATCH6             0x3010084
+#define MPNPU_PUB_SCRATCH7             0x3010088
+#define MPNPU_PUB_SCRATCH8             0x301008C
+#define MPNPU_PUB_SCRATCH9             0x3010090
+#define MPNPU_PUB_SCRATCH10            0x3010094
+#define MPNPU_PUB_SCRATCH11            0x3010098
+#define MPNPU_PUB_SCRATCH12            0x301009C
+#define MPNPU_PUB_SCRATCH13            0x30100A0
+#define MPNPU_PUB_SCRATCH14            0x30100A4
+#define MPNPU_PUB_SCRATCH15            0x30100A8
+#define MP0_C2PMSG_73                  0x3810A24
+#define MP0_C2PMSG_123                 0x3810AEC
+
+#define MP1_C2PMSG_0                   0x3B10900
+#define MP1_C2PMSG_60                  0x3B109F0
+#define MP1_C2PMSG_61                  0x3B109F4
+
+#define MPNPU_SRAM_X2I_MAILBOX_0       0x3600000
+#define MPNPU_SRAM_X2I_MAILBOX_15      0x361E000
+#define MPNPU_SRAM_X2I_MAILBOX_31      0x363E000
+#define MPNPU_SRAM_I2X_MAILBOX_31      0x363F000
+
+#define MMNPU_APERTURE0_BASE           0x3000000
+#define MMNPU_APERTURE1_BASE           0x3600000
+#define MMNPU_APERTURE3_BASE           0x3810000
+#define MMNPU_APERTURE4_BASE           0x3B10000
+
+/* PCIe BAR Index for NPU5 */
+#define NPU5_REG_BAR_INDEX	0
+#define NPU5_MBOX_BAR_INDEX	0
+#define NPU5_PSP_BAR_INDEX	4
+#define NPU5_SMU_BAR_INDEX	5
+#define NPU5_SRAM_BAR_INDEX	2
+/* Associated BARs and Apertures */
+#define NPU5_REG_BAR_BASE	MMNPU_APERTURE0_BASE
+#define NPU5_MBOX_BAR_BASE	MMNPU_APERTURE0_BASE
+#define NPU5_PSP_BAR_BASE	MMNPU_APERTURE3_BASE
+#define NPU5_SMU_BAR_BASE	MMNPU_APERTURE4_BASE
+#define NPU5_SRAM_BAR_BASE	MMNPU_APERTURE1_BASE
+
+#define NPU5_RT_CFG_TYPE_PDI_LOAD 5
+
+#define NPU5_RT_CFG_VAL_PDI_LOAD_APP 1
+
+#define NPU5_MPNPUCLK_FREQ_MAX  1267
+#define NPU5_HCLK_FREQ_MAX      1800
+
+const struct npu_dev_priv npu5_dev_priv = {
+	.fw_path        = "amdnpu/17f0_11/npu.sbin",
+	.protocol_major = 0x6,
+	.protocol_minor = 0x1,
+	.rt_config	= {NPU5_RT_CFG_TYPE_PDI_LOAD, NPU5_RT_CFG_VAL_PDI_LOAD_APP},
+	.col_align	= COL_ALIGN_NATURE,
+	.mbox_dev_addr  = NPU5_MBOX_BAR_BASE,
+	.mbox_size      = 0, /* Use BAR size */
+	.sram_dev_addr  = NPU5_SRAM_BAR_BASE,
+	.sram_offs      = {
+		DEFINE_BAR_OFFSET(MBOX_CHANN_OFF, NPU5_SRAM, MPNPU_SRAM_X2I_MAILBOX_0),
+		DEFINE_BAR_OFFSET(FW_ALIVE_OFF,   NPU5_SRAM, MPNPU_SRAM_X2I_MAILBOX_15),
+	},
+	.psp_regs_off   = {
+		DEFINE_BAR_OFFSET(PSP_CMD_REG,    NPU5_PSP, MP0_C2PMSG_123),
+		DEFINE_BAR_OFFSET(PSP_ARG0_REG,   NPU5_REG, MPNPU_PUB_SCRATCH3),
+		DEFINE_BAR_OFFSET(PSP_ARG1_REG,   NPU5_REG, MPNPU_PUB_SCRATCH4),
+		DEFINE_BAR_OFFSET(PSP_ARG2_REG,   NPU5_REG, MPNPU_PUB_SCRATCH9),
+		DEFINE_BAR_OFFSET(PSP_INTR_REG,   NPU5_PSP, MP0_C2PMSG_73),
+		DEFINE_BAR_OFFSET(PSP_STATUS_REG, NPU5_PSP, MP0_C2PMSG_123),
+		DEFINE_BAR_OFFSET(PSP_RESP_REG,   NPU5_REG, MPNPU_PUB_SCRATCH3),
+	},
+	.smu_regs_off   = {
+		DEFINE_BAR_OFFSET(SMU_CMD_REG,  NPU5_SMU, MP1_C2PMSG_0),
+		DEFINE_BAR_OFFSET(SMU_ARG_REG,  NPU5_SMU, MP1_C2PMSG_60),
+		DEFINE_BAR_OFFSET(SMU_INTR_REG, NPU5_SMU, MMNPU_APERTURE4_BASE),
+		DEFINE_BAR_OFFSET(SMU_RESP_REG, NPU5_SMU, MP1_C2PMSG_61),
+		DEFINE_BAR_OFFSET(SMU_OUT_REG,  NPU5_SMU, MP1_C2PMSG_60),
+	},
+
+	.smu_mpnpuclk_freq_max = NPU5_MPNPUCLK_FREQ_MAX,
+	.smu_hclk_freq_max     = NPU5_HCLK_FREQ_MAX,
+};
+
+const struct amdxdna_dev_info dev_npu5_info = {
+	.reg_bar           = NPU5_REG_BAR_INDEX,
+	.mbox_bar          = NPU5_MBOX_BAR_INDEX,
+	.sram_bar          = NPU5_SRAM_BAR_INDEX,
+	.psp_bar           = NPU5_PSP_BAR_INDEX,
+	.smu_bar           = NPU5_SMU_BAR_INDEX,
+	.first_col         = 0,
+	.dev_mem_buf_shift = 15, /* 32 KiB aligned */
+	.dev_mem_base      = NPU_DEVM_BASE,
+	.dev_mem_size      = NPU_DEVM_SIZE,
+	.vbnv              = "RyzenAI-npu5",
+	.device_type       = AMDXDNA_DEV_TYPE_KMQ,
+	.dev_priv          = &npu5_dev_priv,
+	.ops               = &npu1_ops, /* NPU45 can share NPU1's callback */
+};

--- a/test/shim_test.cpp
+++ b/test/shim_test.cpp
@@ -36,6 +36,7 @@ const uint16_t npu1_device_id = 0x1502;
 const uint16_t npu2_device_id = 0x17f0;
 const uint16_t npu2_revision_id = 0x0;
 const uint16_t npu4_revision_id = 0x10;
+const uint16_t npu5_revision_id = 0x11;
 
 std::string program;
 // Test harness setup helpers
@@ -337,7 +338,29 @@ xclbin_info xclbin_infos[] = {
     },
     .workspace = "npu4_workspace",
   },
-
+  {
+    .name = "1x4.xclbin",
+    .device = npu2_device_id,
+    .revision_id = npu5_revision_id,
+    .ip_name2idx = {
+      { "DPU_PDI_0:IPUV1CNN",         {0} },
+      { "DPU_PDI_1:IPUV1CNN",         {1} },
+      { "DPU_PDI_2:IPUV1CNN",         {2} },
+      { "DPU_PDI_3:IPUV1CNN",         {3} },
+      { "DPU_PDI_4:IPUV1CNN",         {4} },
+      { "DPU_PDI_5:IPUV1CNN",         {5} },
+      { "DPU_PDI_6:IPUV1CNN",         {6} },
+      { "DPU_PDI_7:IPUV1CNN",         {7} },
+      { "DPU_PDI_8:IPUV1CNN",         {8} },
+      { "DPU_PDI_9:IPUV1CNN",         {9} },
+      { "DPU_PDI_10:IPUV1CNN",        {10} },
+      { "DPU_PDI_11:IPUV1CNN",        {11} },
+      { "DPU_PDI_12:IPUV1CNN",        {12} },
+      { "DPU_PDI_13:IPUV1CNN",        {13} },
+      { "DPU_PDI_14:IPUV1CNN",        {14} },
+    },
+    .workspace = "npu5_workspace",
+  }
 };
 
 const xclbin_info&

--- a/tools/info.json
+++ b/tools/info.json
@@ -28,6 +28,14 @@
 			"pci_revision_id": "10",
 			"version": "0.7.11.78",
 			"fw_name": "npu.sbin"
+		},
+		{
+			"device": "npu5",
+			"url": "",
+			"pci_device_id": "17f0",
+			"pci_revision_id": "11",
+			"version": "0.2.9.45",
+			"fw_name": "npu.sbin"
 		}
 	]
 }


### PR DESCRIPTION
1. strix halo is named npu5
2. add fw version for npu5
3. npu5 has the same register addresses as npu4
4. npu5 uses the same xclbin and testdata as npu4