### PR TITLE
support extra_drv.mk

### DIFF
--- a/src/driver/CMakeLists.txt
+++ b/src/driver/CMakeLists.txt
@@ -6,13 +6,27 @@ set(XDNA_DRV amdxdna)
 set(XDNA_DRV_DIR amdxdna)
 set(XDNA_DRV_TGT ${XDNA_DRV}.ko)
 set(XDNA_DRV_PATH ${CMAKE_BINARY_DIR}/driver/${XDNA_DRV_TGT})
-set(XDNA_DRV_BLD_SRC ${CMAKE_CURRENT_SOURCE_DIR}/${XDNA_DRV_DIR})
+set(XDNA_DRV_BLD_DIR full_driver/${XDNA_DRV_DIR})
+set(XDNA_DRV_BLD_SRC ${CMAKE_CURRENT_BINARY_DIR}/${XDNA_DRV_BLD_DIR})
 set(XDNA_DRV_BLD_TGT ${CMAKE_CURRENT_BINARY_DIR}/${XDNA_DRV_DIR})
+
+message("-- Extra driver source dir: ${XDNA_EXTRA_DRV_DIR}")
+add_custom_command(
+  OUTPUT all_driver_source
+  COMMENT "Collect all driver source code"
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+  COMMAND $(CMAKE_COMMAND) -E make_directory ${XDNA_DRV_BLD_DIR}
+  COMMAND cp -rf ${CMAKE_CURRENT_SOURCE_DIR}/${XDNA_DRV_DIR}/* ${XDNA_EXTRA_DRV_DIR} ${XDNA_DRV_BLD_DIR}
+  COMMAND cp -r ${CMAKE_CURRENT_SOURCE_DIR}/../include .
+  )
+
+# Because ${XDNA_DRV_TGT} is generated in ${XDNA_DRV_BLD_TGT}. So this custom command will always run.
 add_custom_command(
   OUTPUT ${XDNA_DRV_TGT}
   COMMENT "Build ${XDNA_DRV_TGT}"
   COMMAND $(MAKE) -f ${XDNA_DRV_BLD_SRC}/Makefile BUILD_DIR=${XDNA_DRV_BLD_TGT} SRC_DIR=${XDNA_DRV_BLD_SRC} ${KERNEL_VER} ${UMQ_HELLO_TEST}
   COMMAND $(CMAKE_COMMAND) -E copy ${XDNA_DRV_BLD_TGT}/${XDNA_DRV_TGT} ${XDNA_DRV_PATH}
+  DEPENDS all_driver_source
   )
 add_custom_target(driver ALL DEPENDS ${XDNA_DRV_TGT})
 

--- a/src/driver/amdxdna/Kbuild
+++ b/src/driver/amdxdna/Kbuild
@@ -38,3 +38,5 @@ amdxdna-y += amdxdna_devel.o
 
 # Place holder for npu3 support
 include $(ROOT)/npu3.mk
+
+-include $(src)/extra_drv.mk


### PR DESCRIPTION
Support extra_drv.mk.
In driver/CMakeList.txt, copy all driver source code to CMAKE_CURRENT_BINARY_DIR, instead of build from CMAKE_CURRENT_SOURCE_DIR