### PR TITLE
Check that __counted_by is defined in UAPI header

### DIFF
--- a/src/include/uapi/drm_local/amdxdna_accel.h
+++ b/src/include/uapi/drm_local/amdxdna_accel.h
@@ -8,13 +8,10 @@
 
 #include <drm/drm.h>
 #include <linux/const.h>
+#include <linux/stddef.h>
 
 #if defined(__cplusplus)
 extern "C" {
-#endif
-
-#ifndef __counted_by
-#define __counted_by(cnt)
 #endif
 
 #define AMDXDNA_DRIVER_MAJOR	1

--- a/src/include/uapi/drm_local/amdxdna_accel.h
+++ b/src/include/uapi/drm_local/amdxdna_accel.h
@@ -13,6 +13,10 @@
 extern "C" {
 #endif
 
+#ifndef __counted_by
+#define __counted_by(cnt)
+#endif
+
 #define AMDXDNA_DRIVER_MAJOR	1
 #define AMDXDNA_DRIVER_MINOR	0
 


### PR DESCRIPTION
When using this header in user space runtimes __counted_by may not be defined for all compilers. Check for its definition and define a dummy version if it is not defined to avoid compilation errors.