### PR TITLE
Bug fixes in aie mem read/write apis flow

### DIFF
--- a/src/driver/amdxdna/aie2_pci.c
+++ b/src/driver/amdxdna/aie2_pci.c
@@ -724,7 +724,7 @@ static int aie2_get_hwctx_status(struct amdxdna_client *client,
 		idx = srcu_read_lock(&tmp_client->hwctx_srcu);
 		next = 0;
 		idr_for_each_entry_continue(&tmp_client->hwctx_idr, hwctx, next) {
-			req_bytes += sizeof(tmp);
+			req_bytes += sizeof(*tmp);
 			if (args->buffer_size < req_bytes) {
 				/* Continue iterating to get the required size */
 				overflow = true;

--- a/src/shim/device.h
+++ b/src/shim/device.h
@@ -64,6 +64,16 @@ public:
   void
   register_xclbin(const xrt::xclbin& xclbin) const override;
 
+  void
+  open_aie_context(xrt::aie::access_mode) override
+  {
+    // return success everytime as this flow doesn't support
+    // calling driver to open aie context
+    // this is to satisfy xrt::aie::device class constructor
+    // which calls open_aie_context of ishim
+    return;
+  }
+
   std::vector<char>
   read_aie_mem(uint16_t col, uint16_t row, uint32_t offset, uint32_t size) override;
 


### PR DESCRIPTION
couple of bug fixes
> fix size calculation
> added overridden function for open_aie_context which is used in xrt::aie::device construction