### PR TITLE
update NPU1 firmware

### DIFF
--- a/src/shim/pcidev.cpp
+++ b/src/shim/pcidev.cpp
@@ -56,7 +56,7 @@ pdev(std::shared_ptr<const drv> driver, std::string sysfs_name)
   // Default of force_unchained_command should be false once command
   // chaining is natively supported by driver/firmware.
   , m_force_unchained_command(xrt_core::config::detail::get_bool_value(
-    "Debug.force_unchained_command", true))
+    "Debug.force_unchained_command", false))
 {
   m_is_ready = true; // We're always ready.
 }

--- a/tools/info.json
+++ b/tools/info.json
@@ -7,10 +7,10 @@
 	"firmwares": [
 		{
 			"device": "npu1",
-			"url": "https://gitlab.freedesktop.org/drm/firmware/-/raw/amd-ipu-staging/amdnpu/1502_00/npu.sbin.1.4.1.309",
+			"url": "https://gitlab.freedesktop.org/drm/firmware/-/raw/amd-ipu-staging/amdnpu/1502_00/npu.sbin.1.4.2.313",
 			"pci_device_id": "1502",
 			"pci_revision_id": "00",
-			"version": "1.4.1.309",
+			"version": "1.4.2.313",
 			"fw_name": "npu.sbin"
 		},
 		{


### PR DESCRIPTION
Update NPU1 firmware and by default support run list.

Example application will be added in future PR.