### PR TITLE
Enhance driver make system

### DIFF
--- a/src/driver/CMake/config/dkms.conf.in
+++ b/src/driver/CMake/config/dkms.conf.in
@@ -4,6 +4,6 @@ BUILD_EXCLUSIVE_KERNEL_MIN=6.8
 MAKE[0]="cd driver/@XDNA_DRV_DIR@; make KERNEL_SRC=${kernel_source_dir}; cd ../.."
 CLEAN="cd driver/@XDNA_DRV_DIR@; make clean KERNEL_SRC=${kernel_source_dir}; cd ../.."
 BUILT_MODULE_NAME[0]=@XDNA_DRV@
-BUILT_MODULE_LOCATION[0]="driver/@XDNA_DRV_DIR@/build/amdxdna"
+BUILT_MODULE_LOCATION[0]="driver/@XDNA_DRV_DIR@/build/driver/amdxdna"
 DEST_MODULE_LOCATION[0]="/kernel/extras"
 AUTOINSTALL="yes"

--- a/src/driver/CMakeLists.txt
+++ b/src/driver/CMakeLists.txt
@@ -24,7 +24,8 @@ add_custom_command(
 add_custom_command(
   OUTPUT ${XDNA_DRV_TGT}
   COMMENT "Build ${XDNA_DRV_TGT}"
-  COMMAND $(MAKE) -f ${XDNA_DRV_BLD_SRC}/Makefile BUILD_DIR=${XDNA_DRV_BLD_TGT} SRC_DIR=${XDNA_DRV_BLD_SRC} ${KERNEL_VER} ${UMQ_HELLO_TEST}
+  COMMAND $(MAKE) -f ${XDNA_DRV_BLD_SRC}/Makefile BUILD_ROOT_DIR=${XDNA_DRV_BLD_TGT} ${KERNEL_VER} ${UMQ_HELLO_TEST}
+  COMMAND $(MAKE) -f ${XDNA_DRV_BLD_SRC}/Makefile BUILD_ROOT_DIR=${XDNA_DRV_BLD_TGT} copy_ko
   COMMAND $(CMAKE_COMMAND) -E copy ${XDNA_DRV_BLD_TGT}/${XDNA_DRV_TGT} ${XDNA_DRV_PATH}
   DEPENDS all_driver_source
   )
@@ -39,6 +40,7 @@ set(XDNA_DRV_EXCLUDES
   --exclude=CMake*
   --exclude=tools
   --exclude=doc
+  ${XNDA_EXTRA_DRV_EXCLUDES}
   )
 file(GLOB_RECURSE ALL_DRV_FILES
   ${XDNA_DRV_BLD_SRC}/Makefile

--- a/src/driver/amdxdna/Kbuild
+++ b/src/driver/amdxdna/Kbuild
@@ -36,11 +36,6 @@ amdxdna-y := \
 	npu5_regs.o \
 	amdxdna_pci_drv.o
 
-# TODO: This is a hack for 6.10. Looking for a solution
-$(obj)/%.o : $(src)/%.c FORCE
-	$(call if_changed_rule,cc_o_c)
-	$(call cmd,force_checksrc)
-
 # Helper functions for amdxdna development, but not for upstreaming
 amdxdna-y += amdxdna_devel.o
 

--- a/src/driver/amdxdna/Makefile
+++ b/src/driver/amdxdna/Makefile
@@ -14,21 +14,6 @@ ifeq ($(BUILD_ROOT_DIR),$(SRC_DIR))
 $(error BUILD_ROOT_DIR and SRC_DIR can NOT be the same)
 endif
 
-define enable_extra_drv
-	@if [ -f extra_drv.mk ]; then \
-		echo "[INFO] enable all includes in extra_drv.mk"; \
-		cp extra_drv.mk extra_drv.mk.orig; \
-		sed 's/-include/include/' extra_drv.mk.orig > extra_drv.mk; \
-		fi
-endef
-
-define restore_extra_drv
-	@if [ -f extra_drv.mk ]; then \
-		cp extra_drv.mk.orig extra_drv.mk; \
-		rm extra_drv.mk.orig; \
-		fi
-endef
-
 .PHONY: all clean modules modules_install copy_ko
 
 all: $(BUILD_ROOT_DIR)
@@ -36,9 +21,7 @@ all: $(BUILD_ROOT_DIR)
 
 # add EXTRA_CFLAGS='-save-temps' to keep intermedia files
 modules:
-	$(call enable_extra_drv)
 	$(MAKE) -C $(KERNEL_SRC) M=$(SRC_DIR) CFLAGS_MODULE='-DAMDXDNA_DEVEL' modules
-	$(call restore_extra_drv)
 
 modules_install:
 	$(MAKE) -C $(KERNEL_SRC) M=$(SRC_DIR) modules_install

--- a/src/driver/amdxdna/Makefile
+++ b/src/driver/amdxdna/Makefile
@@ -6,23 +6,56 @@
 KERNEL_VER ?= $(shell uname -r)
 KERNEL_SRC ?= /lib/modules/$(KERNEL_VER)/build
 
-SRC_DIR ?= $(shell pwd)
-BUILD_DIR ?= $(SRC_DIR)/build/amdxdna
+mkfile_path = $(abspath $(lastword $(MAKEFILE_LIST)))
+SRC_DIR = $(patsubst %/,%,$(dir $(mkfile_path)))
+BUILD_ROOT_DIR := $(SRC_DIR)/build
 
-BUILD_DIR_MAKEFILE := $(BUILD_DIR)/Makefile
+ifeq ($(BUILD_ROOT_DIR),$(SRC_DIR))
+$(error BUILD_ROOT_DIR and SRC_DIR can NOT be the same)
+endif
+
+define enable_extra_drv
+	@if [ -f extra_drv.mk ]; then \
+		echo "[INFO] enable all includes in extra_drv.mk"; \
+		cp extra_drv.mk extra_drv.mk.orig; \
+		sed 's/-include/include/' extra_drv.mk.orig > extra_drv.mk; \
+		fi
+endef
+
+define restore_extra_drv
+	@if [ -f extra_drv.mk ]; then \
+		cp extra_drv.mk.orig extra_drv.mk; \
+		rm extra_drv.mk.orig; \
+		fi
+endef
+
+.PHONY: all clean modules modules_install copy_ko
+
+all: $(BUILD_ROOT_DIR)
+	$(MAKE) -C $(BUILD_ROOT_DIR)/driver/$(notdir $(SRC_DIR)) modules
 
 # add EXTRA_CFLAGS='-save-temps' to keep intermedia files
-modules: $(BUILD_DIR_MAKEFILE)
-	$(MAKE) -C $(KERNEL_SRC) M=$(BUILD_DIR) src=$(SRC_DIR) CFLAGS_MODULE='-DAMDXDNA_DEVEL' modules
+modules:
+	$(call enable_extra_drv)
+	$(MAKE) -C $(KERNEL_SRC) M=$(SRC_DIR) CFLAGS_MODULE='-DAMDXDNA_DEVEL' modules
+	$(call restore_extra_drv)
 
-modules_install: $(BUILD_DIR_MAKEFILE)
-	$(MAKE) -C $(KERNEL_SRC) M=$(BUILD_DIR) src=$(SRC_DIR) modules_install
+modules_install:
+	$(MAKE) -C $(KERNEL_SRC) M=$(SRC_DIR) modules_install
 
-$(BUILD_DIR):
-	mkdir -p "$@"
+$(BUILD_ROOT_DIR): $(SRC_DIR)
+	@echo "[INFO] BUILD Directory not exist or SRC Directory is newer"
+	@echo "[INFO] Re-Generate BUILD_ROOT_DIR: $(BUILD_ROOT_DIR)"
+	@rm -rf $@
+	@$(eval TMP_DIR := $(shell mktemp -d))
+	@mkdir -p $(TMP_DIR)/driver
+	@cp -rs $(SRC_DIR) $(TMP_DIR)/driver
+	@cp -rs $(SRC_DIR)/../../include $(TMP_DIR)
+	@mv $(TMP_DIR) $(BUILD_ROOT_DIR)
 
-$(BUILD_DIR_MAKEFILE): $(BUILD_DIR)
-	touch "$@"
+copy_ko:
+	@find $(BUILD_ROOT_DIR) -mindepth 2 -name *.ko -type f -exec cp -f {} $(BUILD_ROOT_DIR) \;
 
 clean:
-	rm -rf $(SRC_DIR)/build
+	rm -rf $(BUILD_ROOT_DIR)
+	rm -rf *.o *.cmd .*.cmd *.ko *.dwo *.mod* modules.order Module.symvers


### PR DESCRIPTION
1. Do not use src=, make it 6.10 kernel build system friendly
2. Copy driver/amdxdna and include/ folders to BUILD_ROOT_DIR. Symbolic link is used
3. Add XNDA_EXTRA_DRV_EXCLUDES to avoid package some dir or files

This change is transparent to build.sh user.

For who build driver on src/driver/amdxdna/ folder by running make, 
1. The amdxdna.ko can be found at ./build/driver/amdxdna/ folder
2. Run `make copy_ko` can copy amdxdna.ko to ./build/ folder

If any files changed on amdxdna/ folder, run `make` again will trigger re-generate build/ folder. 