### PR TITLE
Refine xdna_job trace

### DIFF
--- a/src/driver/amdxdna/aie2_ctx.c
+++ b/src/driver/amdxdna/aie2_ctx.c
@@ -219,7 +219,7 @@ static inline void
 aie2_sched_notify(struct amdxdna_sched_job *job)
 {
 	dma_fence_signal(job->fence);
-	trace_xdna_job(job->hwctx->name, "signaled fence", job->seq);
+	trace_xdna_job(&job->base, job->hwctx->name, "signaled fence", job->seq);
 	dma_fence_put(job->fence);
 	mmput(job->mm);
 	amdxdna_job_put(job);
@@ -368,7 +368,7 @@ out:
 		mmput(job->mm);
 		fence = ERR_PTR(ret);
 	}
-	trace_xdna_job(hwctx->name, "sent to device", job->seq);
+	trace_xdna_job(sched_job, hwctx->name, "sent to device", job->seq);
 
 	return fence;
 }
@@ -378,7 +378,7 @@ static void aie2_sched_job_free(struct drm_sched_job *sched_job)
 	struct amdxdna_sched_job *job = drm_job_to_xdna_job(sched_job);
 	struct amdxdna_hwctx *hwctx = job->hwctx;
 
-	trace_xdna_job(hwctx->name, "job free", job->seq);
+	trace_xdna_job(sched_job, hwctx->name, "job free", job->seq);
 	drm_sched_job_cleanup(sched_job);
 	job->fence = NULL;
 	amdxdna_job_put(job);
@@ -394,7 +394,7 @@ aie2_sched_job_timedout(struct drm_sched_job *sched_job)
 	struct amdxdna_dev *xdna;
 
 	xdna = hwctx->client->xdna;
-	trace_xdna_job(hwctx->name, "job timedout", job->seq);
+	trace_xdna_job(sched_job, hwctx->name, "job timedout", job->seq);
 	mutex_lock(&xdna->dev_lock);
 	aie2_hwctx_stop(xdna, hwctx, sched_job);
 

--- a/src/driver/amdxdna/amdxdna_ctx.c
+++ b/src/driver/amdxdna/amdxdna_ctx.c
@@ -363,7 +363,7 @@ static void amdxdna_sched_job_release(struct kref *ref)
 
 	job = container_of(ref, struct amdxdna_sched_job, refcnt);
 
-	trace_xdna_job(job->hwctx->name, "job release", job->seq);
+	trace_amdxdna_debug_point(job->hwctx->name, job->seq, "job release");
 	amdxdna_arg_bos_put(job);
 	amdxdna_gem_put_obj(job->cmd_bo);
 	kfree(job);
@@ -442,7 +442,7 @@ int amdxdna_cmd_submit(struct amdxdna_client *client,
 	 * For here we can unlock SRCU.
 	 */
 	srcu_read_unlock(&client->hwctx_srcu, idx);
-	trace_xdna_job(hwctx->name, "job pushed", *seq);
+	trace_amdxdna_debug_point(hwctx->name, *seq, "job pushed");
 
 	return 0;
 


### PR DESCRIPTION
1. Add fence info to the xdna_job trace print. This will match the latest gpu scheduler proposal. With this, it will be nice to cross reference xdna_job and gpu scheduler trace.
2. Make amdxdna_debug_point tracepoint more generic and replace xdna_job trace in amdxdna_ctx.c. Because the gpu scheduler fence might already free at that two points.