### PR TITLE
Use raw userptr in aie mem read/write

### DIFF
--- a/src/driver/amdxdna/amdxdna_devel.c
+++ b/src/driver/amdxdna/amdxdna_devel.c
@@ -108,10 +108,9 @@ int amdxdna_mem_map(struct amdxdna_dev *xdna, struct amdxdna_mem *mem)
 		goto free_sgt;
 	}
 
-	if (iommu_mode == AMDXDNA_IOMMU_NO_PASID &&
-	    drm_prime_get_contiguous_size(sgt) != mem->size) {
-		XDNA_ERR(xdna, "failed to map contiguous dma address for size:%ld",
-			 mem->size);
+	/* Device doesn't do scatter/gather, fail non-contiguous map */
+	if (drm_prime_get_contiguous_size(sgt) != mem->size) {
+		XDNA_ERR(xdna, "noncontiguous dma map, size:%ld", mem->size);
 		ret = -ENOMEM;
 		goto unmap_and_free;
 	}

--- a/src/include/uapi/drm_local/amdxdna_accel.h
+++ b/src/include/uapi/drm_local/amdxdna_accel.h
@@ -411,11 +411,11 @@ struct amdxdna_drm_query_hwctx {
 
 /**
  * struct amdxdna_drm_aie_mem - The data for AIE memory read/write
- * @col: The AIE column index
- * @row: The AIE row index
- * @boh: The BO to store input or output data
- * @addr: The AIE memory address to read/write
- * @size: The size of bytes to read/write
+ * @col:   The AIE column index
+ * @row:   The AIE row index
+ * @addr:  The AIE memory address to read/write
+ * @size:  The size of bytes to read/write
+ * @buf_p: The buffer to store read/write data
  *
  * This is used for DRM_AMDXDNA_READ_AIE_MEM and DRM_AMDXDNA_WRITE_AIE_MEM
  * parameters.
@@ -423,9 +423,10 @@ struct amdxdna_drm_query_hwctx {
 struct amdxdna_drm_aie_mem {
 	__u32 col;
 	__u32 row;
-	__u32 boh;
+	__u32 boh; /* TODO: delete */
 	__u32 addr;
 	__u32 size;
+	__u64 buf_p;
 };
 
 /**

--- a/src/shim/kmq/device.cpp
+++ b/src/shim/kmq/device.cpp
@@ -68,16 +68,13 @@ read_aie_mem(uint16_t col, uint16_t row, uint32_t offset, uint32_t size)
 {
   amdxdna_drm_aie_mem mem;
 
-  auto tmp_bo = alloc_bo(size, XCL_BO_FLAGS_EXECBUF);
-  /* Make sure cache is flushed */
-  tmp_bo->sync(xrt_core::buffer_handle::direction::host2device,
-    tmp_bo->get_properties().size, 0);
+  std::vector<char> store_buf(size);
 
   mem.col = col;
   mem.row = row;
   mem.addr = offset;
   mem.size = size;
-  mem.boh = static_cast<bo*>(tmp_bo.get())->get_drm_bo_handle();
+  mem.buf_p = reinterpret_cast<uintptr_t>(store_buf.data());
 
   amdxdna_drm_get_info arg = {
     .param = DRM_AMDXDNA_READ_AIE_MEM,
@@ -86,11 +83,6 @@ read_aie_mem(uint16_t col, uint16_t row, uint32_t offset, uint32_t size)
   };
 
   m_pdev.ioctl(DRM_IOCTL_AMDXDNA_GET_INFO, &arg);
-
-  auto tmp_vaddr = reinterpret_cast<char *>(
-    tmp_bo->map(xrt_core::buffer_handle::map_type::read));
-  std::vector<char> store_buf(size);
-  std::memcpy(store_buf.data(), tmp_vaddr, size);
 
   return store_buf;
 }
@@ -124,19 +116,11 @@ write_aie_mem(uint16_t col, uint16_t row, uint32_t offset, const std::vector<cha
   amdxdna_drm_aie_mem mem;
   uint32_t size = static_cast<uint32_t>(buf.size());
 
-  auto tmp_bo = alloc_bo(size, XCL_BO_FLAGS_EXECBUF);
-  auto tmp_vaddr = reinterpret_cast<char *>(
-    tmp_bo->map(xrt_core::buffer_handle::map_type::write));
-  std::memcpy(tmp_vaddr, buf.data(), size);
-
-  tmp_bo->sync(xrt_core::buffer_handle::direction::host2device,
-    tmp_bo->get_properties().size, 0);
-
   mem.col = col;
   mem.row = row;
   mem.addr = offset;
   mem.size = size;
-  mem.boh = static_cast<bo*>(tmp_bo.get())->get_drm_bo_handle();
+  mem.buf_p = reinterpret_cast<uintptr_t>(buf.data());
 
   amdxdna_drm_get_info arg = {
     .param = DRM_AMDXDNA_WRITE_AIE_MEM,


### PR DESCRIPTION
1. In 6.10, if device supports SVA, the dma_map_sg() might return noncontiguous mapping in this path. Error out if mapping is non-contiguous.
2. Use raw pointer in aie_mem read/write.