### PR TITLE
Include linux/bitfield.h

### DIFF
--- a/src/driver/amdxdna/amdxdna_ctx.h
+++ b/src/driver/amdxdna/amdxdna_ctx.h
@@ -6,6 +6,7 @@
 #ifndef _AMDXDNA_CTX_H_
 #define _AMDXDNA_CTX_H_
 
+#include <linux/bitfield.h>
 #include <linux/kref.h>
 #include <linux/wait.h>
 #include <drm/drm_drv.h>


### PR DESCRIPTION
Compilation currently fails on Ubuntu 22.04.4 because FIELD_GET is not defined in amdxdna_ctx.h. This change includes <linux/bitfield.h> in amdxdna_ctx.h to fix this issue.