### PR TITLE
Fix issues for multiple threads

### DIFF
--- a/src/shim/kmq/bo.h
+++ b/src/shim/kmq/bo.h
@@ -39,7 +39,7 @@ private:
     size_t size, uint64_t flags, amdxdna_bo_type type);
 
   // Only for AMDXDNA_BO_CMD type
-  std::set<uint32_t> m_args_set;
+  std::map<size_t, uint32_t> m_args_map;
   mutable std::mutex m_args_map_lock;
 };
 

--- a/src/shim/pcidev.h
+++ b/src/shim/pcidev.h
@@ -50,13 +50,22 @@ public:
   // This is only a temporary hack for supporting forcibly unchained runlist.
   void
   insert_hdl_mapping(uint32_t hdl, uint64_t ptr) const
-  { m_hdl_map[hdl] = ptr; }
+  {
+    const std::lock_guard<std::mutex> lock(m_lock);
+    m_hdl_map[hdl] = ptr;
+  }
   void
   remove_hdl_mapping(uint32_t hdl) const
-  { m_hdl_map.erase(hdl); }
+  {
+    const std::lock_guard<std::mutex> lock(m_lock);
+    m_hdl_map.erase(hdl);
+  }
   uint64_t
   lookup_hdl_mapping(uint32_t hdl) const
-  { return m_hdl_map[hdl]; }
+  {
+    const std::lock_guard<std::mutex> lock(m_lock);
+    return m_hdl_map[hdl];
+  }
 
 private:
   mutable int m_dev_fd = -1;


### PR DESCRIPTION
1. m_args_set is a std::set. When xrt::run object reused and other bo is insert, a wrong arg bo size will pass down to driver. Then driver will report ENOENT(-2) when submit command.
2. m_hdl_map needs lock protect. Otherwise app might segmentation fault.