### PR TITLE
device wide timeout detect and recovery

### DIFF
--- a/src/driver/amdxdna/Kbuild
+++ b/src/driver/amdxdna/Kbuild
@@ -22,6 +22,7 @@ amdxdna-y := \
 	amdxdna_sysfs.o \
 	amdxdna_mailbox.o \
 	amdxdna_mailbox_helper.o \
+	amdxdna_tdr.o \
 	aie2_solver.o \
 	aie2_smu.o \
 	aie2_psp.o \

--- a/src/driver/amdxdna/aie2_pci.c
+++ b/src/driver/amdxdna/aie2_pci.c
@@ -760,7 +760,7 @@ static int aie2_get_hwctx_status(struct amdxdna_client *client,
 			tmp->context_id = hwctx->id;
 			tmp->start_col = hwctx->start_col;
 			tmp->num_col = hwctx->num_col;
-			tmp->command_submissions = hwctx->seq;
+			tmp->command_submissions = hwctx->submitted;
 			tmp->command_completions = hwctx->completed;
 			tmp->migrations = 0;
 			tmp->preemptions = 0;

--- a/src/driver/amdxdna/aie2_pci.c
+++ b/src/driver/amdxdna/aie2_pci.c
@@ -563,6 +563,20 @@ skip_pasid:
 	pci_free_irq_vectors(pdev);
 }
 
+static void aie2_recover(struct amdxdna_dev *xdna)
+{
+	struct amdxdna_client *client;
+
+	mutex_lock(&xdna->dev_lock);
+	list_for_each_entry(client, &xdna->client_list, node)
+		aie2_stop_ctx(client);
+
+	/* The AIE will reset after all hardware contexts are destroyed */
+	list_for_each_entry(client, &xdna->client_list, node)
+		aie2_restart_ctx(client);
+	mutex_unlock(&xdna->dev_lock);
+}
+
 static int aie2_get_aie_status(struct amdxdna_client *client,
 			       struct amdxdna_drm_get_info *args)
 {
@@ -746,8 +760,8 @@ static int aie2_get_hwctx_status(struct amdxdna_client *client,
 			tmp->context_id = hwctx->id;
 			tmp->start_col = hwctx->start_col;
 			tmp->num_col = hwctx->num_col;
-			tmp->command_submissions = hwctx->priv->seq;
-			tmp->command_completions = hwctx->priv->completed;
+			tmp->command_submissions = hwctx->seq;
+			tmp->command_completions = hwctx->completed;
 			tmp->migrations = 0;
 			tmp->preemptions = 0;
 			tmp->errors = 0;
@@ -876,6 +890,7 @@ const struct amdxdna_dev_ops aie2_ops = {
 	.mmap           = NULL,
 	.init           = aie2_init,
 	.fini           = aie2_fini,
+	.recover        = aie2_recover,
 	.resume         = aie2_hw_start,
 	.suspend        = aie2_hw_stop,
 	.get_aie_info   = aie2_get_info,

--- a/src/driver/amdxdna/aie2_pci.h
+++ b/src/driver/amdxdna/aie2_pci.h
@@ -163,13 +163,6 @@ struct amdxdna_hwctx_priv {
 	struct wait_queue_head		job_free_wq;
 	struct amdxdna_sched_job	*pending[HWCTX_MAX_CMDS];
 	u32				num_pending;
-	/*
-	 * Sequence number for next job; As this is start from 0,
-	 * it can be used as the submitted job counter.
-	 */
-	u64				seq;
-	/* Completed job counter */
-	u64				completed;
 
 	struct amdxdna_gem_obj		*cmd_buf[HWCTX_MAX_CMDS];
 };
@@ -302,7 +295,7 @@ void aie2_hwctx_suspend(struct amdxdna_hwctx *hwctx);
 void aie2_hwctx_resume(struct amdxdna_hwctx *hwctx);
 int aie2_cmd_submit(struct amdxdna_hwctx *hwctx, struct amdxdna_sched_job *job, u64 *seq);
 int aie2_cmd_wait(struct amdxdna_hwctx *hwctx, u64 seq, u32 timeout);
-void aie2_stop_ctx_by_col_map(struct amdxdna_client *client, u32 col_map);
+void aie2_stop_ctx(struct amdxdna_client *client);
 void aie2_restart_ctx(struct amdxdna_client *client);
 
 #endif /* _AIE2_PCI_H_ */

--- a/src/driver/amdxdna/amdxdna_ctx.c
+++ b/src/driver/amdxdna/amdxdna_ctx.c
@@ -147,7 +147,7 @@ int amdxdna_drm_create_hwctx_ioctl(struct drm_device *dev, void *data, struct dr
 
 	hwctx->client = client;
 	hwctx->fw_ctx_id = -1;
-	hwctx->tdr_last = -1;
+	hwctx->tdr_last_completed = -1;
 	hwctx->num_tiles = args->num_tiles;
 	hwctx->mem_size = args->mem_size;
 	hwctx->max_opc = args->max_opc;

--- a/src/driver/amdxdna/amdxdna_ctx.c
+++ b/src/driver/amdxdna/amdxdna_ctx.c
@@ -147,6 +147,7 @@ int amdxdna_drm_create_hwctx_ioctl(struct drm_device *dev, void *data, struct dr
 
 	hwctx->client = client;
 	hwctx->fw_ctx_id = -1;
+	hwctx->tdr_last = -1;
 	hwctx->num_tiles = args->num_tiles;
 	hwctx->mem_size = args->mem_size;
 	hwctx->max_opc = args->max_opc;

--- a/src/driver/amdxdna/amdxdna_ctx.h
+++ b/src/driver/amdxdna/amdxdna_ctx.h
@@ -111,6 +111,15 @@ struct amdxdna_hwctx {
 #define HWCTX_STAT_STOP  2
 	u32				status;
 	u32				old_status;
+	/*
+	 * Sequence number for next job; As this is start from 0,
+	 * it can be used as the submitted job counter.
+	 */
+	u64				seq;
+	/* Completed job counter */
+	u64				completed;
+	/* For TDR worker to keep last completed */
+	u64				tdr_last;
 
 	struct amdxdna_qos_info		     qos;
 	struct amdxdna_hwctx_param_config_cu *cus;

--- a/src/driver/amdxdna/amdxdna_ctx.h
+++ b/src/driver/amdxdna/amdxdna_ctx.h
@@ -111,18 +111,15 @@ struct amdxdna_hwctx {
 #define HWCTX_STAT_STOP  2
 	u32				status;
 	u32				old_status;
-	/*
-	 * Sequence number for next job; As this is start from 0,
-	 * it can be used as the submitted job counter.
-	 */
-	u64				seq;
-	/* Completed job counter */
-	u64				completed;
-	/* For TDR worker to keep last completed */
-	u64				tdr_last;
 
 	struct amdxdna_qos_info		     qos;
 	struct amdxdna_hwctx_param_config_cu *cus;
+
+	/* Submitted and Completed job counter */
+	u64				submitted;
+	u64				completed ____cacheline_aligned_in_smp;
+	/* For TDR worker to keep last completed. low frequency update */
+	u64				tdr_last_completed;
 };
 
 #define drm_job_to_xdna_job(j) \

--- a/src/driver/amdxdna/amdxdna_drm.h
+++ b/src/driver/amdxdna/amdxdna_drm.h
@@ -17,6 +17,7 @@
 #else
 #include "amdxdna_gem_dma.h"
 #endif
+#include "amdxdna_tdr.h"
 
 #define XDNA_INFO(xdna, fmt, args...)	dev_info((xdna)->ddev.dev, fmt, ##args)
 #define XDNA_WARN(xdna, fmt, args...)	dev_warn((xdna)->ddev.dev, "%s: "fmt, __func__, ##args)
@@ -27,6 +28,9 @@
 
 #define to_xdna_dev(drm_dev) \
 	((struct amdxdna_dev *)container_of(drm_dev, struct amdxdna_dev, ddev))
+
+#define tdr_to_xdna_dev(t) \
+	((struct amdxdna_dev *)container_of(t, struct amdxdna_dev, tdr))
 
 extern const struct drm_driver amdxdna_drm_drv;
 
@@ -41,6 +45,7 @@ struct amdxdna_dev_priv;
 struct amdxdna_dev_ops {
 	int (*init)(struct amdxdna_dev *xdna);
 	void (*fini)(struct amdxdna_dev *xdna);
+	void (*recover)(struct amdxdna_dev *xdna);
 	int (*resume)(struct amdxdna_dev *xdna);
 	void (*suspend)(struct amdxdna_dev *xdna);
 	int (*mmap)(struct amdxdna_dev *xdna, struct vm_area_struct *vma);
@@ -108,6 +113,7 @@ struct amdxdna_dev {
 	struct mutex			dev_lock; /* protect client list, dev_info->ops, xrs_hdl */
 	struct list_head		client_list;
 	struct amdxdna_fw_ver		fw_ver;
+	struct amdxdna_tdr		tdr;
 #ifdef AMDXDNA_DEVEL
 	struct ida			pdi_ida;
 #endif

--- a/src/driver/amdxdna/amdxdna_pci_drv.c
+++ b/src/driver/amdxdna/amdxdna_pci_drv.c
@@ -103,6 +103,8 @@ static int amdxdna_probe(struct pci_dev *pdev, const struct pci_device_id *id)
 	pm_runtime_use_autosuspend(dev);
 	pm_runtime_allow(dev);
 
+	amdxdna_tdr_start(&xdna->tdr);
+
 	ret = drm_dev_register(&xdna->ddev, 0);
 	if (ret) {
 		XDNA_ERR(xdna, "DRM register failed, ret %d", ret);
@@ -141,6 +143,7 @@ static void amdxdna_remove(struct pci_dev *pdev)
 
 	drm_dev_unplug(&xdna->ddev);
 	amdxdna_sysfs_fini(xdna);
+	amdxdna_tdr_stop(&xdna->tdr);
 
 	mutex_lock(&xdna->dev_lock);
 	client = list_first_entry_or_null(&xdna->client_list,

--- a/src/driver/amdxdna/amdxdna_tdr.c
+++ b/src/driver/amdxdna/amdxdna_tdr.c
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Copyright (C) 2024, Advanced Micro Devices, Inc.
+ */
+
+#include "amdxdna_drm.h"
+#include "amdxdna_tdr.h"
+
+int timeout_in_sec = 2;
+module_param(timeout_in_sec, int, 0644);
+MODULE_PARM_DESC(timeout_in_sec, "Seconds to timeout and recovery, default 2; 0 - No TDR");
+
+#define TDR_TIMEOUT_JIFF msecs_to_jiffies(timeout_in_sec * 1000)
+
+static void amdxdna_tdr_work(struct work_struct *work)
+{
+	struct amdxdna_tdr *tdr = to_tdr(work);
+	struct amdxdna_client *client;
+	struct amdxdna_hwctx *hwctx;
+	struct amdxdna_dev *xdna;
+	bool active = false;
+	int stop_cnt = 0;
+	int ctx_cnt = 0;
+	int next;
+	int idx;
+
+	xdna = tdr_to_xdna_dev(tdr);
+	mutex_lock(&xdna->dev_lock);
+	list_for_each_entry(client, &xdna->client_list, node) {
+		next = 0;
+		idx = srcu_read_lock(&client->hwctx_srcu);
+		idr_for_each_entry_continue(&client->hwctx_idr, hwctx, next) {
+			u64 completed = hwctx->completed; /* To avoid race */
+			u64 tdr_last = hwctx->tdr_last;
+			u64 seq = hwctx->seq;
+
+			XDNA_DBG(xdna, "%s seq %lld completed %lld tdr_last %lld",
+				 hwctx->name, seq, completed, tdr_last);
+			ctx_cnt++;
+			if (seq == completed) {
+				stop_cnt++;
+				continue;
+			}
+
+			if (tdr_last != completed) {
+				hwctx->tdr_last = completed;
+				active = true;
+				break;
+			}
+		}
+		srcu_read_unlock(&client->hwctx_srcu, idx);
+		if (active)
+			break;
+	}
+	mutex_unlock(&xdna->dev_lock);
+
+	/* Recover the device when all running context are inactive */
+	if (ctx_cnt != stop_cnt && !active) {
+		XDNA_WARN(xdna, "Recovering... Count %d", ++tdr->tdr_counter);
+		xdna->dev_info->ops->recover(xdna);
+	}
+}
+
+static void amdxdna_tdr_timer(struct timer_list *t)
+{
+	struct amdxdna_tdr *tdr = from_timer(tdr, t, timer);
+
+	queue_work(system_long_wq, &tdr->tdr_work);
+
+	mod_timer(t, jiffies + TDR_TIMEOUT_JIFF);
+}
+
+void amdxdna_tdr_start(struct amdxdna_tdr *tdr)
+{
+	struct amdxdna_dev *xdna = tdr_to_xdna_dev(tdr);
+
+	if (!xdna->dev_info->ops->recover) {
+		XDNA_DBG(xdna, "Not support recovery, watchdog NOT started");
+		return;
+	}
+
+	if (!timeout_in_sec) {
+		XDNA_DBG(xdna, "timeout_in_sec is zero, watchdog NOT started");
+		return;
+	}
+
+	timer_setup(&tdr->timer, amdxdna_tdr_timer, 0);
+	INIT_WORK(&tdr->tdr_work, amdxdna_tdr_work);
+
+	tdr->timer.expires = jiffies + TDR_TIMEOUT_JIFF;
+	add_timer(&tdr->timer);
+	tdr->started = 1;
+	XDNA_DBG(xdna, "Check activities in every %d secs", timeout_in_sec);
+}
+
+void amdxdna_tdr_stop(struct amdxdna_tdr *tdr)
+{
+	struct amdxdna_dev *xdna = tdr_to_xdna_dev(tdr);
+
+	if (!tdr->started)
+		return;
+
+	timer_delete_sync(&tdr->timer);
+	XDNA_DBG(xdna, "Timer stopped");
+}

--- a/src/driver/amdxdna/amdxdna_tdr.c
+++ b/src/driver/amdxdna/amdxdna_tdr.c
@@ -31,19 +31,19 @@ static void amdxdna_tdr_work(struct work_struct *work)
 		idx = srcu_read_lock(&client->hwctx_srcu);
 		idr_for_each_entry_continue(&client->hwctx_idr, hwctx, next) {
 			u64 completed = hwctx->completed; /* To avoid race */
-			u64 tdr_last = hwctx->tdr_last;
-			u64 seq = hwctx->seq;
+			u64 last = hwctx->tdr_last_completed;
+			u64 submitted = hwctx->submitted;
 
-			XDNA_DBG(xdna, "%s seq %lld completed %lld tdr_last %lld",
-				 hwctx->name, seq, completed, tdr_last);
+			XDNA_DBG(xdna, "%s submitted %lld completed %lld last %lld",
+				 hwctx->name, submitted, completed, last);
 			ctx_cnt++;
-			if (seq == completed) {
+			if (submitted == completed) {
 				stop_cnt++;
 				continue;
 			}
 
-			if (tdr_last != completed) {
-				hwctx->tdr_last = completed;
+			if (last != completed) {
+				hwctx->tdr_last_completed = completed;
 				active = true;
 				break;
 			}

--- a/src/driver/amdxdna/amdxdna_tdr.h
+++ b/src/driver/amdxdna/amdxdna_tdr.h
@@ -1,0 +1,27 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+/*
+ * Copyright (C) 2024, Advanced Micro Devices, Inc.
+ */
+
+#ifndef _AMDXDNA_TDR_H_
+#define _AMDXDNA_TDR_H_
+
+#include <linux/list.h>
+#include <linux/timer.h>
+#include <linux/spinlock.h>
+#include <linux/workqueue.h>
+
+#define to_tdr(work) \
+	((struct amdxdna_tdr *)container_of(work, struct amdxdna_tdr, tdr_work))
+
+struct amdxdna_tdr {
+	struct timer_list	timer;
+	struct work_struct	tdr_work;
+	int			tdr_counter;
+	int			started;
+};
+
+void amdxdna_tdr_start(struct amdxdna_tdr *tdr);
+void amdxdna_tdr_stop(struct amdxdna_tdr *tdr);
+
+#endif /* _AMDXDNA_TDR_H_ */


### PR DESCRIPTION
The per hardware context timeout design is not working well. In the real world, a hardware context is not able to know how to set the timeout.

This PR is to build up a device wide timeout detect and recovery mechanism in AMD XDNA driver.
1. A per device periodic timer is setup and running. It will check the status of each hardware context. If no hardware context makes any progress after last check, it will trigger a device wide recovery. All contexts will be destroyed and restarted.
2. The timer expires is determined by a module parameter, timeout_in_sec. User can change it when loading driver. Default is 2.