### PR TITLE
Fix packaging issue and <drm/drm.h> include directive

### DIFF
--- a/CMake/pkg.cmake
+++ b/CMake/pkg.cmake
@@ -14,6 +14,7 @@ execute_process(
   )
 execute_process(
   COMMAND awk -F= "$1==\"ID\" {print $2}" /etc/os-release
+  COMMAND tr -d "\""
   OUTPUT_VARIABLE XDNA_CPACK_LINUX_FLAVOR
   OUTPUT_STRIP_TRAILING_WHITESPACE
   )

--- a/README.md
+++ b/README.md
@@ -144,6 +144,6 @@ A: Create a debug DEB package, see above question. Then install debug DEB packag
 ### Checkpatch
 There is a pre-commit script for this purpose.
 ``` bash
-cp amd-aie/tools/pre-commit <root-of-source-tree>/.git/hooks/
+cp xdna-driver/tools/pre-commit <root-of-source-tree>/.git/hooks/
 ```
 `git commit` will reject the commit if error/warning is found, until you make `checkpatch.pl` happy.


### PR DESCRIPTION
Hello, I'm an Arch User Repository (AUR) packager who is interested in your XDNA accelerator. While building and packaging this driver, I encountered some problems and tried to fix them with this commit. Here are some details:
1. I'm working on endeavourOS (An Archlinux derived distro), and I noticed that the built deb package contains quotes in its name. This is caused by the linux flavor querying logic inside `pkg.cmake` file not removing the quotes.
2. When building this driver, I encountered missing header error, which is triggered by the `<drm/drm.h>` inclusion in the `amdxdna_accel.h` header. This header is used for both compiling the kernel module and the userspace library. While it's fine to include `<drm/drm.h>` in kernel module compilation, this inclusion will cause error when compiling the userspace library with the default compiler setting. Since including kernel header in userspace code is generally considered bad, I implemented a logic to conditionally choose `<drm/drm.h>` or `<libdrm/drm.h>`.
3. Before committing these changes, I tried to check my patch with `checkpatch.pl` as mentioned in `README.md`. However at the first glance I got quite confused with the name `amd-aie`. I think maybe this should have been changed to `xdna-driver`, which is the current name of this repository.