### PR TITLE
Set power mode is not supported. return error

### DIFF
--- a/src/driver/amdxdna/aie2_pci.c
+++ b/src/driver/amdxdna/aie2_pci.c
@@ -874,7 +874,7 @@ static int aie2_set_power_mode(struct amdxdna_client *client, struct amdxdna_drm
 	/* Set resource solver power property to the user choice */
 
 	/* Set power level within the device */
-	return 0;
+	return -EOPNOTSUPP;
 }
 
 static int aie2_set_state(struct amdxdna_client *client, struct amdxdna_drm_set_state *args)


### PR DESCRIPTION
On Linux, the xrt-smi configure power mode, `sudo xrt-smi configure -d --pmode POWERSAVER`, passed. But actually driver doesn't do anything real. It should return EOPNOTSUPP to avoid confusion.

