### PR TITLE
set mgmt_chann and mbox to NULL right after destroyed

### DIFF
--- a/src/driver/amdxdna/aie2_pci.c
+++ b/src/driver/amdxdna/aie2_pci.c
@@ -279,7 +279,9 @@ static void aie2_hw_stop(struct amdxdna_dev *xdna)
 	aie2_mgmt_fw_fini(ndev);
 	xdna_mailbox_stop_channel(ndev->mgmt_chann);
 	xdna_mailbox_destroy_channel(ndev->mgmt_chann);
+	ndev->mgmt_chann = NULL;
 	xdna_mailbox_destroy(ndev->mbox);
+	ndev->mbox = NULL;
 	aie2_psp_stop(ndev->psp_hdl);
 	aie2_smu_fini(ndev);
 	pci_clear_master(pdev);
@@ -361,8 +363,10 @@ static int aie2_hw_start(struct amdxdna_dev *xdna)
 destroy_mgmt_chann:
 	xdna_mailbox_stop_channel(ndev->mgmt_chann);
 	xdna_mailbox_destroy_channel(ndev->mgmt_chann);
+	ndev->mgmt_chann = NULL;
 destroy_mbox:
 	xdna_mailbox_destroy(ndev->mbox);
+	ndev->mbox = NULL;
 stop_psp:
 	aie2_psp_stop(ndev->psp_hdl);
 fini_smu:


### PR DESCRIPTION
Because aie2_hw_start() and aie2_hw_stop() are used in probe()/remove() and suspend()/resume() path.

Consider when suspend success, but resume runs into issue. The mgmt_chann and mbox are pointing to invalid address. If we remove driver at this moment, the mailbox will access an invalid address then OS can panic.

This is to fix this issue. The mailbox can nicely return when pointer is NULL.