### PR TITLE
revert fw version for NPU1 for now

### DIFF
--- a/tools/info.json
+++ b/tools/info.json
@@ -7,10 +7,10 @@
 	"firmwares": [
 		{
 			"device": "npu1",
-			"url": "https://gitlab.freedesktop.org/drm/firmware/-/raw/amd-ipu-staging/amdnpu/1502_00/npu.sbin.1.4.2.323",
+			"url": "https://gitlab.freedesktop.org/drm/firmware/-/raw/amd-ipu-staging/amdnpu/1502_00/npu.sbin.1.4.2.313",
 			"pci_device_id": "1502",
 			"pci_revision_id": "00",
-			"version": "1.4.2.323",
+			"version": "1.4.2.313",
 			"fw_name": "npu.sbin"
 		},
 		{


### PR DESCRIPTION
The .323 firmware of NPU1 is buggy. Revert back to last known good version for now.