### PR TITLE
enable move memtile

### DIFF
--- a/test/shim_test/dev_info.cpp
+++ b/test/shim_test/dev_info.cpp
@@ -62,6 +62,24 @@ xclbin_info xclbin_infos[] = {
     .workspace = "npu3_workspace",
   },
   {
+    .name = "move_memtiles.xclbin",
+    .device = npu3_device_id,
+    .revision_id = npu_any_revision_id,
+    .ip_name2idx = {
+      { "dpu:vadd", {0} },
+    },
+    .workspace = "npu3_workspace",
+  },
+  {
+    .name = "move_memtiles.xclbin",
+    .device = npu3_device_id1,
+    .revision_id = npu_any_revision_id,
+    .ip_name2idx = {
+      { "dpu:vadd", {0} },
+    },
+    .workspace = "npu3_workspace",
+  },
+  {
     .name = "1x4.xclbin",
     .device = npu2_device_id,
     .revision_id = npu4_revision_id,

--- a/test/shim_test/exec_buf.h
+++ b/test/shim_test/exec_buf.h
@@ -48,6 +48,7 @@ public:
   add_ctrl_bo(bo& bo_ctrl)
   {
     auto cmd_packet = reinterpret_cast<ert_start_kernel_cmd *>(m_exec_buf_bo.map());
+
     switch (m_op) {
     case ERT_START_CU:
       break;

--- a/test/shim_test/shim_test.cpp
+++ b/test/shim_test/shim_test.cpp
@@ -31,6 +31,7 @@ void TEST_io(device::id_type, std::shared_ptr<device>, arg_type&);
 void TEST_io_latency(device::id_type, std::shared_ptr<device>, arg_type&);
 void TEST_io_throughput(device::id_type, std::shared_ptr<device>, arg_type&);
 void TEST_shim_umq_vadd(device::id_type, std::shared_ptr<device>, arg_type&);
+void TEST_shim_umq_memtiles(device::id_type, std::shared_ptr<device>, arg_type&);
 void TEST_txn_elf_flow(device::id_type, std::shared_ptr<device>, arg_type&);
 void TEST_cmd_fence_host(device::id_type, std::shared_ptr<device>, arg_type&);
 void TEST_cmd_fence_device(device::id_type, std::shared_ptr<device>, arg_type&);
@@ -531,6 +532,9 @@ std::vector<test_case> test_list {
   },
   test_case{ "measure no-op kernel throughput listed command",
     TEST_POSITIVE, dev_filter_is_aie2, TEST_io_throughput, { IO_TEST_NOOP_RUN }
+  },
+  test_case{ "npu3 shim move memory tiles",
+    TEST_POSITIVE, dev_filter_is_aie4, TEST_shim_umq_memtiles, {}
   },
   test_case{ "npu3 shim vadd",
     TEST_POSITIVE, dev_filter_is_aie4, TEST_shim_umq_vadd, {}

--- a/test/shim_test/shim_test.cpp
+++ b/test/shim_test/shim_test.cpp
@@ -533,9 +533,6 @@ std::vector<test_case> test_list {
   test_case{ "measure no-op kernel throughput listed command",
     TEST_POSITIVE, dev_filter_is_aie2, TEST_io_throughput, { IO_TEST_NOOP_RUN }
   },
-  test_case{ "npu3 shim move memory tiles",
-    TEST_POSITIVE, dev_filter_is_aie4, TEST_shim_umq_memtiles, {}
-  },
   test_case{ "npu3 shim vadd",
     TEST_POSITIVE, dev_filter_is_aie4, TEST_shim_umq_vadd, {}
   },
@@ -547,6 +544,9 @@ std::vector<test_case> test_list {
   },
   test_case{ "Cmd fencing (host side)",
     TEST_POSITIVE, dev_filter_is_aie2, TEST_cmd_fence_host, {}
+  },
+  test_case{ "npu3 shim move memory tiles",
+    TEST_POSITIVE, dev_filter_is_aie4, TEST_shim_umq_memtiles, {}
   },
   //test_case{ "Cmd fencing (device side)",
   //  TEST_POSITIVE, dev_filter_is_aie2, TEST_cmd_fence_device, {}


### PR DESCRIPTION
This is the shim_test part of move_memtiles which is the few tests that we can run for npu3 devices.