### PR TITLE
enhance mailbox_polling

### DIFF
--- a/src/driver/amdxdna/aie2_ctx.c
+++ b/src/driver/amdxdna/aie2_ctx.c
@@ -357,6 +357,7 @@ aie2_sched_job_run(struct drm_sched_job *sched_job)
 	if (!hwctx->priv->mbox_chann)
 		return ERR_PTR(-ENODEV);
 
+	trace_xdna_job(sched_job, hwctx->name, "job run", job->seq);
 	kref_get(&job->refcnt);
 	fence = dma_fence_get(job->fence);
 
@@ -386,7 +387,6 @@ out:
 		mmput(job->mm);
 		fence = ERR_PTR(ret);
 	}
-	trace_xdna_job(sched_job, hwctx->name, "sent to device", job->seq);
 
 	return fence;
 }

--- a/src/driver/amdxdna/aie2_message.c
+++ b/src/driver/amdxdna/aie2_message.c
@@ -8,6 +8,7 @@
 
 #include "drm_local/amdxdna_accel.h"
 #include "amdxdna_mailbox_helper.h"
+#include "amdxdna_trace.h"
 #include "amdxdna_ctx.h"
 #include "aie2_msg_priv.h"
 #include "aie2_pci.h"
@@ -303,6 +304,7 @@ int aie2_create_context(struct amdxdna_dev_hdl *ndev, struct amdxdna_hwctx *hwct
 		goto out_destroy_context;
 	}
 
+	trace_amdxdna_debug_point(hwctx->name, ret, "channel created");
 	XDNA_DBG(xdna, "%s mailbox channel irq: %d, msix_id: %d",
 		 hwctx->name, ret, resp.msix_id);
 	XDNA_DBG(xdna, "%s created fw ctx %d pasid %d", hwctx->name,
@@ -332,6 +334,7 @@ int aie2_destroy_context(struct amdxdna_dev_hdl *ndev, struct amdxdna_hwctx *hwc
 		XDNA_WARN(xdna, "%s destroy context failed, ret %d", hwctx->name, ret);
 
 	xdna_mailbox_destroy_channel(hwctx->priv->mbox_chann);
+	trace_amdxdna_debug_point(hwctx->name, 0, "channel destroyed");
 	XDNA_DBG(xdna, "%s destroyed fw ctx %d", hwctx->name,
 		 hwctx->fw_ctx_id);
 	hwctx->priv->mbox_chann = NULL;

--- a/src/driver/amdxdna/amdxdna_mailbox.c
+++ b/src/driver/amdxdna/amdxdna_mailbox.c
@@ -450,11 +450,12 @@ static int mailbox_polld(void *data)
 		if (!iohub)
 			continue;
 
+		trace_mbox_poll_handle(MAILBOX_NAME, mb_chann->msix_irq);
+
 		/* Clear pending events */
 		iohub = 0;
 		mailbox_reg_write(mb_chann, mb_chann->iohub_int_addr, iohub);
 
-		/* TODO: maybe a trace point? */
 		do {
 			ret = mailbox_get_msg(mb_chann);
 		} while (!ret);

--- a/src/driver/amdxdna/amdxdna_trace.h
+++ b/src/driver/amdxdna/amdxdna_trace.h
@@ -106,23 +106,33 @@ DEFINE_EVENT(xdna_mbox_msg, mbox_set_head,
 	     TP_ARGS(name, chann_id, opcode, id)
 );
 
-TRACE_EVENT(mbox_irq_handle,
-	    TP_PROTO(char *name, int irq),
+DECLARE_EVENT_CLASS(xdna_mbox_name_id,
+		    TP_PROTO(char *name, int irq),
 
-	    TP_ARGS(name, irq),
+		    TP_ARGS(name, irq),
 
-	    TP_STRUCT__entry(__string(name, name)
-			     __field(int, irq)),
+		    TP_STRUCT__entry(__string(name, name)
+				     __field(int, irq)),
 
 #if LINUX_VERSION_CODE < KERNEL_VERSION(6, 10, 0)
-	    TP_fast_assign(__assign_str(name, name);
-			   __entry->irq = irq;),
+		    TP_fast_assign(__assign_str(name, name);
+				   __entry->irq = irq;),
 #else
-	    TP_fast_assign(__assign_str(name);
-			   __entry->irq = irq;),
+		    TP_fast_assign(__assign_str(name);
+				   __entry->irq = irq;),
 #endif
 
-	    TP_printk("%s.%d", __get_str(name), __entry->irq)
+		    TP_printk("%s.%d", __get_str(name), __entry->irq)
+);
+
+DEFINE_EVENT(xdna_mbox_name_id, mbox_irq_handle,
+	     TP_PROTO(char *name, int irq),
+	     TP_ARGS(name, irq)
+);
+
+DEFINE_EVENT(xdna_mbox_name_id, mbox_poll_handle,
+	     TP_PROTO(char *name, int irq),
+	     TP_ARGS(name, irq)
 );
 
 #endif /* !defined(_AMDXDNA_TRACE_EVENTS_H_) || defined(TRACE_HEADER_MULTI_READ) */


### PR DESCRIPTION
Enhance the mailbox_polling parameter. 

In before, mailbox_polling is a switch, it switch mailbox as polling base or interrupt base.

After this change,
when mailbox_polling is 0, this is default, mailbox working on interrupt mode.
when mailbox_polling > 0, mailbox will check message in every 'mailbox_polling' miliseconds.
when mailbox_polling < 0, mailbox will be a busy polling. It will call schedule() to yield CPU to avoid soft lock warning. It will sleep when all channels are idle.

``` shell
# Interrupt mode
$ sudo modprobe amdxdna

# Busy polling mode
$ sudo modprobe amdxdna mailbox_polling=-1

# Interval polling mode
$ sudo modprobe amdxdna mailbox_polling=1             # poll every 1 ms
$ sudo modprobe amdxdna mailbox_polling=100        # poll every 100 ms
```