### PR TITLE
add more tests for npu3

### DIFF
--- a/test/shim_test/dev_info.cpp
+++ b/test/shim_test/dev_info.cpp
@@ -80,6 +80,24 @@ xclbin_info xclbin_infos[] = {
     .workspace = "npu3_workspace",
   },
   {
+    .name = "ddr_memtile.xclbin",
+    .device = npu3_device_id1,
+    .revision_id = npu_any_revision_id,
+    .ip_name2idx = {
+      { "dpu:vadd", {0} },
+    },
+    .workspace = "npu3_workspace",
+  },
+  {
+    .name = "remote_barrier.xclbin",
+    .device = npu3_device_id1,
+    .revision_id = npu_any_revision_id,
+    .ip_name2idx = {
+      { "dpu:vadd", {0} },
+    },
+    .workspace = "npu3_workspace",
+  },
+  {
     .name = "1x4.xclbin",
     .device = npu2_device_id,
     .revision_id = npu4_revision_id,

--- a/test/shim_test/shim_test.cpp
+++ b/test/shim_test/shim_test.cpp
@@ -32,6 +32,8 @@ void TEST_io_latency(device::id_type, std::shared_ptr<device>, arg_type&);
 void TEST_io_throughput(device::id_type, std::shared_ptr<device>, arg_type&);
 void TEST_shim_umq_vadd(device::id_type, std::shared_ptr<device>, arg_type&);
 void TEST_shim_umq_memtiles(device::id_type, std::shared_ptr<device>, arg_type&);
+void TEST_shim_umq_ddr_memtile(device::id_type, std::shared_ptr<device>, arg_type&);
+void TEST_shim_umq_remote_barrier(device::id_type, std::shared_ptr<device>, arg_type&);
 void TEST_txn_elf_flow(device::id_type, std::shared_ptr<device>, arg_type&);
 void TEST_cmd_fence_host(device::id_type, std::shared_ptr<device>, arg_type&);
 void TEST_cmd_fence_device(device::id_type, std::shared_ptr<device>, arg_type&);
@@ -547,6 +549,12 @@ std::vector<test_case> test_list {
   },
   test_case{ "npu3 shim move memory tiles",
     TEST_POSITIVE, dev_filter_is_aie4, TEST_shim_umq_memtiles, {}
+  },
+  test_case{ "npu3 shim move ddr memory tiles",
+    TEST_POSITIVE, dev_filter_is_aie4, TEST_shim_umq_ddr_memtile, {}
+  },
+  test_case{ "npu3 shim multi col remote barrier",
+    TEST_POSITIVE, dev_filter_is_aie4, TEST_shim_umq_remote_barrier, {}
   },
   //test_case{ "Cmd fencing (device side)",
   //  TEST_POSITIVE, dev_filter_is_aie2, TEST_cmd_fence_device, {}


### PR DESCRIPTION
add move_memtiles, move_ddr_memtile and remote_barrier for both shim_test and xrt_test.

Both move_memtiles and move_ddr_memtile pass for shim_test and xrt_test with the XRT patch fix.
The remote_barrier needs more XRT patch fixes, but we'd go ahead to have the test cases ready, so that other team can also verify their work by using this end-to-end test.