### PR TITLE
pmode support, part I

### DIFF
--- a/src/driver/amdxdna/Kbuild
+++ b/src/driver/amdxdna/Kbuild
@@ -30,6 +30,7 @@ amdxdna-y := \
 	aie2_error.o \
 	aie2_debugfs.o \
 	aie2_message.o \
+	aie2_pm.o \
 	aie2_pci.o \
 	npu1_regs.o \
 	npu2_regs.o \

--- a/src/driver/amdxdna/aie2_pci.c
+++ b/src/driver/amdxdna/aie2_pci.c
@@ -874,7 +874,6 @@ static int aie2_set_power_mode(struct amdxdna_client *client, struct amdxdna_drm
 	struct amdxdna_drm_set_power_mode power_state;
 	enum amdxdna_power_mode_type power_mode;
 	struct amdxdna_dev *xdna = client->xdna;
-	int ret;
 
 	if (args->buffer_size != sizeof(power_state)) {
 		XDNA_ERR(xdna, "Invalid buffer size. Given: %u Need: %lu.",

--- a/src/driver/amdxdna/aie2_pci.h
+++ b/src/driver/amdxdna/aie2_pci.h
@@ -11,6 +11,7 @@
 #include <linux/io.h>
 #include <drm/gpu_scheduler.h>
 
+#include "drm_local/amdxdna_accel.h"
 #include "amdxdna_pci_drv.h"
 #include "amdxdna_ctx.h"
 #include "amdxdna_gem.h"
@@ -144,11 +145,6 @@ struct smu {
 	u32			power_state;
 };
 
-struct rt_config {
-	u32	type;
-	u32	value;
-};
-
 #ifdef AMDXDNA_DEVEL
 struct hwctx_pdi {
 	int			id;
@@ -200,6 +196,7 @@ struct amdxdna_dev_hdl {
 	struct aie_version		version;
 	struct aie_metadata		metadata;
 	struct smu			smu;
+	enum amdxdna_power_mode_type	pw_mode;
 
 	/* Mailbox and the management channel */
 	struct mailbox			*mbox;
@@ -213,6 +210,18 @@ struct amdxdna_dev_hdl {
 struct aie2_bar_off_pair {
 	int	bar_idx;
 	u32	offset;
+};
+
+struct rt_config {
+	u32	type;
+	u32	value;
+};
+
+struct rt_config_clk_gating {
+	const u32	*types;
+	u32		num_types;
+	u32		value_enable;
+	u32		value_disable;
 };
 
 struct amdxdna_dev_priv {
@@ -231,6 +240,7 @@ struct amdxdna_dev_priv {
 	struct aie2_bar_off_pair	sram_offs[SRAM_MAX_INDEX];
 	struct aie2_bar_off_pair	psp_regs_off[PSP_MAX_REGS];
 	struct aie2_bar_off_pair	smu_regs_off[SMU_MAX_REGS];
+	struct rt_config_clk_gating	clk_gating;
 	u32				smu_mpnpuclk_freq_max;
 	u32				smu_hclk_freq_max;
 	/* npu1: 0, not support dpm; npu2+: support dpm up to 7 */
@@ -323,5 +333,10 @@ void aie2_hmm_invalidate(struct amdxdna_gem_obj *abo, unsigned long cur_seq);
 void aie2_stop_ctx(struct amdxdna_client *client);
 void aie2_restart_ctx(struct amdxdna_client *client);
 void aie2_stop_ctx_by_col_map(struct amdxdna_client *client, u32 col_map);
+
+/* aie2_pm.c */
+int aie2_pm_start(struct amdxdna_dev_hdl *ndev);
+void aie2_pm_stop(struct amdxdna_dev_hdl *ndev);
+int aie2_pm_set_mode(struct amdxdna_dev_hdl *ndev, enum amdxdna_power_mode_type target);
 
 #endif /* _AIE2_PCI_H_ */

--- a/src/driver/amdxdna/aie2_pm.c
+++ b/src/driver/amdxdna/aie2_pm.c
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Copyright (C) 2024, Advanced Micro Devices, Inc.
+ */
+
+#include "aie2_pci.h"
+
+static int aie2_pm_clock_gating(struct amdxdna_dev_hdl *ndev, bool enable)
+{
+	const struct rt_config_clk_gating *config;
+	u32 value;
+	int ret;
+	int i;
+
+	config = &ndev->priv->clk_gating;
+	if (enable)
+		value = config->value_enable;
+	else
+		value = config->value_disable;
+
+	XDNA_DBG(ndev->xdna, "%s clock gating, %d type(s)",
+		 (enable) ? "Enable" : "Disable", config->num_types);
+
+	for (i = 0; i < config->num_types; i++) {
+		ret = aie2_set_runtime_cfg(ndev, config->types[i], value);
+		if (ret) {
+			XDNA_ERR(ndev->xdna, "Config type %d, value %d",
+				 config->types[i], value);
+			break;
+		}
+	}
+
+	return ret;
+}
+
+int aie2_pm_set_mode(struct amdxdna_dev_hdl *ndev, enum amdxdna_power_mode_type target)
+{
+	struct amdxdna_dev *xdna = ndev->xdna;
+	int ret = 0;
+
+	if (ndev->pw_mode == target)
+		return 0;
+
+	if (target == POWER_MODE_LOW || target == POWER_MODE_MEDIUM)
+		return -EOPNOTSUPP;
+
+	XDNA_DBG(xdna, "Changing power mode from %d to %d", ndev->pw_mode, target);
+	/* Set resource solver power property to the user choice */
+
+	/* Set power level within the device */
+
+	/*
+	 * Other mode -> POWER_MODE_HIGH: Turn off clock gating
+	 * POWER_MODE_HIGH -> Other mode: Turn on clock gating
+	 * Otherwise, no change
+	 */
+	if (target == POWER_MODE_HIGH) {
+		XDNA_DBG(xdna, "Clock gating turning off");
+		ret = aie2_pm_clock_gating(ndev, false);
+	} else if (ndev->pw_mode == POWER_MODE_HIGH) {
+		XDNA_DBG(xdna, "Clock gating turning on");
+		ret = aie2_pm_clock_gating(ndev, true);
+	}
+	if (ret) {
+		XDNA_ERR(xdna, "Failed to config clock gating");
+		return ret;
+	}
+
+	ndev->pw_mode = target;
+	XDNA_INFO(xdna, "Power mode changed into %d", ndev->pw_mode);
+	return 0;
+}
+
+int aie2_pm_start(struct amdxdna_dev_hdl *ndev)
+{
+	/*
+	 * TODO: should only skip POWER_MODE_DEFAULT.
+	 * Let's make it right after full DPM support is ready
+	 */
+	if (ndev->pw_mode != POWER_MODE_HIGH)
+		return 0;
+
+	return aie2_pm_clock_gating(ndev, false);
+}
+
+void aie2_pm_stop(struct amdxdna_dev_hdl *ndev)
+{
+	if (ndev->pw_mode != POWER_MODE_HIGH)
+		return;
+
+	/* Clock gating must be turned ON before suspend firmware */
+	aie2_pm_clock_gating(ndev, true);
+}

--- a/src/driver/amdxdna/npu1_regs.c
+++ b/src/driver/amdxdna/npu1_regs.c
@@ -38,8 +38,12 @@
 #define NPU1_SMU_BAR_BASE  MPNPU_APERTURE0_BASE
 #define NPU1_SRAM_BAR_BASE MPNPU_APERTURE1_BASE
 
+#define NPU1_RT_CFG_TYPE_CLK_GATING 1
 #define NPU1_RT_CFG_TYPE_PDI_LOAD 2
 #define NPU1_RT_CFG_TYPE_DEBUG_BO 4
+
+#define NPU1_RT_CFG_VAL_CLK_GATING_OFF 0
+#define NPU1_RT_CFG_VAL_CLK_GATING_ON 1
 
 #define NPU1_RT_CFG_VAL_PDI_LOAD_MGMT 0
 #define NPU1_RT_CFG_VAL_PDI_LOAD_APP 1
@@ -54,6 +58,8 @@ const struct rt_config npu1_rt_cfg[] = {
 	{NPU1_RT_CFG_TYPE_PDI_LOAD, NPU1_RT_CFG_VAL_PDI_LOAD_APP},
 	{NPU1_RT_CFG_TYPE_DEBUG_BO, NPU1_RT_CFG_VAL_DEBUG_BO_LARGE},
 };
+
+const u32 npu1_clk_gating_types[] = {NPU1_RT_CFG_TYPE_CLK_GATING};
 
 const struct amdxdna_dev_priv npu1_dev_priv = {
 	.fw_path        = "amdnpu/1502_00/npu.sbin",
@@ -84,6 +90,12 @@ const struct amdxdna_dev_priv npu1_dev_priv = {
 		DEFINE_BAR_OFFSET(SMU_INTR_REG, NPU1_SMU, MPNPU_PUB_PWRMGMT_INTR),
 		DEFINE_BAR_OFFSET(SMU_RESP_REG, NPU1_SMU, MPNPU_PUB_SCRATCH6),
 		DEFINE_BAR_OFFSET(SMU_OUT_REG,  NPU1_SMU, MPNPU_PUB_SCRATCH7),
+	},
+	.clk_gating = {
+		.types = npu1_clk_gating_types,
+		.num_types = ARRAY_SIZE(npu1_clk_gating_types),
+		.value_enable = NPU1_RT_CFG_VAL_CLK_GATING_ON,
+		.value_disable = NPU1_RT_CFG_VAL_CLK_GATING_OFF,
 	},
 	.smu_mpnpuclk_freq_max = NPU1_MPNPUCLK_FREQ_MAX,
 	.smu_hclk_freq_max     = NPU1_HCLK_FREQ_MAX,

--- a/src/driver/amdxdna/npu2_regs.c
+++ b/src/driver/amdxdna/npu2_regs.c
@@ -55,8 +55,15 @@
 #define NPU2_SMU_BAR_BASE	MMNPU_APERTURE4_BASE
 #define NPU2_SRAM_BAR_BASE	MMNPU_APERTURE1_BASE
 
-#define NPU2_RT_CFG_TYPE_PDI_LOAD 5
-#define NPU2_RT_CFG_TYPE_DEBUG_BO 10
+#define NPU2_RT_CFG_TYPE_CLK_GATING   1
+#define NPU2_RT_CFG_TYPE_HCLK_GATING  2
+#define NPU2_RT_CFG_TYPE_PWR_GATING   3
+#define NPU2_RT_CFG_TYPE_L1IMU_GATING 4
+#define NPU2_RT_CFG_TYPE_PDI_LOAD     5
+#define NPU2_RT_CFG_TYPE_DEBUG_BO     10
+
+#define NPU2_RT_CFG_VAL_CLK_GATING_OFF 0
+#define NPU2_RT_CFG_VAL_CLK_GATING_ON 1
 
 #define NPU2_RT_CFG_VAL_PDI_LOAD_MGMT 0
 #define NPU2_RT_CFG_VAL_PDI_LOAD_APP 1
@@ -70,6 +77,13 @@
 const struct rt_config npu2_rt_cfg[] = {
 	{NPU2_RT_CFG_TYPE_PDI_LOAD, NPU2_RT_CFG_VAL_PDI_LOAD_APP},
 	{NPU2_RT_CFG_TYPE_DEBUG_BO, NPU2_RT_CFG_VAL_DEBUG_BO_LARGE},
+};
+
+const u32 npu2_clk_gating_types[] = {
+	NPU2_RT_CFG_TYPE_CLK_GATING,
+	NPU2_RT_CFG_TYPE_HCLK_GATING,
+	NPU2_RT_CFG_TYPE_PWR_GATING,
+	NPU2_RT_CFG_TYPE_L1IMU_GATING,
 };
 
 const struct amdxdna_dev_priv npu2_dev_priv = {
@@ -101,6 +115,12 @@ const struct amdxdna_dev_priv npu2_dev_priv = {
 		DEFINE_BAR_OFFSET(SMU_INTR_REG, NPU2_SMU, MMNPU_APERTURE4_BASE),
 		DEFINE_BAR_OFFSET(SMU_RESP_REG, NPU2_SMU, MP1_C2PMSG_61),
 		DEFINE_BAR_OFFSET(SMU_OUT_REG,  NPU2_SMU, MP1_C2PMSG_60),
+	},
+	.clk_gating = {
+		.types = npu2_clk_gating_types,
+		.num_types = ARRAY_SIZE(npu2_clk_gating_types),
+		.value_enable = NPU2_RT_CFG_VAL_CLK_GATING_ON,
+		.value_disable = NPU2_RT_CFG_VAL_CLK_GATING_OFF,
 	},
 	.smu_mpnpuclk_freq_max = NPU2_MPNPUCLK_FREQ_MAX,
 	.smu_hclk_freq_max     = NPU2_HCLK_FREQ_MAX,

--- a/src/driver/amdxdna/npu4_regs.c
+++ b/src/driver/amdxdna/npu4_regs.c
@@ -55,8 +55,15 @@
 #define NPU4_SMU_BAR_BASE	MMNPU_APERTURE4_BASE
 #define NPU4_SRAM_BAR_BASE	MMNPU_APERTURE1_BASE
 
-#define NPU4_RT_CFG_TYPE_PDI_LOAD 5
-#define NPU4_RT_CFG_TYPE_DEBUG_BO 10
+#define NPU4_RT_CFG_TYPE_CLK_GATING   1
+#define NPU4_RT_CFG_TYPE_HCLK_GATING  2
+#define NPU4_RT_CFG_TYPE_PWR_GATING   3
+#define NPU4_RT_CFG_TYPE_L1IMU_GATING 4
+#define NPU4_RT_CFG_TYPE_PDI_LOAD     5
+#define NPU4_RT_CFG_TYPE_DEBUG_BO     10
+
+#define NPU4_RT_CFG_VAL_CLK_GATING_OFF 0
+#define NPU4_RT_CFG_VAL_CLK_GATING_ON 1
 
 #define NPU4_RT_CFG_VAL_PDI_LOAD_MGMT 0
 #define NPU4_RT_CFG_VAL_PDI_LOAD_APP 1
@@ -70,6 +77,13 @@
 const struct rt_config npu4_rt_cfg[] = {
 	{NPU4_RT_CFG_TYPE_PDI_LOAD, NPU4_RT_CFG_VAL_PDI_LOAD_APP},
 	{NPU4_RT_CFG_TYPE_DEBUG_BO, NPU4_RT_CFG_VAL_DEBUG_BO_LARGE},
+};
+
+const u32 npu4_clk_gating_types[] = {
+	NPU4_RT_CFG_TYPE_CLK_GATING,
+	NPU4_RT_CFG_TYPE_HCLK_GATING,
+	NPU4_RT_CFG_TYPE_PWR_GATING,
+	NPU4_RT_CFG_TYPE_L1IMU_GATING,
 };
 
 const struct amdxdna_dev_priv npu4_dev_priv = {
@@ -101,6 +115,12 @@ const struct amdxdna_dev_priv npu4_dev_priv = {
 		DEFINE_BAR_OFFSET(SMU_INTR_REG, NPU4_SMU, MMNPU_APERTURE4_BASE),
 		DEFINE_BAR_OFFSET(SMU_RESP_REG, NPU4_SMU, MP1_C2PMSG_61),
 		DEFINE_BAR_OFFSET(SMU_OUT_REG,  NPU4_SMU, MP1_C2PMSG_60),
+	},
+	.clk_gating = {
+		.types = npu4_clk_gating_types,
+		.num_types = ARRAY_SIZE(npu4_clk_gating_types),
+		.value_enable = NPU4_RT_CFG_VAL_CLK_GATING_ON,
+		.value_disable = NPU4_RT_CFG_VAL_CLK_GATING_OFF,
 	},
 	.smu_mpnpuclk_freq_max = NPU4_MPNPUCLK_FREQ_MAX,
 	.smu_hclk_freq_max     = NPU4_HCLK_FREQ_MAX,

--- a/src/driver/amdxdna/npu5_regs.c
+++ b/src/driver/amdxdna/npu5_regs.c
@@ -55,8 +55,15 @@
 #define NPU5_SMU_BAR_BASE	MMNPU_APERTURE4_BASE
 #define NPU5_SRAM_BAR_BASE	MMNPU_APERTURE1_BASE
 
-#define NPU5_RT_CFG_TYPE_PDI_LOAD 5
-#define NPU5_RT_CFG_TYPE_DEBUG_BO 10
+#define NPU5_RT_CFG_TYPE_CLK_GATING   1
+#define NPU5_RT_CFG_TYPE_HCLK_GATING  2
+#define NPU5_RT_CFG_TYPE_PWR_GATING   3
+#define NPU5_RT_CFG_TYPE_L1IMU_GATING 4
+#define NPU5_RT_CFG_TYPE_PDI_LOAD     5
+#define NPU5_RT_CFG_TYPE_DEBUG_BO     10
+
+#define NPU5_RT_CFG_VAL_CLK_GATING_OFF 0
+#define NPU5_RT_CFG_VAL_CLK_GATING_ON 1
 
 #define NPU5_RT_CFG_VAL_PDI_LOAD_MGMT 0
 #define NPU5_RT_CFG_VAL_PDI_LOAD_APP 1
@@ -70,6 +77,13 @@
 const struct rt_config npu5_rt_cfg[] = {
 	{NPU5_RT_CFG_TYPE_PDI_LOAD, NPU5_RT_CFG_VAL_PDI_LOAD_APP},
 	{NPU5_RT_CFG_TYPE_DEBUG_BO, NPU5_RT_CFG_VAL_DEBUG_BO_LARGE},
+};
+
+const u32 npu5_clk_gating_types[] = {
+	NPU5_RT_CFG_TYPE_CLK_GATING,
+	NPU5_RT_CFG_TYPE_HCLK_GATING,
+	NPU5_RT_CFG_TYPE_PWR_GATING,
+	NPU5_RT_CFG_TYPE_L1IMU_GATING,
 };
 
 const struct amdxdna_dev_priv npu5_dev_priv = {
@@ -101,6 +115,12 @@ const struct amdxdna_dev_priv npu5_dev_priv = {
 		DEFINE_BAR_OFFSET(SMU_INTR_REG, NPU5_SMU, MMNPU_APERTURE4_BASE),
 		DEFINE_BAR_OFFSET(SMU_RESP_REG, NPU5_SMU, MP1_C2PMSG_61),
 		DEFINE_BAR_OFFSET(SMU_OUT_REG,  NPU5_SMU, MP1_C2PMSG_60),
+	},
+	.clk_gating = {
+		.types = npu5_clk_gating_types,
+		.num_types = ARRAY_SIZE(npu5_clk_gating_types),
+		.value_enable = NPU5_RT_CFG_VAL_CLK_GATING_ON,
+		.value_disable = NPU5_RT_CFG_VAL_CLK_GATING_OFF,
 	},
 	.smu_mpnpuclk_freq_max = NPU5_MPNPUCLK_FREQ_MAX,
 	.smu_hclk_freq_max     = NPU5_HCLK_FREQ_MAX,

--- a/src/driver/amdxdna/npu6_regs.c
+++ b/src/driver/amdxdna/npu6_regs.c
@@ -55,8 +55,15 @@
 #define NPU6_SMU_BAR_BASE	MMNPU_APERTURE4_BASE
 #define NPU6_SRAM_BAR_BASE	MMNPU_APERTURE1_BASE
 
-#define NPU6_RT_CFG_TYPE_PDI_LOAD 5
-#define NPU6_RT_CFG_TYPE_DEBUG_BO 10
+#define NPU6_RT_CFG_TYPE_CLK_GATING   1
+#define NPU6_RT_CFG_TYPE_HCLK_GATING  2
+#define NPU6_RT_CFG_TYPE_PWR_GATING   3
+#define NPU6_RT_CFG_TYPE_L1IMU_GATING 4
+#define NPU6_RT_CFG_TYPE_PDI_LOAD     5
+#define NPU6_RT_CFG_TYPE_DEBUG_BO     10
+
+#define NPU6_RT_CFG_VAL_CLK_GATING_OFF 0
+#define NPU6_RT_CFG_VAL_CLK_GATING_ON 1
 
 #define NPU6_RT_CFG_VAL_PDI_LOAD_MGMT 0
 #define NPU6_RT_CFG_VAL_PDI_LOAD_APP 1
@@ -70,6 +77,13 @@
 const struct rt_config npu6_rt_cfg[] = {
 	{NPU6_RT_CFG_TYPE_PDI_LOAD, NPU6_RT_CFG_VAL_PDI_LOAD_APP},
 	{NPU6_RT_CFG_TYPE_DEBUG_BO, NPU6_RT_CFG_VAL_DEBUG_BO_LARGE},
+};
+
+const u32 npu6_clk_gating_types[] = {
+	NPU6_RT_CFG_TYPE_CLK_GATING,
+	NPU6_RT_CFG_TYPE_HCLK_GATING,
+	NPU6_RT_CFG_TYPE_PWR_GATING,
+	NPU6_RT_CFG_TYPE_L1IMU_GATING,
 };
 
 const struct amdxdna_dev_priv npu6_dev_priv = {
@@ -101,6 +115,12 @@ const struct amdxdna_dev_priv npu6_dev_priv = {
 		DEFINE_BAR_OFFSET(SMU_INTR_REG, NPU6_SMU, MMNPU_APERTURE4_BASE),
 		DEFINE_BAR_OFFSET(SMU_RESP_REG, NPU6_SMU, MP1_C2PMSG_61),
 		DEFINE_BAR_OFFSET(SMU_OUT_REG,  NPU6_SMU, MP1_C2PMSG_60),
+	},
+	.clk_gating = {
+		.types = npu6_clk_gating_types,
+		.num_types = ARRAY_SIZE(npu6_clk_gating_types),
+		.value_enable = NPU6_RT_CFG_VAL_CLK_GATING_ON,
+		.value_disable = NPU6_RT_CFG_VAL_CLK_GATING_OFF,
 	},
 	.smu_mpnpuclk_freq_max = NPU6_MPNPUCLK_FREQ_MAX,
 	.smu_hclk_freq_max     = NPU6_HCLK_FREQ_MAX,

--- a/src/include/uapi/drm_local/amdxdna_accel.h
+++ b/src/include/uapi/drm_local/amdxdna_accel.h
@@ -496,10 +496,10 @@ struct amdxdna_drm_get_info {
 };
 
 enum amdxdna_power_mode_type {
-    XRT_POWER_MODE_DEFAULT, /**< Fallback to calculated DPM */
-    XRT_POWER_MODE_LOW,     /**< Set frequency to lowest DPM */
-    XRT_POWER_MODE_MEDIUM,  /**< Set frequency to medium DPM */
-    XRT_POWER_MODE_HIGH,    /**< Set frequency to highest DPM */
+	POWER_MODE_DEFAULT, /**< Fallback to calculated DPM */
+	POWER_MODE_LOW,     /**< Set frequency to lowest DPM */
+	POWER_MODE_MEDIUM,  /**< Set frequency to medium DPM */
+	POWER_MODE_HIGH,    /**< Set frequency to highest DPM */
 };
 
 /**


### PR DESCRIPTION
This is the part 1 of supporting "xrt-smi configure -d --pmode".

After this change, the xrt-smi will still get -EOPNOTSUPP from driver for powersaver and balanced modes.
For performance mode, xdna driver will disable NPU clock gating on hardware.
For default mode, xdna driver will enable NPU clock gating.

``` shell
# To disable NPU clock gating
$ xrt-smi configure -d --pmode performance

# To enable NPU clock gating
$ xrt-smi configure -d --pmode default 
```