### PR TITLE
somehow auto suspend not work then crash in remove()

### DIFF
--- a/src/driver/amdxdna/aie2_pci.c
+++ b/src/driver/amdxdna/aie2_pci.c
@@ -297,8 +297,10 @@ static void aie2_hw_stop(struct amdxdna_dev *xdna)
 	xdna_mailbox_stop_channel(ndev->mgmt_chann);
 	xdna_mailbox_destroy_channel(ndev->mgmt_chann);
 	ndev->mgmt_chann = NULL;
-	xdna_mailbox_destroy(ndev->mbox);
-	ndev->mbox = NULL;
+	if (ndev->mbox) {
+		xdna_mailbox_destroy(ndev->mbox);
+		ndev->mbox = NULL;
+	}
 	aie2_psp_stop(ndev->psp_hdl);
 	aie2_smu_stop(ndev);
 	pci_clear_master(pdev);


### PR DESCRIPTION
Today, I encounter weird SMU failed and I saw kernel oops about NULL pointer when destroy mailbox. I'm still investigating why SMU failed.

But even SMU failed randomly, the driver should still be strong.
With this fix, if SMU failed, user is still able to remove and re-load driver and run application.
In my test, the autosuspend is not working for xdna driver any more.

I will look into this further to fully root cause it.