### PR TITLE
Once signald job->fence, drm will cleanup job->base. Thus tracepoint …

### DIFF
--- a/src/driver/amdxdna/aie2_ctx.c
+++ b/src/driver/amdxdna/aie2_ctx.c
@@ -230,8 +230,8 @@ aie2_sched_notify(struct amdxdna_sched_job *job)
 	struct dma_fence *fence = job->fence;
 
 	job->hwctx->completed++;
+	trace_xdna_job(&job->base, job->hwctx->name, "signale fence", job->seq);
 	dma_fence_signal(fence);
-	trace_xdna_job(&job->base, job->hwctx->name, "signaled fence", job->seq);
 	dma_fence_put(fence);
 	mmput(job->mm);
 	amdxdna_job_put(job);


### PR DESCRIPTION
Once signald job->fence, drm will cleanup job->base. Thus tracepoint …should be in before that to avoid race.