### PR TITLE
npu6 and npu4 shared same firmware binary

### DIFF
--- a/src/driver/amdxdna/npu6_regs.c
+++ b/src/driver/amdxdna/npu6_regs.c
@@ -6,7 +6,7 @@
 #include "npu4_family.h"
 
 const struct amdxdna_dev_priv npu6_dev_priv = {
-	.fw_path        = "amdnpu/17f0_20/npu.sbin",
+	.fw_path        = "amdnpu/17f0_10/npu.sbin",
 	.protocol_major = 0x6,
 	.protocol_minor = 0x6,
 	NPU4_COMMON_DEV_PRIV,

--- a/tools/info.json
+++ b/tools/info.json
@@ -36,14 +36,6 @@
 			"pci_revision_id": "11",
 			"version": "0.7.30.101",
 			"fw_name": "npu.sbin"
-		},
-		{
-			"device": "npu6",
-			"url": "https://gitlab.freedesktop.org/drm/firmware/-/raw/amd-ipu-staging/amdnpu/17f0_20/npu.sbin.0.7.30.20",
-			"pci_device_id": "17f0",
-			"pci_revision_id": "20",
-			"version": "0.7.30.20",
-			"fw_name": "npu.sbin"
 		}
 	]
 }


### PR DESCRIPTION
.