### PR TITLE
Fix no QoS parameters case

### DIFF
--- a/src/driver/amdxdna/aie2_debugfs.c
+++ b/src/driver/amdxdna/aie2_debugfs.c
@@ -291,7 +291,7 @@ static ssize_t aie2_dpm_level_set(struct file *file, const char __user *ptr,
 		return ret;
 	}
 
-	ret = aie2_smu_set_dpm_level(ndev, val, true);
+	ret = aie2_smu_set_dpm_level(ndev, val);
 	if (ret) {
 		XDNA_ERR(ndev->xdna, "Setting dpm_level:%d failed, ret: %d", val, ret);
 		return ret;

--- a/src/driver/amdxdna/aie2_pci.c
+++ b/src/driver/amdxdna/aie2_pci.c
@@ -306,7 +306,7 @@ static int aie2_set_dpm_level(void *cb_arg, u32 dpm_level)
 
 	xdna = hwctx->client->xdna;
 
-	ret = aie2_smu_set_dpm_level(xdna->dev_handle, dpm_level, true);
+	ret = aie2_smu_set_dpm_level(xdna->dev_handle, dpm_level);
 	if (ret)
 		XDNA_ERR(xdna, "set dpm level failed, ret %d", ret);
 
@@ -589,6 +589,7 @@ skip_pasid:
 	}
 	ndev->total_col = min(aie2_max_col, ndev->metadata.cols);
 
+	xrs_cfg.max_dpm_level = SMU_DPM_MAX(ndev);
 	xrs_cfg.clk_list.num_levels = ndev->priv->smu_npu_dpm_levels;
 	xrs_cfg.clk_list.cu_clk_list = ndev->priv->smu_npu_dpm_clk_table;
 	xrs_cfg.sys_eff_factor = 1;

--- a/src/driver/amdxdna/aie2_pci.h
+++ b/src/driver/amdxdna/aie2_pci.h
@@ -296,7 +296,7 @@ int aie2_smu_set_power_on(struct amdxdna_dev_hdl *ndev);
 int aie2_smu_set_power_off(struct amdxdna_dev_hdl *ndev);
 int aie2_smu_get_power_state(struct amdxdna_dev_hdl *ndev);
 int aie2_smu_get_dpm_level(struct amdxdna_dev_hdl *ndev);
-int aie2_smu_set_dpm_level(struct amdxdna_dev_hdl *ndev, u32 dpm_level, bool cache);
+int aie2_smu_set_dpm_level(struct amdxdna_dev_hdl *ndev, u32 dpm_level);
 void aie2_smu_prepare_s0i3(struct amdxdna_dev_hdl *ndev);
 
 /* aie2_psp.c */

--- a/src/driver/amdxdna/aie2_smu.c
+++ b/src/driver/amdxdna/aie2_smu.c
@@ -165,7 +165,7 @@ int aie2_smu_get_dpm_level(struct amdxdna_dev_hdl *ndev)
 	return ndev->smu.curr_dpm_level;
 }
 
-int aie2_smu_set_dpm_level(struct amdxdna_dev_hdl *ndev, u32 dpm_level, bool cache)
+int aie2_smu_set_dpm_level(struct amdxdna_dev_hdl *ndev, u32 dpm_level)
 {
 	int ret;
 
@@ -177,8 +177,10 @@ int aie2_smu_set_dpm_level(struct amdxdna_dev_hdl *ndev, u32 dpm_level, bool cac
 	else
 		ret = aie2_smu_set_dpm_level_v1(ndev, dpm_level);
 
-	if (!ret & cache)
+	if (!ret) {
 		ndev->smu.curr_dpm_level = dpm_level;
+		XDNA_DBG(ndev->xdna, "The dpm level is set to %d", dpm_level);
+	}
 
 	return ret;
 }
@@ -243,7 +245,7 @@ int aie2_smu_start(struct amdxdna_dev_hdl *ndev)
 	XDNA_INFO_ONCE(ndev->xdna, "Set %s = %d mhz", smu->h_clock.name, freq_mhz);
 
 	if (SMU_DPM_MAX(ndev) > 0) {
-		ret = aie2_smu_set_dpm_level(ndev, smu->curr_dpm_level, true);
+		ret = aie2_smu_set_dpm_level(ndev, smu->curr_dpm_level);
 		if (ret) {
 			XDNA_ERR(ndev->xdna, "Set dpm level failed, ret %d", ret);
 			return ret;
@@ -269,7 +271,7 @@ void aie2_smu_prepare_s0i3(struct amdxdna_dev_hdl *ndev)
 		XDNA_ERR(ndev->xdna, "Set hclk freq %d mhz failed, ret %d", freq_mhz, ret);
 
 	if (SMU_DPM_MAX(ndev) > 0) {
-		ret = aie2_smu_set_dpm_level(ndev, 0, false);
+		ret = aie2_smu_set_dpm_level(ndev, 0);
 		if (ret)
 			XDNA_ERR(ndev->xdna, "Set dpm level 0 failed, ret %d", ret);
 	}

--- a/src/driver/amdxdna/aie2_solver.c
+++ b/src/driver/amdxdna/aie2_solver.c
@@ -95,6 +95,14 @@ static int sanity_check(struct solver_state *xrs, struct alloc_requests *req)
 	return 0;
 }
 
+static bool is_valid_qos_dpm_params(struct aie_qos *rqos)
+{
+	if (rqos->gops > 0 || rqos->fps > 0 ||  rqos->latency > 0)
+		return true;
+
+	return false;
+}
+
 static u32 find_dpm_level(struct solver_state *xrs, struct alloc_requests *req)
 {
 	struct cdo_parts *cdop = &req->cdo;
@@ -103,8 +111,9 @@ static u32 find_dpm_level(struct solver_state *xrs, struct alloc_requests *req)
 	struct solver_node *node;
 	u32 cu_clk_freq, dpm_level;
 
-	if (cdop->ncols > xrs->cfg.total_col)
-		return -EINVAL;
+	/* If no QoS parameters are passed, set it to the max DPM level */
+	if (!is_valid_qos_dpm_params(rqos))
+		return xrs->cfg.max_dpm_level;
 
         /*
          * We can find at least one CDOs groups that meet the

--- a/src/driver/amdxdna/aie2_solver.h
+++ b/src/driver/amdxdna/aie2_solver.h
@@ -91,6 +91,7 @@ struct init_config {
 	u32			total_col;
 	u32			sys_eff_factor; /* system efficiency factor */
 	u32			latency_adj;    /* latency adjustment in ms */
+	u32			max_dpm_level;	/* Max dpm level in the system */
 	struct clk_list_info	clk_list;       /* List of frequencies available in system */
 	struct device		*dev;
 	struct xrs_action_ops	*actions;


### PR DESCRIPTION
When there are no QoS parameters are passed
set the DPM level to max, since this is
the default DPM level.
Also, no need to cache the dpm levels, since
the solver will always set a valid DPM level.