### PR TITLE
timeout_in_sec should be uint

### DIFF
--- a/src/driver/amdxdna/amdxdna_tdr.c
+++ b/src/driver/amdxdna/amdxdna_tdr.c
@@ -6,8 +6,8 @@
 #include "amdxdna_drm.h"
 #include "amdxdna_tdr.h"
 
-int timeout_in_sec = 2;
-module_param(timeout_in_sec, int, 0644);
+uint timeout_in_sec = 2;
+module_param(timeout_in_sec, uint, 0644);
 MODULE_PARM_DESC(timeout_in_sec, "Seconds to timeout and recovery, default 2; 0 - No TDR");
 
 #define TDR_TIMEOUT_JIFF msecs_to_jiffies(timeout_in_sec * 1000)


### PR DESCRIPTION
In the code, timeout_in_sec is used as unsigned value. If user set negative, it will be a very large integer. It is good to define it as uint not int.