### PR TITLE
remove eu, looks like Vitis AI python env doesn't like it

### DIFF
--- a/src/driver/tools/npu_perf_trace.sh
+++ b/src/driver/tools/npu_perf_trace.sh
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (C) 2024, Advanced Micro Devices, Inc.
 
-set -eu
+#set -eu
 
 bold=$(tput bold)
 normal=$(tput sgr0)


### PR DESCRIPTION
Vitis AI development environment doesn't like set -eu. Somehow, before we have a better solution. Remove it for now.