### PR TITLE
indirect dpu pkt handling with device firmware host_queue changes

### DIFF
--- a/src/driver/amdxdna/amdxdna_mailbox.c
+++ b/src/driver/amdxdna/amdxdna_mailbox.c
@@ -487,10 +487,8 @@ static void mailbox_timer(struct timer_list *t)
 
 	/* The timer mimic interrupt. It is good to reuse irq routine */
 	tail = mailbox_get_tailptr(mb_chann, CHAN_RES_I2X);
-	if (tail) {
-		//MB_DBG(mb_chann, "Mimic interrupt...");
+	if (tail)
 		mailbox_irq_handler(0, mb_chann);
-	}
 
 	mod_timer(&mb_chann->timer, jiffies + MB_TIMER_JIFF);
 }

--- a/src/driver/amdxdna/amdxdna_mailbox.c
+++ b/src/driver/amdxdna/amdxdna_mailbox.c
@@ -488,7 +488,7 @@ static void mailbox_timer(struct timer_list *t)
 	/* The timer mimic interrupt. It is good to reuse irq routine */
 	tail = mailbox_get_tailptr(mb_chann, CHAN_RES_I2X);
 	if (tail) {
-		MB_DBG(mb_chann, "Mimic interrupt...");
+		//MB_DBG(mb_chann, "Mimic interrupt...");
 		mailbox_irq_handler(0, mb_chann);
 	}
 

--- a/src/shim/umq/host_queue.h
+++ b/src/shim/umq/host_queue.h
@@ -1,59 +1,8 @@
-/*  (c) Copyright 2014 - 2022 Xilinx, Inc. All rights reserved.
-   
-    This file contains confidential and proprietary information
-    of Xilinx, Inc. and is protected under U.S. and
-    international copyright and other intellectual property
-    laws.
-   
-    DISCLAIMER
-    This disclaimer is not a license and does not grant any
-    rights to the materials distributed herewith. Except as
-    otherwise provided in a valid license issued to you by
-    Xilinx, and to the maximum extent permitted by applicable
-    law: (1) THESE MATERIALS ARE MADE AVAILABLE "AS IS" AND
-    WITH ALL FAULTS, AND XILINX HEREBY DISCLAIMS ALL WARRANTIES
-    AND CONDITIONS, EXPRESS, IMPLIED, OR STATUTORY, INCLUDING
-    BUT NOT LIMITED TO WARRANTIES OF MERCHANTABILITY, NON-
-    INFRINGEMENT, OR FITNESS FOR ANY PARTICULAR PURPOSE; and
-    (2) Xilinx shall not be liable (whether in contract or tort,
-    including negligence, or under any other theory of
-    liability) for any loss or damage of any kind or nature
-    related to, arising under or in connection with these
-    materials, including for any direct, or any indirect,
-    special, incidental, or consequential loss or damage
-    (including loss of data, profits, goodwill, or any type of
-    loss or damage suffered as a result of any action brought
-    by a third party) even if such damage or loss was
-    reasonably foreseeable or Xilinx had been advised of the
-    possibility of the same.
-   
-    CRITICAL APPLICATIONS
-    Xilinx products are not designed or intended to be fail-
-    safe, or for use in any application requiring fail-safe
-    performance, such as life-support or safety devices or
-    systems, Class III medical devices, nuclear facilities,
-    applications related to the deployment of airbags, or any
-    other applications that could lead to death, personal
-    injury, or severe property or environmental damage
-    (individually and collectively, "Critical
-    Applications"). Customer assumes the sole risk and
-    liability of any use of Xilinx products in Critical
-    Applications, subject only to applicable laws and
-    regulations governing limitations on product liability.
-   
-    THIS COPYRIGHT NOTICE AND DISCLAIMER MUST BE RETAINED AS
-    PART OF THIS FILE AT ALL TIMES.                       */
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2023-2024, Advanced Micro Devices, Inc. All rights reserved.
 
 #ifndef _HOST_QUEUE_H_
 #define _HOST_QUEUE_H_
-
-#include <stdbool.h>
-#include <stdint.h>
-
-#define SHIM_USER_EVENT_0_ID 0xb6
-#define DOORBELL_EVENT_ID SHIM_USER_EVENT_0_ID
-
-#define PDI_TABLE_SIZE 64
 
 #define HSA_PKT_SUCCESS (0)
 /*
@@ -62,7 +11,8 @@
  * will check them on all devices/platforms.
  * HSA specific error code will be on high 28 bits.
  */ 
-enum hsa_cmd_state { // ert_cmd_state essentially
+enum hsa_cmd_state
+{ // ert_cmd_state essentially
   HSA_CMD_STATE_NEW = 1,
   HSA_CMD_STATE_QUEUED = 2,
   HSA_CMD_STATE_RUNNING = 3,
@@ -83,46 +33,14 @@ enum hsa_cmd_state { // ert_cmd_state essentially
 #define HSA_INVALID_OPCODE        HSA_ERR(column_index_rel * 100 + 3)
 #define HSA_INVALID_PKT           HSA_ERR(4)
 #define HSA_INVALID_PAGE          HSA_ERR(column_index_rel * 100 + 5)
+#define HSA_INDIRECT_PKT_NUM      6
 
-typedef enum     
+enum host_queue_packet_opcode
 {            
   HOST_QUEUE_PACKET_EXEC_BUF = 1,
   HOST_QUEUE_PACKET_TEST = 2,
   HOST_QUEUE_PACKET_EXIT = 3,
-}            
-host_queue_packet_opcode_t;
-
-/*
- * cu_config contains cu <-> pdi mapping info
- *
- * due to memory footprint limitation, the pdi info (host address) is not saved in CERT
- * if num_mappings == 1, then pdi_info_host_addr contains the host addr of the pdi
- * if num_mappings > 1, then pdi_info_host_addr contains the host addr of a table, in which
- * the host addr of all the pdi are saved.
- *
- * note: both cu_index and pdi_index should be start from 0
- * e.g mapping[0] = 0, mapping[1] = 1, mapping[2] = 0,
- * means,
- * cu0 <-> pdi0
- * cu1 <-> pdi1
- * cu2 <-> pdi0
- * there are 3 mappings, and 2 pdi in pdi_info_host_addr table 
- */
-typedef struct
-{
-  uint32_t num_mappings;
-  uint32_t pdi_info_host_addr_low;
-  uint32_t pdi_info_host_addr_high;
-  uint8_t mapping[PDI_TABLE_SIZE];
-}
-config_cu_t;
-
-#define INVALID_PDI_ID (0xFF)
-
-/*
- * Maximum number of exec buf args in 4B
- */ 
-#define EXEC_BUF_ARGS_MAX_LEN (20)
+};            
 
 /*
  * hsa pkt payload of exec_buf
@@ -134,7 +52,7 @@ config_cu_t;
  * args contains the info of input/output frame, parameter of network
  * etc, which are all transparent to CERT 
  */ 
-typedef struct
+struct exec_buf
 {
   uint16_t cu_index;
   uint16_t reserved0;
@@ -144,48 +62,28 @@ typedef struct
   uint16_t reserved1;
   uint32_t args_host_addr_low;
   uint32_t args_host_addr_high;
-}
-exec_buf_t;
+};
 
-
-typedef struct
+struct host_queue_header
 {
   uint64_t read_index;
-  
-  uint32_t reserved;
-  
-  //! @note Queue capacity, must be a power of two.
-  uint32_t capacity;
-
-  /*
-   * NOTE!!!
-   *  Due to the cache is not cache coherence between host and device.  We have
-   *  to flush the cache of the host queue.
-   *
-   *  Most importantly, the read_index has to be in different cache line
-   *  (64Bytes in linux) than the write_index. Because the read_index might be
-   *  flushed from a different context from kernel driver that is monitoring
-   *  the completed message. While at the same time, the write_index might be 
-   *  being flushed from UMQ.
-   */ 
-  //Note: temporary disable padding because FW has not been fully changed yet.
-  //uint64_t padding[6];
-
+  struct
+  {
+    uint16_t major;
+    uint16_t minor;
+  }
+  version;
+  uint32_t capacity; //Queue capacity, must be a power of two.
   uint64_t write_index;
-  
   uint64_t data_address;
-  
-  // TODO Ready signal?
-}
-host_queue_header_t;
+};
 
 
-typedef enum     
+enum host_queue_packet_type
 {            
   HOST_QUEUE_PACKET_TYPE_VENDOR_SPECIFIC = 0,
   HOST_QUEUE_PACKET_TYPE_INVALID = 1,
-}            
-host_queue_packet_type_t;
+}; 
 
 /*
  * 8 Bytes common header of hsa pkt used in CERT.
@@ -199,7 +97,7 @@ host_queue_packet_type_t;
  * for 'indirect', 'count' is used to calc the number of indirect pkt entry,
  * see below
  */ 
-typedef struct
+struct common_header
 {
   union {
     struct {
@@ -214,29 +112,24 @@ typedef struct
   uint16_t count;
   uint8_t distribute;
   uint8_t indirect;
-}
-common_header_t;
+};
 
-typedef struct
+struct xrt_packet_header
 {
-  common_header_t common_header;	
+  struct common_header common_header;	
   uint64_t completion_signal;
-}
-xrt_packet_header_t;
+};
 
 /*
  * format of indirect pkt. multiple-indirect-level is supported
  * there is vendor specific header (common header plus completion_signal) in 1st indirect level
  * there is common header in all the remaining indirect levels
  */ 
-typedef struct
+struct host_indirect_packet_entry
 {
-  uint16_t column_index;
-  uint16_t reserved;
   uint32_t host_addr_low;
   uint32_t host_addr_high;
-}
-host_indirect_packet_entry_t;
+};
 
 /*
  * hsa pkt format -- 64Bytes fixed length
@@ -245,23 +138,23 @@ host_indirect_packet_entry_t;
  * xrt_packet_header:
  *   type: 0 (vendor specific)
  *   opcode: 1 (exec_buf)
- *   count: 24 (sizeof(exec_buf_t))
+ *   count: 24 (sizeof(struct exec_buf))
  *   distribute: 0
  *   indirect: 0
  *   completion_signal: xxx
  * data:
- *   exec_buf_t
+ *   struct exec_buf
  *
  * case 2 -- indirect config_cu 
  * xrt_packet_header:
  *   type: 0 (vendor specific)
  *   opcode: 0 (config_cu)
- *   count: 12 (1 * sizeof(host_indirect_packet_entry_t))
+ *   count: 12 (1 * sizeof(struct host_indirect_packet_entry))
  *   distribute: 0
  *   indirect: 1 // common header of indirect
  *   completion_signal: xxx
  * data:
- *   host_indirect_packet_entry_t:
+ *   struct host_indirect_packet_entry:
  *     column_index: index of lead uc
  *     host_addr*: host addr of next level
  *       common_header:
@@ -270,123 +163,97 @@ host_indirect_packet_entry_t;
  *         count: 72 (config_cu with 16 entries)) //10 entry config_cu can fit in direct pkt
  *         indirect: 0 // common header of direct
  *       payload:
- *         config_cu_t: 16 entries of mapping table
+ *         struct config_cu: 16 entries of mapping table
  *
  * case 3 -- indirect exec_buf on 4 column partition
  * xrt_packet_header:
  *   type: 0 (vendor specific)
  *   opcode: 1 (exec_buf)
- *   count: 48 (4 *sizeof(host_indirect_packet_entry_t))
+ *   count: 48 (6 * sizeof(struct host_indirect_packet_entry))
  *   distribute: 1
  *   indirect: 1 // common header of indirect
  *   completion_signal: xxx
  * data:
- *   host_indirect_packet_entry_t:
- *     column_index: index of lead uc
+ *   struct host_indirect_packet_entry:
  *     host_addr*: host addr of next level
  *       common_header:
  *         type: 0 (vendor specific)
  *         opcode: 1 (exec_buf)
- *         count: 24 (sizeof(exec_buf_t))
+ *         count: 24 (sizeof(struct exec_buf))
  *         indirect: 0 // common header of direct
  *       payload:
- *          exec_buf_t 
- *   host_indirect_packet_entry_t:
- *     column_index: index of slave1
+ *          struct exec_buf 
+ *   struct host_indirect_packet_entry:
  *     host_addr*: host addr of next level
  *       common_header:
  *          type: 0 (vendor specific)
  *          opcode: 1 (exec_buf)
- *          count: 24 (sizeof(exec_buf_t))
+ *          count: 24 (struct sizeof(exec_buf))
  *          indirect: 0 // common header of direct
  *       payload:
- *          exec_buf_t
- *   host_indirect_packet_entry_t:
+ *          struct exec_buf
+ *   struct host_indirect_packet_entry:
  *     slave2,3,etc...
  *
  * case 4 -- indirect exec_buf on 8 column partition 
  * xrt_packet_header:
  *   type: 0 (vendor specific)
  *   opcode: 1 (exec_buf)
- *   count: 12 (sizeof(host_indirect_packet_entry_t))
+ *   count: 12 (sizeof(struct host_indirect_packet_entry))
  *   distribute: 1
  *   indirect: 1 // common_header of level-1 indirect
  *   completion_signal: xxx
  * data:
- *   host_indirect_packet_entry_t:
- *     column_index: index of lead uc
+ *   struct host_indirect_packet_entry:
  *     host_addr*: host addr of next level
  *       common_header:
  *         type: 0 (vendor specific)
  *         opcode: 1 (exec_buf)
- *         count: 12*8 (12 * sizeof(host_indirect_packet_entry_t))
+ *         count: 12*8 (12 * sizeof(struct host_indirect_packet_entry))
  *         distribute: 1
  *         indirect: 1 // common header of level-2 indirect
  *       indirect_payload: 
- *         host_indirect_packet_entry_t:
- *           column_index: index of lead uc
+ *         struct host_indirect_packet_entry:
  *           host_addr*: host addr of next level
  *             common_header:
  *               type: 0 (vendor specific)
  *               opcode: 1 (exec_buf)
- *               count: 24 (sizeof(exec_buf_t))
+ *               count: 24 (sizeof(struct exec_buf))
  *               distribute: 1
  *               indirect: 0  // common_header of direct
  *             payload: 
- *               exec_buf_t
- *         host_indirect_packet_entry_t:
- *           column_index: index of slave1
+ *               struct exec_buf
+ *         struct host_indirect_packet_entry:
  *           host_addr*: host addr of next level
  *             common_header:
  *               type: 0 (vendor specific)
  *               opcode: 1 (exec_buf)
- *               count: 24 (sizeof(exec_buf_t))
+ *               count: 24 (sizeof(struct exec_buf))
  *               distribute: 1
  *               indirect: 0 // common_header of direct
  *             payload: 
- *               exec_buf_t
- *         host_indirect_packet_entry_t:
+ *               struct exec_buf
+ *         struct host_indirect_packet_entry:
  *           slave2,3,etc...
  */ 
-typedef struct
+struct host_queue_packet
 {
-  xrt_packet_header_t xrt_header;	
+  struct xrt_packet_header xrt_header;	
   uint32_t data[12];
-}
-host_queue_packet_t;
+};
 
 /*
  * xrt pkt with random length.
  */ 
-typedef struct
+struct xrt_packet
 {
-  xrt_packet_header_t xrt_header;	
+  struct xrt_packet_header xrt_header;	
   uint64_t xrt_payload_host_addr;
-}
-xrt_packet_t;
+};
 
-#define XRT_PKT_TYPE(p) ((p)->xrt_header.common_header.type)
-#define XRT_PKT_OPCODE(p) ((p)->xrt_header.common_header.opcode)
-#define XRT_PKT_LEN(p) ((p)->xrt_header.common_header.count)
-#define XRT_PKT_DISTRIBUTE(p) ((p)->xrt_header.common_header.distribute)
-#define XRT_PKT_INDIRECT(p) ((p)->xrt_header.common_header.indirect)
-#define XRT_PKT_COMPLETION(p) ((p)->xrt_header.completion_signal)
-#define XRT_PKT_PAYLOAD(p) ((p)->xrt_payload_host_addr)
-
-#define ADDR_HIGH(x)        ((x) >> 32)
-#define ADDR_LOW(x)         ((x) & 0xFFFFFFFF)
-#define MOD_POW2(x, y)      ((x) & ((y) - 1)) 
-
-typedef struct
+struct host_queue
 {
   uint64_t address;
-}
-host_queue_t;
-
-void host_queue_init(host_queue_t *queue, uint64_t address);
-
-xrt_packet_t *host_queue_pop(host_queue_t *queue, bool block);
-
-void host_queue_finish_packet(host_queue_t *queue, xrt_packet_t *packet, uint32_t completion);
+};
 
 #endif

--- a/src/shim/umq/hwq.cpp
+++ b/src/shim/umq/hwq.cpp
@@ -22,13 +22,13 @@ clflush_data(void *data, int len)
 }
 
 inline void
-mark_slot_invalid(volatile host_queue_packet_t *pkt)
+mark_slot_invalid(volatile struct host_queue_packet *pkt)
 {
   pkt->xrt_header.common_header.type = HOST_QUEUE_PACKET_TYPE_INVALID;
 }
 
 inline void
-mark_slot_valid(volatile host_queue_packet_t *pkt)
+mark_slot_valid(volatile struct host_queue_packet *pkt)
 {
   /* Issue mfence instruction to make sure all writes to the slot before is done */
   std::atomic_thread_fence(std::memory_order::memory_order_seq_cst);
@@ -38,7 +38,7 @@ mark_slot_valid(volatile host_queue_packet_t *pkt)
 }
 
 inline bool
-is_slot_valid(volatile host_queue_packet_t *pkt)
+is_slot_valid(volatile struct host_queue_packet *pkt)
 {
   return pkt->xrt_header.common_header.type == HOST_QUEUE_PACKET_TYPE_VENDOR_SPECIFIC;
 }
@@ -47,33 +47,62 @@ is_slot_valid(volatile host_queue_packet_t *pkt)
 
 namespace shim_xdna {
 
+void
+hw_q_umq::
+init_indirect_buf(volatile struct host_indirect_data *indirect_buf, int size)
+{
+  for (int i = 0; i < size; i++) {
+    indirect_buf[i].header.type = HOST_QUEUE_PACKET_TYPE_VENDOR_SPECIFIC;
+    indirect_buf[i].header.opcode = HOST_QUEUE_PACKET_EXEC_BUF;
+    indirect_buf[i].header.count = sizeof(struct exec_buf);
+    indirect_buf[i].header.distribute = 1;
+    indirect_buf[i].header.indirect = 0;
+  }
+}
+
 hw_q_umq::
 hw_q_umq(const device& dev, size_t nslots) : hw_q(dev)
 {
 #ifdef UMQ_HELLO_TEST
   const size_t header_sz = 8192; // Hard code to 2 pages
   const size_t queue_sz = 0;
+  const size_t indirect_sz = 0;
 #else
-  const size_t header_sz = sizeof(host_queue_header_t);
-  const size_t queue_sz = sizeof(host_queue_packet_t) * nslots;
+  //
+  // host queue layout:
+  //   host_queue_header_t
+  //   host_queue_packet_t [nslots]
+  //   indirect [4 * indirect_buffer * nslots]
+  const size_t header_sz = sizeof(struct host_queue_header);
+  const size_t queue_sz = sizeof(struct host_queue_packet) * nslots;
+  const size_t indirect_sz = (sizeof(struct host_indirect_data) * HSA_INDIRECT_PKT_NUM) * nslots;
 #endif
-  const size_t umq_sz = header_sz + queue_sz;
+  const size_t umq_sz = header_sz + queue_sz + indirect_sz;
+  shim_debug("umq sz %ld", umq_sz);
 
   m_umq_bo = const_cast<device &>(dev).alloc_bo(umq_sz, XCL_BO_FLAGS_EXECBUF);
   m_umq_bo_buf = m_umq_bo->map(bo::map_type::write);
-  m_umq_hdr = reinterpret_cast<volatile host_queue_header_t *>(m_umq_bo_buf);
-  m_umq_pkt = reinterpret_cast<volatile host_queue_packet_t *>
+  m_umq_hdr = reinterpret_cast<volatile struct host_queue_header *>(m_umq_bo_buf);
+  m_umq_pkt = reinterpret_cast<volatile struct host_queue_packet *>
     ((char *)m_umq_bo_buf + header_sz);
+  m_umq_indirect_buf = reinterpret_cast<volatile struct host_indirect_data *>
+    ((char *)m_umq_bo_buf + header_sz + queue_sz);
 
   // set all mapped memory to 0 
   std::memset(m_umq_bo_buf, 0, umq_sz);
   
-  for (int i = 0; i < nslots; i++)
+  // init slots and indirect buf
+  for (int i = 0; i < nslots; i++) {
     mark_slot_invalid(&m_umq_pkt[i]);
+    init_indirect_buf(&m_umq_indirect_buf[i * HSA_INDIRECT_PKT_NUM], HSA_INDIRECT_PKT_NUM);
+  }
 
   m_umq_hdr->capacity = nslots;
   // data_address starts after header
   m_umq_hdr->data_address = m_umq_bo->get_properties().paddr + header_sz;
+
+  // indirect buf starts after queue
+  m_indirect_paddr = m_umq_hdr->data_address + queue_sz;
 
   // this is the bo handler defined in parent class
   m_queue_boh = static_cast<bo*>(m_umq_bo.get())->get_drm_bo_handle();
@@ -98,11 +127,11 @@ map_doorbell(uint32_t doorbell_offset)
     m_pdev.mmap(0, sizeof(uint32_t), PROT_WRITE, MAP_SHARED, doorbell_offset));
 }
 
-volatile host_queue_header_t *
+volatile struct host_queue_header *
 hw_q_umq::
 get_header_ptr() const
 {
-  return reinterpret_cast<volatile host_queue_header_t *>(m_umq_bo_buf);
+  return reinterpret_cast<volatile struct host_queue_header *>(m_umq_bo_buf);
 }
 
 void
@@ -129,9 +158,33 @@ dump() const
     shim_debug("\tdistribute:\t%u", pkt->xrt_header.common_header.distribute);
     shim_debug("\tindirect:\t%u", pkt->xrt_header.common_header.indirect);
     shim_debug("\tcomplete addr:\t%p", pkt->xrt_header.completion_signal);
-    for (int j = 0; j < sizeof(pkt->data) / sizeof(pkt->data[0]); j++)
-      shim_debug("\tdata[%d]:\t0x%08x", j, pkt->data[j]);
+    if (pkt->xrt_header.common_header.indirect == 0) {
+      volatile struct exec_buf *ebp =
+        reinterpret_cast<volatile struct exec_buf *>(pkt->data);
+
+      shim_debug("\tcu_index:\t%d", ebp->cu_index);
+      shim_debug("\tdpu: [0x%x 0x%x]",
+        ebp->dpu_control_code_host_addr_high,
+        ebp->dpu_control_code_host_addr_low);
+    } else {
+      volatile struct host_indirect_packet_entry *hp =
+        reinterpret_cast<volatile struct host_indirect_packet_entry *>(pkt->data);
+
+      for (int i = 0; i < HSA_INDIRECT_PKT_NUM; i++, hp++) {
+        shim_debug("\thost addr: [0x%x 0x%x]", hp->host_addr_high, hp->host_addr_low);
+
+	volatile struct host_indirect_data *data =
+	  reinterpret_cast<volatile struct host_indirect_data *>(m_umq_indirect_buf);
+	shim_debug("\t\th:distribute:\t%d", data[i].header.distribute);
+	shim_debug("\t\th:indirect:\t%d", data[i].header.indirect);
+	shim_debug("\t\tp:cu_index:\t%d", data[i].payload.cu_index);
+	shim_debug("\t\tp:dpu: [0x%x 0x%x]",
+          data[i].payload.dpu_control_code_host_addr_high,
+          data[i].payload.dpu_control_code_host_addr_low);
+      }
+    }
   }
+  shim_debug("dump finished\r\n");
 }
 
 void
@@ -139,7 +192,7 @@ hw_q_umq::
 dump_raw() const
 {
   auto d = reinterpret_cast<volatile uint32_t *>(m_umq_pkt);
-  auto sz = get_header_ptr()->capacity * sizeof(host_queue_packet_t) / sizeof(uint32_t);
+  auto sz = get_header_ptr()->capacity * sizeof(struct host_queue_packet) / sizeof(uint32_t);
   shim_debug("Dumping raw UMQ queue slot data @%p, len=%ld WORDs:", m_umq_pkt, sz);
   for (int i = 0; i < sz; i++)
     shim_debug("0x%08x", d[i]);
@@ -172,11 +225,18 @@ reserve_slot()
   return cur_slot;
 }
 
-volatile host_queue_packet_t *
+int
 hw_q_umq::
-get_slot(uint64_t index)
+get_pkt_idx(uint64_t index)
 {
-  auto pkt = &m_umq_pkt[index & (get_header_ptr()->capacity - 1)];
+  return index & (get_header_ptr()->capacity - 1);
+}
+
+volatile struct host_queue_packet *
+hw_q_umq::
+get_pkt(uint64_t index)
+{
+  auto pkt = &m_umq_pkt[get_pkt_idx(index)];
   if (is_slot_valid(pkt)) {
     shim_err(EINVAL, "Slot is ready before use! index=0x%lx", index);
     dump();
@@ -188,26 +248,102 @@ uint64_t
 hw_q_umq::
 issue_exec_buf(uint16_t cu_idx, ert_dpu_data *dpu, uint64_t comp)
 {
-  auto idx = reserve_slot();
-  auto pkt = get_slot(idx);
+  auto slot_idx = reserve_slot();
+  auto pkt = get_pkt(slot_idx);
+  size_t pkt_size;
+
+  if (get_ert_dpu_data_next(dpu))
+    pkt_size = fill_indirect_exec_buf(slot_idx, cu_idx, pkt, dpu);
+  else
+    pkt_size = fill_direct_exec_buf(cu_idx, pkt, dpu); 
+
   auto hdr = &pkt->xrt_header;
   hdr->common_header.opcode = HOST_QUEUE_PACKET_EXEC_BUF;
-  hdr->common_header.distribute = 0;
-  hdr->common_header.indirect = 0;
   hdr->completion_signal = comp;
 
-  exec_buf_t payload = {};
-  payload.cu_index = cu_idx;
-  payload.dpu_control_code_host_addr_low = static_cast<uint32_t>(dpu->instruction_buffer);
-  payload.dpu_control_code_host_addr_high = static_cast<uint32_t>(dpu->instruction_buffer >> 32);
+  fill_slot_and_send(pkt, pkt_size);
 
-  fill_slot_and_send(pkt, &payload, sizeof(payload));
-  return idx;
+  return slot_idx;
+}
+
+size_t
+hw_q_umq::
+fill_indirect_exec_buf(uint64_t slot_idx, uint16_t cu_idx,
+                        volatile struct host_queue_packet *pkt,
+                        ert_dpu_data *dpu) {
+  auto pkt_size = (dpu->chained + 1) * sizeof(struct host_indirect_packet_entry);
+
+  if (dpu->chained + 1 >= HSA_INDIRECT_PKT_NUM)
+    shim_err(EINVAL, "unsupported indirect number %d, valid number <= %d",
+      dpu->chained + 1, HSA_INDIRECT_PKT_NUM);
+
+  if (pkt_size > sizeof(pkt->data))
+    shim_err(EINVAL, "dpu pkt_size=0x%lx > pkt_data max size=%x%lx",
+      pkt_size, sizeof(pkt->data));
+
+  // no need to memset to zero, all buffer will be set
+  volatile struct host_indirect_packet_entry *hp =
+    reinterpret_cast<volatile struct host_indirect_packet_entry *>(pkt->data);
+
+  for (int i = 0; dpu && dpu->chained >= 0;
+    i++, hp++, dpu = get_ert_dpu_data_next(dpu)) {
+    auto data_size = sizeof(struct host_indirect_data) * HSA_INDIRECT_PKT_NUM;
+    auto prefix_off = get_pkt_idx(slot_idx) * data_size;
+    auto prefix_idx = get_pkt_idx(slot_idx) * HSA_INDIRECT_PKT_NUM;
+    auto buf_paddr = m_indirect_paddr + prefix_off +
+       sizeof(struct host_indirect_data) * i;
+
+    hp->host_addr_low = static_cast<uint32_t>(buf_paddr);
+    hp->host_addr_high = static_cast<uint32_t>(buf_paddr >> 32);
+
+    auto cebp = &m_umq_indirect_buf[prefix_idx + i];
+    // do not zero this buffer, the cebp->header is pre-set 
+    // set every cebp->payload field in case of garbage data
+    cebp->payload.cu_index = cu_idx;
+    cebp->payload.dpu_control_code_host_addr_low =
+      static_cast<uint32_t>(dpu->instruction_buffer);
+    cebp->payload.dpu_control_code_host_addr_high =
+      static_cast<uint32_t>(dpu->instruction_buffer >> 32);
+    cebp->payload.args_len = 0;
+    cebp->payload.args_host_addr_low = 0;
+    cebp->payload.args_host_addr_high = 0;
+  }
+
+  auto hdr = &pkt->xrt_header;
+  hdr->common_header.distribute = 1;
+  hdr->common_header.indirect = 1;
+
+  return pkt_size;
+}
+
+size_t
+hw_q_umq::
+fill_direct_exec_buf(uint16_t cu_idx, volatile struct host_queue_packet *pkt,
+                     ert_dpu_data *dpu) {
+  auto pkt_size = sizeof(struct exec_buf);
+  if (pkt_size > sizeof(pkt->data))
+    shim_err(EINVAL, "dpu pkt_size=0x%lx > pkt_data max size=%x%lx",
+      pkt_size, sizeof(pkt->data));
+  
+  // zero this buffer
+  auto data = const_cast<uint32_t *>(pkt->data);
+  std::memset(data, 0, pkt_size);
+  // set correct dpu control code
+  volatile struct exec_buf *ebp = reinterpret_cast<volatile struct exec_buf *>(pkt->data);
+  ebp->cu_index = cu_idx;
+  ebp->dpu_control_code_host_addr_low = static_cast<uint32_t>(dpu->instruction_buffer);
+  ebp->dpu_control_code_host_addr_high = static_cast<uint32_t>(dpu->instruction_buffer >> 32);
+
+  auto hdr = &pkt->xrt_header;
+  hdr->common_header.distribute = 0;
+  hdr->common_header.indirect = 0;
+
+  return pkt_size;
 }
 
 void
 hw_q_umq::
-fill_slot_and_send(volatile host_queue_packet_t *pkt, void *payload, size_t size)
+fill_slot_and_send(volatile struct host_queue_packet *pkt, size_t size)
 {
   if (size > sizeof(pkt->data))
     shim_err(EINVAL, "HSA packet payload too big, size=0x%lx", size);
@@ -215,10 +351,11 @@ fill_slot_and_send(volatile host_queue_packet_t *pkt, void *payload, size_t size
   auto hdr = &pkt->xrt_header;
   hdr->common_header.count = size;
 
-  auto data = const_cast<uint32_t *>(pkt->data);
-  std::memcpy(data, payload, size);
   /* must flush data to make cache coherence */
-  clflush_data((void *)data, size);
+  clflush_data((void *)(pkt->data), size);
+
+  //comment this out, debug only
+  //dump();
 
   /* Always done as last step. */
   mark_slot_valid(pkt);
@@ -247,9 +384,9 @@ issue_command(xrt_core::buffer_handle *cmd_bo)
   }
 
   if (get_ert_dpu_data_next(dpu_data))
-    shim_err(EOPNOTSUPP, "chained dpu data is not supported yet");
+    shim_debug("this is a multi-column dpu request.");
 
-  // Completion signal area has to be a full WORD
+  // Completion signal area has to be a full WORD, we utilze the command_bo
   uint64_t comp = boh->get_properties().paddr + offsetof(ert_start_kernel_cmd, header);
 
   auto id = issue_exec_buf(ffs(cmd->cu_mask) - 1, dpu_data, comp);


### PR DESCRIPTION
With this fix, we enable the multiple column request, aka. the remote barrier. During the test, we can see 3 columns received correct patched paddr. We would like to enable this end-to-end test for future development.

Note: the end-to-end test for this case is not fully passed, but we have made the runtime and fimware test ready. @Brian Xu for more details about what is still not working yet.