### PR TITLE
Adding buffer size in GET_INFO

### DIFF
--- a/src/driver/amdxdna/amdxdna_gem.c
+++ b/src/driver/amdxdna/amdxdna_gem.c
@@ -800,6 +800,7 @@ int amdxdna_drm_get_bo_info_ioctl(struct drm_device *dev, void *data, struct drm
 	abo = to_xdna_obj(gobj);
 	args->vaddr = abo->mem.userptr;
 	args->xdna_addr = abo->mem.dev_addr;
+	args->size = abo->mem.size;
 
 	if (abo->type != AMDXDNA_BO_DEV)
 		args->map_offset = drm_vma_node_offset_addr(&gobj->vma_node);

--- a/src/include/uapi/drm_local/amdxdna_accel.h
+++ b/src/include/uapi/drm_local/amdxdna_accel.h
@@ -208,6 +208,7 @@ struct amdxdna_drm_create_bo {
  * @map_offset: Returned DRM fake offset for mmap().
  * @vaddr: Returned user VA of buffer. 0 in case user needs mmap().
  * @xdna_addr: Returned XDNA device virtual address.
+ * @size: Size in bytes.
  */
 struct amdxdna_drm_get_bo_info {
 	__u64 ext;
@@ -217,6 +218,7 @@ struct amdxdna_drm_get_bo_info {
 	__u64 map_offset;
 	__u64 vaddr;
 	__u64 xdna_addr;
+	__u64	size;
 };
 
 /**


### PR DESCRIPTION
Adding size in amdxdna_drm_get_bo_info. Used when importing via dma-buf.  