### PR TITLE
allow npu_perf_trace.sh to trace shim_test

### DIFF
--- a/src/driver/tools/npu_perf_analyze.sh
+++ b/src/driver/tools/npu_perf_analyze.sh
@@ -67,6 +67,7 @@ while [ $# -gt 0 ]; do
 			;;
 		*)
 			break
+			;;
 	esac
 	shift
 done

--- a/src/driver/tools/npu_perf_trace.sh
+++ b/src/driver/tools/npu_perf_trace.sh
@@ -69,6 +69,17 @@ fi
 # Global variables
 sdt_pre_enabled=0
 xrt_lib_prefix="/opt/xilinx/xrt/lib"
+while [ $# -gt 0 ]; do
+	case "$1" in
+		-libdir | -l)
+			xrt_lib_prefix=$2
+			shift
+			;;
+		*)
+			break
+	esac
+	shift
+done
 accel_debugfs="/sys/kernel/debug/accel"
 xrt_libs="${xrt_lib_prefix}/libxrt_coreutil.so,${xrt_lib_prefix}/libxrt_driver_xdna.so"
 perf_record_args="-e amdxdna_trace:* "

--- a/src/driver/tools/npu_perf_trace.sh
+++ b/src/driver/tools/npu_perf_trace.sh
@@ -77,6 +77,7 @@ while [ $# -gt 0 ]; do
 			;;
 		*)
 			break
+			;;
 	esac
 	shift
 done

--- a/test/shim_test/io_config.h
+++ b/test/shim_test/io_config.h
@@ -208,7 +208,7 @@ int verify_output(int8_t* buf, const std::string &wrk_path)
     ss >> key >> str_val;
     ss.clear();
     golden_output_files.push_back(wrk_path + "golden_" + str_val + ".bin");
-    dump_output_files.push_back(wrk_path + "dump_" + str_val + ".bin");
+    dump_output_files.push_back("/tmp/dump_" + str_val + "." + std::to_string(getpid()) + ".bin");
 
     getline(myfile, line);
     ss.str(line);
@@ -239,12 +239,14 @@ int verify_output(int8_t* buf, const std::string &wrk_path)
 
   int ret = 0;
   for (int i = 0; i < num_outputs; i++) {
-    std::cout << "Examing output: " << golden_output_files[i] << std::endl;
     ret = comp_buf_strides(buf + output_ddr_addr[i], golden_output_files[i],
                            dump_output_files[i], output_shapes[i], output_strides[i]);
     if (ret) {
         std::cout << "Examing failed, ret " << ret << std::endl;
+        std::cout << "Examing output: " << dump_output_files[i] << std::endl;
         break;
+    } else {
+        std::remove(dump_output_files[i].c_str());
     }
   }
 


### PR DESCRIPTION
shim_test uses libs from build directory. Added -l option to npu_perf_trace.sh to allow user to specify the lib directory for tracing.