### PR TITLE
Support turbo mode for better latency but burn more power on CPU & NPU

### DIFF
--- a/src/driver/amdxdna/aie2_ctx.c
+++ b/src/driver/amdxdna/aie2_ctx.c
@@ -910,34 +910,6 @@ put_mm:
 	return ret;
 }
 
-static int aie2_hwctx_poll(struct amdxdna_hwctx *hwctx, struct amdxdna_sched_job *job)
-{
-	struct mailbox_channel *chann = hwctx->priv->mbox_chann;
-	struct dma_fence *fence;
-	int ret;
-
-	mutex_lock(&hwctx->priv->io_lock);
-	fence = aie2_sched_job_run(&job->base);
-	if (!fence)
-		goto unlock_and_out;
-	dma_fence_put(fence);
-
-	while (1) {
-		ret = xdna_mailbox_get_response(chann);
-		if (ret == -ENOENT)
-			continue;
-		else
-			break;
-	};
-
-	dma_fence_signal(job->out_fence);
-	aie2_sched_job_free(&job->base);
-
-unlock_and_out:
-	mutex_unlock(&hwctx->priv->io_lock);
-	return ret;
-}
-
 int aie2_cmd_submit(struct amdxdna_hwctx *hwctx, struct amdxdna_sched_job *job, u64 *seq)
 {
 	struct amdxdna_dev *xdna = hwctx->client->xdna;
@@ -992,14 +964,6 @@ retry:
 		dma_resv_add_fence(job->bos[i]->resv, job->out_fence, DMA_RESV_USAGE_WRITE);
 	amdxdna_unlock_objects(job, &acquire_ctx);
 
-	if (xdna_mailbox_is_upoll(hwctx->priv->mbox_chann)) {
-		ret = aie2_hwctx_poll(hwctx, job);
-		if (ret)
-			goto signal_fence;
-
-		return 0;
-	}
-
 	mutex_lock(&hwctx->priv->io_lock);
 	ret = aie2_hwctx_add_job(hwctx, job);
 	if (ret) {
@@ -1027,9 +991,6 @@ int aie2_cmd_wait(struct amdxdna_hwctx *hwctx, u64 seq, u32 timeout)
 	struct amdxdna_sched_job *job;
 	struct dma_fence *out_fence;
 	long ret;
-
-	if (xdna_mailbox_is_upoll(hwctx->priv->mbox_chann))
-		return 0;
 
 	mutex_lock(&hwctx->priv->io_lock);
 	job = aie2_hwctx_get_job(hwctx, seq);

--- a/src/driver/amdxdna/aie2_msg_priv.h
+++ b/src/driver/amdxdna/aie2_msg_priv.h
@@ -186,7 +186,6 @@ struct exec_dpu_req {
 	u32     inst_prop_cnt;
 	u32     cu_idx;
 	u32	payload[35];
-
 } __packed;
 
 struct exec_dpu_preempt_req {

--- a/src/driver/amdxdna/aie2_pci.c
+++ b/src/driver/amdxdna/aie2_pci.c
@@ -576,6 +576,7 @@ skip_pasid:
 	aie2_smu_setup(ndev);
 
 	ndev->pw_mode = POWER_MODE_DEFAULT;
+	ndev->clk_gate_enabled = true;
 	ret = aie2_hw_start(xdna);
 	if (ret) {
 		XDNA_ERR(xdna, "start npu failed, ret %d", ret);

--- a/src/driver/amdxdna/aie2_pci.c
+++ b/src/driver/amdxdna/aie2_pci.c
@@ -986,9 +986,8 @@ static int aie2_set_power_mode(struct amdxdna_client *client, struct amdxdna_drm
 		return -EFAULT;
 	}
 
-	/* Interpret the given buf->power_mode into the correct power mode*/
 	power_mode = power_state.power_mode;
-	if (power_mode > POWER_MODE_HIGH) {
+	if (power_mode > POWER_MODE_TURBO) {
 		XDNA_ERR(xdna, "Invalid power mode %d", power_mode);
 		return -EINVAL;
 	}

--- a/src/driver/amdxdna/aie2_pci.c
+++ b/src/driver/amdxdna/aie2_pci.c
@@ -428,7 +428,7 @@ static int aie2_hw_start(struct amdxdna_dev *xdna)
 						       &ndev->mgmt_x2i,
 						       &ndev->mgmt_i2x,
 						       xdna_mailbox_intr_reg,
-						       mgmt_mb_irq);
+						       mgmt_mb_irq, MB_CHANNEL_MGMT);
 	if (!ndev->mgmt_chann) {
 		XDNA_ERR(xdna, "failed to create management mailbox channel");
 		ret = -EINVAL;

--- a/src/driver/amdxdna/aie2_pci.h
+++ b/src/driver/amdxdna/aie2_pci.h
@@ -368,6 +368,7 @@ void aie2_stop_ctx_by_col_map(struct amdxdna_client *client, u32 col_map);
 /* aie2_pm.c */
 int aie2_pm_start(struct amdxdna_dev_hdl *ndev);
 void aie2_pm_stop(struct amdxdna_dev_hdl *ndev);
+bool aie2_pm_is_turbo(struct amdxdna_dev_hdl *ndev);
 int aie2_pm_set_mode(struct amdxdna_dev_hdl *ndev, enum amdxdna_power_mode_type target);
 
 #endif /* _AIE2_PCI_H_ */

--- a/src/driver/amdxdna/aie2_pci.h
+++ b/src/driver/amdxdna/aie2_pci.h
@@ -223,6 +223,7 @@ struct amdxdna_dev_hdl {
 	struct aie_metadata		metadata;
 	struct smu			smu;
 	enum amdxdna_power_mode_type	pw_mode;
+	bool				clk_gate_enabled;
 
 	/* Mailbox and the management channel */
 	struct mailbox			*mbox;

--- a/src/driver/amdxdna/amdxdna_mailbox.h
+++ b/src/driver/amdxdna/amdxdna_mailbox.h
@@ -82,7 +82,8 @@ void xdna_mailbox_destroy(struct mailbox *mailbox);
 
 enum xdna_mailbox_channel_type {
 	MB_CHANNEL_MGMT = 0,
-	MB_CHANNEL_USER,
+	MB_CHANNEL_USER_NORMAL,
+	MB_CHANNEL_USER_POLL,
 	MB_CHANNEL_MAX_TYPE,
 };
 
@@ -158,8 +159,5 @@ int xdna_mailbox_info_show(struct mailbox *mailbox,
 int xdna_mailbox_ringbuf_show(struct mailbox *mailbox,
 			      struct seq_file *m);
 #endif
-#ifdef AMDXDNA_DEVEL
-bool xdna_mailbox_is_upoll(struct mailbox_channel *mailbox_chann);
-int xdna_mailbox_get_response(struct mailbox_channel *mailbox_chann);
-#endif
+
 #endif /* _AIE2_MAILBOX_ */

--- a/src/driver/amdxdna/amdxdna_mailbox.h
+++ b/src/driver/amdxdna/amdxdna_mailbox.h
@@ -80,6 +80,12 @@ struct mailbox *xdna_mailbox_create(struct device *dev,
  */
 void xdna_mailbox_destroy(struct mailbox *mailbox);
 
+enum xdna_mailbox_channel_type {
+	MB_CHANNEL_MGMT = 0,
+	MB_CHANNEL_USER,
+	MB_CHANNEL_MAX_TYPE,
+};
+
 /*
  * xdna_mailbox_create_channel() -- Create a mailbox channel instance
  *
@@ -88,6 +94,7 @@ void xdna_mailbox_destroy(struct mailbox *mailbox);
  * @i2x: firmware to host mailbox resources
  * @xdna_mailbox_intr_reg: register addr of MSI-X interrupt
  * @mb_irq: Linux IRQ number associated with mailbox MSI-X interrupt vector index
+ * @type: Type of channel
  *
  * Return: If success, return a handle of mailbox channel. Otherwise, return NULL.
  */
@@ -96,7 +103,7 @@ xdna_mailbox_create_channel(struct mailbox *mailbox,
 			    const struct xdna_mailbox_chann_res *x2i,
 			    const struct xdna_mailbox_chann_res *i2x,
 			    u32 xdna_mailbox_intr_reg,
-			    int mb_irq);
+			    int mb_irq, enum xdna_mailbox_channel_type type);
 
 /*
  * xdna_mailbox_destroy_channel() -- destroy mailbox channel
@@ -151,5 +158,8 @@ int xdna_mailbox_info_show(struct mailbox *mailbox,
 int xdna_mailbox_ringbuf_show(struct mailbox *mailbox,
 			      struct seq_file *m);
 #endif
-
+#ifdef AMDXDNA_DEVEL
+bool xdna_mailbox_is_upoll(struct mailbox_channel *mailbox_chann);
+int xdna_mailbox_get_response(struct mailbox_channel *mailbox_chann);
+#endif
 #endif /* _AIE2_MAILBOX_ */

--- a/src/include/uapi/drm_local/amdxdna_accel.h
+++ b/src/include/uapi/drm_local/amdxdna_accel.h
@@ -461,6 +461,7 @@ enum amdxdna_power_mode_type {
 	POWER_MODE_LOW,     /**< Set frequency to lowest DPM */
 	POWER_MODE_MEDIUM,  /**< Set frequency to medium DPM */
 	POWER_MODE_HIGH,    /**< Set frequency to highest DPM */
+	POWER_MODE_TURBO,   /**< More power, more performance */
 };
 
 /**

--- a/src/shim/hwq.h
+++ b/src/shim/hwq.h
@@ -21,6 +21,9 @@ public:
   submit_command(xrt_core::buffer_handle *) override;
 
   int
+  poll_command(xrt_core::buffer_handle *) const override;
+
+  int
   wait_command(xrt_core::buffer_handle *, uint32_t timeout_ms) const override;
 
   void

--- a/test/shim_test/io_param.h
+++ b/test/shim_test/io_param.h
@@ -14,6 +14,9 @@ struct io_test_parameter {
 #define IO_TEST_NOOP_RUN      1
 #define IO_TEST_BAD_RUN       2
   int type;
+#define IO_TEST_IOCTL_WAIT    0
+#define IO_TEST_POLL_WAIT     1
+  int wait;
   bool debug;
 };
 

--- a/test/shim_test/io_test.cpp
+++ b/test/shim_test/io_test.cpp
@@ -83,20 +83,12 @@ io_test_init_runlist_cmd(bo* cmd_bo, std::vector<bo*>& cmd_bos)
   }
 }
 
-#define IO_TEST_TIMEOUT 5000 /* millisecond */
-
 void io_test_cmd_wait(hwqueue_handle *hwq, std::shared_ptr<bo> bo)
 {
     if (io_test_parameters.wait == IO_TEST_POLL_WAIT) {
-        auto start = clk::now();
-        while(!hwq->poll_command(bo->get())) {
-            auto now = clk::now();
-            auto elapsed = std::chrono::duration_cast<ms_t>(now - start).count();
-            if (elapsed > IO_TEST_TIMEOUT)
-                throw std::runtime_error("Polling timeout");
-        }
+        while(!hwq->poll_command(bo->get()));
     } else {
-        hwq->wait_command(bo->get(), IO_TEST_TIMEOUT);
+        hwq->wait_command(bo->get(), 0);
     }
 }
 

--- a/test/shim_test/shim_test.cpp
+++ b/test/shim_test/shim_test.cpp
@@ -29,9 +29,9 @@ using arg_type = const std::vector<uint64_t>;
 void TEST_export_import_bo(device::id_type, std::shared_ptr<device>, arg_type&);
 void TEST_io(device::id_type, std::shared_ptr<device>, arg_type&);
 void TEST_io_latency(device::id_type, std::shared_ptr<device>, arg_type&);
-void TEST_io_runlist_latency(device::id_type, std::shared_ptr<device>, arg_type&);
-void TEST_io_e_throughput(device::id_type, std::shared_ptr<device>, arg_type&);
 void TEST_io_throughput(device::id_type, std::shared_ptr<device>, arg_type&);
+void TEST_io_runlist_latency(device::id_type, std::shared_ptr<device>, arg_type&);
+void TEST_io_runlist_throughput(device::id_type, std::shared_ptr<device>, arg_type&);
 void TEST_noop_io_with_dup_bo(device::id_type, std::shared_ptr<device>, arg_type&);
 void TEST_shim_umq_vadd(device::id_type, std::shared_ptr<device>, arg_type&);
 void TEST_shim_umq_memtiles(device::id_type, std::shared_ptr<device>, arg_type&);
@@ -521,10 +521,10 @@ std::vector<test_case> test_list {
     TEST_POSITIVE, dev_filter_is_aie2, TEST_io, { IO_TEST_NORMAL_RUN, 1 }
   },
   test_case{ "measure no-op kernel latency",
-    TEST_POSITIVE, dev_filter_is_aie2, TEST_io_latency, { IO_TEST_NOOP_RUN }
+    TEST_POSITIVE, dev_filter_is_aie2, TEST_io_latency, { IO_TEST_NOOP_RUN, IO_TEST_IOCTL_WAIT, 32000 }
   },
   test_case{ "measure real kernel latency",
-    TEST_POSITIVE, dev_filter_is_aie2, TEST_io_latency, { IO_TEST_NORMAL_RUN }
+    TEST_POSITIVE, dev_filter_is_aie2, TEST_io_latency, { IO_TEST_NORMAL_RUN, IO_TEST_IOCTL_WAIT, 32000 }
   },
   test_case{ "create and free debug bo",
     TEST_POSITIVE, dev_filter_is_aie2, TEST_create_free_debug_bo, { 0x1000 }
@@ -536,7 +536,7 @@ std::vector<test_case> test_list {
     TEST_POSITIVE, dev_filter_is_aie2, TEST_io, { IO_TEST_NORMAL_RUN, 3 }
   },
   test_case{ "measure no-op kernel throughput listed command",
-    TEST_POSITIVE, dev_filter_is_aie2, TEST_io_throughput, { IO_TEST_NOOP_RUN }
+    TEST_POSITIVE, dev_filter_is_aie2, TEST_io_runlist_throughput, { IO_TEST_NOOP_RUN, IO_TEST_IOCTL_WAIT, 32000 }
   },
   test_case{ "npu3 shim vadd",
     TEST_POSITIVE, dev_filter_is_aie4, TEST_shim_umq_vadd, {}
@@ -565,11 +565,23 @@ std::vector<test_case> test_list {
   test_case{ "io test no op with duplicated BOs",
     TEST_POSITIVE, dev_filter_is_aie2, TEST_noop_io_with_dup_bo, {}
   },
-  test_case{ "io test no-op kernel latency listed command",
-    TEST_POSITIVE, dev_filter_is_aie2, TEST_io_runlist_latency, { IO_TEST_NOOP_RUN }
+  test_case{ "measure no-op kernel latency listed command",
+    TEST_POSITIVE, dev_filter_is_aie2, TEST_io_runlist_latency, { IO_TEST_NOOP_RUN, IO_TEST_IOCTL_WAIT, 32000 }
   },
   test_case{ "measure no-op kernel throuput",
-    TEST_POSITIVE, dev_filter_is_aie2, TEST_io_e_throughput, { IO_TEST_NOOP_RUN }
+    TEST_POSITIVE, dev_filter_is_aie2, TEST_io_throughput, { IO_TEST_NOOP_RUN, IO_TEST_IOCTL_WAIT, 32000 }
+  },
+  test_case{ "measure no-op kernel latency (polling)",
+    TEST_POSITIVE, dev_filter_is_aie2, TEST_io_latency, { IO_TEST_NOOP_RUN, IO_TEST_POLL_WAIT, 32000 }
+  },
+  test_case{ "measure no-op kernel throuput (polling)",
+    TEST_POSITIVE, dev_filter_is_aie2, TEST_io_throughput, { IO_TEST_NOOP_RUN, IO_TEST_POLL_WAIT, 32000 }
+  },
+  test_case{ "measure no-op kernel latency listed command (polling)",
+    TEST_POSITIVE, dev_filter_is_aie2, TEST_io_runlist_latency, { IO_TEST_NOOP_RUN, IO_TEST_POLL_WAIT, 32000 }
+  },
+  test_case{ "measure no-op kernel throughput listed command (polling)",
+    TEST_POSITIVE, dev_filter_is_aie2, TEST_io_runlist_throughput, { IO_TEST_NOOP_RUN, IO_TEST_POLL_WAIT, 32000 }
   },
 };
 

--- a/test/shim_test/speed.h
+++ b/test/shim_test/speed.h
@@ -7,6 +7,7 @@
 #include <chrono>
 
 using clk = std::chrono::high_resolution_clock;
+using ms_t = std::chrono::milliseconds;
 using us_t = std::chrono::microseconds;
 using ns_t = std::chrono::nanoseconds;
 

--- a/tools/info.json
+++ b/tools/info.json
@@ -1,7 +1,7 @@
 {
 	"copyright": "Copyright (C) 2023-2024 Advanced Micro Devices, Inc. All rights reserved.",
 	"xrt" : {
-		"version": "202420.2.18.101",
+		"version": "202420.2.18.134",
 		"os_rel": "22.04"
 	},
 	"firmwares": [


### PR DESCRIPTION
1. Mailbox channel support three types: MGMT, USER_NORMAL and USER_POLL
- MGMT channel is interrupt based and good for not critical path.
- USER_NORMAL channel is interrupt based and good for critical path.
- USER_POLL channel is polling based and good for critical path which needs the best latency.
2. Support "xrt-smi configure --pmode turbo"
- Only when no context is opened, change pmode from/to turbo are allowed.
- In turbo mode, all contexts are creating USER_POLL mailbox channel for best latency.  
3. Support hwq::poll_command() in shim
4. Add shim_test for polling

|  test name  |  ID (wait in ioctl)   |   ID (polling)  |
|---------|------------------|-----------|
| latency           | 25 | 41 |
| throughput    | 40 | 42 |
| runlist latency | 39 | 43 |
| runlist throughput | 30 | 44 |