### PR TITLE
Add aie2_control_flags and some bug fix

### DIFF
--- a/src/driver/amdxdna/aie2_pci.c
+++ b/src/driver/amdxdna/aie2_pci.c
@@ -21,9 +21,16 @@
 #include "aie2_internal.h"
 #endif
 
-int aie2_max_col = XRS_MAX_COL;
-module_param(aie2_max_col, int, 0600);
+uint aie2_max_col = XRS_MAX_COL;
+module_param(aie2_max_col, uint, 0600);
 MODULE_PARM_DESC(aie2_max_col, "Maximum column could be used");
+
+uint aie2_control_flags;
+module_param(aie2_control_flags, uint, 0400);
+MODULE_PARM_DESC(aie2_control_flags,
+		 " Bit " __stringify(AIE2_BIT_BYPASS_POWER_SWITCH) ": Bypass power on/off,"
+		 " Bit " __stringify(AIE2_BIT_BYPASS_SET_FREQ) ": Bypass set freq,"
+		 " Bit " __stringify(AIE2_BIT_BYPASS_FW_LOAD) ": Bypass FW loading");
 
 /*
  * The management mailbox channel is allocated by firmware.
@@ -477,6 +484,7 @@ static int aie2_init(struct amdxdna_dev *xdna)
 	void __iomem * const *tbl;
 	int i, bars, nvec, ret;
 
+	XDNA_DBG(xdna, "Control flags 0x%x", aie2_control_flags);
 	ndev = devm_kzalloc(&pdev->dev, sizeof(*ndev), GFP_KERNEL);
 	if (!ndev)
 		return -ENOMEM;

--- a/src/driver/amdxdna/aie2_pci.h
+++ b/src/driver/amdxdna/aie2_pci.h
@@ -282,7 +282,6 @@ int aie2_check_protocol(struct amdxdna_dev_hdl *ndev, u32 fw_major, u32 fw_minor
 void aie2_smu_setup(struct amdxdna_dev_hdl *ndev);
 int aie2_smu_start(struct amdxdna_dev_hdl *ndev);
 void aie2_smu_stop(struct amdxdna_dev_hdl *ndev);
-int aie2_smu_set_clock_freq(struct amdxdna_dev_hdl *ndev, struct clock *clock, u32 freq_mhz);
 char *aie2_smu_get_mpnpu_clock_name(struct amdxdna_dev_hdl *ndev);
 char *aie2_smu_get_hclock_name(struct amdxdna_dev_hdl *ndev);
 int aie2_smu_get_mpnpu_clock_freq(struct amdxdna_dev_hdl *ndev);
@@ -292,7 +291,6 @@ int aie2_smu_set_power_off(struct amdxdna_dev_hdl *ndev);
 int aie2_smu_get_power_state(struct amdxdna_dev_hdl *ndev);
 int aie2_smu_get_dpm_level(struct amdxdna_dev_hdl *ndev);
 int aie2_smu_set_dpm_level(struct amdxdna_dev_hdl *ndev, u32 dpm_level);
-void aie2_smu_prepare_s0i3(struct amdxdna_dev_hdl *ndev);
 
 /* aie2_psp.c */
 struct psp_device *aie2m_psp_create(struct device *dev, struct psp_config *conf);

--- a/src/driver/amdxdna/aie2_smu.c
+++ b/src/driver/amdxdna/aie2_smu.c
@@ -10,12 +10,21 @@
 /* SMU commands */
 #define AIE2_SMU_POWER_ON		0x3
 #define AIE2_SMU_POWER_OFF		0x4
+/* For SMU v0 */
 #define AIE2_SMU_SET_MPNPUCLK_FREQ	0x5
 #define AIE2_SMU_SET_HCLK_FREQ		0x6
+/* For SMU v1 */
 #define AIE2_SMU_SET_SOFT_DPMLEVEL	0x7
 #define AIE2_SMU_SET_HARD_DPMLEVEL	0x8
 
-static int aie2_smu_exec(struct amdxdna_dev_hdl *ndev, u32 reg_cmd, u32 reg_arg)
+/* This is a hack for NPU1 device */
+const struct dpm_clk npu1_hack_dpm_clk_table[] = {
+	{400, 800},
+	{600, 1024},
+};
+
+static int aie2_smu_exec(struct amdxdna_dev_hdl *ndev, u32 reg_cmd,
+			 u32 reg_arg, u32 *out)
 {
 	u32 resp;
 	int ret;
@@ -35,6 +44,9 @@ static int aie2_smu_exec(struct amdxdna_dev_hdl *ndev, u32 reg_cmd, u32 reg_arg)
 		return ret;
 	}
 
+	if (out)
+		*out = readl(SMU_REG(ndev, SMU_OUT_REG));
+
 	if (resp != SMU_RESULT_OK) {
 		XDNA_ERR(ndev->xdna, "SMU cmd %d failed, 0x%x", reg_cmd, resp);
 		return -EINVAL;
@@ -48,7 +60,7 @@ static int aie2_smu_update_clock_freq(struct amdxdna_dev_hdl *ndev, u32 cmd,
 {
 	int ret;
 
-	ret = aie2_smu_exec(ndev, cmd, freq_mhz);
+	ret = aie2_smu_exec(ndev, cmd, freq_mhz, NULL);
 	if (ret)
 		return ret;
 
@@ -82,14 +94,6 @@ int aie2_smu_set_clock_freq(struct amdxdna_dev_hdl *ndev,
 	if (freq_mhz == clock->freq_mhz)
 		return 0;
 
-#if defined(CONFIG_DEBUG_FS)
-	/* If freq is set by debugfs, respect it until debugfs write freq 0 */
-	if (clock->dbg_freq_mhz && freq_mhz != clock->dbg_freq_mhz) {
-		XDNA_DBG(ndev->xdna, "%s debug freq %d, ignore target freq %d",
-			 clock->name, clock->dbg_freq_mhz, freq_mhz);
-		return 0;
-	}
-#endif
 	ret = aie2_smu_update_clock_freq(ndev, smu_cmd, clock, freq_mhz);
 	if (ret)
 		return ret;
@@ -120,23 +124,23 @@ char *aie2_smu_get_hclock_name(struct amdxdna_dev_hdl *ndev)
 
 static int aie2_smu_set_dpm_level_v0(struct amdxdna_dev_hdl *ndev, u32 dpm_level)
 {
-	int ret;
-	const struct dpm_clk *dpm_entry = SMU_NPU_DPM_TABLE_ENTRY(ndev, dpm_level);
+	const struct dpm_clk *dpm_entry = SMU_DPM_TABLE_ENTRY(ndev, dpm_level);
 	struct clock *clk;
+	int ret;
 
 	clk = &ndev->smu.mp_npu_clock;
-
 	ret = aie2_smu_set_clock_freq(ndev, clk, dpm_entry->npuclk);
 	if (ret) {
-		XDNA_ERR(ndev->xdna, "setting npu clk failed for dpm level %d, ret: %d", dpm_level, ret);
+		XDNA_ERR(ndev->xdna, "setting npu clk failed for dpm level %d, ret: %d",
+			 dpm_level, ret);
 		return ret;
 	}
 
 	clk = &ndev->smu.h_clock;
-
 	ret = aie2_smu_set_clock_freq(ndev, clk, dpm_entry->hclk);
 	if (ret) {
-		XDNA_ERR(ndev->xdna, "setting hclk failed for dpm level %d, ret: %d", dpm_level, ret);
+		XDNA_ERR(ndev->xdna, "setting hclk failed for dpm level %d, ret: %d",
+			 dpm_level, ret);
 		return ret;
 	}
 
@@ -147,13 +151,13 @@ static int aie2_smu_set_dpm_level_v1(struct amdxdna_dev_hdl *ndev, u32 dpm_level
 {
 	int ret;
 
-	ret = aie2_smu_exec(ndev, AIE2_SMU_SET_HARD_DPMLEVEL, dpm_level);
+	ret = aie2_smu_exec(ndev, AIE2_SMU_SET_HARD_DPMLEVEL, dpm_level, NULL);
 	if (!ret)
 		XDNA_INFO_ONCE(ndev->xdna, "Set hard dpm level = %d", dpm_level);
 	else
 		return ret;
 
-	ret = aie2_smu_exec(ndev, AIE2_SMU_SET_SOFT_DPMLEVEL, dpm_level);
+	ret = aie2_smu_exec(ndev, AIE2_SMU_SET_SOFT_DPMLEVEL, dpm_level, NULL);
 	if (!ret)
 		XDNA_INFO_ONCE(ndev->xdna, "Set soft dpm level = %d", dpm_level);
 
@@ -168,6 +172,11 @@ int aie2_smu_get_dpm_level(struct amdxdna_dev_hdl *ndev)
 int aie2_smu_set_dpm_level(struct amdxdna_dev_hdl *ndev, u32 dpm_level)
 {
 	int ret;
+
+	if (aie2_control_flags && BIT(AIE2_BIT_BYPASS_SET_FREQ)) {
+		XDNA_DBG(ndev->xdna, "Bypassed set dpm level");
+		return 0;
+	}
 
 	if (dpm_level > SMU_DPM_MAX(ndev))
 		return -EINVAL;
@@ -189,7 +198,7 @@ int aie2_smu_set_power_on(struct amdxdna_dev_hdl *ndev)
 {
 	int ret;
 
-	ret = aie2_smu_exec(ndev, AIE2_SMU_POWER_ON, 0);
+	ret = aie2_smu_exec(ndev, AIE2_SMU_POWER_ON, 0, NULL);
 	if (ret)
 		return ret;
 
@@ -201,7 +210,7 @@ int aie2_smu_set_power_off(struct amdxdna_dev_hdl *ndev)
 {
 	int ret;
 
-	ret = aie2_smu_exec(ndev, AIE2_SMU_POWER_OFF, 0);
+	ret = aie2_smu_exec(ndev, AIE2_SMU_POWER_OFF, 0, NULL);
 	if (ret)
 		return ret;
 
@@ -217,7 +226,6 @@ int aie2_smu_get_power_state(struct amdxdna_dev_hdl *ndev)
 int aie2_smu_start(struct amdxdna_dev_hdl *ndev)
 {
 	struct smu *smu = &ndev->smu;
-	u32 freq_mhz;
 	int ret;
 
 	ret = aie2_smu_set_power_on(ndev);
@@ -226,30 +234,10 @@ int aie2_smu_start(struct amdxdna_dev_hdl *ndev)
 		return ret;
 	}
 
-	freq_mhz = smu->mp_npu_clock.freq_mhz;
-	ret = aie2_smu_update_clock_freq(ndev, AIE2_SMU_SET_MPNPUCLK_FREQ,
-					 &smu->mp_npu_clock, freq_mhz);
+	ret = aie2_smu_set_dpm_level(ndev, smu->curr_dpm_level);
 	if (ret) {
-		XDNA_ERR(ndev->xdna, "Set mpnpu clk freq failed, ret %d", ret);
+		XDNA_ERR(ndev->xdna, "Set dpm level failed, ret %d", ret);
 		return ret;
-	}
-	XDNA_INFO_ONCE(ndev->xdna, "Set %s = %d mhz", smu->mp_npu_clock.name, freq_mhz);
-
-	freq_mhz = smu->h_clock.freq_mhz;
-	ret = aie2_smu_update_clock_freq(ndev, AIE2_SMU_SET_HCLK_FREQ,
-					 &smu->h_clock, freq_mhz);
-	if (ret) {
-		XDNA_ERR(ndev->xdna, "Set hclk freq failed, ret %d", ret);
-		return ret;
-	}
-	XDNA_INFO_ONCE(ndev->xdna, "Set %s = %d mhz", smu->h_clock.name, freq_mhz);
-
-	if (SMU_DPM_MAX(ndev) > 0) {
-		ret = aie2_smu_set_dpm_level(ndev, smu->curr_dpm_level);
-		if (ret) {
-			XDNA_ERR(ndev->xdna, "Set dpm level failed, ret %d", ret);
-			return ret;
-		}
 	}
 
 	return 0;
@@ -257,24 +245,11 @@ int aie2_smu_start(struct amdxdna_dev_hdl *ndev)
 
 void aie2_smu_prepare_s0i3(struct amdxdna_dev_hdl *ndev)
 {
-	u32 freq_mhz;
 	int ret;
 
-	freq_mhz = 400;
-	ret = aie2_smu_exec(ndev, AIE2_SMU_SET_MPNPUCLK_FREQ, freq_mhz);
+	ret = aie2_smu_set_dpm_level(ndev, 0);
 	if (ret)
-		XDNA_ERR(ndev->xdna, "Set mpnpu clk freq %d mhz failed, ret %d", freq_mhz, ret);
-
-	freq_mhz = 800;
-	ret = aie2_smu_exec(ndev, AIE2_SMU_SET_HCLK_FREQ, freq_mhz);
-	if (ret)
-		XDNA_ERR(ndev->xdna, "Set hclk freq %d mhz failed, ret %d", freq_mhz, ret);
-
-	if (SMU_DPM_MAX(ndev) > 0) {
-		ret = aie2_smu_set_dpm_level(ndev, 0);
-		if (ret)
-			XDNA_ERR(ndev->xdna, "Set dpm level 0 failed, ret %d", ret);
-	}
+		XDNA_ERR(ndev->xdna, "Set dpm level 0 failed, ret %d", ret);
 }
 
 void aie2_smu_stop(struct amdxdna_dev_hdl *ndev)
@@ -294,13 +269,26 @@ void aie2_smu_setup(struct amdxdna_dev_hdl *ndev)
 	struct smu *smu = &ndev->smu;
 
 	snprintf(smu->mp_npu_clock.name, sizeof(smu->mp_npu_clock.name), "MP-NPU Clock");
-	smu->mp_npu_clock.max_freq_mhz = SMU_MPNPUCLK_FREQ_MAX(ndev);
-
 	snprintf(smu->h_clock.name, sizeof(smu->h_clock.name), "H Clock");
-	smu->h_clock.max_freq_mhz = SMU_HCLK_FREQ_MAX(ndev);
-
-	/* The first time SMU start, it will use below clock frequency */
-	smu->mp_npu_clock.freq_mhz = smu->mp_npu_clock.max_freq_mhz;
-	smu->h_clock.freq_mhz = smu->h_clock.max_freq_mhz;
+	smu->dpm_table = ndev->priv->smu_npu_dpm_clk_table;
+	smu->num_dpm_levels = ndev->priv->smu_npu_dpm_levels;
 	smu->curr_dpm_level = SMU_DPM_MAX(ndev);
+
+	if (!ndev->priv->smu_rev) {
+		u32 npuclk_freq;
+		u32 out;
+
+		/* This is a hack for special NPU1 device */
+		npuclk_freq = SMU_DPM_TABLE_ENTRY(ndev, smu->curr_dpm_level)->npuclk;
+		aie2_smu_exec(ndev, AIE2_SMU_SET_MPNPUCLK_FREQ, npuclk_freq, &out);
+		if (npuclk_freq != out) {
+			XDNA_DBG(ndev->xdna, "Use small DPM table");
+			smu->dpm_table = npu1_hack_dpm_clk_table;
+			smu->num_dpm_levels = ARRAY_SIZE(npu1_hack_dpm_clk_table);
+			smu->curr_dpm_level = SMU_DPM_MAX(ndev);
+		}
+	}
+
+	smu->mp_npu_clock.max_freq_mhz = SMU_DPM_TABLE_ENTRY(ndev, smu->curr_dpm_level)->npuclk;
+	smu->h_clock.max_freq_mhz = SMU_DPM_TABLE_ENTRY(ndev, smu->curr_dpm_level)->hclk;
 }

--- a/src/driver/amdxdna/npu1_regs.c
+++ b/src/driver/amdxdna/npu1_regs.c
@@ -51,9 +51,6 @@
 #define NPU1_RT_CFG_VAL_DEBUG_BO_DEFAULT 0
 #define NPU1_RT_CFG_VAL_DEBUG_BO_LARGE   1
 
-#define NPU1_MPNPUCLK_FREQ_MAX  847
-#define NPU1_HCLK_FREQ_MAX      1600
-
 /*fill in the dpm clock frequencies */
 const struct dpm_clk npu1_dpm_clk_table[] = {
 	{400, 800},
@@ -109,9 +106,6 @@ const struct amdxdna_dev_priv npu1_dev_priv = {
 		.value_enable = NPU1_RT_CFG_VAL_CLK_GATING_ON,
 		.value_disable = NPU1_RT_CFG_VAL_CLK_GATING_OFF,
 	},
-	.smu_mpnpuclk_freq_max = NPU1_MPNPUCLK_FREQ_MAX,
-	.smu_hclk_freq_max     = NPU1_HCLK_FREQ_MAX,
-	.smu_dpm_max           = 7,
 	.smu_rev = SMU_REVISION_V0,
 	.smu_npu_dpm_clk_table = npu1_dpm_clk_table,
 	.smu_npu_dpm_levels = ARRAY_SIZE(npu1_dpm_clk_table),

--- a/src/driver/amdxdna/npu4_family.h
+++ b/src/driver/amdxdna/npu4_family.h
@@ -74,9 +74,6 @@
 #define NPU4_RT_CFG_VAL_DEBUG_BO_DEFAULT 0
 #define NPU4_RT_CFG_VAL_DEBUG_BO_LARGE   1
 
-#define NPU4_MPNPUCLK_FREQ_MAX  1267
-#define NPU4_HCLK_FREQ_MAX      1800
-
 #define NPU4_INIT_RT_CFG_NUM	2
 #define NPU4_CLK_GATING_CFG_NUM 4
 
@@ -118,9 +115,6 @@ extern const u32 npu4_clk_gating_types[NPU4_CLK_GATING_CFG_NUM];
 		.value_enable = NPU4_RT_CFG_VAL_CLK_GATING_ON,					\
 		.value_disable = NPU4_RT_CFG_VAL_CLK_GATING_OFF,				\
 	},											\
-	.smu_mpnpuclk_freq_max = NPU4_MPNPUCLK_FREQ_MAX,					\
-	.smu_hclk_freq_max     = NPU4_HCLK_FREQ_MAX,						\
-	.smu_dpm_max           = 7,								\
 	.smu_rev = SMU_REVISION_V1,								\
 	.smu_npu_dpm_clk_table = npu4_dpm_clk_table,						\
 	.smu_npu_dpm_levels = ARRAY_SIZE(npu4_dpm_clk_table)


### PR DESCRIPTION
1. fix NPU1 clock on dmesg is incorrect issue on specific device.
2. fix NPU4 not able to config DPM level issue.
3. cat dpm_level debugfs node will list all available clocks and selected one.

Some clean up.
1. Remove npuclock and hclock debugfs node. Use dpm_level node instead.
2. In *_regs.c files, remove max freq macro and related data structure.