### PR TITLE
Turn on the SMU before setting the clks

### DIFF
--- a/src/driver/amdxdna/aie2_pci.h
+++ b/src/driver/amdxdna/aie2_pci.h
@@ -20,9 +20,6 @@
 #include "amdxdna_devel.h"
 #endif
 
-#define SMU_REVISION_V0 0x0
-#define SMU_REVISION_V1 0x1
-
 #define AIE2_INTERVAL	20000	/* us */
 #define AIE2_TIMEOUT	1000000	/* us */
 
@@ -82,6 +79,13 @@ enum aie2_smu_reg_idx {
 	SMU_RESP_REG,
 	SMU_OUT_REG,
 	SMU_MAX_REGS /* Kepp this at the end */
+};
+
+enum aie2_smu_rev {
+	SMU_REVISION_NONE = 0,
+	SMU_REVISION_NPU1,
+	SMU_REVISION_NPU4,
+	SMU_REVISION_MAX
 };
 
 enum aie2_sram_reg_idx {

--- a/src/driver/amdxdna/npu1_regs.c
+++ b/src/driver/amdxdna/npu1_regs.c
@@ -106,7 +106,7 @@ const struct amdxdna_dev_priv npu1_dev_priv = {
 		.value_enable = NPU1_RT_CFG_VAL_CLK_GATING_ON,
 		.value_disable = NPU1_RT_CFG_VAL_CLK_GATING_OFF,
 	},
-	.smu_rev = SMU_REVISION_V0,
+	.smu_rev = SMU_REVISION_NPU1,
 	.smu_npu_dpm_clk_table = npu1_dpm_clk_table,
 	.smu_npu_dpm_levels = ARRAY_SIZE(npu1_dpm_clk_table),
 #ifdef AMDXDNA_DEVEL

--- a/src/driver/amdxdna/npu4_family.h
+++ b/src/driver/amdxdna/npu4_family.h
@@ -115,7 +115,7 @@ extern const u32 npu4_clk_gating_types[NPU4_CLK_GATING_CFG_NUM];
 		.value_enable = NPU4_RT_CFG_VAL_CLK_GATING_ON,					\
 		.value_disable = NPU4_RT_CFG_VAL_CLK_GATING_OFF,				\
 	},											\
-	.smu_rev = SMU_REVISION_V1,								\
+	.smu_rev = SMU_REVISION_NPU4,								\
 	.smu_npu_dpm_clk_table = npu4_dpm_clk_table,						\
 	.smu_npu_dpm_levels = ARRAY_SIZE(npu4_dpm_clk_table)
 


### PR DESCRIPTION
For NPU1 there are two revisions that uses different DPM tables. So we are using set clk and retrieving it to decide the revision. But, without turning on the SMU we won't be able to read the proper clk values, so fix that up.