### PR TITLE
add stress test and fix queue full issue

### DIFF
--- a/test/shim_test/umq_tests.cpp
+++ b/test/shim_test/umq_tests.cpp
@@ -134,6 +134,7 @@ TEST_shim_umq_remote_barrier(device::id_type id, std::shared_ptr<device> sdev, c
     }
   }
 }
+
 void
 TEST_shim_umq_ddr_memtile(device::id_type id, std::shared_ptr<device> sdev, const std::vector<uint64_t>& arg)
 {


### PR DESCRIPTION
The stress for xrt::run passed.
The stress for hwctx can only support up to 2 for now due to mpnpu current version is not handling this well yet.