### PR TITLE
fix compilation errors

### DIFF
--- a/src/driver/amdxdna/amdxdna_gem.c
+++ b/src/driver/amdxdna/amdxdna_gem.c
@@ -21,7 +21,7 @@
 
 #define XDNA_MAX_CMD_BO_SIZE	SZ_32K
 
-MODULE_IMPORT_NS(DMA_BUF);
+MODULE_IMPORT_NS("DMA_BUF");
 
 static int
 amdxdna_gem_insert_node_locked(struct amdxdna_gem_obj *abo, bool use_vmap)

--- a/src/driver/amdxdna/amdxdna_gem.c
+++ b/src/driver/amdxdna/amdxdna_gem.c
@@ -21,7 +21,11 @@
 
 #define XDNA_MAX_CMD_BO_SIZE	SZ_32K
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 13, 0)
+MODULE_IMPORT_NS(DMA_BUF);
+#else
 MODULE_IMPORT_NS("DMA_BUF");
+#endif
 
 static int
 amdxdna_gem_insert_node_locked(struct amdxdna_gem_obj *abo, bool use_vmap)

--- a/src/include/uapi/drm_local/amdxdna_accel.h
+++ b/src/include/uapi/drm_local/amdxdna_accel.h
@@ -6,7 +6,11 @@
 #ifndef AMDXDNA_ACCEL_H_
 #define AMDXDNA_ACCEL_H_
 
+#ifdef __KERNEL__
 #include <drm/drm.h>
+#else
+#include <libdrm/drm.h>
+#endif
 #include <linux/const.h>
 #include <linux/stddef.h>
 


### PR DESCRIPTION
Compilation fails for me on Arch Linux x86_64 without these changes:

- put "DMA_BUF" in quotes when importing module
- include `libdrm/drm.h` instead of `dm/drm.h` depending on `__KERNEL__` context