### PR TITLE
throw when creating BO with none flag

### DIFF
--- a/src/shim/kmq/bo.cpp
+++ b/src/shim/kmq/bo.cpp
@@ -13,7 +13,6 @@ flag_to_type(uint64_t bo_flags)
   auto flags = xcl_bo_flags{bo_flags};
   auto boflags = (static_cast<uint32_t>(flags.boflags) << 24);
   switch (boflags) {
-  case XCL_BO_FLAGS_NONE:
   case XCL_BO_FLAGS_HOST_ONLY:
     return AMDXDNA_BO_SHMEM;
   case XCL_BO_FLAGS_CACHEABLE:

--- a/src/shim/kmq/device.cpp
+++ b/src/shim/kmq/device.cpp
@@ -33,8 +33,12 @@ device_kmq::
 alloc_bo(void* userptr, xrt_core::hwctx_handle::slot_id ctx_id,
   size_t size, uint64_t flags)
 {
+  // Sanity check
+  auto f = xcl_bo_flags{flags};
+  if (f.boflags == 0)
+    shim_not_supported_err("unsupported buffer type: none flag");
   if (userptr)
-    shim_not_supported_err("User ptr BO");;
+    shim_not_supported_err("User ptr BO");
 
   return std::make_unique<bo_kmq>(*this, ctx_id, size, flags);
 }

--- a/test/shim_test/shim_test.cpp
+++ b/test/shim_test/shim_test.cpp
@@ -353,7 +353,7 @@ TEST_map_read_bo(device::id_type id, std::shared_ptr<device> sdev, arg_type& arg
 {
   auto dev = sdev.get();
   auto size = static_cast<size_t>(arg[0]);
-  auto bo_hdl = dev->alloc_bo(size, get_bo_flags(XRT_BO_FLAGS_NONE, 0));
+  auto bo_hdl = dev->alloc_bo(size, get_bo_flags(XCL_BO_FLAGS_HOST_ONLY, 0));
 
   auto buf = bo_hdl->map(buffer_handle::map_type::read);
 }
@@ -519,27 +519,27 @@ std::vector<test_case> test_list {
     {XCL_BO_FLAGS_CACHEABLE, 0, 0x2000, 0x400, 0x3000, 0x100}
   },
   test_case{ "create_and_free_input_output_bo 1 pages", {},
-    TEST_POSITIVE, dev_filter_xdna, TEST_create_free_bo, {XCL_BO_FLAGS_NONE, 0, 128}
+    TEST_POSITIVE, dev_filter_xdna, TEST_create_free_bo, {XCL_BO_FLAGS_HOST_ONLY, 0, 128}
   },
   test_case{ "create_and_free_input_output_bo multiple pages", {},
     TEST_POSITIVE, dev_filter_xdna, TEST_create_free_bo,
-    {XCL_BO_FLAGS_NONE, 0, 0x10000, 0x23000, 0x2000}
+    {XCL_BO_FLAGS_HOST_ONLY, 0, 0x10000, 0x23000, 0x2000}
   },
   test_case{ "create_and_free_input_output_bo huge pages", {},
     TEST_POSITIVE, dev_filter_is_aie, TEST_create_free_bo,
-    {XCL_BO_FLAGS_NONE, 0, 0x20000000}
+    {XCL_BO_FLAGS_HOST_ONLY, 0, 0x20000000}
   },
   test_case{ "sync_bo for dpu sequence bo", {},
     TEST_POSITIVE, dev_filter_xdna, TEST_sync_bo, {XCL_BO_FLAGS_CACHEABLE, 0, 128}
   },
   test_case{ "sync_bo for input_output", {},
-    TEST_POSITIVE, dev_filter_xdna, TEST_sync_bo, {XCL_BO_FLAGS_NONE, 0, 128}
+    TEST_POSITIVE, dev_filter_xdna, TEST_sync_bo, {XCL_BO_FLAGS_HOST_ONLY, 0, 128}
   },
   test_case{ "map dpu sequence bo and test perf", {},
     TEST_POSITIVE, dev_filter_xdna, TEST_map_bo, {XCL_BO_FLAGS_CACHEABLE, 0, 361264 /*0x10000*/}
   },
   test_case{ "map input_output bo and test perf", {},
-    TEST_POSITIVE, dev_filter_xdna, TEST_map_bo, {XCL_BO_FLAGS_NONE, 0, 361264}
+    TEST_POSITIVE, dev_filter_xdna, TEST_map_bo, {XCL_BO_FLAGS_HOST_ONLY, 0, 361264}
   },
   test_case{ "map bo for read only", {},
     TEST_NEGATIVE, dev_filter_xdna, TEST_map_read_bo, {0x1000}
@@ -624,10 +624,10 @@ std::vector<test_case> test_list {
     TEST_POSITIVE, dev_filter_is_aie2, TEST_cmd_fence_device, {}
   },
   test_case{ "sync_bo for input_output 1MiB BO", {},
-    TEST_POSITIVE, dev_filter_xdna, TEST_sync_bo, {XCL_BO_FLAGS_NONE, 0, 0x100000}
+    TEST_POSITIVE, dev_filter_xdna, TEST_sync_bo, {XCL_BO_FLAGS_HOST_ONLY, 0, 0x100000}
   },
   test_case{ "sync_bo for input_output 1MiB BO w/ offset and size", {},
-    TEST_POSITIVE, dev_filter_xdna, TEST_sync_bo_off_size, {XCL_BO_FLAGS_NONE, 0, 0x100000, 0x1004, 0x3c}
+    TEST_POSITIVE, dev_filter_xdna, TEST_sync_bo_off_size, {XCL_BO_FLAGS_HOST_ONLY, 0, 0x100000, 0x1004, 0x3c}
   },
 };
 


### PR DESCRIPTION
When user application tries to create BO without specifying any flag, we throw exactly for this reason.