### PR TITLE
Addition of xrt_smi_configuration.json to xdna tools

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,3 +45,12 @@ install(FILES ${amdxdna_tools}
   DESTINATION xrt/${XDNA_COMPONENT}
   COMPONENT ${XDNA_COMPONENT}
   )
+
+set(amdxdna_xrt_smi_config
+  ${CMAKE_CURRENT_SOURCE_DIR}/tools/xrt_smi_config.json
+  )
+install(FILES ${amdxdna_xrt_smi_config}
+  PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE
+  DESTINATION xrt/${XDNA_COMPONENT}
+  COMPONENT ${XDNA_COMPONENT}
+  )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,12 +45,3 @@ install(FILES ${amdxdna_tools}
   DESTINATION xrt/${XDNA_COMPONENT}
   COMPONENT ${XDNA_COMPONENT}
   )
-
-set(amdxdna_xrt_smi_config
-  ${CMAKE_CURRENT_SOURCE_DIR}/tools/xrt_smi_config.json
-  )
-install(FILES ${amdxdna_xrt_smi_config}
-  PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE
-  DESTINATION xrt/${XDNA_COMPONENT}
-  COMPONENT ${XDNA_COMPONENT}
-  )

--- a/WHENCE
+++ b/WHENCE
@@ -14,5 +14,6 @@ File:
 	tools/bins/17f0_11/validate.xclbin
 	tools/bins/17f0_20/validate.xclbin
 	tools/bins/elf/nop.elf
+	src/tools/xrt_smi_config.json
 
 Licence: Redistributable. See LICENSE.amdnpu for details.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -3,3 +3,13 @@
 
 add_subdirectory(driver)
 add_subdirectory(shim)
+
+set(amdxdna_xrt_smi_config
+  ${CMAKE_CURRENT_SOURCE_DIR}/tools/xrt_smi_config.json
+  )
+install(FILES ${amdxdna_xrt_smi_config}
+  PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE
+  DESTINATION xrt/${XDNA_COMPONENT}
+  COMPONENT ${XDNA_COMPONENT}
+  )
+  

--- a/src/shim/device.cpp
+++ b/src/shim/device.cpp
@@ -585,6 +585,37 @@ struct sensor_info
   }
 };
 
+/* This structure can be extended to provide
+*  other configurations supporting xrt-smi
+*/
+struct xrt_smi_config
+{
+  static std::any
+  get(const xrt_core::device* /*device*/, key_type key)
+  {
+    throw xrt_core::query::no_such_key(key, "Not implemented");
+  }
+
+  static std::any
+  get(const xrt_core::device* device, key_type key, const std::any& param)
+  {
+    if (key != key_type::xrt_smi_config)
+      throw xrt_core::query::no_such_key(key, "Not implemented");
+
+    const auto& pcie_id = xrt_core::device_query<xrt_core::query::pcie_id>(device);
+
+    std::string xrt_smi_config_name;
+    const auto xrt_smi_config_type = std::any_cast<xrt_core::query::xrt_smi_config::type>(param);
+    switch (xrt_smi_config_type) {
+    case xrt_core::query::xrt_smi_config::type::options_config:
+      xrt_smi_config_name = "xrt_smi_config.json";
+      break;
+    }
+
+    return boost::str(boost::format(xrt_smi_config_name));
+  }
+};
+
 struct xclbin_name
 {
   static std::any
@@ -812,6 +843,7 @@ initialize_query_table()
   emplace_func1_request<query::sequence_name,                  sequence_name>();
   emplace_func1_request<query::elf_name,		       elf_name>();
   emplace_func1_request<query::xclbin_name,                    xclbin_name>();
+  emplace_func1_request<query::xrt_smi_config,                 xrt_smi_config>();
   emplace_func0_request<query::firmware_version,               firmware_version>();
 }
 

--- a/src/tools/xrt_smi_config.json
+++ b/src/tools/xrt_smi_config.json
@@ -1,4 +1,5 @@
-"subcommands":
+{
+  "subcommands":
   [{
     "name" : "validate",
     "description" : "Validates the given device by executing the platform's validate executable.",

--- a/tools/info.json
+++ b/tools/info.json
@@ -1,7 +1,7 @@
 {
 	"copyright": "Copyright (C) 2023-2024 Advanced Micro Devices, Inc. All rights reserved.",
 	"xrt" : {
-		"version": "202510.2.19.52",
+		"version": "202510.2.19.72",
 		"os_rel": ["22.04", "24.04"]
 	},
 	"firmwares": [

--- a/tools/xrt_smi_config.json
+++ b/tools/xrt_smi_config.json
@@ -1,0 +1,193 @@
+"subcommands":
+  [{
+    "name" : "validate",
+    "description" : "Validates the given device by executing the platform's validate executable.",
+    "tag" : "basic",
+    "options" :
+    [
+      {
+        "name": "device",
+        "alias": "d",
+        "description": "The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest",
+        "tag": "basic",
+        "default_value": "",
+        "option_type": "common", 
+        "value_type" : "string"
+      },
+      {
+        "name": "format",
+        "alias": "f",
+        "description": "Report output format",
+        "tag": "basic",
+        "default_value": "JSON",
+        "option_type": "common", 
+        "value_type" : "string"
+      },
+      {
+        "name": "output",
+        "alias": "o",
+        "description" : "Direct the output to the given file",
+        "tag": "basic",
+        "default_value": "",
+        "option_type": "common", 
+        "value_type" : "string"
+      },
+      {
+        "name": "help",
+        "alias": "h",
+        "description" : "Help to use this sub-command",
+        "tag": "basic",
+        "default_value": "",
+        "option_type": "common", 
+        "value_type" : "none"
+      },
+      {
+        "name" : "run",
+        "alias" : "r",
+        "description" : "Run a subset of the test suite",
+        "tag" : "basic",
+        "option_type": "common",
+        "value_type" : "array",
+        "options" : [
+          {
+            "name" : "latency",
+            "tag" : "basic",
+            "description" : "Run end-to-end latency test"
+          },
+          {
+            "name" : "throughput",
+            "tag" : "basic",
+            "description" : "Run end-to-end throughput test"
+          },
+          {
+            "name" : "cmd-chain-latency",
+            "tag" : "basic",
+            "description" : "Run command chain latency test"
+          },
+          {
+            "name" : "cmd-chain-throughput",
+            "tag" : "basic",
+            "description" : "Run end-to-end throughput test using command chaining"
+          },
+          {
+            "name" : "df-bw",
+            "tag" : "basic",
+            "description" : "Run dataflow bandwidth test"
+          },
+          {
+            "name" : "tct-one-col",
+            "tag" : "basic",
+            "description" : "Run TCT test with one column"
+          },
+          {
+            "name" : "tct-all-col",
+            "tag" : "basic",
+            "description" : "Run TCT test with all columns"
+          },
+          {
+            "name" : "gemm",
+            "tag" : "basic",
+            "description" : "Run GEMM test"
+          },
+          {
+            "name" : "aie-reconfig-overhead",
+            "tag" : "advanced",
+            "description" : "Run AIE reconfiguration overhead test"
+          },
+          {
+            "name" : "spatial-sharing-overhead",
+            "tag" : "advanced",
+            "description" : "Run spatial sharing overhead test"
+          },
+          {
+            "name" : "temporal-sharing-overhead",
+            "tag" : "advanced",
+            "description" : "Run temporal sharing overhead test"
+          }
+        ]
+      },
+      {
+        "name" : "path",
+        "alias" : "p",
+        "description" : "Path to the directory containing validate xclbins",
+        "tag" : "basic",
+        "default_value": "",
+        "option_type": "hidden",
+        "value_type" : "string"
+      },
+      {
+        "name" : "param",
+        "description" : "Extended parameter for a given test. Format: <test-name>:<key>:<value>",
+        "tag" : "basic",
+        "option_type": "hidden",
+        "default_value": "",
+        "value_type" : "string"
+      },
+      {
+        "name" : "pmode",
+        "description" : "Specify which power mode to run the benchmarks in. Note: Some tests might be unavailable for some modes",
+        "tag" : "basic",
+        "option_type": "hidden",
+        "default_value": "",
+        "value_type" : "string"
+      }
+    ]
+  },
+  {
+    "name" : "examine",
+    "tag" : "basic",
+    "description": "This command will 'examine' the state of the system/device and will generate a report of interest in a text or JSON format.",
+    "options":
+    [
+      {
+        "name": "device",
+        "description": "The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest",
+        "tag": "devl",
+        "value_type": "string"
+      },
+      {
+        "name": "format",
+        "description": "Report output format",
+        "tag": "devl",
+        "value_type": "string"
+      },
+      {
+        "name": "report",
+        "description": "The type of report to be produced. Reports currently available are:",
+        "tag": "basic",
+        "options": [
+          {
+            "name": "aie-partitions",
+            "tag": "basic",
+            "description": "AIE partition information"
+          },
+          {
+            "name": "telemetry",
+            "tag": "devl",
+            "description": "Telemetry data for the device"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "name" : "configure",
+    "tag" : "devl",
+    "description" : "Device and host configuration.",
+    "options" :
+    [
+      {
+        "name": "device",
+        "description": "The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest",
+        "tag": "devl",
+        "value_type" : "string"
+      },
+      {
+        "name": "pmode",
+        "description": "Modes: default, powersaver, balanced, performance, turbo",
+        "tag": "basic",
+        "value_type": "string"
+      }
+    ]
+  }]
+}


### PR DESCRIPTION
This PR adds the xrt_smi_configuration.json to xdna tools and adds a new query object in ishim to provide the path to it at run-time.
This is required for xrt-smi architectural change that we plan to do for https://jira.xilinx.com/browse/VITIS-13804. 