### PR TITLE
Change xrt_smi_config query type to a string returning type

### DIFF
--- a/WHENCE
+++ b/WHENCE
@@ -14,6 +14,5 @@ File:
 	tools/bins/17f0_11/validate.xclbin
 	tools/bins/17f0_20/validate.xclbin
 	tools/bins/elf/nop.elf
-	src/tools/xrt_smi_config.json
 
 Licence: Redistributable. See LICENSE.amdnpu for details.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -3,13 +3,3 @@
 
 add_subdirectory(driver)
 add_subdirectory(shim)
-
-set(amdxdna_xrt_smi_config
-  ${CMAKE_CURRENT_SOURCE_DIR}/tools/xrt_smi_config.json
-  )
-install(FILES ${amdxdna_xrt_smi_config}
-  PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE
-  DESTINATION xrt/${XDNA_COMPONENT}
-  COMPONENT ${XDNA_COMPONENT}
-  )
-  

--- a/src/shim/device.cpp
+++ b/src/shim/device.cpp
@@ -5,6 +5,7 @@
 #include "device.h"
 #include "hwctx.h"
 #include "fence.h"
+#include "smi.h"
 
 #include "core/common/query_requests.h"
 
@@ -604,15 +605,15 @@ struct xrt_smi_config
 
     const auto& pcie_id = xrt_core::device_query<xrt_core::query::pcie_id>(device);
 
-    std::string xrt_smi_config_name;
+    std::string xrt_smi_config;
     const auto xrt_smi_config_type = std::any_cast<xrt_core::query::xrt_smi_config::type>(param);
     switch (xrt_smi_config_type) {
     case xrt_core::query::xrt_smi_config::type::options_config:
-      xrt_smi_config_name = "xrt_smi_config.json";
+      xrt_smi_config = shim_xdna::smi::get_smi_config();
       break;
     }
 
-    return boost::str(boost::format(xrt_smi_config_name));
+    return boost::str(boost::format(xrt_smi_config));
   }
 };
 

--- a/src/shim/smi.cpp
+++ b/src/shim/smi.cpp
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
+#include "smi.h"
+
+namespace shim_xdna::smi {
+std::string 
+get_smi_config()
+{
+  return std::string(xrt_smi_config);
+}
+} // namespace shim_xdna::smi

--- a/src/shim/smi.h
+++ b/src/shim/smi.h
@@ -1,4 +1,13 @@
-{
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
+
+#include <string>
+
+namespace shim_xdna::smi {
+
+static constexpr std::string_view xrt_smi_config =
+ R"(
+ {
   "subcommands":
   [{
     "name" : "validate",
@@ -192,3 +201,10 @@
     ]
   }]
 }
+)"; 
+
+
+std::string 
+get_smi_config();
+
+} // namespace shim_xdna::smi


### PR DESCRIPTION
This PR changes the query type for xrt_smi_config to a string returning type. This makes the architecture cleaner across XDNA, MCDM and XRT. 
shim.h and shim.cpp can be extended further to gain more control over how the configuration is to be sent to xrt-smi going forward. This also removes the dependency to update the file everytime the xrt-smi configuration changes.