### PR TITLE
add umq_version for npu.info

### DIFF
--- a/tools/info.json
+++ b/tools/info.json
@@ -36,12 +36,9 @@
 			"pci_revision_id": "11",
 			"version": "1.0.4.180",
 			"fw_name": "npu.sbin"
-		},
-                {
-			"device": "npu3",
-			"version": "20250108-6b53eb8f",
-			"fw_name": "app.elf"
-                }
-
-	]
+		}
+	],
+	"aie4_firmwares" : {
+		"umq_version": "20250108-6b53eb8f"
+	}
 }

--- a/tools/info.json
+++ b/tools/info.json
@@ -39,7 +39,7 @@
 		},
                 {
 			"device": "npu3",
-			"umq_version": "20250108-6b53eb8f",
+			"version": "20250108-6b53eb8f",
 			"fw_name": "app.elf"
                 }
 

--- a/tools/info.json
+++ b/tools/info.json
@@ -36,6 +36,12 @@
 			"pci_revision_id": "11",
 			"version": "1.0.4.180",
 			"fw_name": "npu.sbin"
-		}
+		},
+                {
+			"device": "npu3",
+			"umq_version": "20250108-6b53eb8f",
+			"fw_name": "app.elf"
+                }
+
 	]
 }


### PR DESCRIPTION
@maxzhen this is needed for npu3 driver umq, but we have to get this in the core.