### PR TITLE
Ctx limit and module parameters

### DIFF
--- a/src/driver/amdxdna/aie2_ctx.c
+++ b/src/driver/amdxdna/aie2_ctx.c
@@ -626,8 +626,6 @@ int aie2_ctx_init(struct amdxdna_ctx *ctx)
 		goto syncobj_destroy;
 	}
 
-	xdna->dev_handle->ctx_num++;
-
 	XDNA_DBG(xdna, "ctx %s init completed", ctx->name);
 	return 0;
 
@@ -653,10 +651,8 @@ free_priv:
 
 void aie2_ctx_fini(struct amdxdna_ctx *ctx)
 {
-	struct amdxdna_dev *xdna = ctx->client->xdna;
 	int idx;
 
-	xdna->dev_handle->ctx_num--;
 	aie2_ctx_wait_for_idle(ctx);
 	aie2_hwctx_stop(ctx);
 	destroy_workqueue(ctx->priv->submit_wq);

--- a/src/driver/amdxdna/aie2_hwctx.c
+++ b/src/driver/amdxdna/aie2_hwctx.c
@@ -68,7 +68,7 @@ int aie2_hwctx_start(struct amdxdna_ctx *ctx)
 	int ret;
 
 	ndev = xdna->dev_handle;
-	if (ndev->priv->hwctx_limit == ndev->ctx_num) {
+	if (ndev->hwctx_limit == ndev->hwctx_num) {
 		XDNA_ERR(xdna, "Exceed hardware context limit");
 		return -ENOENT;
 	}
@@ -116,7 +116,7 @@ skip:
 	}
 
 	ctx->status |= FIELD_PREP(CTX_STATE_CONNECTED, 1);
-	ndev->ctx_num++;
+	ndev->hwctx_num++;
 	return 0;
 
 release_resource:
@@ -143,7 +143,7 @@ void aie2_hwctx_stop(struct amdxdna_ctx *ctx)
 		   (ctx->submitted == atomic64_read(&ctx->job_free_cnt)));
 	drm_sched_fini(&ctx->priv->sched);
 	ctx->status &= ~CTX_STATE_CONNECTED;
-	xdna->dev_handle->ctx_num--;
+	xdna->dev_handle->hwctx_num--;
 }
 
 int aie2_xrs_load_hwctx(struct amdxdna_ctx *ctx, struct xrs_action_load *action)

--- a/src/driver/amdxdna/aie2_hwctx.c
+++ b/src/driver/amdxdna/aie2_hwctx.c
@@ -68,7 +68,7 @@ int aie2_hwctx_start(struct amdxdna_ctx *ctx)
 	int ret;
 
 	ndev = xdna->dev_handle;
-	if (ndev->hwctx_limit == ndev->hwctx_num) {
+	if (ndev->hwctx_limit == ndev->hwctx_cnt) {
 		XDNA_ERR(xdna, "Exceed hardware context limit");
 		return -ENOENT;
 	}
@@ -116,7 +116,7 @@ skip:
 	}
 
 	ctx->status |= FIELD_PREP(CTX_STATE_CONNECTED, 1);
-	ndev->hwctx_num++;
+	ndev->hwctx_cnt++;
 	return 0;
 
 release_resource:
@@ -143,7 +143,7 @@ void aie2_hwctx_stop(struct amdxdna_ctx *ctx)
 		   (ctx->submitted == atomic64_read(&ctx->job_free_cnt)));
 	drm_sched_fini(&ctx->priv->sched);
 	ctx->status &= ~CTX_STATE_CONNECTED;
-	xdna->dev_handle->hwctx_num--;
+	xdna->dev_handle->hwctx_cnt--;
 }
 
 int aie2_xrs_load_hwctx(struct amdxdna_ctx *ctx, struct xrs_action_load *action)

--- a/src/driver/amdxdna/aie2_pci.c
+++ b/src/driver/amdxdna/aie2_pci.c
@@ -27,6 +27,10 @@ uint aie2_max_col = XRS_MAX_COL;
 module_param(aie2_max_col, uint, 0600);
 MODULE_PARM_DESC(aie2_max_col, "Maximum column could be used");
 
+uint aie2_hwctx_limit;
+module_param(aie2_hwctx_limit, uint, 0400);
+MODULE_PARM_DESC(aie2_hwctx_limit, "[Debug] Maximum number of hwctx. 0 = Use default");
+
 uint aie2_control_flags;
 module_param(aie2_control_flags, uint, 0400);
 MODULE_PARM_DESC(aie2_control_flags,
@@ -475,6 +479,14 @@ static int aie2_init(struct amdxdna_dev *xdna)
 	ndev->priv = xdna->dev_info->dev_priv;
 	ndev->xdna = xdna;
 	init_rwsem(&ndev->recover_lock);
+
+	if (aie2_hwctx_limit)
+		ndev->hwctx_limit = aie2_hwctx_limit;
+	else
+		ndev->hwctx_limit = ndev->priv->hwctx_limit;
+	XDNA_DBG(xdna, "Maximum limit %d hardware context(s)", ndev->hwctx_limit);
+
+	xdna->ctx_limit = ndev->priv->ctx_limit;
 
 	ret = request_firmware(&fw, ndev->priv->fw_path, &pdev->dev);
 	if (ret) {

--- a/src/driver/amdxdna/aie2_pci.h
+++ b/src/driver/amdxdna/aie2_pci.h
@@ -257,7 +257,8 @@ struct amdxdna_dev_hdl {
 	struct async_events		*async_events;
 
 	u32				dev_status;
-	u32				ctx_num;
+	u32				hwctx_num;
+	u32				hwctx_limit;
 };
 
 #define DEFINE_BAR_OFFSET(reg_name, bar, reg_addr) \
@@ -286,6 +287,7 @@ struct amdxdna_dev_priv {
 	/* If mbox_size is 0, use BAR size. See MBOX_SIZE macro */
 	u32				mbox_size;
 	u32				hwctx_limit; /* Hardware determine */
+	u32				ctx_limit; /* Driver determine */
 	u32				sram_dev_addr;
 	struct aie2_bar_off_pair	sram_offs[SRAM_MAX_INDEX];
 	struct aie2_bar_off_pair	psp_regs_off[PSP_MAX_REGS];

--- a/src/driver/amdxdna/aie2_pci.h
+++ b/src/driver/amdxdna/aie2_pci.h
@@ -257,7 +257,7 @@ struct amdxdna_dev_hdl {
 	struct async_events		*async_events;
 
 	u32				dev_status;
-	u32				hwctx_num;
+	u32				hwctx_cnt;
 	u32				hwctx_limit;
 };
 

--- a/src/driver/amdxdna/aie2_pci.h
+++ b/src/driver/amdxdna/aie2_pci.h
@@ -285,6 +285,7 @@ struct amdxdna_dev_priv {
 	u32				mbox_dev_addr;
 	/* If mbox_size is 0, use BAR size. See MBOX_SIZE macro */
 	u32				mbox_size;
+	u32				hwctx_limit; /* Hardware determine */
 	u32				sram_dev_addr;
 	struct aie2_bar_off_pair	sram_offs[SRAM_MAX_INDEX];
 	struct aie2_bar_off_pair	psp_regs_off[PSP_MAX_REGS];

--- a/src/driver/amdxdna/aie2_pm.c
+++ b/src/driver/amdxdna/aie2_pm.c
@@ -68,7 +68,7 @@ int aie2_pm_set_mode(struct amdxdna_dev_hdl *ndev, enum amdxdna_power_mode_type 
 
 	switch (target) {
 	case POWER_MODE_TURBO:
-		if (ndev->ctx_num) {
+		if (ndev->hwctx_num) {
 			XDNA_ERR(xdna, "Can not set turbo when there is active ctx");
 			return -EINVAL;
 		}

--- a/src/driver/amdxdna/aie2_pm.c
+++ b/src/driver/amdxdna/aie2_pm.c
@@ -68,7 +68,7 @@ int aie2_pm_set_mode(struct amdxdna_dev_hdl *ndev, enum amdxdna_power_mode_type 
 
 	switch (target) {
 	case POWER_MODE_TURBO:
-		if (ndev->hwctx_num) {
+		if (xdna->ctx_cnt) {
 			XDNA_ERR(xdna, "Can not set turbo when there is active ctx");
 			return -EINVAL;
 		}

--- a/src/driver/amdxdna/amdxdna_drm.h
+++ b/src/driver/amdxdna/amdxdna_drm.h
@@ -125,6 +125,9 @@ struct amdxdna_dev {
 #endif
 	struct rw_semaphore		notifier_lock; /* for mmu notifier */
 	struct workqueue_struct		*notifier_wq;
+
+	u32				ctx_cnt;
+	u32				ctx_limit;
 };
 
 struct amdxdna_stats {

--- a/src/driver/amdxdna/amdxdna_pci_drv.c
+++ b/src/driver/amdxdna/amdxdna_pci_drv.c
@@ -116,6 +116,11 @@ static int amdxdna_probe(struct pci_dev *pdev, const struct pci_device_id *id)
 
 	if (context_limit)
 		xdna->ctx_limit = context_limit;
+	// FIXME: Remove below check later
+	if (!xdna->ctx_limit) {
+		XDNA_WARN(xdna, "Device doesn't define context limit");
+		xdna->ctx_limit = 32;
+	}
 	XDNA_DBG(xdna, "Maximum limit %d context(s)", xdna->ctx_limit);
 
 	ret = amdxdna_sysfs_init(xdna);

--- a/src/driver/amdxdna/amdxdna_pci_drv.c
+++ b/src/driver/amdxdna/amdxdna_pci_drv.c
@@ -20,6 +20,10 @@ int autosuspend_ms = -1;
 module_param(autosuspend_ms, int, 0644);
 MODULE_PARM_DESC(autosuspend_ms, "runtime suspend delay in miliseconds. < 0: prevent it");
 
+uint context_limit;
+module_param(context_limit, uint, 0444);
+MODULE_PARM_DESC(context_limit, "Maximum number of context, 0 = Driver determine (Default)");
+
 /*
  *  There are platforms which share the same PCI device ID
  *  but have different PCI revision IDs. So, let the PCI class
@@ -109,6 +113,10 @@ static int amdxdna_probe(struct pci_dev *pdev, const struct pci_device_id *id)
 		XDNA_ERR(xdna, "Hardware init failed, ret %d", ret);
 		goto destroy_notifier_wq;
 	}
+
+	if (context_limit)
+		xdna->ctx_limit = context_limit;
+	XDNA_DBG(xdna, "Maximum limit %d context(s)", xdna->ctx_limit);
 
 	ret = amdxdna_sysfs_init(xdna);
 	if (ret) {

--- a/src/driver/amdxdna/npu1_regs.c
+++ b/src/driver/amdxdna/npu1_regs.c
@@ -67,6 +67,7 @@ const struct amdxdna_dev_priv npu1_dev_priv = {
 	.mbox_dev_addr  = NPU1_MBOX_BAR_BASE,
 	.mbox_size      = 0, /* Use BAR size */
 	.hwctx_limit	= 6,
+	.ctx_limit	= 6,
 	.sram_dev_addr  = NPU1_SRAM_BAR_BASE,
 	.sram_offs      = {
 		DEFINE_BAR_OFFSET(MBOX_CHANN_OFF, NPU1_SRAM, MPNPU_SRAM_X2I_MAILBOX_0),

--- a/src/driver/amdxdna/npu1_regs.c
+++ b/src/driver/amdxdna/npu1_regs.c
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0
 /*
- * Copyright (C) 2023-2024, Advanced Micro Devices, Inc.
+ * Copyright (C) 2023-2025, Advanced Micro Devices, Inc.
  */
 
 #include "drm_local/amdxdna_accel.h"
@@ -66,6 +66,7 @@ const struct amdxdna_dev_priv npu1_dev_priv = {
 	.col_align	= COL_ALIGN_NONE,
 	.mbox_dev_addr  = NPU1_MBOX_BAR_BASE,
 	.mbox_size      = 0, /* Use BAR size */
+	.hwctx_limit	= 6,
 	.sram_dev_addr  = NPU1_SRAM_BAR_BASE,
 	.sram_offs      = {
 		DEFINE_BAR_OFFSET(MBOX_CHANN_OFF, NPU1_SRAM, MPNPU_SRAM_X2I_MAILBOX_0),

--- a/src/driver/amdxdna/npu4_family.h
+++ b/src/driver/amdxdna/npu4_family.h
@@ -66,7 +66,8 @@
 	.mbox_dev_addr  = NPU4_MBOX_BAR_BASE,							\
 	.mbox_size      = 0, /* Use BAR size */							\
 	.sram_dev_addr  = NPU4_SRAM_BAR_BASE,							\
-	.hwctx_limit	= 6,									\
+	.hwctx_limit	= 16,									\
+	.ctx_limit	= 32,									\
 	.sram_offs      = {									\
 		DEFINE_BAR_OFFSET(MBOX_CHANN_OFF, NPU4_SRAM, MPNPU_SRAM_X2I_MAILBOX_0),		\
 		DEFINE_BAR_OFFSET(FW_ALIVE_OFF,   NPU4_SRAM, MPNPU_SRAM_X2I_MAILBOX_15),	\

--- a/src/driver/amdxdna/npu4_family.h
+++ b/src/driver/amdxdna/npu4_family.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: GPL-2.0 */
 /*
- * Copyright (C) 2024, Advanced Micro Devices, Inc.
+ * Copyright (C) 2024-2025, Advanced Micro Devices, Inc.
  */
 
 #ifndef _NPU4_FAMILY_H_
@@ -66,6 +66,7 @@
 	.mbox_dev_addr  = NPU4_MBOX_BAR_BASE,							\
 	.mbox_size      = 0, /* Use BAR size */							\
 	.sram_dev_addr  = NPU4_SRAM_BAR_BASE,							\
+	.hwctx_limit	= 6,									\
 	.sram_offs      = {									\
 		DEFINE_BAR_OFFSET(MBOX_CHANN_OFF, NPU4_SRAM, MPNPU_SRAM_X2I_MAILBOX_0),		\
 		DEFINE_BAR_OFFSET(FW_ALIVE_OFF,   NPU4_SRAM, MPNPU_SRAM_X2I_MAILBOX_15),	\


### PR DESCRIPTION
1. Add hardware context limit and context limit for each device.
2. Add module parameters to config the above limitation.