### PR TITLE
Add support to display the context priority in xrt-smi reports

### DIFF
--- a/src/driver/amdxdna/aie2_message.c
+++ b/src/driver/amdxdna/aie2_message.c
@@ -25,8 +25,6 @@ static int map_app_priority_to_fw(enum amdxdna_qos_priority avalue, u32 *fvalue)
 	case AMDXDNA_QOS_REALTIME_PRIORITY:
 		*fvalue = AIE2_QOS_REALTIME_PRIORITY;
 		break;
-	case AMDXDNA_QOS_DEFAULT_PRIORITY:
-		/* fallthrough */
 	case AMDXDNA_QOS_HIGH_PRIORITY:
 		*fvalue = AIE2_QOS_HIGH_PRIORITY;
 		break;
@@ -263,6 +261,10 @@ int aie2_create_context(struct amdxdna_dev_hdl *ndev, struct amdxdna_ctx *ctx,
 	struct cq_pair *cq_pair;
 	u32 priority;
 	int ret;
+
+	/* Default to high priority, if unset */
+	if (!ctx->qos.priority)
+		ctx->qos.priority = AMDXDNA_QOS_HIGH_PRIORITY;
 
 	ret = map_app_priority_to_fw(ctx->qos.priority, &priority);
 	if (ret) {

--- a/src/driver/amdxdna/aie2_pci.c
+++ b/src/driver/amdxdna/aie2_pci.c
@@ -904,6 +904,7 @@ static int aie2_get_ctx_status(struct amdxdna_client *client,
 			tmp->migrations = 0;
 			tmp->preemptions = 0;
 			tmp->errors = 0;
+			tmp->priority = ctx->qos.priority;
 
 			if (copy_to_user(&buf[hw_i], tmp, sizeof(*tmp))) {
 				ret = -EFAULT;

--- a/src/include/uapi/drm_local/amdxdna_accel.h
+++ b/src/include/uapi/drm_local/amdxdna_accel.h
@@ -62,7 +62,6 @@ enum amdxdna_device_type {
 
 /*
  * Enum for priority in application's QoS. Values copied from Window shim layer.
- * AMDXDNA_QOS_DEFAULT_PRIORITY: Default priority.
  * AMDXDNA_QOS_REALTIME_PRIORITY: Real time clients.
  * AMDXDNA_QOS_HIGH_PRIORITY: Best effort foreground clients.
  * AMDXDNA_QOS_NORMAL_PRIORITY: Best effort or background clients.
@@ -70,7 +69,6 @@ enum amdxdna_device_type {
  *                           completion.
  */
 enum amdxdna_qos_priority {
-	AMDXDNA_QOS_DEFAULT_PRIORITY = 0x0,
 	AMDXDNA_QOS_REALTIME_PRIORITY = 0x100,
 	AMDXDNA_QOS_HIGH_PRIORITY = 0x180,
 	AMDXDNA_QOS_NORMAL_PRIORITY = 0x200,
@@ -425,6 +423,7 @@ struct amdxdna_drm_query_sensor {
  * @preemptions: The number of times this context has been preempted by another context in the
  *               same partition.
  * @errors: The errors for this context.
+ * @priority: Context priority
  */
 struct amdxdna_drm_query_ctx {
 	__u32 context_id;
@@ -437,6 +436,7 @@ struct amdxdna_drm_query_ctx {
 	__u64 migrations;
 	__u64 preemptions;
 	__u64 errors;
+	__u64 priority;
 };
 
 /**

--- a/src/shim/device.cpp
+++ b/src/shim/device.cpp
@@ -274,6 +274,7 @@ struct partition_info
       new_entry.migrations = entry.migrations;
       new_entry.preemptions = entry.preemptions;
       new_entry.errors = entry.errors;
+      new_entry.qos.priority = entry.priority;
       output.push_back(std::move(new_entry));
     }
     return output;


### PR DESCRIPTION
Add support to display the context priority in xrt-smi aie-partitions report.

Here's a screenshot of the output: 

![image](https://github.com/user-attachments/assets/9303addd-6c43-481c-92f3-9c519e192e78)
