### PR TITLE
Implement xrt-smi query to report preemption counters

### DIFF
--- a/src/driver/amdxdna/aie2_pci.c
+++ b/src/driver/amdxdna/aie2_pci.c
@@ -895,6 +895,7 @@ static int aie2_get_ctx_status(struct amdxdna_client *client,
 
 			tmp->pid = tmp_client->pid;
 			tmp->context_id = ctx->id;
+			tmp->hwctx_id = ctx->priv->id;
 			tmp->start_col = ctx->start_col;
 			tmp->num_col = ctx->num_col;
 			tmp->command_submissions = ctx->submitted;

--- a/src/include/uapi/drm_local/amdxdna_accel.h
+++ b/src/include/uapi/drm_local/amdxdna_accel.h
@@ -406,7 +406,7 @@ struct amdxdna_drm_query_sensor {
  * @context_id: The ID for this context.
  * @start_col: The starting column for the partition assigned to this context.
  * @num_col: The number of columns in the partition assigned to this context.
- * @pad: Structure padding.
+ * @nwctx_id: Hardware context ID.
  * @pid: The Process ID of the process that created this context.
  * @command_submissions: The number of commands submitted to this context.
  * @command_completions: The number of commands completed by this context.
@@ -420,7 +420,7 @@ struct amdxdna_drm_query_ctx {
 	__u32 context_id;
 	__u32 start_col;
 	__u32 num_col;
-	__u32 pad;
+	__u32 hwctx_id;
 	__s64 pid;
 	__u64 command_submissions;
 	__u64 command_completions;


### PR DESCRIPTION
Implement xrt-smi query to report preemption counters.

![image](https://github.com/user-attachments/assets/a4c5451e-645d-4251-a053-4cc1acd44559)

![image](https://github.com/user-attachments/assets/c6fc0257-b8a1-4438-bbf1-84c8fe51406b)

PS: Error "Subcommand not found" is due to the recent changes in xrt, unrelated to this change. 