### PR TITLE
Part I - Virtual Context

### DIFF
--- a/src/driver/amdxdna/Kbuild
+++ b/src/driver/amdxdna/Kbuild
@@ -17,6 +17,7 @@ ccflags-y += -g -Werror
 obj-m	+= amdxdna.o
 amdxdna-y := \
 	amdxdna_ctx.o \
+	amdxdna_ctx_runqueue.o \
 	amdxdna_gem.o \
 	amdxdna_drm.o \
 	amdxdna_sysfs.o \

--- a/src/driver/amdxdna/aie2_hwctx.c
+++ b/src/driver/amdxdna/aie2_hwctx.c
@@ -69,8 +69,8 @@ int aie2_hwctx_start(struct amdxdna_ctx *ctx)
 
 	ndev = xdna->dev_handle;
 	if (ndev->hwctx_limit == ndev->hwctx_cnt) {
-		XDNA_ERR(xdna, "Exceed hardware context limit");
-		return -ENOENT;
+		XDNA_DBG(xdna, "Exceed hardware context limit");
+		return -EAGAIN;
 	}
 
 	sched = &ctx->priv->sched;

--- a/src/driver/amdxdna/aie2_pci.c
+++ b/src/driver/amdxdna/aie2_pci.c
@@ -15,6 +15,7 @@
 #include "aie2_solver.h"
 #include "aie2_msg_priv.h"
 
+#include "amdxdna_ctx_runqueue.h"
 #ifdef AMDXDNA_DEVEL
 #include "amdxdna_devel.h"
 #endif
@@ -674,12 +675,9 @@ static void aie2_recover(struct amdxdna_dev *xdna, bool dump_only)
 
 	down_write(&ndev->recover_lock);
 	mutex_lock(&xdna->dev_lock);
-	list_for_each_entry(client, &xdna->client_list, node)
-		aie2_stop_ctx(client);
+	amdxdna_rq_pause_all(&xdna->ctx_rq);
 
-	/* The AIE will reset after all contexts are destroyed */
-	list_for_each_entry(client, &xdna->client_list, node)
-		aie2_restart_ctx(client);
+	amdxdna_rq_run_all(&xdna->ctx_rq);
 	mutex_unlock(&xdna->dev_lock);
 	up_write(&ndev->recover_lock);
 }

--- a/src/driver/amdxdna/aie2_pci.h
+++ b/src/driver/amdxdna/aie2_pci.h
@@ -408,9 +408,7 @@ int aie2_cmd_submit(struct amdxdna_ctx *ctx, struct amdxdna_sched_job *job,
 int aie2_cmd_wait(struct amdxdna_ctx *ctx, u64 seq, u32 timeout);
 struct dma_fence *aie2_cmd_get_out_fence(struct amdxdna_ctx *ctx, u64 seq);
 void aie2_hmm_invalidate(struct amdxdna_gem_obj *abo, unsigned long cur_seq);
-void aie2_stop_ctx(struct amdxdna_client *client);
 void aie2_dump_ctx(struct amdxdna_client *client);
-void aie2_restart_ctx(struct amdxdna_client *client);
 
 /* aie2_hwctx.c */
 int aie2_hwctx_start(struct amdxdna_ctx *ctx);

--- a/src/driver/amdxdna/aie2_pci.h
+++ b/src/driver/amdxdna/aie2_pci.h
@@ -8,6 +8,7 @@
 
 #include <linux/device.h>
 #include <linux/iopoll.h>
+#include <linux/wait.h>
 #include <linux/io.h>
 #include <linux/semaphore.h>
 #include <drm/gpu_scheduler.h>

--- a/src/driver/amdxdna/aie2_smu.c
+++ b/src/driver/amdxdna/aie2_smu.c
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0
 /*
- * Copyright (C) 2022-2024, Advanced Micro Devices, Inc.
+ * Copyright (C) 2022-2025, Advanced Micro Devices, Inc.
  */
 
 #include "aie2_pci.h"

--- a/src/driver/amdxdna/amdxdna_ctx.c
+++ b/src/driver/amdxdna/amdxdna_ctx.c
@@ -158,6 +158,7 @@ int amdxdna_drm_create_ctx_ioctl(struct drm_device *dev, void *data, struct drm_
 	mutex_unlock(&xdna->dev_lock);
 
 	atomic64_set(&ctx->job_free_cnt, 0);
+	init_waitqueue_head(&ctx->connect_waitq);
 
 	XDNA_DBG(xdna, "PID %d create context %d, ret %d", client->pid, args->handle, ret);
 	drm_dev_exit(idx);

--- a/src/driver/amdxdna/amdxdna_ctx.c
+++ b/src/driver/amdxdna/amdxdna_ctx.c
@@ -56,28 +56,6 @@ static struct dma_fence *amdxdna_fence_create(struct amdxdna_ctx *ctx)
 	return &fence->base;
 }
 
-void amdxdna_ctx_suspend(struct amdxdna_client *client)
-{
-	struct amdxdna_dev *xdna = client->xdna;
-	struct amdxdna_ctx *ctx;
-	unsigned long ctx_id;
-
-	drm_WARN_ON(&xdna->ddev, !mutex_is_locked(&xdna->dev_lock));
-	amdxdna_for_each_ctx(client, ctx_id, ctx)
-		xdna->dev_info->ops->ctx_disconnect(ctx);
-}
-
-void amdxdna_ctx_resume(struct amdxdna_client *client)
-{
-	struct amdxdna_dev *xdna = client->xdna;
-	struct amdxdna_ctx *ctx;
-	unsigned long ctx_id;
-
-	drm_WARN_ON(&xdna->ddev, !mutex_is_locked(&xdna->dev_lock));
-	amdxdna_for_each_ctx(client, ctx_id, ctx)
-		xdna->dev_info->ops->ctx_connect(ctx);
-}
-
 static void amdxdna_ctx_destroy_rcu(struct amdxdna_ctx *ctx, struct srcu_struct *ss)
 {
 	struct amdxdna_dev *xdna = ctx->client->xdna;
@@ -274,7 +252,6 @@ int amdxdna_drm_config_ctx_ioctl(struct drm_device *dev, void *data, struct drm_
 		return -EINVAL;
 	}
 
-	mutex_lock(&xdna->dev_lock);
 	idx = srcu_read_lock(&client->ctx_srcu);
 	ctx = xa_load(&client->ctx_xa, args->handle);
 	if (!ctx) {
@@ -287,7 +264,6 @@ int amdxdna_drm_config_ctx_ioctl(struct drm_device *dev, void *data, struct drm_
 
 unlock_srcu:
 	srcu_read_unlock(&client->ctx_srcu, idx);
-	mutex_unlock(&xdna->dev_lock);
 	kfree(buf);
 	return ret;
 }

--- a/src/driver/amdxdna/amdxdna_ctx.h
+++ b/src/driver/amdxdna/amdxdna_ctx.h
@@ -8,8 +8,8 @@
 
 #include <linux/bitfield.h>
 #include <linux/kref.h>
-#include <linux/wait.h>
 #include <linux/list.h>
+#include <linux/wait.h>
 #include <drm/drm_drv.h>
 #include <drm/gpu_scheduler.h>
 #include "drm_local/amdxdna_accel.h"
@@ -120,6 +120,11 @@ struct amdxdna_ctx {
  * Set CTX_STATE_DEAD bit means context marked as dead by TDR.
  */
 #define CTX_STATE_DEAD		BIT(2)
+/*
+ * Set CTX_STATE_CONNECTING bit means context is run queue selected this context
+ * to connect soon.
+ */
+#define CTX_STATE_CONNECTING	BIT(3)
 	u32				status;
 
 	struct amdxdna_qos_info		     qos;
@@ -137,6 +142,8 @@ struct amdxdna_ctx {
 
 	/* For context runqueue */
 	struct list_head		entry;
+	wait_queue_head_t		connect_waitq;
+	u32				idle_cnt;
 };
 
 #define drm_job_to_xdna_job(j) \

--- a/src/driver/amdxdna/amdxdna_ctx.h
+++ b/src/driver/amdxdna/amdxdna_ctx.h
@@ -9,6 +9,7 @@
 #include <linux/bitfield.h>
 #include <linux/kref.h>
 #include <linux/wait.h>
+#include <linux/list.h>
 #include <drm/drm_drv.h>
 #include <drm/gpu_scheduler.h>
 #include "drm_local/amdxdna_accel.h"
@@ -133,6 +134,9 @@ struct amdxdna_ctx {
 	u64				tdr_last_completed;
 	/* For command completion notification. */
 	u32				syncobj_hdl;
+
+	/* For context runqueue */
+	struct list_head		entry;
 };
 
 #define drm_job_to_xdna_job(j) \
@@ -246,8 +250,6 @@ static inline u32 amdxdna_ctx_col_map(struct amdxdna_ctx *ctx)
 void amdxdna_ctx_wait_jobs(struct amdxdna_ctx *ctx, long timeout);
 void amdxdna_sched_job_cleanup(struct amdxdna_sched_job *job);
 void amdxdna_ctx_remove_all(struct amdxdna_client *client);
-void amdxdna_ctx_suspend(struct amdxdna_client *client);
-void amdxdna_ctx_resume(struct amdxdna_client *client);
 
 int amdxdna_lock_objects(struct amdxdna_sched_job *job, struct ww_acquire_ctx *ctx);
 void amdxdna_unlock_objects(struct amdxdna_sched_job *job, struct ww_acquire_ctx *ctx);
@@ -264,6 +266,5 @@ int amdxdna_drm_config_ctx_ioctl(struct drm_device *dev, void *data, struct drm_
 int amdxdna_drm_destroy_ctx_ioctl(struct drm_device *dev, void *data, struct drm_file *filp);
 int amdxdna_drm_submit_cmd_ioctl(struct drm_device *dev, void *data, struct drm_file *filp);
 int amdxdna_drm_wait_cmd_ioctl(struct drm_device *dev, void *data, struct drm_file *filp);
-int amdxdna_drm_create_ctx_unsec_ioctl(struct drm_device *dev, void *data, struct drm_file *filp);
 
 #endif /* _AMDXDNA_CTX_H_ */

--- a/src/driver/amdxdna/amdxdna_ctx_runqueue.c
+++ b/src/driver/amdxdna/amdxdna_ctx_runqueue.c
@@ -6,6 +6,8 @@
 #include "amdxdna_drm.h"
 #include "amdxdna_ctx_runqueue.h"
 
+#define RQ_WORK_JIFF msecs_to_jiffies(1000)
+
 static int amdxdna_rq_start(struct amdxdna_ctx_rq *rq, struct amdxdna_ctx *ctx)
 {
 	struct amdxdna_dev *xdna;
@@ -17,12 +19,16 @@ static int amdxdna_rq_start(struct amdxdna_ctx_rq *rq, struct amdxdna_ctx *ctx)
 		goto unlock_and_out; /* Connected */
 
 	ret = xdna->dev_info->ops->ctx_connect(ctx);
-	if (ret) {
-		XDNA_ERR(xdna, "Cannot connect");
+	if (ret == -EAGAIN)
+		rq->max_connected = rq->connected_cnt;
+	if (ret)
 		goto unlock_and_out;
-	}
 
+	if (list_empty(&rq->conn_list))
+		queue_delayed_work(rq->delay_wq, &rq->delay_work, RQ_WORK_JIFF);
 	list_move_tail(&ctx->entry, &rq->conn_list);
+	rq->connected_cnt++;
+	XDNA_DBG(xdna, "ctx %s started and moved to connect list", ctx->name);
 
 unlock_and_out:
 	mutex_unlock(&xdna->dev_lock);
@@ -37,7 +43,52 @@ static void amdxdna_rq_stop(struct amdxdna_ctx_rq *rq, struct amdxdna_ctx *ctx)
 	if (!FIELD_GET(CTX_STATE_CONNECTED, ctx->status))
 		return;
 
+	drm_WARN_ON(&xdna->ddev, !mutex_is_locked(&xdna->dev_lock));
 	xdna->dev_info->ops->ctx_disconnect(ctx);
+	list_move_tail(&ctx->entry, &rq->disconn_list);
+	rq->connected_cnt--;
+	if (list_empty(&rq->conn_list))
+		cancel_delayed_work(&rq->delay_work);
+	XDNA_DBG(xdna, "ctx %s stopped and moved to disconnect list", ctx->name);
+}
+
+static void amdxdna_rq_work(struct work_struct *work)
+{
+	struct amdxdna_ctx_rq *rq;
+	struct amdxdna_dev *xdna;
+	struct amdxdna_ctx *ctx;
+	struct amdxdna_ctx *tmp;
+
+	rq = container_of(work, struct amdxdna_ctx_rq, delay_work.work);
+	xdna = ctx_rq_to_xdna_dev(rq);
+	mutex_lock(&xdna->dev_lock);
+	list_for_each_entry_safe(ctx, tmp, &rq->conn_list, entry) {
+		u64 completed = ctx->completed;
+		u64 submitted = ctx->submitted;
+
+		if (submitted == completed)
+			ctx->idle_cnt++;
+		else
+			ctx->idle_cnt = 0;
+
+		if (ctx->idle_cnt < 5)
+			continue;
+
+		amdxdna_rq_stop(rq, ctx);
+	}
+
+	if (rq->max_connected && rq->max_connected == rq->connected_cnt)
+		goto skip;
+
+	list_for_each_entry_safe(ctx, tmp, &rq->disconn_list, entry) {
+		ctx->status |= FIELD_PREP(CTX_STATE_CONNECTING, 1);
+		XDNA_DBG(xdna, "Wakeup %s", ctx->name);
+		wake_up(&ctx->connect_waitq);
+	}
+skip:
+	mutex_unlock(&xdna->dev_lock);
+
+	mod_delayed_work(rq->delay_wq, &rq->delay_work, RQ_WORK_JIFF);
 }
 
 /*
@@ -70,30 +121,56 @@ void amdxdna_rq_run_all(struct amdxdna_ctx_rq *rq)
 {
 	struct amdxdna_dev *xdna;
 	struct amdxdna_ctx *ctx;
+	struct amdxdna_ctx *tmp;
+	int ret;
 
 	xdna = ctx_rq_to_xdna_dev(rq);
 	WARN_ON(!rq->paused);
 
 	drm_WARN_ON(&xdna->ddev, !mutex_is_locked(&xdna->dev_lock));
-	list_for_each_entry(ctx, &rq->conn_list, entry)
-		xdna->dev_info->ops->ctx_connect(ctx);
+	list_for_each_entry_safe(ctx, tmp, &rq->conn_list, entry) {
+		ret = xdna->dev_info->ops->ctx_connect(ctx);
+		if (!ret)
+			continue;
+
+		list_move_tail(&ctx->entry, &rq->disconn_list);
+		rq->connected_cnt--;
+	}
 
 	rq->paused = false;
 }
 
 int amdxdna_rq_wait_for_run(struct amdxdna_ctx_rq *rq, struct amdxdna_ctx *ctx)
 {
+	struct amdxdna_dev *xdna = ctx_rq_to_xdna_dev(rq);
 	int ret;
 
+try_connect:
 	if (FIELD_GET(CTX_STATE_CONNECTED, ctx->status))
 		return 0;
 
-	// TODO:
-	// 1. Move from disconn list to run queue
-	// 2. Schedule which context to start
 	ret = amdxdna_rq_start(rq, ctx);
+	if (!ret) {
+		wake_up_all(&ctx->connect_waitq);
+		return 0; /* started */
+	}
 
-	// TODO: Wait this ctx status change to connected
+	if (ret && ret != -EAGAIN) {
+		XDNA_ERR(xdna, "Failed to start %s", ctx->name);
+		return ret;
+	}
+
+	// TODO: -EAGAIN from device.
+	// Move this context to run queue -> amdxdna_rq_enqueue();
+	// Select next context to run -> amdxdna_rq_sched();
+	// Note: amdxdna_rq_sched() might or might not select current ctx to run
+
+	ret = wait_event_interruptible(ctx->connect_waitq,
+				       FIELD_GET(CTX_STATE_CONNECTING, ctx->status) ||
+				       FIELD_GET(CTX_STATE_CONNECTED, ctx->status));
+	if (!ret)
+		goto try_connect;
+
 	return ret;
 }
 
@@ -120,13 +197,22 @@ void amdxdna_rq_del(struct amdxdna_ctx_rq *rq, struct amdxdna_ctx *ctx)
 	XDNA_DBG(xdna, "ctx %s deleted status 0x%x", ctx->name, ctx->status);
 }
 
-void amdxdna_rq_init(struct amdxdna_ctx_rq *rq)
+int amdxdna_rq_init(struct amdxdna_ctx_rq *rq)
 {
+	rq->delay_wq = alloc_ordered_workqueue("xdna_ctx_runqueue", 0);
+	if (!rq->delay_wq)
+		return -ENOMEM;
+
 	INIT_LIST_HEAD(&rq->conn_list);
 	INIT_LIST_HEAD(&rq->disconn_list);
+	INIT_DELAYED_WORK(&rq->delay_work, amdxdna_rq_work);
 	rq->paused = false;
+
+	return 0;
 }
 
 void amdxdna_rq_fini(struct amdxdna_ctx_rq *rq)
 {
+	cancel_delayed_work_sync(&rq->delay_work);
+	destroy_workqueue(rq->delay_wq);
 }

--- a/src/driver/amdxdna/amdxdna_ctx_runqueue.c
+++ b/src/driver/amdxdna/amdxdna_ctx_runqueue.c
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Copyright (C) 2025, Advanced Micro Devices, Inc.
+ */
+
+#include "amdxdna_drm.h"
+#include "amdxdna_ctx_runqueue.h"
+
+static int amdxdna_rq_start(struct amdxdna_ctx_rq *rq, struct amdxdna_ctx *ctx)
+{
+	struct amdxdna_dev *xdna;
+	int ret = 0;
+
+	xdna = ctx_rq_to_xdna_dev(rq);
+	mutex_lock(&xdna->dev_lock);
+	if (FIELD_GET(CTX_STATE_CONNECTED, ctx->status))
+		goto unlock_and_out; /* Connected */
+
+	ret = xdna->dev_info->ops->ctx_connect(ctx);
+	if (ret) {
+		XDNA_ERR(xdna, "Cannot connect");
+		goto unlock_and_out;
+	}
+
+	list_move_tail(&ctx->entry, &rq->conn_list);
+
+unlock_and_out:
+	mutex_unlock(&xdna->dev_lock);
+	return ret;
+}
+
+static void amdxdna_rq_stop(struct amdxdna_ctx_rq *rq, struct amdxdna_ctx *ctx)
+{
+	struct amdxdna_dev *xdna;
+
+	xdna = ctx_rq_to_xdna_dev(rq);
+	if (!FIELD_GET(CTX_STATE_CONNECTED, ctx->status))
+		return;
+
+	xdna->dev_info->ops->ctx_disconnect(ctx);
+}
+
+/*
+ * amdxdna_rq_pause_all - Disconnect all context with hardware context
+ *
+ * This can be used in suspend/resume flow or whenever temporarily stop all
+ * the connecting contexts is needed.
+ */
+void amdxdna_rq_pause_all(struct amdxdna_ctx_rq *rq)
+{
+	struct amdxdna_dev *xdna;
+	struct amdxdna_ctx *ctx;
+
+	xdna = ctx_rq_to_xdna_dev(rq);
+	WARN_ON(rq->paused);
+
+	drm_WARN_ON(&xdna->ddev, !mutex_is_locked(&xdna->dev_lock));
+	list_for_each_entry(ctx, &rq->conn_list, entry)
+		xdna->dev_info->ops->ctx_disconnect(ctx);
+
+	rq->paused = true;
+}
+
+/*
+ * amdxdna_rq_pause_all - Disconnect all context with hardware context
+ *
+ * This shoudl be called after amdxdna_rq_pause_all() to rerun all paused context.
+ */
+void amdxdna_rq_run_all(struct amdxdna_ctx_rq *rq)
+{
+	struct amdxdna_dev *xdna;
+	struct amdxdna_ctx *ctx;
+
+	xdna = ctx_rq_to_xdna_dev(rq);
+	WARN_ON(!rq->paused);
+
+	drm_WARN_ON(&xdna->ddev, !mutex_is_locked(&xdna->dev_lock));
+	list_for_each_entry(ctx, &rq->conn_list, entry)
+		xdna->dev_info->ops->ctx_connect(ctx);
+
+	rq->paused = false;
+}
+
+int amdxdna_rq_wait_for_run(struct amdxdna_ctx_rq *rq, struct amdxdna_ctx *ctx)
+{
+	int ret;
+
+	if (FIELD_GET(CTX_STATE_CONNECTED, ctx->status))
+		return 0;
+
+	// TODO:
+	// 1. Move from disconn list to run queue
+	// 2. Schedule which context to start
+	ret = amdxdna_rq_start(rq, ctx);
+
+	// TODO: Wait this ctx status change to connected
+	return ret;
+}
+
+void amdxdna_rq_add(struct amdxdna_ctx_rq *rq, struct amdxdna_ctx *ctx)
+{
+	struct amdxdna_dev *xdna;
+
+	xdna = ctx_rq_to_xdna_dev(rq);
+	drm_WARN_ON(&xdna->ddev, !mutex_is_locked(&xdna->dev_lock));
+	list_add_tail(&ctx->entry, &rq->disconn_list);
+
+	XDNA_DBG(xdna, "ctx %s added status 0x%x", ctx->name, ctx->status);
+}
+
+void amdxdna_rq_del(struct amdxdna_ctx_rq *rq, struct amdxdna_ctx *ctx)
+{
+	struct amdxdna_dev *xdna;
+
+	xdna = ctx_rq_to_xdna_dev(rq);
+	drm_WARN_ON(&xdna->ddev, !mutex_is_locked(&xdna->dev_lock));
+	amdxdna_rq_stop(rq, ctx);
+	list_del(&ctx->entry);
+
+	XDNA_DBG(xdna, "ctx %s deleted status 0x%x", ctx->name, ctx->status);
+}
+
+void amdxdna_rq_init(struct amdxdna_ctx_rq *rq)
+{
+	INIT_LIST_HEAD(&rq->conn_list);
+	INIT_LIST_HEAD(&rq->disconn_list);
+	rq->paused = false;
+}
+
+void amdxdna_rq_fini(struct amdxdna_ctx_rq *rq)
+{
+}

--- a/src/driver/amdxdna/amdxdna_ctx_runqueue.h
+++ b/src/driver/amdxdna/amdxdna_ctx_runqueue.h
@@ -1,0 +1,30 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+/*
+ * Copyright (C) 2025, Advanced Micro Devices, Inc.
+ */
+
+#ifndef _AMDXDNA_CTX_RUNQUEUE_H_
+#define _AMDXDNA_CTX_RUNQUEUE_H_
+
+#include <linux/list.h>
+
+#include "amdxdna_ctx.h"
+
+struct amdxdna_ctx_rq {
+	struct list_head	conn_list;
+	struct list_head	disconn_list;
+
+	bool			paused;
+};
+
+void amdxdna_rq_init(struct amdxdna_ctx_rq *rq);
+void amdxdna_rq_fini(struct amdxdna_ctx_rq *rq);
+
+void amdxdna_rq_add(struct amdxdna_ctx_rq *rq, struct amdxdna_ctx *ctx);
+void amdxdna_rq_del(struct amdxdna_ctx_rq *rq, struct amdxdna_ctx *ctx);
+int amdxdna_rq_wait_for_run(struct amdxdna_ctx_rq *rq, struct amdxdna_ctx *ctx);
+
+void amdxdna_rq_pause_all(struct amdxdna_ctx_rq *rq);
+void amdxdna_rq_run_all(struct amdxdna_ctx_rq *rq);
+
+#endif /* _AMDXDNA_CTX_RUNQUEUE_H_ */

--- a/src/driver/amdxdna/amdxdna_ctx_runqueue.h
+++ b/src/driver/amdxdna/amdxdna_ctx_runqueue.h
@@ -7,6 +7,7 @@
 #define _AMDXDNA_CTX_RUNQUEUE_H_
 
 #include <linux/list.h>
+#include <linux/workqueue.h>
 
 #include "amdxdna_ctx.h"
 
@@ -14,10 +15,15 @@ struct amdxdna_ctx_rq {
 	struct list_head	conn_list;
 	struct list_head	disconn_list;
 
+	struct delayed_work	delay_work;
+	struct workqueue_struct	*delay_wq;
+
 	bool			paused;
+	u32			connected_cnt;
+	u32			max_connected;
 };
 
-void amdxdna_rq_init(struct amdxdna_ctx_rq *rq);
+int amdxdna_rq_init(struct amdxdna_ctx_rq *rq);
 void amdxdna_rq_fini(struct amdxdna_ctx_rq *rq);
 
 void amdxdna_rq_add(struct amdxdna_ctx_rq *rq, struct amdxdna_ctx *ctx);

--- a/src/driver/amdxdna/amdxdna_drm.h
+++ b/src/driver/amdxdna/amdxdna_drm.h
@@ -15,6 +15,7 @@
 #include <linux/workqueue.h>
 
 #include "amdxdna_ctx.h"
+#include "amdxdna_ctx_runqueue.h"
 #ifdef AMDXDNA_SHMEM
 #include "amdxdna_gem.h"
 #else
@@ -34,6 +35,9 @@
 
 #define tdr_to_xdna_dev(t) \
 	((struct amdxdna_dev *)container_of(t, struct amdxdna_dev, tdr))
+
+#define ctx_rq_to_xdna_dev(r) \
+	((struct amdxdna_dev *)container_of(r, struct amdxdna_dev, ctx_rq))
 
 extern const struct drm_driver amdxdna_drm_drv;
 
@@ -116,7 +120,7 @@ struct amdxdna_dev {
 	const struct amdxdna_dev_info	*dev_info;
 	void				*xrs_hdl;
 
-	struct mutex			dev_lock; /* protect client list, dev_info->ops, xrs_hdl */
+	struct mutex			dev_lock; /* protect client list, xrs_hdl */
 	struct list_head		client_list;
 	struct amdxdna_fw_ver		fw_ver;
 	struct amdxdna_tdr		tdr;
@@ -128,6 +132,7 @@ struct amdxdna_dev {
 
 	u32				ctx_cnt;
 	u32				ctx_limit;
+	struct amdxdna_ctx_rq		ctx_rq;
 };
 
 struct amdxdna_stats {

--- a/src/driver/amdxdna/amdxdna_gem.h
+++ b/src/driver/amdxdna/amdxdna_gem.h
@@ -11,7 +11,6 @@
 #include <drm/drm_gem_shmem_helper.h>
 #include <linux/hmm.h>
 
-
 struct amdxdna_umap {
 	struct vm_area_struct		*vma;
 	struct mmu_interval_notifier	notifier;

--- a/test/shim_test/dev_info.cpp
+++ b/test/shim_test/dev_info.cpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright (C) 2024, Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (C) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
 
 #include "dev_info.h"
 
@@ -30,7 +30,7 @@ xclbin_info xclbin_infos[] = {
   },
   {
     .name = "1x4.xclbin",
-    .device = npu2_device_id,
+    .device = npu4_device_id,
     .revision_id = npu2_revision_id,
     .ip_name2idx = {
       { "DPU_PDI_0:IPUV1CNN",         {0} },
@@ -107,7 +107,7 @@ xclbin_info xclbin_infos[] = {
   },
   {
     .name = "1x4.xclbin",
-    .device = npu2_device_id,
+    .device = npu4_device_id,
     .revision_id = npu4_revision_id,
     .ip_name2idx = {
       { "DPU_PDI_0:IPUV1CNN",         {0} },
@@ -130,7 +130,7 @@ xclbin_info xclbin_infos[] = {
   },
   {
     .name = "1x4.xclbin",
-    .device = npu2_device_id,
+    .device = npu4_device_id,
     .revision_id = npu5_revision_id,
     .ip_name2idx = {
       { "DPU_PDI_0:IPUV1CNN",         {0} },
@@ -153,7 +153,7 @@ xclbin_info xclbin_infos[] = {
   },
   {
     .name = "1x4.xclbin",
-    .device = npu2_device_id,
+    .device = npu4_device_id,
     .revision_id = npu6_revision_id,
     .ip_name2idx = {
       { "DPU_PDI_0:IPUV1CNN",         {0} },
@@ -186,7 +186,7 @@ xclbin_info xclbin_infos[] = {
   },
   {
     .name = "design.xclbin",
-    .device = npu2_device_id,
+    .device = npu4_device_id,
     .revision_id = npu_any_revision_id,
     .ip_name2idx = {
       { "DPU:IPUV1CNN", {0} },

--- a/test/shim_test/dev_info.h
+++ b/test/shim_test/dev_info.h
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright (C) 2024, Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (C) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
 
 #ifndef _SHIMTEST_DEV_INFO_H_
 #define _SHIMTEST_DEV_INFO_H_
@@ -19,9 +19,9 @@ struct xclbin_info {
 };
 
 const uint16_t npu1_device_id = 0x1502;
-const uint16_t npu2_device_id = 0x17f0;
 const uint16_t npu3_device_id = 0x1569;
 const uint16_t npu3_device_id1 = 0x1640;
+const uint16_t npu4_device_id = 0x17f0;
 const uint16_t npu_any_revision_id = 0xffff;
 const uint16_t npu1_revision_id = 0x0;
 const uint16_t npu2_revision_id = 0x0;

--- a/test/shim_test/io.cpp
+++ b/test/shim_test/io.cpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright (C) 2024, Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (C) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
 
 #include "io.h"
 #include "hwctx.h"
@@ -268,7 +268,7 @@ init_cmd(xrt_core::cuidx_type idx, bool dump)
     ebuf.add_arg_64(0);
     ebuf.add_arg_64(0);
     ebuf.patch_ctrl_code(*m_bo_array[IO_TEST_BO_INSTRUCTION].tbo.get(), m_elf_path);
-  } else if (dev_id == npu2_device_id) {
+  } else if (dev_id == npu4_device_id) {
     ebuf.add_ctrl_bo(*m_bo_array[IO_TEST_BO_INSTRUCTION].tbo.get());
     ebuf.add_arg_32(3);
     ebuf.add_arg_64(0);

--- a/test/shim_test/shim_test.cpp
+++ b/test/shim_test/shim_test.cpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright (C) 2022-2023, Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (C) 2022-2025, Advanced Micro Devices, Inc. All rights reserved.
 //
 // WARNING: This file contains test cases calling XRT's SHIM layer APIs directly.
 // These APIs are XRT's internal APIs and are not meant for any external XRT
@@ -141,7 +141,7 @@ dev_filter_is_aie2(device::id_type id, device* dev)
   if (!is_xdna_dev(dev))
     return false;
   auto device_id = device_query<query::pcie_device>(dev);
-  return device_id == npu1_device_id || device_id == npu2_device_id;
+  return device_id == npu1_device_id || device_id == npu4_device_id;
 }
 
 bool
@@ -254,6 +254,32 @@ TEST_create_destroy_hw_context(device::id_type id, std::shared_ptr<device> sdev,
   {
     auto dev = get_userpf_device(id);
     hw_ctx hwctx{dev.get()};
+  }
+}
+
+void
+TEST_create_destroy_virtual_context(device::id_type id, std::shared_ptr<device> sdev, arg_type& arg)
+{
+  auto dev = sdev.get();
+  auto device_id = device_query<query::pcie_device>(dev);
+  int is_negative = static_cast<unsigned int>(arg[0]);
+  int num_virt_ctx;
+
+  // XDNA driver by default supports 6 virtual context on npu1 and 32 virtual context on npu4
+  if (device_id == npu1_device_id)
+    num_virt_ctx = 6;
+  else
+    num_virt_ctx = 32;
+
+  if (is_negative)
+    num_virt_ctx += 1;
+
+  std::cout << "Creating " << num_virt_ctx << " contexts" << std::endl;
+  // Try opening device and creating ctx twice
+  {
+    std::vector<std::unique_ptr<hw_ctx>> ctxs;
+    for (int i = 0; i < num_virt_ctx; i++)
+      ctxs.push_back(std::make_unique<hw_ctx>(dev));
   }
 }
 
@@ -635,6 +661,12 @@ std::vector<test_case> test_list {
   },
   test_case{ "multi-command ELF io test real kernel good run", {},
     TEST_POSITIVE, dev_filter_is_aie2, TEST_elf_io, { IO_TEST_NORMAL_RUN, 3 }
+  },
+  test_case{ "virtual context test", {},
+    TEST_POSITIVE, dev_filter_is_aie2, TEST_create_destroy_virtual_context, { 0 }
+  },
+  test_case{ "virtual context bad test", {},
+    TEST_NEGATIVE, dev_filter_is_aie2, TEST_create_destroy_virtual_context, { 1 }
   },
 };
 

--- a/test/shim_test/shim_test.cpp
+++ b/test/shim_test/shim_test.cpp
@@ -6,6 +6,7 @@
 // user to call. We can't provide any support if you use APIs here and run into issues.
 
 
+#include "multi_threads.h"
 #include "dev_info.h"
 #include "io_param.h"
 #include "hwctx.h"
@@ -159,6 +160,24 @@ dev_filter_is_aie(device::id_type id, device* dev)
   return dev_filter_is_aie2(id, dev) || dev_filter_is_aie4(id, dev);
 }
 
+bool
+dev_filter_is_npu1(device::id_type id, device* dev)
+{
+  if (!is_xdna_dev(dev))
+    return false;
+  auto device_id = device_query<query::pcie_device>(dev);
+  return device_id == npu1_device_id;
+}
+
+bool
+dev_filter_is_npu4(device::id_type id, device* dev)
+{
+  if (!is_xdna_dev(dev))
+    return false;
+  auto device_id = device_query<query::pcie_device>(dev);
+  return device_id == npu4_device_id;
+}
+
 // All test case runners
 
 void
@@ -281,6 +300,17 @@ TEST_create_destroy_virtual_context(device::id_type id, std::shared_ptr<device> 
     for (int i = 0; i < num_virt_ctx; i++)
       ctxs.push_back(std::make_unique<hw_ctx>(dev));
   }
+}
+
+void
+TEST_multi_context_io_test(device::id_type id, std::shared_ptr<device> sdev, arg_type& arg)
+{
+  auto dev = sdev.get();
+  auto device_id = device_query<query::pcie_device>(dev);
+  int num_virt_ctx = static_cast<unsigned int>(arg[0]);
+
+  multi_thread threads(num_virt_ctx, TEST_io_latency);
+  threads.run_test(id, sdev, {IO_TEST_NORMAL_RUN, IO_TEST_IOCTL_WAIT, 3000});
 }
 
 void
@@ -667,6 +697,30 @@ std::vector<test_case> test_list {
   },
   test_case{ "virtual context bad test", {},
     TEST_NEGATIVE, dev_filter_is_aie2, TEST_create_destroy_virtual_context, { 1 }
+  },
+  test_case{ "Multi context IO test 1 (npu1)", {},
+    TEST_POSITIVE, dev_filter_is_npu1, TEST_multi_context_io_test, { 2 }
+  },
+  test_case{ "Multi context IO test 2 (npu1)", {},
+    TEST_POSITIVE, dev_filter_is_npu1, TEST_multi_context_io_test, { 4 }
+  },
+  test_case{ "Multi context IO test 3 (npu1)", {},
+    TEST_POSITIVE, dev_filter_is_npu1, TEST_multi_context_io_test, { 6 }
+  },
+  //test_case{ "Multi context IO test 4 (npu1)", {},
+  //  TEST_POSITIVE, dev_filter_is_npu1, TEST_multi_context_io_test, { 10 }
+  //},
+  test_case{ "Multi context IO test 1 (npu4)", {},
+    TEST_POSITIVE, dev_filter_is_npu4, TEST_multi_context_io_test, { 2 }
+  },
+  test_case{ "Multi context IO test 1 (npu4)", {},
+    TEST_POSITIVE, dev_filter_is_npu4, TEST_multi_context_io_test, { 4 }
+  },
+  test_case{ "Multi context IO test 1 (npu4)", {},
+    TEST_POSITIVE, dev_filter_is_npu4, TEST_multi_context_io_test, { 16 }
+  },
+  test_case{ "Multi context IO test 1 (npu4)", {},
+    TEST_POSITIVE, dev_filter_is_npu4, TEST_multi_context_io_test, { 20 }
   },
 };
 


### PR DESCRIPTION
This is the Part I change for the virtual context support. There will be a Part II change to fully support virtual context.
1. Add context runqueue
2. Create context doesn't connect hardware context
3. Configure CU ioctl doesn't send configure CU command to firmware
4. The hardware context will be connected when the first command comes
5. If there is not hardware context available, the command will block in the submit command ioctl
6. Add shim test cases

This has been test on NPU1 and NPU4. All shim test passed.