### PR TITLE
move priority convert function to shim;

### DIFF
--- a/src/driver/amdxdna/aie2_message.c
+++ b/src/driver/amdxdna/aie2_message.c
@@ -240,9 +240,6 @@ int aie2_create_context(struct amdxdna_dev_hdl *ndev, struct amdxdna_ctx *ctx,
 	struct cq_pair *cq_pair;
 	int ret;
 
-	if (ctx->qos.priority == AMDXDNA_QOS_DEFAULT_PRIORITY)
-		ctx->qos.priority = AMDXDNA_QOS_HIGH_PRIORITY;
-
 	req.aie_type = 1;
 	req.start_col = ctx->start_col;
 	req.num_col = ctx->num_col;

--- a/src/driver/amdxdna/aie2_message.c
+++ b/src/driver/amdxdna/aie2_message.c
@@ -19,27 +19,6 @@
 #define aie2_send_mgmt_msg_wait(ndev, msg) \
 	aie2_send_mgmt_msg_wait_offset(ndev, msg, 0)
 
-static int map_app_priority_to_fw(enum amdxdna_qos_priority avalue, u32 *fvalue)
-{
-	switch (avalue) {
-	case AMDXDNA_QOS_REALTIME_PRIORITY:
-		*fvalue = AIE2_QOS_REALTIME_PRIORITY;
-		break;
-	case AMDXDNA_QOS_HIGH_PRIORITY:
-		*fvalue = AIE2_QOS_HIGH_PRIORITY;
-		break;
-	case AMDXDNA_QOS_NORMAL_PRIORITY:
-		*fvalue = AIE2_QOS_NORMAL_PRIORITY;
-		break;
-	case AMDXDNA_QOS_LOW_PRIORITY:
-		*fvalue = AIE2_QOS_LOW_PRIORITY;
-		break;
-	default:
-		return -EINVAL;
-	}
-	return 0;
-}
-
 static int
 aie2_send_mgmt_msg_wait_offset(struct amdxdna_dev_hdl *ndev,
 			       struct xdna_mailbox_msg *msg,
@@ -259,25 +238,17 @@ int aie2_create_context(struct amdxdna_dev_hdl *ndev, struct amdxdna_ctx *ctx,
 	DECLARE_AIE2_MSG(create_ctx, MSG_OP_CREATE_CONTEXT);
 	struct amdxdna_dev *xdna = ndev->xdna;
 	struct cq_pair *cq_pair;
-	u32 priority;
 	int ret;
 
-	/* Default to high priority, if unset */
-	if (!ctx->qos.priority)
+	if (ctx->qos.priority == AMDXDNA_QOS_DEFAULT_PRIORITY)
 		ctx->qos.priority = AMDXDNA_QOS_HIGH_PRIORITY;
-
-	ret = map_app_priority_to_fw(ctx->qos.priority, &priority);
-	if (ret) {
-		XDNA_ERR(xdna, "Invalid context priority: 0x%x\n", ctx->qos.priority);
-		return ret;
-	}
 
 	req.aie_type = 1;
 	req.start_col = ctx->start_col;
 	req.num_col = ctx->num_col;
 	req.num_cq_pairs_requested = 1;
 	req.pasid = ctx->client->pasid;
-	req.context_priority = priority;
+	req.context_priority = ctx->qos.priority;
 
 	ret = aie2_send_mgmt_msg_wait(ndev, &msg);
 	if (ret)
@@ -306,8 +277,8 @@ int aie2_create_context(struct amdxdna_dev_hdl *ndev, struct amdxdna_ctx *ctx,
 	info->i2x.rb_size	  = cq_pair->i2x_q.buf_size;
 
 	aie2_calc_intr_reg(info);
-	XDNA_DBG(xdna, "%s created fw ctx %d pasid %d priority %d", ctx->name,
-		 ctx->priv->id, ctx->client->pasid, priority);
+	XDNA_DBG(xdna, "%s created hwctx %d pasid %d priority %d", ctx->name,
+		 ctx->priv->id, ctx->client->pasid, ctx->qos.priority);
 
 	return 0;
 }
@@ -327,7 +298,7 @@ int aie2_destroy_context(struct amdxdna_dev_hdl *ndev, struct amdxdna_ctx *ctx)
 		XDNA_WARN(xdna, "%s destroy context failed, ret %d", ctx->name, ret);
 
 	trace_amdxdna_debug_point(ctx->name, 0, "channel destroyed");
-	XDNA_DBG(xdna, "%s destroyed fw ctx %d", ctx->name, ctx->priv->id);
+	XDNA_DBG(xdna, "%s destroyed hwctx %d", ctx->name, ctx->priv->id);
 	ctx->priv->id = -1;
 
 	return ret;
@@ -346,7 +317,7 @@ int aie2_map_host_buf(struct amdxdna_dev_hdl *ndev, u32 context_id, u64 addr, u6
 	if (ret)
 		return ret;
 
-	XDNA_DBG(xdna, "fw ctx %d map host buf addr 0x%llx size 0x%llx",
+	XDNA_DBG(xdna, "hwctx %d map host buf addr 0x%llx size 0x%llx",
 		 context_id, addr, size);
 
 	return 0;

--- a/src/driver/amdxdna/aie2_msg_priv.h
+++ b/src/driver/amdxdna/aie2_msg_priv.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: GPL-2.0 */
 /*
- * Copyright (C) 2022-2024, Advanced Micro Devices, Inc.
+ * Copyright (C) 2022-2025, Advanced Micro Devices, Inc.
  */
 
 #ifndef _AIE2_MSG_PRIV_H_
@@ -88,13 +88,6 @@ enum aie2_msg_status {
 	AIE2_STATUS_DEBUG_BO_CONFIG_FAILED,
 	AIE2_STATUS_MAX_RTOS_STATUS_CODE,
 	MAX_AIE2_STATUS_CODE
-};
-
-enum aie2_qos_priority {
-	AIE2_QOS_REALTIME_PRIORITY = 1,
-	AIE2_QOS_HIGH_PRIORITY,
-	AIE2_QOS_NORMAL_PRIORITY,
-	AIE2_QOS_LOW_PRIORITY
 };
 
 struct assign_mgmt_pasid_req {

--- a/src/driver/amdxdna/amdxdna_ctx.c
+++ b/src/driver/amdxdna/amdxdna_ctx.c
@@ -118,6 +118,8 @@ int amdxdna_drm_create_ctx_ioctl(struct drm_device *dev, void *data, struct drm_
 		goto free_ctx;
 	}
 
+	if (ctx->qos.priority == AMDXDNA_QOS_DEFAULT_PRIORITY)
+		ctx->qos.priority = AMDXDNA_QOS_HIGH_PRIORITY;
 	ctx->client = client;
 	ctx->tdr_last_completed = -1;
 	ctx->num_tiles = args->num_tiles;

--- a/src/driver/amdxdna/amdxdna_ctx_runqueue.c
+++ b/src/driver/amdxdna/amdxdna_ctx_runqueue.c
@@ -15,7 +15,7 @@ static int amdxdna_rq_start(struct amdxdna_ctx_rq *rq, struct amdxdna_ctx *ctx)
 
 	xdna = ctx_rq_to_xdna_dev(rq);
 	mutex_lock(&xdna->dev_lock);
-	if (FIELD_GET(CTX_STATE_CONNECTED, ctx->status))
+	if (FIELD_GET(CTX_STATE_READY, ctx->status))
 		goto unlock_and_out; /* Connected */
 
 	ret = xdna->dev_info->ops->ctx_connect(ctx);
@@ -40,7 +40,7 @@ static void amdxdna_rq_stop(struct amdxdna_ctx_rq *rq, struct amdxdna_ctx *ctx)
 	struct amdxdna_dev *xdna;
 
 	xdna = ctx_rq_to_xdna_dev(rq);
-	if (!FIELD_GET(CTX_STATE_CONNECTED, ctx->status))
+	if (!FIELD_GET(CTX_STATE_READY, ctx->status))
 		return;
 
 	drm_WARN_ON(&xdna->ddev, !mutex_is_locked(&xdna->dev_lock));
@@ -146,7 +146,7 @@ int amdxdna_rq_wait_for_run(struct amdxdna_ctx_rq *rq, struct amdxdna_ctx *ctx)
 	int ret;
 
 try_connect:
-	if (FIELD_GET(CTX_STATE_CONNECTED, ctx->status))
+	if (FIELD_GET(CTX_STATE_READY, ctx->status))
 		return 0;
 
 	ret = amdxdna_rq_start(rq, ctx);
@@ -167,7 +167,7 @@ try_connect:
 
 	ret = wait_event_interruptible(ctx->connect_waitq,
 				       FIELD_GET(CTX_STATE_CONNECTING, ctx->status) ||
-				       FIELD_GET(CTX_STATE_CONNECTED, ctx->status));
+				       FIELD_GET(CTX_STATE_READY, ctx->status));
 	if (!ret)
 		goto try_connect;
 

--- a/src/include/uapi/drm_local/amdxdna_accel.h
+++ b/src/include/uapi/drm_local/amdxdna_accel.h
@@ -61,7 +61,7 @@ enum amdxdna_device_type {
 };
 
 /*
- * Enum for priority in application's QoS.
+ * Define priority in application's QoS.
  * AMDXDNA_QOS_DEFAULT_PRIORITY: Driver decide priority for client.
  * AMDXDNA_QOS_REALTIME_PRIORITY: Real time clients.
  * AMDXDNA_QOS_HIGH_PRIORITY: Best effort foreground clients.
@@ -69,13 +69,13 @@ enum amdxdna_device_type {
  * AMDXDNA_QOS_LOW_PRIORITY: Clients that can wait indefinite amount of time for
  *                           completion.
  */
-enum amdxdna_qos_priority {
-	AMDXDNA_QOS_DEFAULT_PRIORITY	= 0,
-	AMDXDNA_QOS_REALTIME_PRIORITY	= 1,
-	AMDXDNA_QOS_HIGH_PRIORITY	= 2,
-	AMDXDNA_QOS_NORMAL_PRIORITY	= 3,
-	AMDXDNA_QOS_LOW_PRIORITY	= 4,
-};
+#define	AMDXDNA_QOS_DEFAULT_PRIORITY	0
+#define	AMDXDNA_QOS_REALTIME_PRIORITY	1
+#define	AMDXDNA_QOS_HIGH_PRIORITY	2
+#define	AMDXDNA_QOS_NORMAL_PRIORITY	3
+#define	AMDXDNA_QOS_LOW_PRIORITY	4
+/* The maximum number of priority */
+#define	AMDXDNA_NUM_PRIORITY		4
 
 /**
  * struct qos_info - QoS information for driver.

--- a/src/include/uapi/drm_local/amdxdna_accel.h
+++ b/src/include/uapi/drm_local/amdxdna_accel.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: GPL-2.0 WITH Linux-syscall-note */
 /*
- * Copyright (C) 2022-2024, Advanced Micro Devices, Inc.
+ * Copyright (C) 2022-2025, Advanced Micro Devices, Inc.
  */
 
 #ifndef AMDXDNA_ACCEL_H_
@@ -61,7 +61,8 @@ enum amdxdna_device_type {
 };
 
 /*
- * Enum for priority in application's QoS. Values copied from Window shim layer.
+ * Enum for priority in application's QoS.
+ * AMDXDNA_QOS_DEFAULT_PRIORITY: Driver decide priority for client.
  * AMDXDNA_QOS_REALTIME_PRIORITY: Real time clients.
  * AMDXDNA_QOS_HIGH_PRIORITY: Best effort foreground clients.
  * AMDXDNA_QOS_NORMAL_PRIORITY: Best effort or background clients.
@@ -69,10 +70,11 @@ enum amdxdna_device_type {
  *                           completion.
  */
 enum amdxdna_qos_priority {
-	AMDXDNA_QOS_REALTIME_PRIORITY = 0x100,
-	AMDXDNA_QOS_HIGH_PRIORITY = 0x180,
-	AMDXDNA_QOS_NORMAL_PRIORITY = 0x200,
-	AMDXDNA_QOS_LOW_PRIORITY = 0x280
+	AMDXDNA_QOS_DEFAULT_PRIORITY	= 0,
+	AMDXDNA_QOS_REALTIME_PRIORITY	= 1,
+	AMDXDNA_QOS_HIGH_PRIORITY	= 2,
+	AMDXDNA_QOS_NORMAL_PRIORITY	= 3,
+	AMDXDNA_QOS_LOW_PRIORITY	= 4,
 };
 
 /**

--- a/src/shim/hwctx.cpp
+++ b/src/shim/hwctx.cpp
@@ -37,6 +37,24 @@ destroy_syncobj(const shim_xdna::pdev& dev, uint32_t hdl)
   dev.ioctl(DRM_IOCTL_SYNCOBJ_DESTROY, &dsobj);
 }
 
+int
+convert_priority(int p)
+{
+  // Below value of cases are copy from MCDM for application porting friendly
+  switch (p) {
+    case 0x100:
+      return AMDXDNA_QOS_REALTIME_PRIORITY;
+    case 0x180:
+      return AMDXDNA_QOS_HIGH_PRIORITY;
+    case 0x200:
+      return AMDXDNA_QOS_NORMAL_PRIORITY;
+    case 0x280:
+      return AMDXDNA_QOS_LOW_PRIORITY;
+    default:
+      shim_err(EINVAL, "Invalid priority %d", p);
+  };
+}
+
 }
 namespace shim_xdna {
 
@@ -141,7 +159,7 @@ init_qos_info(const qos_type& qos)
     else if (key == "frame_execution_time")
       m_qos.frame_exec_time = value;
     else if (key == "priority")
-      m_qos.priority = value;
+      m_qos.priority = convert_priority(value);
   }
 }
 


### PR DESCRIPTION
 the origin priority is application defined, shim is a better place to convert it to driver defined priority value