### PR TITLE
XDNA changes for xrt submodule update and shim changes

### DIFF
--- a/CMake/pkg.cmake
+++ b/CMake/pkg.cmake
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (C) 2023-2024, Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (C) 2023-2025, Advanced Micro Devices, Inc. All rights reserved.
 
 execute_process(
   COMMAND uname -m
@@ -44,7 +44,7 @@ set(CPACK_DEB_COMPONENT_INSTALL yes)
 set(CPACK_PACKAGE_FILE_NAME
   "${CPACK_PACKAGE_NAME}.${CPACK_PACKAGE_VERSION_MAJOR}.${CPACK_PACKAGE_VERSION_MINOR}.${CPACK_PACKAGE_VERSION_PATCH}_${XDNA_CPACK_LINUX_FLAVOR}${XDNA_CPACK_LINUX_VERSION}-${XDNA_CPACK_ARCH}")
 math(EXPR next_minor "${CPACK_PACKAGE_VERSION_MINOR} + 1")
-set(CPACK_DEBIAN_PACKAGE_DEPENDS "xrt-npu (>= ${CPACK_PACKAGE_VERSION_MAJOR}.${CPACK_PACKAGE_VERSION_MINOR}), xrt-npu (<< ${CPACK_PACKAGE_VERSION_MAJOR}.${next_minor})")
+set(CPACK_DEBIAN_PACKAGE_DEPENDS "xrt-base (>= ${CPACK_PACKAGE_VERSION_MAJOR}.${CPACK_PACKAGE_VERSION_MINOR}), xrt-base (<< ${CPACK_PACKAGE_VERSION_MAJOR}.${next_minor})")
 
 install(DIRECTORY ${AMDXDNA_BINS_DIR}/firmware/
   DESTINATION /lib/firmware/amdnpu

--- a/src/shim/device.cpp
+++ b/src/shim/device.cpp
@@ -610,11 +610,40 @@ struct xrt_smi_config
     const auto xrt_smi_config_type = std::any_cast<xrt_core::query::xrt_smi_config::type>(param);
     switch (xrt_smi_config_type) {
     case xrt_core::query::xrt_smi_config::type::options_config:
-      xrt_smi_config = shim_xdna::smi::get_smi_config();
-      break;
+      return shim_xdna::smi::get_smi_config();
+    default:
+      throw xrt_core::query::no_such_key(key, "Not implemented");
     }
 
     return xrt_smi_config;
+  }
+};
+
+struct xrt_smi_lists
+{
+  using result_type = std::any;
+
+  static result_type
+  get(const xrt_core::device* /*device*/, key_type key)
+  {
+    throw xrt_core::query::no_such_key(key, "Not implemented");
+  }
+
+  static result_type
+  get(const xrt_core::device* /*device*/, key_type key, const std::any& reqType)
+  {
+    if (key != key_type::xrt_smi_lists)
+      throw xrt_core::query::no_such_key(key, "Not implemented");
+
+    const auto xrt_smi_lists_type = std::any_cast<xrt_core::query::xrt_smi_lists::type>(reqType);
+    switch (xrt_smi_lists_type) {
+    case xrt_core::query::xrt_smi_lists::type::validate_tests:
+      return shim_xdna::smi::get_validate_tests();
+    case xrt_core::query::xrt_smi_lists::type::examine_reports:
+      return shim_xdna::smi::get_examine_reports();
+    default:
+      throw xrt_core::query::no_such_key(key, "Not implemented");
+    }
   }
 };
 
@@ -846,6 +875,7 @@ initialize_query_table()
   emplace_func1_request<query::elf_name,		       elf_name>();
   emplace_func1_request<query::xclbin_name,                    xclbin_name>();
   emplace_func1_request<query::xrt_smi_config,                 xrt_smi_config>();
+  emplace_func1_request<query::xrt_smi_lists,                  xrt_smi_lists>();
   emplace_func0_request<query::firmware_version,               firmware_version>();
 }
 

--- a/src/shim/smi.cpp
+++ b/src/shim/smi.cpp
@@ -4,48 +4,56 @@
 
 namespace shim_xdna::smi {
 
-const std::vector<std::tuple<std::string, std::string, std::string>>& 
 smi_xdna::
-get_validate_test_desc() const 
+smi_xdna() : smi_base() 
 {
-  static const std::vector<std::tuple<std::string, std::string, std::string>> validate_test_desc = {
+  // Filter validate_test_desc to include only relevant entries
+  validate_test_desc = {
     {"aie-reconfig-overhead", "Run end-to-end array reconfiguration overhead through shim DMA", "hidden"},
     {"all", "All applicable validate tests will be executed (default)", "common"},
-    {"cmd-chain-latency", "Run end-to-end latency test using command chaining", "common"},
-    {"cmd-chain-throughput", "Run end-to-end throughput test using command chaining", "common"},
-    {"df-bw", "Run bandwidth test on data fabric", "common"},
+    {"cmd-chain-latency", "Run end-to-end latency test using command chaining", "hidden"},
+    {"cmd-chain-throughput", "Run end-to-end throughput test using command chaining", "hidden"},
+    {"df-bw", "Run bandwidth test on data fabric", "hidden"},
     {"gemm", "Measure the TOPS value of GEMM operations", "common"},
     {"latency", "Run end-to-end latency test", "common"},
-    {"quick", "Run a subset of four tests: \n1. latency \n2. throughput \n3. cmd-chain-latency \n4. cmd-chain-throughput", "common"},
+    {"quick", "Run a subset of four tests: \n1. latency \n2. throughput \n3. cmd-chain-latency \n4. cmd-chain-throughput", "hidden"},
     {"spatial-sharing-overhead", "Run Spatial Sharing Overhead Test", "hidden"},
-    {"tct-all-col", "Measure average TCT processing time for all columns", "common"},
-    {"tct-one-col", "Measure average TCT processing time for one column", "common"},
+    {"tct-all-col", "Measure average TCT processing time for all columns", "hidden"},
+    {"tct-one-col", "Measure average TCT processing time for one column", "hidden"},
     {"temporal-sharing-overhead", "Run Temporal Sharing Overhead Test", "hidden"},
     {"throughput", "Run end-to-end throughput test", "common"}
   };
-  return validate_test_desc;
-}
 
-const std::vector<std::tuple<std::string, std::string, std::string>>& 
-smi_xdna::
-get_examine_report_desc() const 
-{
-  static const std::vector<std::tuple<std::string, std::string, std::string>> examine_report_desc = {
+  // Filter examine_report_desc to include only relevant entries
+  examine_report_desc = {
     {"aie-partitions", "AIE partition information", "common"},
     {"host", "Host information", "common"},
     {"platform", "Platforms flashed on the device", "common"},
-    {"telemetry", "Telemetry data for the device", "common"}
+    {"telemetry", "Telemetry data for the device", "hidden"}
   };
-  return examine_report_desc;
 }
+  
+static shim_xdna::smi::smi_xdna smi_instance;
 
 std::string
 get_smi_config()
 {
-  // Create an instance of the derived class
-  shim_xdna::smi::smi_xdna smi_instance;
-
   // Call the get_smi_config method
   return smi_instance.get_smi_config();
 }
+
+const xrt_core::smi::tuple_vector&
+get_validate_tests()
+{
+  // Call the get_validate_tests method
+  return smi_instance.get_validate_tests();
+}
+
+const xrt_core::smi::tuple_vector&
+get_examine_reports()
+{
+  // Call the get_examine_reports method
+  return smi_instance.get_examine_reports();
+}
+
 } // namespace shim_xdna::smi

--- a/src/shim/smi.h
+++ b/src/shim/smi.h
@@ -7,14 +7,17 @@
 namespace shim_xdna::smi {
 
 class smi_xdna : public xrt_core::smi::smi_base {
-protected:
-  const std::vector<std::tuple<std::string, std::string, std::string>>& 
-  get_validate_test_desc() const override;
-
-  const std::vector<std::tuple<std::string, std::string, std::string>>& 
-  get_examine_report_desc() const override;
+public:
+  smi_xdna();
 };
 
 /* This API can be device specific since this is used by the shim*/
 std::string get_smi_config();
+
+const xrt_core::smi::tuple_vector&
+get_validate_tests();
+
+const xrt_core::smi::tuple_vector&
+get_examine_reports();
+
 } // namespace shim_xdna::smi

--- a/tools/info.json
+++ b/tools/info.json
@@ -1,7 +1,7 @@
 {
 	"copyright": "Copyright (C) 2023-2025 Advanced Micro Devices, Inc. All rights reserved.",
 	"xrt" : {
-		"version": "202510.2.19.104",
+		"version": "202510.2.19.107",
 		"os_rel": ["22.04", "24.04"]
 	},
 	"firmwares": [

--- a/tools/info.json
+++ b/tools/info.json
@@ -1,7 +1,7 @@
 {
 	"copyright": "Copyright (C) 2023-2025 Advanced Micro Devices, Inc. All rights reserved.",
 	"xrt" : {
-		"version": "202510.2.19.98",
+		"version": "202510.2.19.104",
 		"os_rel": ["22.04", "24.04"]
 	},
 	"firmwares": [


### PR DESCRIPTION
This change updates the XRT submodule to e4dfa2
The XRT change (0f3822) adds a new device query to get the list of xrt-smi validate tests and examine reports. This change adds the implementation for this device query on the XDNA side. The change e4dfa2 takes care of the ordering for validate tests and examine reports required for https://jira.xilinx.com/browse/CR-1219113

Bugs : https://jira.xilinx.com/browse/VITIS-14366