### PR TITLE
Add carvedout memory support - part 1

### DIFF
--- a/src/driver/amdxdna/aie2_ctx.c
+++ b/src/driver/amdxdna/aie2_ctx.c
@@ -529,7 +529,7 @@ int aie2_ctx_init(struct amdxdna_ctx *ctx)
 			.size = MAX_CHAIN_CMDBUF_SIZE,
 		};
 
-		abo = amdxdna_drm_alloc_dev_bo(&xdna->ddev, &args, client->filp, true);
+		abo = amdxdna_drm_create_dev_bo(&xdna->ddev, &args, client->filp, true);
 		if (IS_ERR(abo)) {
 			ret = PTR_ERR(abo);
 			goto free_cmd_bufs;

--- a/src/driver/amdxdna/aie2_pci.c
+++ b/src/driver/amdxdna/aie2_pci.c
@@ -551,7 +551,7 @@ static int aie2_init(struct amdxdna_dev *xdna)
 	ret = amdxdna_iommu_mode_setup(xdna);
 	if (ret) {
 		XDNA_ERR(xdna, "Setup iommu mode %d failed, ret %d", iommu_mode, ret);
-		return ret;
+		goto free_irq;
 	}
 	if (iommu_mode != AMDXDNA_IOMMU_PASID)
 		goto skip_pasid;

--- a/src/driver/amdxdna/amdxdna_devel.c
+++ b/src/driver/amdxdna/amdxdna_devel.c
@@ -14,6 +14,20 @@ int iommu_mode;
 module_param(iommu_mode, int, 0644);
 MODULE_PARM_DESC(iommu_mode, "0 = w/ PASID (Default), 1 = wo/ PASID, 2 = Bypass");
 
+/*
+ * Carvedout memory is a chunck of memory which is physically contiguous and
+ * is reserved during early boot time. There is only one chunck of such memory
+ * per system. Once available, all BOs accessible from device should be
+ * allocated from this memory.
+ */
+u64 carvedout_addr;
+module_param(carvedout_addr, ullong, 0644);
+MODULE_PARM_DESC(carvedout_addr, "Physical memory address for reserved memory chunk");
+
+u64 carvedout_size;
+module_param(carvedout_size, ullong, 0644);
+MODULE_PARM_DESC(carvedout_size, "Physical memory size for reserved memory chunk");
+
 bool priv_load;
 module_param(priv_load, bool, 0644);
 MODULE_PARM_DESC(priv_load, "Privileged loading runtime configure (Default false)");
@@ -22,14 +36,64 @@ int start_col_index = -1;
 module_param(start_col_index, int, 0600);
 MODULE_PARM_DESC(start_col_index, "Force start column, default -1 (auto select)");
 
+struct amdxdna_carvedout {
+	struct drm_mm	mm;
+	struct mutex	lock;
+} carvedout;
+
+bool amdxdna_use_carvedout()
+{
+	return !!carvedout_addr;
+}
+
+void amdxdna_carvedout_init()
+{
+	if (!amdxdna_use_carvedout())
+		return;
+	mutex_init(&carvedout.lock);
+	drm_mm_init(&carvedout.mm, carvedout_addr, carvedout_size);
+}
+
+void amdxdna_carvedout_fini()
+{
+	if (!amdxdna_use_carvedout())
+		return;
+	mutex_destroy(&carvedout.lock);
+	drm_mm_takedown(&carvedout.mm);
+}
+
+int amdxdna_carvedout_alloc(struct drm_mm_node *node, u64 size, u64 alignment)
+{
+	int ret;
+
+	mutex_lock(&carvedout.lock);
+	ret = drm_mm_insert_node_generic(&carvedout.mm, node, size, alignment,
+					 0, DRM_MM_INSERT_BEST);
+	mutex_unlock(&carvedout.lock);
+	return ret;
+}
+
+void amdxdna_carvedout_free(struct drm_mm_node *node)
+{
+	mutex_lock(&carvedout.lock);
+	drm_mm_remove_node(node);
+	mutex_unlock(&carvedout.lock);
+}
+
 int amdxdna_iommu_mode_setup(struct amdxdna_dev *xdna)
 {
 	struct iommu_domain *domain = NULL;
 
 	switch (iommu_mode) {
 	case AMDXDNA_IOMMU_PASID:
+		// default case
 		break;
 	case AMDXDNA_IOMMU_NO_PASID:
+		// Can't use carvedout memory due to no struct page, so can't do dma map
+		if (amdxdna_use_carvedout()) {
+			XDNA_ERR(xdna, "Carvedout memory can't be used with this iommu mode");
+			return -EOPNOTSUPP;
+		}
 #if LINUX_VERSION_CODE < KERNEL_VERSION(6, 13, 0)
 		if (!iommu_present(xdna->ddev.dev->bus)) {
 #else
@@ -47,10 +111,11 @@ int amdxdna_iommu_mode_setup(struct amdxdna_dev *xdna)
 
 		break;
 	case AMDXDNA_IOMMU_BYPASS:
-		/*
-		 * IOMMU bypass mode is always supported, but
-		 * with 4MB contiguous physical memory limitation.
-		 */
+		 // IOMMU bypass mode requires carvedout memory reserved.
+		if (!amdxdna_use_carvedout()) {
+			XDNA_ERR(xdna, "No carvedout memory reserved!");
+			return -EOPNOTSUPP;
+		}
 		break;
 	default:
 		XDNA_ERR(xdna, "Invalid IOMMU mode %d", iommu_mode);

--- a/src/driver/amdxdna/amdxdna_devel.h
+++ b/src/driver/amdxdna/amdxdna_devel.h
@@ -18,6 +18,12 @@ extern int iommu_mode;
 extern bool priv_load;
 extern int start_col_index;
 
+bool amdxdna_use_carvedout(void);
+void amdxdna_carvedout_init(void);
+void amdxdna_carvedout_fini(void);
+int amdxdna_carvedout_alloc(struct drm_mm_node *node, u64 size, u64 alignment);
+void amdxdna_carvedout_free(struct drm_mm_node *node);
+
 int amdxdna_iommu_mode_setup(struct amdxdna_dev *aie);
 struct sg_table *amdxdna_alloc_sgt(struct amdxdna_dev *aie, size_t sz,
 				   struct page **pages, u32 nr_pages);

--- a/src/driver/amdxdna/amdxdna_drm.c
+++ b/src/driver/amdxdna/amdxdna_drm.c
@@ -281,7 +281,7 @@ const struct drm_driver amdxdna_drm_drv = {
 	.show_fdinfo = amdxdna_show_fdinfo,
 
 	/* For shmem object create */
-	.gem_create_object = amdxdna_gem_create_shmem_object,
+	.gem_create_object = amdxdna_gem_create_shmem_object_cb,
 #ifdef AMDXDNA_SHMEM
 	.gem_prime_import = amdxdna_gem_prime_import,
 #else

--- a/src/driver/amdxdna/amdxdna_drm.c
+++ b/src/driver/amdxdna/amdxdna_drm.c
@@ -281,7 +281,7 @@ const struct drm_driver amdxdna_drm_drv = {
 	.show_fdinfo = amdxdna_show_fdinfo,
 
 	/* For shmem object create */
-	.gem_create_object = amdxdna_gem_create_object_cb,
+	.gem_create_object = amdxdna_gem_create_shmem_object,
 #ifdef AMDXDNA_SHMEM
 	.gem_prime_import = amdxdna_gem_prime_import,
 #else

--- a/src/driver/amdxdna/amdxdna_gem.c
+++ b/src/driver/amdxdna/amdxdna_gem.c
@@ -29,28 +29,51 @@ MODULE_IMPORT_NS("DMA_BUF");
 #endif
 
 static int
-amdxdna_gem_insert_node_locked(struct amdxdna_gem_obj *abo, bool use_vmap)
+amdxdna_gem_heap_alloc(struct amdxdna_gem_obj *abo, bool use_vmap)
 {
 	struct amdxdna_client *client = abo->client;
 	struct amdxdna_dev *xdna = client->xdna;
 	struct amdxdna_mem *mem = &abo->mem;
+	struct amdxdna_gem_obj *heap;
 	u64 offset;
 	u32 align;
 	int ret;
 
+	mutex_lock(&client->mm_lock);
+
+	heap = client->dev_heap;
+	if (!heap) {
+		mutex_unlock(&client->mm_lock);
+		return -EINVAL;
+	}
+
+	if (heap->mem.userptr == AMDXDNA_INVALID_ADDR) {
+		XDNA_ERR(xdna, "Invalid dev heap userptr");
+		mutex_unlock(&client->mm_lock);
+		return -EINVAL;
+	}
+
+	if (mem->size == 0 || mem->size > heap->mem.size) {
+		XDNA_ERR(xdna, "Invalid dev bo size 0x%lx, limit 0x%lx",
+			 mem->size, heap->mem.size);
+		mutex_unlock(&client->mm_lock);
+		return -EINVAL;
+	}
+
 	align = 1 << max(PAGE_SHIFT, xdna->dev_info->dev_mem_buf_shift);
-	ret = drm_mm_insert_node_generic(&abo->dev_heap->mm, &abo->mm_node,
+	ret = drm_mm_insert_node_generic(&heap->mm, &abo->mm_node,
 					 mem->size, align,
 					 0, DRM_MM_INSERT_BEST);
 	if (ret) {
 		XDNA_ERR(xdna, "Failed to alloc dev bo memory, ret %d", ret);
+		mutex_unlock(&client->mm_lock);
 		return ret;
 	}
 
 	mem->dev_addr = abo->mm_node.start;
-	offset = mem->dev_addr - abo->dev_heap->mem.dev_addr;
-	mem->userptr = abo->dev_heap->mem.userptr + offset;
-	mem->pages = &abo->dev_heap->base.pages[offset >> PAGE_SHIFT];
+	offset = mem->dev_addr - client->dev_heap->mem.dev_addr;
+	mem->userptr = client->dev_heap->mem.userptr + offset;
+	mem->pages = &client->dev_heap->base.pages[offset >> PAGE_SHIFT];
 	mem->nr_pages = mem->size >> PAGE_SHIFT;
 
 	if (use_vmap) {
@@ -58,11 +81,27 @@ amdxdna_gem_insert_node_locked(struct amdxdna_gem_obj *abo, bool use_vmap)
 		if (!mem->kva) {
 			XDNA_ERR(xdna, "Failed to vmap");
 			drm_mm_remove_node(&abo->mm_node);
+			mutex_unlock(&client->mm_lock);
 			return -EFAULT;
 		}
 	}
 
+	drm_gem_object_get(to_gobj(heap));
+
+	mutex_unlock(&client->mm_lock);
 	return 0;
+}
+
+static void
+amdxdna_gem_heap_free(struct amdxdna_gem_obj *abo)
+{
+	mutex_lock(&abo->client->mm_lock);
+
+	drm_mm_remove_node(&abo->mm_node);
+	drm_gem_object_put(to_gobj(abo->client->dev_heap));
+	vunmap(abo->mem.kva);
+
+	mutex_unlock(&abo->client->mm_lock);
 }
 
 static bool amdxdna_hmm_invalidate(struct mmu_interval_notifier *mni,
@@ -208,7 +247,65 @@ free_map:
 	return ret;
 }
 
-static void amdxdna_gem_obj_free(struct drm_gem_object *gobj)
+static struct amdxdna_gem_obj *
+amdxdna_gem_create_obj(struct drm_device *dev, size_t size)
+{
+	struct amdxdna_gem_obj *abo;
+
+	abo = kzalloc(sizeof(*abo), GFP_KERNEL);
+	if (!abo)
+		return ERR_PTR(-ENOMEM);
+
+	abo->assigned_ctx = AMDXDNA_INVALID_CTX_HANDLE;
+	mutex_init(&abo->lock);
+
+	abo->mem.userptr = AMDXDNA_INVALID_ADDR;
+	abo->mem.dev_addr = AMDXDNA_INVALID_ADDR;
+	abo->mem.size = size;
+	INIT_LIST_HEAD(&abo->mem.umap_list);
+
+	return abo;
+}
+
+static void
+amdxdna_gem_destroy_obj(struct amdxdna_gem_obj *abo)
+{
+	mutex_destroy(&abo->lock);
+	kfree(abo);
+}
+
+static void amdxdna_gem_guest_obj_free(struct drm_gem_object *gobj)
+{
+	struct amdxdna_dev *xdna = to_xdna_dev(gobj->dev);
+	struct amdxdna_gem_obj *abo = to_xdna_obj(gobj);
+
+	XDNA_DBG(xdna, "BO type %d xdna_addr 0x%llx", abo->type, abo->mem.dev_addr);
+	if (abo->flags & BO_SUBMIT_PINNED)
+		amdxdna_gem_unpin(abo);
+
+	if (abo->mem.pages) {
+		unpin_user_pages(abo->mem.pages, abo->mem.nr_pages);
+		kvfree(abo->mem.pages);
+	}
+	drm_gem_object_release(gobj);
+	amdxdna_gem_destroy_obj(abo);
+}
+
+static void amdxdna_gem_dev_obj_free(struct drm_gem_object *gobj)
+{
+	struct amdxdna_dev *xdna = to_xdna_dev(gobj->dev);
+	struct amdxdna_gem_obj *abo = to_xdna_obj(gobj);
+
+	XDNA_DBG(xdna, "BO type %d xdna_addr 0x%llx", abo->type, abo->mem.dev_addr);
+	if (abo->flags & BO_SUBMIT_PINNED)
+		amdxdna_gem_unpin(abo);
+
+	amdxdna_gem_heap_free(abo);
+	drm_gem_object_release(gobj);
+	amdxdna_gem_destroy_obj(abo);
+}
+
+static void amdxdna_gem_shmem_obj_free(struct drm_gem_object *gobj)
 {
 	struct amdxdna_dev *xdna = to_xdna_dev(gobj->dev);
 	struct amdxdna_gem_obj *abo = to_xdna_obj(gobj);
@@ -218,32 +315,8 @@ static void amdxdna_gem_obj_free(struct drm_gem_object *gobj)
 	if (abo->flags & BO_SUBMIT_PINNED)
 		amdxdna_gem_unpin(abo);
 
-	if (abo->type == AMDXDNA_BO_DEV) {
-		mutex_lock(&abo->client->mm_lock);
-		drm_mm_remove_node(&abo->mm_node);
-		mutex_unlock(&abo->client->mm_lock);
-
-		vunmap(abo->mem.kva);
-		drm_gem_object_put(to_gobj(abo->dev_heap));
-		drm_gem_object_release(gobj);
-		mutex_destroy(&abo->lock);
-		kfree(abo);
-		return;
-	}
-
 	if (abo->type == AMDXDNA_BO_DEV_HEAP)
 		drm_mm_takedown(&abo->mm);
-
-	if (abo->type == AMDXDNA_BO_GUEST) {
-		if (abo->mem.pages) {
-			unpin_user_pages(abo->mem.pages, abo->mem.nr_pages);
-			kvfree(abo->mem.pages);
-		}
-		drm_gem_object_release(gobj);
-		mutex_destroy(&abo->lock);
-		kfree(abo);
-		return;
-	}
 
 #ifdef AMDXDNA_DEVEL
 	if (abo->type == AMDXDNA_BO_CMD)
@@ -257,7 +330,7 @@ static void amdxdna_gem_obj_free(struct drm_gem_object *gobj)
 }
 
 static const struct drm_gem_object_funcs amdxdna_gem_dev_obj_funcs = {
-	.free = amdxdna_gem_obj_free,
+	.free = amdxdna_gem_dev_obj_free,
 };
 
 static int amdxdna_insert_pages(struct amdxdna_gem_obj *abo,
@@ -418,7 +491,7 @@ static struct dma_buf *amdxdna_gem_prime_export(struct drm_gem_object *gobj, int
 }
 
 static const struct drm_gem_object_funcs amdxdna_gem_shmem_funcs = {
-	.free = amdxdna_gem_obj_free,
+	.free = amdxdna_gem_shmem_obj_free,
 	.print_info = drm_gem_shmem_object_print_info,
 	.pin = drm_gem_shmem_object_pin,
 	.unpin = drm_gem_shmem_object_unpin,
@@ -436,34 +509,14 @@ static const struct vm_operations_struct drm_vm_ops = {
 };
 
 static const struct drm_gem_object_funcs amdxdna_gem_guest_obj_funcs = {
-	.free = amdxdna_gem_obj_free,
+	.free = amdxdna_gem_guest_obj_free,
 	.mmap = amdxdna_gem_obj_mmap,
 	.vm_ops = &drm_vm_ops,
 };
 
-static struct amdxdna_gem_obj *
-amdxdna_gem_create_obj(struct drm_device *dev, size_t size)
-{
-	struct amdxdna_gem_obj *abo;
-
-	abo = kzalloc(sizeof(*abo), GFP_KERNEL);
-	if (!abo)
-		return ERR_PTR(-ENOMEM);
-
-	abo->assigned_ctx = AMDXDNA_INVALID_CTX_HANDLE;
-	mutex_init(&abo->lock);
-
-	abo->mem.userptr = AMDXDNA_INVALID_ADDR;
-	abo->mem.dev_addr = AMDXDNA_INVALID_ADDR;
-	abo->mem.size = size;
-	INIT_LIST_HEAD(&abo->mem.umap_list);
-
-	return abo;
-}
-
-/* For drm_driver->gem_create_object callback */
+/* For drm_driver->gem_create_object callback, only support shmem */
 struct drm_gem_object *
-amdxdna_gem_create_object_cb(struct drm_device *dev, size_t size)
+amdxdna_gem_create_shmem_object(struct drm_device *dev, size_t size)
 {
 	struct amdxdna_gem_obj *abo;
 
@@ -630,53 +683,25 @@ amdxdna_drm_alloc_dev_bo(struct drm_device *dev,
 	struct amdxdna_client *client = filp->driver_priv;
 	struct amdxdna_dev *xdna = to_xdna_dev(dev);
 	size_t aligned_sz = PAGE_ALIGN(args->size);
-	struct amdxdna_gem_obj *abo, *heap;
+	struct amdxdna_gem_obj *abo;
 	int ret;
 
-	mutex_lock(&client->mm_lock);
-	heap = client->dev_heap;
-	if (!heap) {
-		ret = -EINVAL;
-		goto mm_unlock;
-	}
-
-	if (heap->mem.userptr == AMDXDNA_INVALID_ADDR) {
-		XDNA_ERR(xdna, "Invalid dev heap userptr");
-		ret = -EINVAL;
-		goto mm_unlock;
-	}
-
-	if (args->size > heap->mem.size) {
-		XDNA_ERR(xdna, "Invalid dev bo size 0x%llx, limit 0x%lx",
-			 args->size, heap->mem.size);
-		ret = -EINVAL;
-		goto mm_unlock;
-	}
-
 	abo = amdxdna_gem_create_obj(&xdna->ddev, aligned_sz);
-	if (IS_ERR(abo)) {
-		ret = PTR_ERR(abo);
-		goto mm_unlock;
-	}
+	if (IS_ERR(abo))
+		return abo;
 	to_gobj(abo)->funcs = &amdxdna_gem_dev_obj_funcs;
 	abo->type = AMDXDNA_BO_DEV;
 	abo->client = client;
-	abo->dev_heap = heap;
-	ret = amdxdna_gem_insert_node_locked(abo, use_vmap);
+
+	ret = amdxdna_gem_heap_alloc(abo, use_vmap);
 	if (ret) {
 		XDNA_ERR(xdna, "Failed to alloc dev bo memory, ret %d", ret);
-		goto mm_unlock;
+		amdxdna_gem_destroy_obj(abo);
+		return ERR_PTR(ret);
 	}
 
-	drm_gem_object_get(to_gobj(heap));
 	drm_gem_private_object_init(&xdna->ddev, to_gobj(abo), aligned_sz);
-
-	mutex_unlock(&client->mm_lock);
 	return abo;
-
-mm_unlock:
-	mutex_unlock(&client->mm_lock);
-	return ERR_PTR(ret);
 }
 
 static struct amdxdna_gem_obj *
@@ -772,7 +797,7 @@ amdxdna_drm_create_guest_bo(struct drm_device *dev,
 	pages = kvmalloc_array(bo_sz >> PAGE_SHIFT, sizeof(*pages), GFP_KERNEL);
 	if (!pages) {
 		ret = -ENOMEM;
-		goto put_bo;
+		goto destroy_bo;
 	}
 
 	for (i = 0; i < args->size; i++) {
@@ -799,16 +824,18 @@ amdxdna_drm_create_guest_bo(struct drm_device *dev,
 	drm_gem_private_object_init(&xdna->ddev, to_gobj(abo), bo_sz);
 	ret = drm_gem_create_mmap_offset(to_gobj(abo));
 	if (ret)
-		goto destroy_pages;
+		goto release_bo;
 
 	return abo;
 
+release_bo:
+	drm_gem_object_release(to_gobj(abo));
 destroy_pages:
 	unpin_user_pages(pages, abo->mem.nr_pages);
 	abo->mem.nr_pages = 0;
 	kvfree(pages);
-put_bo:
-	drm_gem_object_put(to_gobj(abo));
+destroy_bo:
+	amdxdna_gem_destroy_obj(abo);
 free_va_tbl:
 	kfree(va_tbl);
 	return ERR_PTR(ret);
@@ -888,7 +915,7 @@ int amdxdna_gem_pin_nolock(struct amdxdna_gem_obj *abo)
 		ret = drm_gem_shmem_pin(&abo->base);
 		break;
 	case AMDXDNA_BO_DEV:
-		ret = drm_gem_shmem_pin(&abo->dev_heap->base);
+		ret = drm_gem_shmem_pin(&abo->client->dev_heap->base);
 		break;
 	default:
 		ret = -EOPNOTSUPP;
@@ -903,7 +930,7 @@ int amdxdna_gem_pin(struct amdxdna_gem_obj *abo)
 	int ret;
 
 	if (abo->type == AMDXDNA_BO_DEV)
-		abo = abo->dev_heap;
+		abo = abo->client->dev_heap;
 
 	mutex_lock(&abo->lock);
 	ret = amdxdna_gem_pin_nolock(abo);
@@ -918,7 +945,7 @@ void amdxdna_gem_unpin(struct amdxdna_gem_obj *abo)
 		return;
 
 	if (abo->type == AMDXDNA_BO_DEV)
-		abo = abo->dev_heap;
+		abo = abo->client->dev_heap;
 
 	mutex_lock(&abo->lock);
 	drm_gem_shmem_unpin(&abo->base);

--- a/src/driver/amdxdna/amdxdna_gem.h
+++ b/src/driver/amdxdna/amdxdna_gem.h
@@ -48,7 +48,6 @@ struct amdxdna_gem_obj {
 
 	/* Below members is uninitialized when needed */
 	struct drm_mm			mm; /* For AMDXDNA_BO_DEV_HEAP */
-	struct amdxdna_gem_obj		*dev_heap; /* For AMDXDNA_BO_DEV */
 	struct drm_mm_node		mm_node; /* For AMDXDNA_BO_DEV */
 	u32				assigned_ctx; /* For debug bo */
 };
@@ -70,7 +69,7 @@ static inline void amdxdna_gem_put_obj(struct amdxdna_gem_obj *abo)
 void amdxdna_umap_put(struct amdxdna_umap *mapp);
 
 struct drm_gem_object *
-amdxdna_gem_create_object_cb(struct drm_device *dev, size_t size);
+amdxdna_gem_create_shmem_object(struct drm_device *dev, size_t size);
 struct drm_gem_object *
 amdxdna_gem_prime_import(struct drm_device *dev, struct dma_buf *dma_buf);
 struct amdxdna_gem_obj *

--- a/src/driver/amdxdna/amdxdna_gem.h
+++ b/src/driver/amdxdna/amdxdna_gem.h
@@ -69,13 +69,13 @@ static inline void amdxdna_gem_put_obj(struct amdxdna_gem_obj *abo)
 void amdxdna_umap_put(struct amdxdna_umap *mapp);
 
 struct drm_gem_object *
-amdxdna_gem_create_shmem_object(struct drm_device *dev, size_t size);
+amdxdna_gem_create_shmem_object_cb(struct drm_device *dev, size_t size);
 struct drm_gem_object *
 amdxdna_gem_prime_import(struct drm_device *dev, struct dma_buf *dma_buf);
 struct amdxdna_gem_obj *
-amdxdna_drm_alloc_dev_bo(struct drm_device *dev,
-			 struct amdxdna_drm_create_bo *args,
-			 struct drm_file *filp, bool use_vmap);
+amdxdna_drm_create_dev_bo(struct drm_device *dev,
+			  struct amdxdna_drm_create_bo *args,
+			  struct drm_file *filp, bool use_vmap);
 
 int amdxdna_gem_pin_nolock(struct amdxdna_gem_obj *abo);
 int amdxdna_gem_pin(struct amdxdna_gem_obj *abo);

--- a/src/driver/amdxdna/amdxdna_pci_drv.c
+++ b/src/driver/amdxdna/amdxdna_pci_drv.c
@@ -303,7 +303,20 @@ static struct pci_driver amdxdna_pci_driver = {
 	.driver.pm = &amdxdna_pm_ops,
 };
 
-module_pci_driver(amdxdna_pci_driver);
+static int __init amdxdna_mod_init(void)
+{
+	amdxdna_carvedout_init();
+	return pci_register_driver(&amdxdna_pci_driver);
+}
+
+static void __exit amdxdna_mod_exit(void)
+{
+	pci_unregister_driver(&amdxdna_pci_driver);
+	amdxdna_carvedout_fini();
+}
+
+module_init(amdxdna_mod_init);
+module_exit(amdxdna_mod_exit);
 
 MODULE_LICENSE("GPL");
 MODULE_AUTHOR("XRT Team <runtimeca39d@amd.com>");

--- a/src/include/uapi/drm_local/amdxdna_accel.h
+++ b/src/include/uapi/drm_local/amdxdna_accel.h
@@ -208,14 +208,14 @@ struct amdxdna_drm_create_bo {
 	__u64	vaddr;
 	__u64	size;
 /*
- * AMDXDNA_BO_SHMEM:	DRM GEM SHMEM bo
+ * AMDXDNA_BO_SHARE:	Regular BO shared between user and device
  * AMDXDNA_BO_DEV_HEAP: Shared host memory to device as heap memory
  * AMDXDNA_BO_DEV_BO:	Allocated from BO_DEV_HEAP
  * AMDXDNA_BO_CMD:	User and driver accessible bo
  * AMDXDNA_BO_DMA:	DRM GEM DMA bo
  */
 #define	AMDXDNA_BO_INVALID	0
-#define	AMDXDNA_BO_SHMEM	1
+#define	AMDXDNA_BO_SHARE	1
 #define	AMDXDNA_BO_DEV_HEAP	2
 #define	AMDXDNA_BO_DEV		3
 #define	AMDXDNA_BO_CMD		4

--- a/src/shim/bo.cpp
+++ b/src/shim/bo.cpp
@@ -99,7 +99,7 @@ import_drm_bo(const shim_xdna::pdev& dev, const shim_xdna::shared& share,
   drm_prime_handle imp_bo = {AMDXDNA_INVALID_BO_HANDLE, 0, fd};
   dev.ioctl(DRM_IOCTL_PRIME_FD_TO_HANDLE, &imp_bo);
 
-  *type = AMDXDNA_BO_SHMEM;
+  *type = AMDXDNA_BO_SHARE;
   *size = lseek(fd, 0, SEEK_END);
   lseek(fd, 0, SEEK_SET);
 
@@ -152,8 +152,8 @@ bo::
 type_to_name() const
 {
   switch (m_type) {
-  case AMDXDNA_BO_SHMEM:
-    return std::string("AMDXDNA_BO_SHMEM");
+  case AMDXDNA_BO_SHARE:
+    return std::string("AMDXDNA_BO_SHARE");
   case AMDXDNA_BO_DEV_HEAP:
     return std::string("AMDXDNA_BO_DEV_HEAP");
   case AMDXDNA_BO_DEV:

--- a/src/shim/kmq/bo.cpp
+++ b/src/shim/kmq/bo.cpp
@@ -14,7 +14,7 @@ flag_to_type(uint64_t bo_flags)
   auto boflags = (static_cast<uint32_t>(flags.boflags) << 24);
   switch (boflags) {
   case XCL_BO_FLAGS_HOST_ONLY:
-    return AMDXDNA_BO_SHMEM;
+    return AMDXDNA_BO_SHARE;
   case XCL_BO_FLAGS_CACHEABLE:
     return AMDXDNA_BO_DEV;
   case XCL_BO_FLAGS_EXECBUF:
@@ -110,7 +110,7 @@ bo_kmq(const device& device, xrt_core::hwctx_handle::slot_id ctx_id,
   // the data in cacheline will be flushed onto memory and pollute the output
   // from device. We perform a cache flush right after the BO is allocated to
   // avoid this issue.
-  if (m_type == AMDXDNA_BO_SHMEM)
+  if (m_type == AMDXDNA_BO_SHARE)
     sync(direction::host2device, size, 0);
 
   attach_to_ctx();
@@ -157,7 +157,7 @@ sync(direction dir, size_t size, size_t offset)
     shim_err(EINVAL, "Invalid BO offset and size for sync'ing: %ld, %ld", offset, size);
 
   switch (m_type) {
-  case AMDXDNA_BO_SHMEM:
+  case AMDXDNA_BO_SHARE:
   case AMDXDNA_BO_CMD:
     clflush_data(m_aligned, offset, size); 
     break;

--- a/src/shim/umq/bo.cpp
+++ b/src/shim/umq/bo.cpp
@@ -23,7 +23,7 @@ umq_flags_to_type(uint64_t bo_flags)
   case XCL_BO_FLAGS_NONE:
   case XCL_BO_FLAGS_HOST_ONLY:
   case XCL_BO_FLAGS_CACHEABLE:
-    return AMDXDNA_BO_SHMEM;
+    return AMDXDNA_BO_SHARE;
   case XCL_BO_FLAGS_EXECBUF:
     return AMDXDNA_BO_CMD;
   default:


### PR DESCRIPTION
- Introduced carvedout memory
- Renamed AMDXDNA_BO_SHMEM to AMDXDNA_BO_SHARE since shmem will not be the only source of memory later
- Cleaned up amdxdna_gem.c to be prepared for carvedout memory version of AMDXDNA_BO_SHARE BO

The next step is to add new set of BO funcs to support carvedout memory for AMDXDNA_BO_SHARE BO.