### PR TITLE
VITIS-13542 Implement shim for xrt-smi telemetry report

### DIFF
--- a/src/shim/device.cpp
+++ b/src/shim/device.cpp
@@ -386,6 +386,7 @@ struct preemption
     pci_dev_impl.ioctl(DRM_IOCTL_AMDXDNA_SET_STATE, &arg);
   }
 };
+
 struct telemetry
 {
   static constexpr uint32_t NPU_RTOS_MAX_USER_ID_COUNT = 16;
@@ -394,6 +395,7 @@ struct telemetry
   static constexpr uint32_t NPU_MAX_OPCODE_COUNT = 30;
   static constexpr uint32_t NPU_MAX_DTLB_COUNT = 12;
   static constexpr uint16_t NPU4_DEVICE_ID = 0x17f0;
+
   struct amdxdna_drm_query_telemetry {
     uint32_t major;
     uint32_t minor;
@@ -441,7 +443,7 @@ struct telemetry
       for (auto i = 0; i < NPU_MAX_SLEEP_COUNT; i++) {
         query::aie_telemetry::data task;
         task.deep_sleep_count = telemetry.deep_sleep_count[i];
-        output.push_back(task);
+        output.push_back(std::move(task));
       }
       return output;
     }
@@ -489,7 +491,7 @@ struct telemetry
       for (auto i = 0; i < NPU_MAX_OPCODE_COUNT; i++) {
         query::opcode_telemetry::data task;
         task.count = telemetry.trace_opcode[i];
-        output.push_back(task);
+        output.push_back(std::move(task));
       }
       return output;
     }
@@ -524,7 +526,7 @@ struct telemetry
       std::array<uint32_t, NPU_RTOS_MAX_USER_ID_COUNT> ctx_map{};
       for (uint32_t i = 0; i < data_size; i++) {
         const auto& entry = data[i];
-        
+
         if (entry.hwctx_id >= NPU_RTOS_MAX_USER_ID_COUNT) {
           throw xrt_core::query::exception(
             boost::str(boost::format("DRM_AMDXDNA_QUERY_HW_CONTEXTS - Invalid hw ctx ID: %u") % entry.hwctx_id));
@@ -557,7 +559,7 @@ struct telemetry
           query::rtos_telemetry::dtlb_data dtlb = {
             .misses = telemetry.dtlb_misses[i][j]
           };
-          dtlbs.push_back(dtlb);
+          dtlbs.push_back(std::move(dtlb));
         }
         task.dtlbs = dtlbs;
 
@@ -590,7 +592,7 @@ struct telemetry
       for (auto i = 0; i < NPU_MAX_STREAM_BUFFER_COUNT; i++) {
         query::stream_buffer_telemetry::data task;
         task.tokens = telemetry.sb_tokens[i];
-        output.push_back(task);
+        output.push_back(std::move(task));
       }
       return output;
     }

--- a/src/shim/device.cpp
+++ b/src/shim/device.cpp
@@ -425,10 +425,6 @@ struct telemetry
     {
       query::aie_telemetry::result_type output;
 
-      auto device_id = sysfs_fcn<uint16_t>::get(get_pcidev(device), "", "device");
-      if (device_id != NPU4_DEVICE_ID)
-        return output;
-
       amdxdna_drm_query_telemetry telemetry{};
 
       amdxdna_drm_get_info query_telemetry = {
@@ -451,10 +447,6 @@ struct telemetry
     {
       query::misc_telemetry::result_type output;
 
-      auto device_id = sysfs_fcn<uint16_t>::get(get_pcidev(device), "", "device");
-      if (device_id != NPU4_DEVICE_ID)
-        return output;
-
       amdxdna_drm_query_telemetry telemetry{};
 
       amdxdna_drm_get_info query_telemetry = {
@@ -472,10 +464,6 @@ struct telemetry
     case key_type::opcode_telemetry:
     {
       query::opcode_telemetry::result_type output;
-
-      auto device_id = sysfs_fcn<uint16_t>::get(get_pcidev(device), "", "device");
-      if (device_id != NPU4_DEVICE_ID)
-        return output;
 
       amdxdna_drm_query_telemetry telemetry{};
 
@@ -573,10 +561,6 @@ struct telemetry
     case key_type::stream_buffer_telemetry:
     {
       query::stream_buffer_telemetry::result_type output;
-
-      auto device_id = sysfs_fcn<uint16_t>::get(get_pcidev(device), "", "device");
-      if (device_id != NPU4_DEVICE_ID)
-        return output;
 
       amdxdna_drm_query_telemetry telemetry{};
 


### PR DESCRIPTION
https://jira.xilinx.com/browse/VITIS-13542
Building upon Nishad's changes in https://github.com/amd/xdna-driver/pull/368 to implement shim for xrt-smi telemetry report. STX currently shows opcode telemetry.
```
------------------------------
[0000:c5:00.1] : RyzenAI-npu4
------------------------------
Telemetry
  |Mailbox Opcode  |Count  |
  |----------------|-------|
  |0               |4      |
  |1               |266    |
  |2               |266    |
  |3               |266    |
  |4               |266    |
  |5               |2      |
  |6               |262    |
  |7               |4      |
  |8               |4      |
  |9               |4      |
  |10              |4      |
  |11              |4      |
  |12              |4      |
  |13              |4      |
  |14              |4      |
  |15              |4      |
  |16              |4      |
  |17              |4      |
  |18              |4      |
  |19              |4      |
  |20              |4      |
  |21              |4      |
  |22              |3      |
  |23              |266    |
  |24              |266    |
  |25              |266    |
  |26              |266    |
  |27              |4      |
  |28              |4      |
  |29              |4      |
```