### PR TITLE
add support for initializing virtio response ring

### DIFF
--- a/src/include/uapi/drm_local/amdxdna_accel.h
+++ b/src/include/uapi/drm_local/amdxdna_accel.h
@@ -207,20 +207,13 @@ struct amdxdna_drm_create_bo {
 	__u64	flags;
 	__u64	vaddr;
 	__u64	size;
-/*
- * AMDXDNA_BO_SHARE:	Regular BO shared between user and device
- * AMDXDNA_BO_DEV_HEAP: Shared host memory to device as heap memory
- * AMDXDNA_BO_DEV_BO:	Allocated from BO_DEV_HEAP
- * AMDXDNA_BO_CMD:	User and driver accessible bo
- * AMDXDNA_BO_DMA:	DRM GEM DMA bo
- */
-#define	AMDXDNA_BO_INVALID	0
-#define	AMDXDNA_BO_SHARE	1
-#define	AMDXDNA_BO_DEV_HEAP	2
-#define	AMDXDNA_BO_DEV		3
-#define	AMDXDNA_BO_CMD		4
-#define	AMDXDNA_BO_DMA		5
-#define	AMDXDNA_BO_GUEST	6
+#define	AMDXDNA_BO_INVALID	0 /* Invalid BO type */
+#define	AMDXDNA_BO_SHARE	1 /* Regular BO shared between user and device */
+#define	AMDXDNA_BO_DEV_HEAP	2 /* Shared host memory to device as heap memory */
+#define	AMDXDNA_BO_DEV		3 /* Allocated from BO_DEV_HEAP */
+#define	AMDXDNA_BO_CMD		4 /* User and driver accessible BO */
+#define	AMDXDNA_BO_DMA		5 /* DRM GEM DMA BO */
+#define	AMDXDNA_BO_GUEST	6 /* BO for virt-io guest */
 	__u32	type;
 	__u32	handle;
 };

--- a/src/shim/CMakeLists.txt
+++ b/src/shim/CMakeLists.txt
@@ -8,6 +8,7 @@ set(XRT_COREUTIL_TARGET xrt_coreutil)
 aux_source_directory(${CMAKE_CURRENT_SOURCE_DIR} MAIN_SOURCES)
 aux_source_directory(${CMAKE_CURRENT_SOURCE_DIR}/kmq KMQ_SOURCES)
 aux_source_directory(${CMAKE_CURRENT_SOURCE_DIR}/umq UMQ_SOURCES)
+aux_source_directory(${CMAKE_CURRENT_SOURCE_DIR}/virtio UMQ_SOURCES)
 add_library(${XDNA_TARGET} SHARED
   ${MAIN_SOURCES}
   ${KMQ_SOURCES}

--- a/src/shim/bo.cpp
+++ b/src/shim/bo.cpp
@@ -7,32 +7,6 @@
 
 namespace {
 
-uint32_t
-alloc_drm_bo(const shim_xdna::pdev& dev, int type, void* buf, size_t size)
-{
-  amdxdna_drm_create_bo cbo = {
-    .vaddr = reinterpret_cast<uintptr_t>(buf),
-    .size = size,
-    .type = static_cast<uint32_t>(type),
-  };
-  dev.ioctl(DRM_IOCTL_AMDXDNA_CREATE_BO, &cbo);
-  return cbo.handle;
-}
-
-void
-free_drm_bo(const shim_xdna::pdev& dev, uint32_t boh)
-{
-  drm_gem_close close_bo = {boh, 0};
-  dev.ioctl(DRM_IOCTL_GEM_CLOSE, &close_bo);
-}
-
-void
-get_drm_bo_info(const shim_xdna::pdev& dev, uint32_t boh, amdxdna_drm_get_bo_info* bo_info)
-{
-  bo_info->handle = boh;
-  dev.ioctl(DRM_IOCTL_AMDXDNA_GET_BO_INFO, bo_info);
-}
-
 void *
 map_parent_range(size_t size)
 {
@@ -41,12 +15,6 @@ map_parent_range(size_t size)
     shim_err(errno, "mmap(len=%ld) failed", size);
 
   return p;
-}
-
-void*
-map_drm_bo(const shim_xdna::pdev& dev, size_t size, int prot, uint64_t offset)
-{
-  return dev.mmap(0, size, prot, MAP_SHARED | MAP_LOCKED, offset);
 }
 
 void*
@@ -141,7 +109,7 @@ bo::drm_bo::
   if (m_handle == AMDXDNA_INVALID_BO_HANDLE)
     return;
   try {
-    free_drm_bo(m_parent.m_pdev, m_handle);
+    m_parent.free_drm_bo(m_parent.m_pdev, m_handle);
   } catch (const xrt_core::system_error& e) {
     shim_debug("Failed to free DRM BO: %s", e.what());
   }
@@ -193,7 +161,8 @@ mmap_bo(size_t align)
   }
 
   if (a == 0) {
-    m_aligned = map_drm_bo(m_pdev, m_aligned_size, PROT_READ | PROT_WRITE, m_bo->m_map_offset);
+    m_aligned = map_drm_bo(m_pdev, nullptr, m_aligned_size, PROT_READ | PROT_WRITE,
+      MAP_SHARED | MAP_LOCKED, m_bo->m_map_offset);
     return;
   }
 
@@ -205,7 +174,8 @@ mmap_bo(size_t align)
   m_parent_size = align * 2 - 1;
   m_parent = map_parent_range(m_parent_size);
   auto aligned = addr_align(m_parent, align);
-  m_aligned = map_drm_bo(m_pdev, aligned, m_aligned_size, PROT_READ | PROT_WRITE, MAP_SHARED | MAP_FIXED, m_bo->m_map_offset);
+  m_aligned = map_drm_bo(m_pdev, aligned, m_aligned_size, PROT_READ | PROT_WRITE,
+    MAP_SHARED | MAP_LOCKED | MAP_FIXED, m_bo->m_map_offset);
 }
 
 void
@@ -225,7 +195,7 @@ void
 bo::
 alloc_bo()
 {
-  uint32_t boh = alloc_drm_bo(m_pdev, m_type, NULL, m_aligned_size);
+  uint32_t boh = alloc_drm_bo(m_pdev, m_type, m_aligned_size);
 
   amdxdna_drm_get_bo_info bo_info = {};
   get_drm_bo_info(m_pdev, boh, &bo_info);
@@ -365,6 +335,35 @@ bo::
 get_type() const
 {
   return m_type;
+}
+
+uint32_t
+bo::
+alloc_drm_bo(const shim_xdna::pdev& dev, int type, size_t size)
+{
+  amdxdna_drm_create_bo cbo = {
+    .vaddr = 0,
+    .size = size,
+    .type = static_cast<uint32_t>(type),
+  };
+  dev.ioctl(DRM_IOCTL_AMDXDNA_CREATE_BO, &cbo);
+  return cbo.handle;
+}
+
+void
+bo::
+get_drm_bo_info(const shim_xdna::pdev& dev, uint32_t boh, amdxdna_drm_get_bo_info* bo_info)
+{
+  bo_info->handle = boh;
+  dev.ioctl(DRM_IOCTL_AMDXDNA_GET_BO_INFO, bo_info);
+}
+
+void
+bo::
+free_drm_bo(const shim_xdna::pdev& dev, uint32_t boh)
+{
+  drm_gem_close close_bo = {boh, 0};
+  dev.ioctl(DRM_IOCTL_GEM_CLOSE, &close_bo);
 }
 
 } // namespace shim_xdna

--- a/src/shim/bo.cpp
+++ b/src/shim/bo.cpp
@@ -221,9 +221,9 @@ free_bo()
 }
 
 bo::
-bo(const device& device, xrt_core::hwctx_handle::slot_id ctx_id,
+bo(const pdev& pdev, xrt_core::hwctx_handle::slot_id ctx_id,
   size_t size, uint64_t flags, int type)
-  : m_pdev(device.get_pdev())
+  : m_pdev(pdev)
   , m_aligned_size(size)
   , m_flags(flags)
   , m_type(type)
@@ -233,8 +233,8 @@ bo(const device& device, xrt_core::hwctx_handle::slot_id ctx_id,
 }
 
 bo::
-bo(const device& device, xrt_core::shared_handle::export_handle ehdl)
-  : m_pdev(device.get_pdev())
+bo(const pdev& pdev, xrt_core::shared_handle::export_handle ehdl)
+  : m_pdev(pdev)
   , m_import(ehdl)
 {
 }

--- a/src/shim/bo.h
+++ b/src/shim/bo.h
@@ -41,10 +41,10 @@ inline void flush_cache_line(const char *cur)
 class bo : public xrt_core::buffer_handle
 {
 public:
-  bo(const device& device, xrt_core::hwctx_handle::slot_id ctx_id,
+  bo(const pdev& pdev, xrt_core::hwctx_handle::slot_id ctx_id,
     size_t size, uint64_t flags, int type);
 
-  bo(const device& device, xrt_core::shared_handle::export_handle ehdl);
+  bo(const pdev& pdev, xrt_core::shared_handle::export_handle ehdl);
 
   ~bo();
 

--- a/src/shim/kmq/bo.cpp
+++ b/src/shim/kmq/bo.cpp
@@ -77,24 +77,22 @@ is_driver_sync()
 namespace shim_xdna {
 
 bo_kmq::
-bo_kmq(const device& device, xrt_core::hwctx_handle::slot_id ctx_id,
-  size_t size, uint64_t flags)
-  : bo_kmq(device, ctx_id, size, flags, flag_to_type(flags))
+bo_kmq(const pdev& pdev, xrt_core::hwctx_handle::slot_id ctx_id, size_t size, uint64_t flags)
+  : bo_kmq(pdev, ctx_id, size, flags, flag_to_type(flags))
 {
   if (m_type == AMDXDNA_BO_INVALID)
     shim_err(EINVAL, "Invalid BO flags: 0x%lx", flags);
 }
 
 bo_kmq::
-bo_kmq(const device& device, size_t size, int type)
-  : bo_kmq(device, AMDXDNA_INVALID_CTX_HANDLE, size, 0, type)
+bo_kmq(const pdev& pdev, size_t size, int type)
+  : bo_kmq(pdev, AMDXDNA_INVALID_CTX_HANDLE, size, 0, type)
 {
 }
 
 bo_kmq::
-bo_kmq(const device& device, xrt_core::hwctx_handle::slot_id ctx_id,
-  size_t size, uint64_t flags, int type)
-  : bo(device, ctx_id, size, flags, type)
+bo_kmq(const pdev& pdev, xrt_core::hwctx_handle::slot_id ctx_id, size_t size, uint64_t flags, int type)
+  : bo(pdev, ctx_id, size, flags, type)
 {
   size_t align = 0;
 
@@ -113,13 +111,12 @@ bo_kmq(const device& device, xrt_core::hwctx_handle::slot_id ctx_id,
 
   attach_to_ctx();
 
-  shim_debug("Allocated KMQ BO (userptr=0x%lx, size=%ld, flags=0x%llx, type=%d, drm_bo=%d)",
-    m_aligned, m_aligned_size, m_flags, m_type, get_drm_bo_handle());
+  shim_debug("Allocated KMQ BO, %s", describe().c_str());
 }
 
 bo_kmq::
-bo_kmq(const device& device, xrt_core::shared_handle::export_handle ehdl)
-  : bo(device, ehdl)
+bo_kmq(const pdev& pdev, xrt_core::shared_handle::export_handle ehdl)
+  : bo(pdev, ehdl)
 {
   import_bo();
   mmap_bo();

--- a/src/shim/kmq/bo.h
+++ b/src/shim/kmq/bo.h
@@ -13,10 +13,10 @@ namespace shim_xdna {
 
 class bo_kmq : public bo {
 public:
-  bo_kmq(const device& device, xrt_core::hwctx_handle::slot_id ctx_id,
+  bo_kmq(const pdev& pdev, xrt_core::hwctx_handle::slot_id ctx_id,
     size_t size, uint64_t flags);
 
-  bo_kmq(const device& device, xrt_core::shared_handle::export_handle ehdl);
+  bo_kmq(const pdev& pdev, xrt_core::shared_handle::export_handle ehdl);
 
   ~bo_kmq();
 
@@ -28,14 +28,14 @@ public:
 
 public:
   // Support BO creation from internal
-  bo_kmq(const device& device, size_t size, int type);
+  bo_kmq(const pdev& pdev, size_t size, int type);
 
   // Obtain array of arg BO handles, returns real number of handles
   uint32_t
   get_arg_bo_handles(uint32_t *handles, size_t num) const;
 
 private:
-  bo_kmq(const device& device, xrt_core::hwctx_handle::slot_id ctx_id,
+  bo_kmq(const pdev& pdev, xrt_core::hwctx_handle::slot_id ctx_id,
     size_t size, uint64_t flags, int type);
 
   // Only for AMDXDNA_BO_CMD type

--- a/src/shim/kmq/device.cpp
+++ b/src/shim/kmq/device.cpp
@@ -6,46 +6,12 @@
 #include "hwctx.h"
 #include "drm_local/amdxdna_accel.h"
 
-namespace {
-
-// Device memory heap needs to be within one 64MB page. The maximum size is 64MB.
-const size_t max_heap_mem_size = (64 << 20);
-const size_t min_heap_mem_size = (1 << 20);
-
-}
-
 namespace shim_xdna {
 
 device_kmq::
 device_kmq(const pdev& pdev, handle_type shim_handle, id_type device_id)
 : device(pdev, shim_handle, device_id)
 {
-  size_t heap_sz = max_heap_mem_size;
-
-  while (m_dev_heap_bo == nullptr) {
-    try {
-      // Alloc device memory on first device creation.
-      // No locking is needed since driver will ensure only one heap BO is created.
-      // ASSUMPTION: one process will only create device once
-      m_dev_heap_bo = std::make_unique<bo_kmq>(*this, heap_sz, AMDXDNA_BO_DEV_HEAP);
-    } catch (const xrt_core::system_error& ex) {
-      switch (ex.get_code()) {
-      case EBUSY:
-        if (m_dev_heap_bo == nullptr)
-          shim_err(EINVAL, "Leaking dev heap BO?");
-        break;
-      case ENOMEM:
-        // Try with smaller size in case of memory pressure or IOMMU_MODE constrain
-        heap_sz /= 2;
-        if (heap_sz < min_heap_mem_size)
-          shim_err(EINVAL, "No mem for dev heap BO, giving up");
-        break;
-      default:
-        throw;
-      }
-    }
-  }
-
   shim_debug("Created KMQ device (%s) ...", get_pdev().m_sysfs_name.c_str());
 }
 
@@ -53,7 +19,6 @@ device_kmq::
 ~device_kmq()
 {
   shim_debug("Destroying KMQ device (%s) ...", get_pdev().m_sysfs_name.c_str());
-  m_dev_heap_bo.reset();
 }
 
 std::unique_ptr<xrt_core::hwctx_handle>
@@ -75,14 +40,14 @@ alloc_bo(void* userptr, xrt_core::hwctx_handle::slot_id ctx_id,
   if (userptr)
     shim_not_supported_err("User ptr BO");
 
-  return std::make_unique<bo_kmq>(*this, ctx_id, size, flags);
+  return std::make_unique<bo_kmq>(get_pdev(), ctx_id, size, flags);
 }
 
 std::unique_ptr<xrt_core::buffer_handle>
 device_kmq::
 import_bo(xrt_core::shared_handle::export_handle ehdl) const
 {
-  return std::make_unique<bo_kmq>(*this, ehdl);
+  return std::make_unique<bo_kmq>(get_pdev(), ehdl);
 }
 
 std::vector<char>

--- a/src/shim/kmq/device.h
+++ b/src/shim/kmq/device.h
@@ -26,9 +26,6 @@ protected:
 
   std::unique_ptr<xrt_core::buffer_handle>
   import_bo(xrt_core::shared_handle::export_handle ehdl) const override;
-
-private:
-  std::unique_ptr<xrt_core::buffer_handle> m_dev_heap_bo;
 };
 
 } // namespace shim_xdna

--- a/src/shim/kmq/pcidev.cpp
+++ b/src/shim/kmq/pcidev.cpp
@@ -5,6 +5,14 @@
 #include "device.h"
 #include "pcidev.h"
 
+namespace {
+
+// Device memory heap needs to be within one 64MB page. The maximum size is 64MB.
+const size_t max_heap_mem_size = (64 << 20);
+const size_t min_heap_mem_size = (1 << 20);
+
+}
+
 namespace shim_xdna {
 
 pdev_kmq::
@@ -25,6 +33,38 @@ pdev_kmq::
 create_device(xrt_core::device::handle_type handle, xrt_core::device::id_type id) const
 {
   return std::make_shared<device_kmq>(*this, handle, id);
+}
+
+void
+pdev_kmq::
+on_first_open() const
+{
+  size_t heap_sz = max_heap_mem_size;
+
+  while (m_dev_heap_bo == nullptr) {
+    try {
+      // Alloc device memory on first device open.
+      m_dev_heap_bo = std::make_unique<bo_kmq>(*this, heap_sz, AMDXDNA_BO_DEV_HEAP);
+    } catch (const xrt_core::system_error& ex) {
+      switch (ex.get_code()) {
+      case ENOMEM:
+        // Try with smaller size in case of memory pressure or IOMMU_MODE constrain
+        heap_sz /= 2;
+        if (heap_sz < min_heap_mem_size)
+          shim_err(EINVAL, "No mem for dev heap BO, giving up");
+        break;
+      default:
+        throw;
+      }
+    }
+  }
+}
+
+void
+pdev_kmq::
+on_last_close() const
+{
+  m_dev_heap_bo.reset();
 }
 
 } // namespace shim_xdna

--- a/src/shim/kmq/pcidev.cpp
+++ b/src/shim/kmq/pcidev.cpp
@@ -5,14 +5,6 @@
 #include "device.h"
 #include "pcidev.h"
 
-namespace {
-
-// Device memory heap needs to be within one 64MB page. The maximum size is 64MB.
-const size_t max_heap_mem_size = (64 << 20);
-const size_t min_heap_mem_size = (1 << 20);
-
-}
-
 namespace shim_xdna {
 
 pdev_kmq::
@@ -32,39 +24,7 @@ std::shared_ptr<xrt_core::device>
 pdev_kmq::
 create_device(xrt_core::device::handle_type handle, xrt_core::device::id_type id) const
 {
-  auto dev = std::make_shared<device_kmq>(*this, handle, id);
-  size_t heap_sz = max_heap_mem_size;
-
-  while (m_dev_heap_bo == nullptr) {
-    try {
-      // Alloc device memory on first device creation.
-      // No locking is needed since driver will ensure only one heap BO is created.
-      m_dev_heap_bo = std::make_unique<bo_kmq>(*dev, heap_sz, AMDXDNA_BO_DEV_HEAP);
-    } catch (const xrt_core::system_error& ex) {
-      switch (ex.get_code()) {
-      case EBUSY:
-        if (m_dev_heap_bo == nullptr)
-          shim_err(EINVAL, "Leaking dev heap BO?");
-        break;
-      case ENOMEM:
-        // Try with smaller size in case of memory pressure or IOMMU_MODE constrain
-        heap_sz /= 2;
-        if (heap_sz < min_heap_mem_size)
-          shim_err(EINVAL, "No mem for dev heap BO, giving up");
-        break;
-      default:
-        throw;
-      }
-    }
-  }
-  return dev;
-}
-
-void
-pdev_kmq::
-on_last_close() const
-{
-  m_dev_heap_bo.reset();
+  return std::make_shared<device_kmq>(*this, handle, id);
 }
 
 } // namespace shim_xdna

--- a/src/shim/kmq/pcidev.h
+++ b/src/shim/kmq/pcidev.h
@@ -4,6 +4,7 @@
 #ifndef PCIDEV_KMQ_H
 #define PCIDEV_KMQ_H
 
+#include "../pcidrv.h"
 #include "../pcidev.h"
 
 
@@ -17,13 +18,6 @@ public:
  
   std::shared_ptr<xrt_core::device>
   create_device(xrt_core::device::handle_type handle, xrt_core::device::id_type id) const override;
-
-private:
-  // Create on first device creation and removed right before device is closed
-  mutable std::unique_ptr<xrt_core::buffer_handle> m_dev_heap_bo;
-
-  virtual void
-  on_last_close() const override;
 };
 
 } // namespace shim_xdna

--- a/src/shim/kmq/pcidev.h
+++ b/src/shim/kmq/pcidev.h
@@ -18,6 +18,15 @@ public:
  
   std::shared_ptr<xrt_core::device>
   create_device(xrt_core::device::handle_type handle, xrt_core::device::id_type id) const override;
+
+private:
+  mutable std::unique_ptr<xrt_core::buffer_handle> m_dev_heap_bo;
+
+  virtual void
+  on_first_open() const override;
+
+  virtual void
+  on_last_close() const override;
 };
 
 } // namespace shim_xdna

--- a/src/shim/pcidev.cpp
+++ b/src/shim/pcidev.cpp
@@ -64,7 +64,7 @@ namespace {
 namespace shim_xdna {
 
 pdev::
-pdev(std::shared_ptr<const drv> driver, std::string sysfs_name)
+pdev(std::shared_ptr<const xrt_core::pci::drv> driver, std::string sysfs_name)
   : xrt_core::pci::dev(driver, std::move(sysfs_name))
 {
   m_is_ready = true; // We're always ready.

--- a/src/shim/pcidev.h
+++ b/src/shim/pcidev.h
@@ -11,13 +11,10 @@
 
 namespace shim_xdna {
 
-// Forward declaration
-class drv;
-
 class pdev : public xrt_core::pci::dev
 {
 public:
-  pdev(std::shared_ptr<const drv> driver, std::string sysfs_name);
+  pdev(std::shared_ptr<const xrt_core::pci::drv> driver, std::string sysfs_name);
   ~pdev();
 
   xrt_core::device::handle_type

--- a/src/shim/pcidrv_virtio.cpp
+++ b/src/shim/pcidrv_virtio.cpp
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2025, Advanced Micro Devices, Inc. All rights reserved.
+//
+#include "virtio/pcidev.h"
+#include "pcidrv_virtio.h"
+#include "core/pcie/linux/system_linux.h"
+#include <fstream>
+
+namespace {
+
+struct X
+{
+  X() { xrt_core::pci::register_driver(std::make_shared<shim_xdna::drv_virtio>()); }
+} x;
+
+}
+
+namespace shim_xdna {
+
+std::string
+drv_virtio::
+name() const
+{
+  return "virtio-pci";
+}
+
+std::string
+drv_virtio::
+dev_node_prefix() const
+{
+  return "renderD";
+}
+
+std::string
+drv_virtio::
+dev_node_dir() const
+{
+  return "dri";
+}
+
+std::string
+drv_virtio::
+sysfs_dev_node_dir() const
+{
+  return "drm";
+}
+
+bool
+drv_virtio::
+is_user() const
+{
+  return true;
+}
+
+std::shared_ptr<xrt_core::pci::dev>
+drv_virtio::
+create_pcidev(const std::string& sysfs) const
+{
+  auto driver = std::static_pointer_cast<const drv_virtio>(shared_from_this());
+  return std::make_shared<pdev_virtio>(driver, sysfs);
+}
+
+} // namespace shim_xdna
+

--- a/src/shim/pcidrv_virtio.h
+++ b/src/shim/pcidrv_virtio.h
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2025, Advanced Micro Devices, Inc. All rights reserved.
+
+#ifndef _PCIDRV_VIRTIO_XDNA_H_
+#define _PCIDRV_VIRTIO_XDNA_H_
+
+#include "pcidev.h"
+
+#include "core/pcie/linux/pcidrv.h"
+
+#include <string>
+
+namespace shim_xdna {
+
+class drv_virtio : public xrt_core::pci::drv
+{
+public:
+  std::string
+  name() const override;
+
+  bool
+  is_user() const override;
+
+  std::string
+  dev_node_prefix() const override;
+
+  std::string
+  dev_node_dir() const override;
+
+  std::string
+  sysfs_dev_node_dir() const override;
+
+private:
+  std::shared_ptr<xrt_core::pci::dev>
+  create_pcidev(const std::string& sysfs) const override;
+};
+
+} // namespace shim_xdna
+
+#endif

--- a/src/shim/umq/bo.cpp
+++ b/src/shim/umq/bo.cpp
@@ -37,31 +37,30 @@ umq_flags_to_type(uint64_t bo_flags)
 namespace shim_xdna {
 
 bo_umq::
-bo_umq(const device& device, xrt_core::hwctx_handle::slot_id ctx_id,
+bo_umq(const pdev& pdev, xrt_core::hwctx_handle::slot_id ctx_id,
   size_t size, uint64_t flags)
-  : bo_umq(device, ctx_id, size, flags, umq_flags_to_type(flags))
+  : bo_umq(pdev, ctx_id, size, flags, umq_flags_to_type(flags))
 {
   if (m_type == AMDXDNA_BO_INVALID)
     shim_err(EINVAL, "Invalid BO flags: 0x%lx", flags);
 }
 
 bo_umq::
-bo_umq(const device& device, xrt_core::hwctx_handle::slot_id ctx_id,
+bo_umq(const pdev& pdev, xrt_core::hwctx_handle::slot_id ctx_id,
   size_t size, uint64_t flags, int type)
-  : bo(device, ctx_id, size, flags, type)
+  : bo(pdev, ctx_id, size, flags, type)
 {
   alloc_bo();
   mmap_bo();
   /*TODO: no need if cache coherent */
   sync(direction::host2device, size, 0);
 
-  shim_debug("Allocated UMQ BO for: userptr=0x%lx, size=%ld, flags=0x%llx",
-    m_aligned, m_aligned_size, m_flags);
+  shim_debug("Allocated UMQ BO, %s", describe().c_str());
 }
 
 bo_umq::
-bo_umq(const device& device, xrt_core::shared_handle::export_handle ehdl)
-  : bo(device, ehdl)
+bo_umq(const pdev& pdev, xrt_core::shared_handle::export_handle ehdl)
+  : bo(pdev, ehdl)
 {
     alloc_bo();
     mmap_bo();

--- a/src/shim/umq/bo.h
+++ b/src/shim/umq/bo.h
@@ -10,10 +10,10 @@ namespace shim_xdna {
 
 class bo_umq : public bo {
 public:
-  bo_umq(const device& device, xrt_core::hwctx_handle::slot_id ctx_id,
+  bo_umq(const pdev& pdev, xrt_core::hwctx_handle::slot_id ctx_id,
     size_t size, uint64_t flags);
 
-  bo_umq(const device& device, xrt_core::shared_handle::export_handle ehdl);
+  bo_umq(const pdev& pdev, xrt_core::shared_handle::export_handle ehdl);
 
   ~bo_umq();
 
@@ -24,7 +24,7 @@ public:
   bind_at(size_t pos, const buffer_handle* bh, size_t offset, size_t size) override;
 
 private:
-  bo_umq(const device& device, xrt_core::hwctx_handle::slot_id ctx_id,
+  bo_umq(const pdev& pdev, xrt_core::hwctx_handle::slot_id ctx_id,
     size_t size, uint64_t flags, int type);
 
 };

--- a/src/shim/umq/device.cpp
+++ b/src/shim/umq/device.cpp
@@ -35,14 +35,14 @@ alloc_bo(void* userptr, xrt_core::hwctx_handle::slot_id ctx_id,
   if (userptr)
     shim_not_supported_err("User ptr BO");;
 
-  return std::make_unique<bo_umq>(*this, ctx_id, size, flags);
+  return std::make_unique<bo_umq>(get_pdev(), ctx_id, size, flags);
 }
 
 std::unique_ptr<xrt_core::buffer_handle>
 device_umq::
 import_bo(xrt_core::shared_handle::export_handle ehdl) const
 {
-  return std::make_unique<bo_umq>(*this, ehdl);
+  return std::make_unique<bo_umq>(get_pdev(), ehdl);
 }
 
 } // namespace shim_xdna

--- a/src/shim/umq/pcidev.h
+++ b/src/shim/umq/pcidev.h
@@ -4,6 +4,7 @@
 #ifndef PCIDEV_UMQ_H
 #define PCIDEV_UMQ_H
 
+#include "../pcidrv.h"
 #include "../pcidev.h"
 
 namespace shim_xdna {

--- a/src/shim/virtio/bo.cpp
+++ b/src/shim/virtio/bo.cpp
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2025, Advanced Micro Devices, Inc. All rights reserved.
+
+#include "bo.h"
+#include "drm_local/amdxdna_accel.h"
+#include <drm/virtgpu_drm.h>
+
+namespace {
+
+int
+flag_to_type(uint64_t bo_flags)
+{
+  auto flags = xcl_bo_flags{bo_flags};
+  auto boflags = (static_cast<uint32_t>(flags.boflags) << 24);
+  switch (boflags) {
+  case XCL_BO_FLAGS_HOST_ONLY:
+    return AMDXDNA_BO_SHARE;
+  case XCL_BO_FLAGS_CACHEABLE:
+    return AMDXDNA_BO_DEV;
+  case XCL_BO_FLAGS_EXECBUF:
+    return AMDXDNA_BO_CMD;
+  default:
+    break;
+  }
+  return AMDXDNA_BO_INVALID;
+}
+
+// flash cache line for non coherence memory
+inline void
+clflush_data(const void *base, size_t offset, size_t len)
+{
+  static long cacheline_size = 0;
+
+  if (!cacheline_size) {
+    long sz = sysconf(_SC_LEVEL1_DCACHE_LINESIZE);
+    if (sz <= 0)
+      shim_err(EINVAL, "Invalid cache line size: %ld", sz);
+    cacheline_size = sz;
+  }
+
+  const char *cur = (const char *)base;
+  cur += offset;
+  uintptr_t lastline = (uintptr_t)(cur + len - 1) | (cacheline_size - 1);
+  do {
+    shim_xdna::flush_cache_line(cur);
+    cur += cacheline_size;
+  } while (cur <= (const char *)lastline);
+}
+
+}
+
+namespace shim_xdna {
+
+bo_virtio::
+bo_virtio(const device& device, xrt_core::hwctx_handle::slot_id ctx_id,
+  size_t size, uint64_t flags)
+  : bo_virtio(device, ctx_id, size, flags, flag_to_type(flags))
+{
+  if (m_type == AMDXDNA_BO_INVALID)
+    shim_err(EINVAL, "Invalid BO flags: 0x%lx", flags);
+}
+
+bo_virtio::
+bo_virtio(const device& device, size_t size, int type)
+  : bo_virtio(device, AMDXDNA_INVALID_CTX_HANDLE, size, 0, type)
+{
+}
+
+bo_virtio::
+bo_virtio(const device& device, xrt_core::hwctx_handle::slot_id ctx_id,
+  size_t size, uint64_t flags, int type)
+  : bo(device, ctx_id, size, flags, type)
+{
+  size_t align = 0;
+
+  if (m_type == AMDXDNA_BO_DEV_HEAP)
+    align = 64 * 1024 * 1024; // Device mem heap must align at 64MB boundary.
+
+  alloc_bo();
+  mmap_bo(align);
+
+  // Newly allocated buffer may contain dirty pages. If used as output buffer,
+  // the data in cacheline will be flushed onto memory and pollute the output
+  // from device. We perform a cache flush right after the BO is allocated to
+  // avoid this issue.
+  if (m_type == AMDXDNA_BO_SHARE)
+    sync(direction::host2device, size, 0);
+
+  shim_debug("Allocated VIRTIO BO (userptr=0x%lx, size=%ld, flags=0x%llx, type=%d, drm_bo=%d)",
+    m_aligned, m_aligned_size, m_flags, m_type, get_drm_bo_handle());
+}
+
+bo_virtio::
+~bo_virtio()
+{
+  shim_debug("Freeing VIRTIO BO, %s", describe().c_str());
+
+  munmap_bo();
+  try {
+    // If BO is in use, we should block and wait in driver
+    free_bo();
+  } catch (const xrt_core::system_error& e) {
+    shim_debug("Failed to free BO: %s", e.what());
+  }
+}
+
+void
+bo_virtio::
+sync(direction dir, size_t size, size_t offset)
+{
+  if (offset + size > m_aligned_size)
+    shim_err(EINVAL, "Invalid BO offset and size for sync'ing: %ld, %ld", offset, size);
+  clflush_data(m_aligned, offset, size); 
+}
+
+uint32_t
+bo_virtio::
+alloc_drm_bo(const shim_xdna::pdev& dev, int type, size_t size)
+{
+  shim_debug("Allocating VIRTIO BO");
+  return 0;
+}
+
+void
+bo_virtio::
+get_drm_bo_info(const shim_xdna::pdev& dev, uint32_t boh, amdxdna_drm_get_bo_info* bo_info)
+{
+  shim_debug("Getting info of VIRTIO BO");
+}
+
+void
+bo_virtio::
+free_drm_bo(const shim_xdna::pdev& dev, uint32_t boh)
+{
+  shim_debug("Allocating VIRTIO BO");
+}
+
+} // namespace shim_xdna

--- a/src/shim/virtio/bo.cpp
+++ b/src/shim/virtio/bo.cpp
@@ -52,24 +52,24 @@ clflush_data(const void *base, size_t offset, size_t len)
 namespace shim_xdna {
 
 bo_virtio::
-bo_virtio(const device& device, xrt_core::hwctx_handle::slot_id ctx_id,
+bo_virtio(const pdev& pdev, xrt_core::hwctx_handle::slot_id ctx_id,
   size_t size, uint64_t flags)
-  : bo_virtio(device, ctx_id, size, flags, flag_to_type(flags))
+  : bo_virtio(pdev, ctx_id, size, flags, flag_to_type(flags))
 {
   if (m_type == AMDXDNA_BO_INVALID)
     shim_err(EINVAL, "Invalid BO flags: 0x%lx", flags);
 }
 
 bo_virtio::
-bo_virtio(const device& device, size_t size, int type)
-  : bo_virtio(device, AMDXDNA_INVALID_CTX_HANDLE, size, 0, type)
+bo_virtio(const pdev& pdev, size_t size, int type)
+  : bo_virtio(pdev, AMDXDNA_INVALID_CTX_HANDLE, size, 0, type)
 {
 }
 
 bo_virtio::
-bo_virtio(const device& device, xrt_core::hwctx_handle::slot_id ctx_id,
+bo_virtio(const pdev& pdev, xrt_core::hwctx_handle::slot_id ctx_id,
   size_t size, uint64_t flags, int type)
-  : bo(device, ctx_id, size, flags, type)
+  : bo(pdev, ctx_id, size, flags, type)
 {
   size_t align = 0;
 
@@ -86,8 +86,7 @@ bo_virtio(const device& device, xrt_core::hwctx_handle::slot_id ctx_id,
   if (m_type == AMDXDNA_BO_SHARE)
     sync(direction::host2device, size, 0);
 
-  shim_debug("Allocated VIRTIO BO (userptr=0x%lx, size=%ld, flags=0x%llx, type=%d, drm_bo=%d)",
-    m_aligned, m_aligned_size, m_flags, m_type, get_drm_bo_handle());
+  shim_debug("Allocated VIRTIO BO, %s", describe().c_str());
 }
 
 bo_virtio::

--- a/src/shim/virtio/bo.h
+++ b/src/shim/virtio/bo.h
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2025, Advanced Micro Devices, Inc. All rights reserved.
+
+#ifndef _BO_VIRTIO_H_
+#define _BO_VIRTIO_H_
+
+#include "../bo.h"
+
+#include <set>
+
+namespace shim_xdna {
+
+class bo_virtio : public bo {
+public:
+  bo_virtio(const device& device, xrt_core::hwctx_handle::slot_id ctx_id,
+    size_t size, uint64_t flags);
+
+  ~bo_virtio();
+
+  void
+  sync(direction dir, size_t size, size_t offset) override;
+
+public:
+  // Support BO creation from internal
+  bo_virtio(const device& device, size_t size, int type);
+
+private:
+  bo_virtio(const device& device, xrt_core::hwctx_handle::slot_id ctx_id,
+    size_t size, uint64_t flags, int type);
+  
+  uint32_t
+  alloc_drm_bo(const shim_xdna::pdev& dev, int type, size_t size) override;
+
+  void
+  get_drm_bo_info(const shim_xdna::pdev& dev, uint32_t boh, amdxdna_drm_get_bo_info* bo_info) override;
+
+  void
+  free_drm_bo(const shim_xdna::pdev& dev, uint32_t boh) override;
+};
+
+} // namespace shim_xdna
+
+#endif // _BO_VIRTIO_H_

--- a/src/shim/virtio/bo.h
+++ b/src/shim/virtio/bo.h
@@ -12,7 +12,7 @@ namespace shim_xdna {
 
 class bo_virtio : public bo {
 public:
-  bo_virtio(const device& device, xrt_core::hwctx_handle::slot_id ctx_id,
+  bo_virtio(const pdev& pdev, xrt_core::hwctx_handle::slot_id ctx_id,
     size_t size, uint64_t flags);
 
   ~bo_virtio();
@@ -22,10 +22,10 @@ public:
 
 public:
   // Support BO creation from internal
-  bo_virtio(const device& device, size_t size, int type);
+  bo_virtio(const pdev& pdev, size_t size, int type);
 
 private:
-  bo_virtio(const device& device, xrt_core::hwctx_handle::slot_id ctx_id,
+  bo_virtio(const pdev& pdev, xrt_core::hwctx_handle::slot_id ctx_id,
     size_t size, uint64_t flags, int type);
   
   uint32_t

--- a/src/shim/virtio/device.cpp
+++ b/src/shim/virtio/device.cpp
@@ -38,7 +38,7 @@ alloc_bo(void* userptr, xrt_core::hwctx_handle::slot_id ctx_id,
   if (userptr)
     shim_not_supported_err("User ptr BO");
 
-  return std::make_unique<bo_virtio>(*this, ctx_id, size, flags);
+  return std::make_unique<bo_virtio>(get_pdev(), ctx_id, size, flags);
 }
 
 std::unique_ptr<xrt_core::buffer_handle>

--- a/src/shim/virtio/device.cpp
+++ b/src/shim/virtio/device.cpp
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2025, Advanced Micro Devices, Inc. All rights reserved.
+
+#include "bo.h"
+#include "device.h"
+
+namespace shim_xdna {
+
+device_virtio::
+device_virtio(const pdev& pdev, handle_type shim_handle, id_type device_id)
+: device(pdev, shim_handle, device_id)
+{
+  shim_debug("Created VIRTIO device (%s)", get_pdev().m_sysfs_name.c_str());
+}
+
+device_virtio::
+~device_virtio()
+{
+  shim_debug("Destroying VIRTIO device (%s)", get_pdev().m_sysfs_name.c_str());
+}
+
+std::unique_ptr<xrt_core::hwctx_handle>
+device_virtio::
+create_hw_context(const device& dev, const xrt::xclbin& xclbin, const xrt::hw_context::qos_type& qos) const
+{
+  shim_not_supported_err(__func__);
+}
+
+std::unique_ptr<xrt_core::buffer_handle>
+device_virtio::
+alloc_bo(void* userptr, xrt_core::hwctx_handle::slot_id ctx_id,
+  size_t size, uint64_t flags)
+{
+  // Sanity check
+  auto f = xcl_bo_flags{flags};
+  if (f.boflags == 0)
+    shim_not_supported_err("unsupported buffer type: none flag");
+  if (userptr)
+    shim_not_supported_err("User ptr BO");
+
+  return std::make_unique<bo_virtio>(*this, ctx_id, size, flags);
+}
+
+std::unique_ptr<xrt_core::buffer_handle>
+device_virtio::
+import_bo(xrt_core::shared_handle::export_handle ehdl) const
+{
+  shim_not_supported_err(__func__);
+}
+
+} // namespace shim_xdna

--- a/src/shim/virtio/device.h
+++ b/src/shim/virtio/device.h
@@ -1,19 +1,19 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright (C) 2023-2024, Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (C) 2025, Advanced Micro Devices, Inc. All rights reserved.
 
-#ifndef _DEVICE_KMQ_H_
-#define _DEVICE_KMQ_H_
+#ifndef _DEVICE_VIRTIO_H_
+#define _DEVICE_VIRTIO_H_
 
 #include "../device.h"
 #include "core/common/memalign.h"
 
 namespace shim_xdna {
 
-class device_kmq : public device {
+class device_virtio : public device {
 public:
-  device_kmq(const pdev& pdev, handle_type shim_handle, id_type device_id);
+  device_virtio(const pdev& pdev, handle_type shim_handle, id_type device_id);
 
-  ~device_kmq();
+  ~device_virtio();
 
   std::unique_ptr<xrt_core::buffer_handle>
   alloc_bo(void* userptr, xrt_core::hwctx_handle::slot_id ctx_id,
@@ -26,11 +26,8 @@ protected:
 
   std::unique_ptr<xrt_core::buffer_handle>
   import_bo(xrt_core::shared_handle::export_handle ehdl) const override;
-
-private:
-  std::unique_ptr<xrt_core::buffer_handle> m_dev_heap_bo;
 };
 
 } // namespace shim_xdna
 
-#endif // _DEVICE_KMQ_H_
+#endif // _DEVICE_VIRTIO_H_

--- a/src/shim/virtio/pcidev.cpp
+++ b/src/shim/virtio/pcidev.cpp
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2025, Advanced Micro Devices, Inc. All rights reserved.
+
+#include "device.h"
+#include "pcidev.h"
+
+namespace {
+
+const size_t shmem_size = 0x1000;
+
+uint32_t
+alloc_shmem(const shim_xdna::pdev& dev)
+{
+  drm_virtgpu_resource_create_blob args = {
+    .blob_mem   = VIRTGPU_BLOB_MEM_HOST3D,
+    .blob_flags = VIRTGPU_BLOB_FLAG_USE_MAPPABLE,
+    .size       = shmem_size,
+    .blob_id    = 0,
+  };
+  dev.ioctl(DRM_IOCTL_VIRTGPU_RESOURCE_CREATE_BLOB, &args);
+  return args.bo_handle;
+}
+
+void
+free_shmem(const shim_xdna::pdev& dev, uint32_t boh)
+{
+  drm_gem_close close_bo = {
+    .handle = boh
+  };
+  dev.ioctl(DRM_IOCTL_GEM_CLOSE, &close_bo);
+}
+
+void *
+map_shmem(const shim_xdna::pdev& dev, uint32_t boh)
+{
+  drm_virtgpu_map args = {
+    .handle = boh,
+  };
+  dev.ioctl(DRM_IOCTL_VIRTGPU_MAP, &args);
+  return dev.mmap(0, shmem_size, PROT_READ | PROT_WRITE, MAP_SHARED, args.offset);
+}
+
+void
+unmap_shmem(const shim_xdna::pdev& dev, void *shmem)
+{
+  dev.munmap(shmem, shmem_size);
+}
+
+}
+
+namespace shim_xdna {
+
+pdev_virtio::
+pdev_virtio(std::shared_ptr<const drv_virtio> driver, std::string sysfs_name)
+  : pdev(driver, sysfs_name)
+{
+  shim_debug("Created VIRTIO pcidev over %s", sysfs_name.c_str());
+}
+
+pdev_virtio::
+~pdev_virtio()
+{
+  shim_debug("Destroying VIRTIO pcidev");
+}
+
+std::shared_ptr<xrt_core::device>
+pdev_virtio::
+create_device(xrt_core::device::handle_type handle, xrt_core::device::id_type id) const
+{
+  return std::make_shared<device_virtio>(*this, handle, id);
+}
+
+void
+pdev_virtio::
+on_first_open() const
+{
+  shim_debug("Setting up response shmem");
+  m_shmem_bo_hdl = alloc_shmem(*this);
+  m_shmem = reinterpret_cast<vdrm_shmem *>(map_shmem(*this, m_shmem_bo_hdl));
+}
+
+void
+pdev_virtio::
+on_last_close() const
+{
+  shim_debug("Tearing down response shmem");
+  unmap_shmem(*this, m_shmem);
+  free_shmem(*this, m_shmem_bo_hdl);
+}
+
+} // namespace shim_xdna
+

--- a/src/shim/virtio/pcidev.h
+++ b/src/shim/virtio/pcidev.h
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2025, Advanced Micro Devices, Inc. All rights reserved.
+
+#ifndef PCIDEV_VIRTIO_H
+#define PCIDEV_VIRTIO_H
+
+#include "../pcidrv_virtio.h"
+#include "../pcidev.h"
+#include <drm/virtgpu_drm.h>
+
+namespace shim_xdna {
+
+class pdev_virtio : public pdev
+{
+public:
+  pdev_virtio(std::shared_ptr<const drv_virtio> driver, std::string sysfs_name);
+  ~pdev_virtio();
+ 
+  std::shared_ptr<xrt_core::device>
+  create_device(xrt_core::device::handle_type handle, xrt_core::device::id_type id) const override;
+
+private:
+  // Below are init'ed on first device open and removed right before device is closed
+  mutable uint32_t m_shmem_bo_hdl;
+  mutable struct vdrm_shmem *m_shmem;
+
+  virtual void
+  on_first_open() const override;
+
+  virtual void
+  on_last_close() const override;
+};
+
+} // namespace shim_xdna
+
+#endif

--- a/test/shim_test/shim_test.cpp
+++ b/test/shim_test/shim_test.cpp
@@ -260,6 +260,13 @@ TEST_query_userpf(device::id_type id, std::shared_ptr<device> sdev, arg_type& ar
 }
 
 void
+TEST_create_destroy_device(device::id_type id, std::shared_ptr<device> sdev, arg_type& arg)
+{
+  auto dev1 = get_userpf_device(id);
+  auto dev2 = get_userpf_device(id);
+}
+
+void
 TEST_create_destroy_hw_context(device::id_type id, std::shared_ptr<device> sdev, arg_type& arg)
 {
   // Close existing device
@@ -721,6 +728,9 @@ std::vector<test_case> test_list {
   },
   test_case{ "Multi context IO test 1 (npu4)", {},
     TEST_POSITIVE, dev_filter_is_npu4, TEST_multi_context_io_test, { 20 }
+  },
+  test_case{ "Create and destroy devices", {},
+    TEST_POSITIVE, dev_filter_is_aie2, TEST_create_destroy_device, {}
   },
 };
 

--- a/test/shim_test/shim_test.cpp
+++ b/test/shim_test/shim_test.cpp
@@ -575,7 +575,7 @@ std::vector<test_case> test_list {
     TEST_POSITIVE, dev_filter_xdna, TEST_create_free_bo,
     {XCL_BO_FLAGS_CACHEABLE, 0, 0x2000, 0x400, 0x3000, 0x100}
   },
-  test_case{ "create_and_free_input_output_bo 1 pages", {},
+  test_case{ "create_and_free_input_output_bo 1 page", {},
     TEST_POSITIVE, dev_filter_xdna, TEST_create_free_bo, {XCL_BO_FLAGS_HOST_ONLY, 0, 128}
   },
   test_case{ "create_and_free_input_output_bo multiple pages", {},


### PR DESCRIPTION
The SHIM changes to allow XRT sees virtgpu device inside guest. Once device object is created, SHIM will try to initialize virtio response ring buffer.