### PR TITLE
Update xrt submodule

### DIFF
--- a/tools/info.json
+++ b/tools/info.json
@@ -1,7 +1,7 @@
 {
 	"copyright": "Copyright (C) 2023-2025 Advanced Micro Devices, Inc. All rights reserved.",
 	"xrt" : {
-		"version": "202510.2.19.107",
+		"version": "202510.2.19.129",
 		"os_rel": ["22.04", "24.04"]
 	},
 	"firmwares": [


### PR DESCRIPTION
Update xrt submodule to 202510.2.19.129 to include recent xrt-smi changes, including using "xrt-smi validate" without sudo.
Commit hash in xrt is 79f5f5adad712270371bbb5c6eee78473cba038e.