### PR TITLE
Add Total Column Query and Placeholder for xrt-smi Platform Report

### DIFF
--- a/src/driver/amdxdna/aie2_pci.c
+++ b/src/driver/amdxdna/aie2_pci.c
@@ -909,11 +909,6 @@ static int aie2_get_ctx_status(struct amdxdna_client *client,
 			tmp->preemptions = 0;
 			tmp->errors = 0;
 			tmp->priority = ctx->qos.priority;
-			tmp->instruction_mem = 0;
-			tmp->gops = 0;
-			tmp->egops = 0;
-			tmp->fps = 0;
-			tmp->latency = 0;
 
 			if (copy_to_user(&buf[hw_i], tmp, sizeof(*tmp))) {
 				ret = -EFAULT;

--- a/src/driver/amdxdna/aie2_pci.c
+++ b/src/driver/amdxdna/aie2_pci.c
@@ -854,7 +854,7 @@ static int aie2_get_sensors(struct amdxdna_client *client,
 		return -ENOMEM;
 
 	sensor->type = AMDXDNA_SENSOR_TYPE_POWER;
-	sensor->input = 1234; /* TODO: query the device and get the power data */
+	sensor->input = __UINT32_MAX__; /* TODO: query the device and get the power data */
 	sensor->unitm = -3; /* in milliwatts */
 	snprintf(sensor->label, sizeof(sensor->label), "Total Power");
 	snprintf(sensor->units, sizeof(sensor->units), "mW");
@@ -909,6 +909,11 @@ static int aie2_get_ctx_status(struct amdxdna_client *client,
 			tmp->preemptions = 0;
 			tmp->errors = 0;
 			tmp->priority = ctx->qos.priority;
+			tmp->instruction_mem = 0;
+			tmp->gops = 0;
+			tmp->egops = 0;
+			tmp->fps = 0;
+			tmp->latency = 0;
 
 			if (copy_to_user(&buf[hw_i], tmp, sizeof(*tmp))) {
 				ret = -EFAULT;

--- a/src/include/uapi/drm_local/amdxdna_accel.h
+++ b/src/include/uapi/drm_local/amdxdna_accel.h
@@ -420,11 +420,6 @@ struct amdxdna_drm_query_sensor {
  *               same partition.
  * @errors: The errors for this context.
  * @priority: Context priority
- * @instruction_mem: The size of the instruction BO in bytes.
- * @gops: Giga operations per second.
- * @egops: Effective giga operations per second.
- * @fps: Frames per second.
- * @latency: Frame response latency.
  */
 struct amdxdna_drm_query_ctx {
 	__u32 context_id;
@@ -438,11 +433,6 @@ struct amdxdna_drm_query_ctx {
 	__u64 preemptions;
 	__u64 errors;
 	__u64 priority;
-	__u64 instruction_mem;
-	__u64 gops;
-	__u64 egops;
-	__u64 fps;
-	__u64 latency;
 };
 
 /**

--- a/src/include/uapi/drm_local/amdxdna_accel.h
+++ b/src/include/uapi/drm_local/amdxdna_accel.h
@@ -420,6 +420,11 @@ struct amdxdna_drm_query_sensor {
  *               same partition.
  * @errors: The errors for this context.
  * @priority: Context priority
+ * @instruction_mem: The size of the instruction BO in bytes.
+ * @gops: Giga operations per second.
+ * @egops: Effective giga operations per second.
+ * @fps: Frames per second.
+ * @latency: Frame response latency.
  */
 struct amdxdna_drm_query_ctx {
 	__u32 context_id;
@@ -433,6 +438,11 @@ struct amdxdna_drm_query_ctx {
 	__u64 preemptions;
 	__u64 errors;
 	__u64 priority;
+	__u64 instruction_mem;
+	__u64 gops;
+	__u64 egops;
+	__u64 fps;
+	__u64 latency;
 };
 
 /**

--- a/src/shim/device.cpp
+++ b/src/shim/device.cpp
@@ -275,11 +275,6 @@ struct partition_info
       new_entry.preemptions = entry.preemptions;
       new_entry.errors = entry.errors;
       new_entry.qos.priority = entry.priority;
-      new_entry.instruction_mem = entry.instruction_mem;
-      new_entry.qos.gops = entry.gops;
-      new_entry.qos.egops = entry.egops;
-      new_entry.qos.fps = entry.fps;
-      new_entry.qos.latency = entry.latency;
       output.push_back(std::move(new_entry));
     }
     return output;


### PR DESCRIPTION
Added total column query in shim to display number of total columns in xrt-smi platform report.

As previously discussed, return UINT32_MAX for power as a placeholder so that xrt-smi can show "N/A" for power reading in platform report.

Sample Platform Report Output:
```
------------------------------
[0000:c5:00.1] : RyzenAI-npu4
------------------------------
Platform
  Name                   : RyzenAI-npu4 
  Power Mode             : Default 
  Total Columns          : 8 

Power                    : N/A
```