### PR TITLE
EDGEML-9445 remove hardcoded log buffer iohub ptr

### DIFF
--- a/src/driver/amdxdna/aie2_event_trace.c
+++ b/src/driver/amdxdna/aie2_event_trace.c
@@ -22,6 +22,7 @@ struct event_trace_req_buf {
 	u64                      resp_timestamp;
 	u64                      sys_start_time;
 	u32                      dram_buffer_size;
+	u32			 msi_address;
 	int                      log_ch_irq;
 	bool                     enabled;
 };
@@ -41,8 +42,10 @@ struct trace_event_log_data {
 
 static void clear_event_trace_msix(struct amdxdna_dev_hdl *ndev)
 {
+	u64 iohub_ptr = ndev->event_trace_req->msi_address;
+
 	/* Clear the log buffer interrupt */
-	writel(0, (void *)((u64)ndev->mbox_base + (u64)LOG_BUF_MB_IOHUB_PTR));
+	writel(0, (void *)((u64)ndev->mbox_base + iohub_ptr));
 }
 
 static int aie2_is_event_trace_supported_on_dev(struct amdxdna_dev_hdl *ndev)
@@ -130,8 +133,9 @@ static void aie2_print_trace_event_log(struct amdxdna_dev_hdl *ndev)
 
 static void deffered_logging_work(struct work_struct *work)
 {
-	struct event_trace_req_buf *trace_rq = container_of(work, struct event_trace_req_buf, work);
+	struct event_trace_req_buf *trace_rq;
 
+	trace_rq = container_of(work, struct event_trace_req_buf, work);
 	aie2_print_trace_event_log(trace_rq->ndev);
 }
 
@@ -294,6 +298,7 @@ void aie2_set_trace_timestamp(struct amdxdna_dev_hdl *ndev,  struct start_event_
 {
 	ndev->event_trace_req->resp_timestamp = resp->current_timestamp;
 	ndev->event_trace_req->sys_start_time = ktime_get_ns() / 1000; /*Convert ns to us*/
+	ndev->event_trace_req->msi_address = resp->msi_address & 0x00FFFFFF;
 	aie2_register_log_buf_irq_hdl(ndev, resp->msi_idx);
 }
 

--- a/src/driver/amdxdna/aie2_msg_priv.h
+++ b/src/driver/amdxdna/aie2_msg_priv.h
@@ -386,9 +386,6 @@ struct async_event_msg_resp {
 #define TRACE_EVENT_BUF_SIZE				0x2000
 #define TRACE_EVENT_BUF_METADATA_SIZE			0x40
 #define MAX_ONE_TIME_LOG_INFO_LEN			16
-/* FIXME: To be deleted */
-#define MPNPU_IOHUB_INT_27_ALIAS			0xD7008
-#define LOG_BUF_MB_IOHUB_PTR				MPNPU_IOHUB_INT_27_ALIAS
 #define LOG_RB_SIZE	(TRACE_EVENT_BUF_SIZE - TRACE_EVENT_BUF_METADATA_SIZE)
 
 enum event_trace_destination {
@@ -415,6 +412,7 @@ struct start_event_trace_resp {
 	enum aie2_msg_status status;
 	u32 msi_idx;
 	u64 current_timestamp;
+	u32 msi_address;
 } __packed;
 
 struct stop_event_trace_req {


### PR DESCRIPTION
[Why]
 Log buff iohub ptr may differ on different HW.

[How]
 Log buff iohub address should be reported by FW.