### PR TITLE
exclude amdxdna from initram on fedora

### DIFF
--- a/CMake/config/postinst.in
+++ b/CMake/config/postinst.in
@@ -15,7 +15,17 @@ fi
 installdir=/opt/xilinx/xrt
 udev_rules_d=/etc/udev/rules.d
 amdxdna_rules_file=99-amdxdna.rules
+dracut_conf_d=/etc/dracut.conf.d
+dracut_conf_file=amdxdna.dracut.conf
 export XILINX_XRT=$installdir
+
+# On Fedora/Redhat system, exclude driver from initram
+if [ -e ${dracut_conf_d} ]; then
+	if [ ! -f ${dracut_conf_d}/${dracut_conf_file} ]; then
+		touch ${dracut_conf_d}/${dracut_conf_file}
+	fi
+	echo "omit_drivers+=\" amdxdna \"" > ${dracut_conf_d}/${dracut_conf_file}
+fi
 
 echo "Installing new amdxdna Linux kernel module in dkms"
 if [ "$build_type" = "Debug" ]; then
@@ -29,11 +39,12 @@ if [ ! -f ${udev_rules_d}/${amdxdna_rules_file} ]; then
 	touch ${udev_rules_d}/${amdxdna_rules_file}
 fi
 echo "KERNEL==\"accel*\",DRIVERS==\"amdxdna\",MODE=\"0666\"" > ${udev_rules_d}/${amdxdna_rules_file}
+
 rmmod amdxdna > /dev/null 2>&1
 if [ "$build_type" = "Debug" ]; then
-modprobe amdxdna dyndbg=+pf
+	modprobe amdxdna dyndbg=+pf
 else
-modprobe amdxdna
+	modprobe amdxdna
 fi
 
 unset XILINX_XRT

--- a/CMake/config/prerm.in
+++ b/CMake/config/prerm.in
@@ -15,11 +15,16 @@ fi
 installdir=/opt/xilinx/xrt
 udev_rules_d=/etc/udev/rules.d
 amdxdna_rules_file=99-amdxdna.rules
+dracut_conf_d=/etc/dracut.conf.d
+dracut_conf_file=amdxdna.dracut.conf
 
 if lsmod | grep -q "amdxdna "; then
 	rmmod amdxdna
 fi
 
+if [ -f ${dracut_conf_d}/${dracut_conf_file} ]; then
+	rm -rf ${dracut_conf_d}/${dracut_conf_file}
+fi
 if [ -f ${udev_rules_d}/${amdxdna_rules_file} ]; then
 	rm -rf ${udev_rules_d}/${amdxdna_rules_file}
 fi


### PR DESCRIPTION
By default amdxdna is included in initram on Fedora. This will not work since the firmware won't be available in initram. Let's make sure amdxdna is excluded from initram since it is not required for booting.