### PR TITLE
Ordered work queue has to be unbound

### DIFF
--- a/src/driver/amdxdna/aie2_hwctx.c
+++ b/src/driver/amdxdna/aie2_hwctx.c
@@ -72,8 +72,7 @@ int aie2_hwctx_start(struct amdxdna_ctx *ctx)
 	heap = ctx->priv->heap;
 
 	drm_WARN_ON(&xdna->ddev, !mutex_is_locked(&ndev->aie2_lock));
-	ret = drm_sched_init(sched, &sched_ops, ctx->priv->submit_wq,
-			     DRM_SCHED_PRIORITY_COUNT,
+	ret = drm_sched_init(sched, &sched_ops, NULL, DRM_SCHED_PRIORITY_COUNT,
 			     CTX_MAX_CMDS, 0, MAX_SCHEDULE_TIMEOUT,
 			     NULL, NULL, ctx->name, xdna->ddev.dev);
 	if (ret) {

--- a/src/driver/amdxdna/aie2_pci.h
+++ b/src/driver/amdxdna/aie2_pci.h
@@ -206,7 +206,6 @@ struct amdxdna_ctx_priv {
 #endif
 	struct semaphore		job_sem;
 
-	struct workqueue_struct		*submit_wq;
 	struct drm_syncobj		*syncobj;
 
 	/* Driver needs to wait for all jobs freed before fini DRM scheduler */

--- a/src/shim/kmq/pcidev.cpp
+++ b/src/shim/kmq/pcidev.cpp
@@ -50,7 +50,6 @@ pdev_kmq::
 on_first_open() const
 {
   auto heap_sz = heap_page_size * get_heap_num_pages();
-  shim_debug("HEAP BO size: 0x%lx", heap_sz);
   // Alloc device memory on first device open.
   m_dev_heap_bo = std::make_unique<bo_kmq>(*this, heap_sz, AMDXDNA_BO_DEV_HEAP);
 }

--- a/src/shim/pcidev.cpp
+++ b/src/shim/pcidev.cpp
@@ -107,7 +107,15 @@ open() const
       shim_debug("Device opened, fd=%d", fd);
     // Publish the fd for other threads to use.
     m_dev_fd = fd;
-    on_first_open();
+
+    // Make sure we close fd if on_first_open() throws
+    try {
+      on_first_open();
+    } catch (...) {
+      ::close(fd);
+      m_dev_fd = -1;
+      throw;
+    }
   }
   ++m_dev_users;
 }


### PR DESCRIPTION
Ordered work queue is implemented as unbound workqueues with max_active of one. Only specify __WQ_ORDERED won't be enough. Sigh.