### PR TITLE
Use XRT defined QoS priority value as shim/driver interface

### DIFF
--- a/src/driver/amdxdna/aie2_ctx_runqueue.c
+++ b/src/driver/amdxdna/aie2_ctx_runqueue.c
@@ -34,7 +34,7 @@ static int qos_to_rq_prio(u32 p)
 	case AMDXDNA_QOS_LOW_PRIORITY:
 		return CTX_RQ_LOW;
 	default:
-		return -EINVAL;
+		return CTX_RQ_LOW;
 	};
 }
 

--- a/src/driver/amdxdna/aie2_message.c
+++ b/src/driver/amdxdna/aie2_message.c
@@ -282,7 +282,7 @@ int aie2_create_context(struct amdxdna_dev_hdl *ndev, struct amdxdna_ctx *ctx,
 	req.num_col = ctx->num_col;
 	req.num_cq_pairs_requested = 1;
 	req.pasid = ctx->client->pasid;
-	req.context_priority = ctx->qos.priority;
+	req.context_priority = ctx->priv->priority + 1;
 
 	ret = aie2_send_mgmt_msg_wait(ndev, &msg);
 	if (ret)
@@ -311,7 +311,7 @@ int aie2_create_context(struct amdxdna_dev_hdl *ndev, struct amdxdna_ctx *ctx,
 	info->i2x.rb_size	  = cq_pair->i2x_q.buf_size;
 
 	aie2_calc_intr_reg(info);
-	XDNA_DBG(xdna, "%s created hwctx %d pasid %d priority %d", ctx->name,
+	XDNA_DBG(xdna, "%s created hwctx %d pasid %d qos priority 0x%x", ctx->name,
 		 ctx->priv->id, ctx->client->pasid, ctx->qos.priority);
 
 	return 0;

--- a/src/driver/amdxdna/aie2_pci.c
+++ b/src/driver/amdxdna/aie2_pci.c
@@ -952,7 +952,7 @@ static int aie2_get_ctx_status(struct amdxdna_client *client,
 			tmp->migrations = 0;
 			tmp->preemptions = 0;
 			tmp->errors = 0;
-			tmp->priority = ctx->priv->priority;
+			tmp->priority = ctx->qos.priority;
 
 			if (copy_to_user(&buf[hw_i], tmp, sizeof(*tmp))) {
 				ret = -EFAULT;

--- a/src/driver/amdxdna/aie2_pci.h
+++ b/src/driver/amdxdna/aie2_pci.h
@@ -231,7 +231,7 @@ struct amdxdna_ctx_priv {
 	u32				status;
 	int				errno; /* when CTX_STATE_DEAD */
 	bool				should_block;
-	u32				priority;
+	int				priority;
 	struct aie2_partition		*part;
 
 	/* Hardware context related in below */
@@ -253,7 +253,12 @@ enum aie2_power_state {
 };
 
 struct aie2_partition {
-	struct list_head	runqueue[AMDXDNA_NUM_PRIORITY];
+#define CTX_RQ_REALTIME		0
+#define CTX_RQ_HIGH		1
+#define CTX_RQ_NORMAL		2
+#define CTX_RQ_LOW		3
+#define CTX_RQ_NUM_QUEUE	4
+	struct list_head	runqueue[CTX_RQ_NUM_QUEUE];
 	struct list_head	conn_list;
 	struct aie2_ctx_rq	*rq;
 

--- a/src/driver/amdxdna/amdxdna_ctx.c
+++ b/src/driver/amdxdna/amdxdna_ctx.c
@@ -111,8 +111,6 @@ int amdxdna_drm_create_ctx_ioctl(struct drm_device *dev, void *data, struct drm_
 		goto free_ctx;
 	}
 
-	if (ctx->qos.priority == AMDXDNA_QOS_DEFAULT_PRIORITY)
-		ctx->qos.priority = AMDXDNA_QOS_HIGH_PRIORITY;
 	ctx->client = client;
 	ctx->last_completed = -1;
 	ctx->num_tiles = args->num_tiles;

--- a/src/include/uapi/drm_local/amdxdna_accel.h
+++ b/src/include/uapi/drm_local/amdxdna_accel.h
@@ -64,18 +64,16 @@ extern "C" {
 
 /*
  * Define priority in application's QoS.
- * AMDXDNA_QOS_DEFAULT_PRIORITY: Driver decide priority for client.
  * AMDXDNA_QOS_REALTIME_PRIORITY: Real time clients.
  * AMDXDNA_QOS_HIGH_PRIORITY: Best effort foreground clients.
  * AMDXDNA_QOS_NORMAL_PRIORITY: Best effort or background clients.
  * AMDXDNA_QOS_LOW_PRIORITY: Clients that can wait indefinite amount of time for
  *                           completion.
  */
-#define	AMDXDNA_QOS_DEFAULT_PRIORITY	0
-#define	AMDXDNA_QOS_REALTIME_PRIORITY	1
-#define	AMDXDNA_QOS_HIGH_PRIORITY	2
-#define	AMDXDNA_QOS_NORMAL_PRIORITY	3
-#define	AMDXDNA_QOS_LOW_PRIORITY	4
+#define	AMDXDNA_QOS_REALTIME_PRIORITY	0x100
+#define	AMDXDNA_QOS_HIGH_PRIORITY	0x180
+#define	AMDXDNA_QOS_NORMAL_PRIORITY	0x200
+#define	AMDXDNA_QOS_LOW_PRIORITY	0x280
 /* The maximum number of priority */
 #define	AMDXDNA_NUM_PRIORITY		4
 

--- a/src/include/uapi/drm_local/amdxdna_accel.h
+++ b/src/include/uapi/drm_local/amdxdna_accel.h
@@ -69,6 +69,9 @@ extern "C" {
  * AMDXDNA_QOS_NORMAL_PRIORITY: Best effort or background clients.
  * AMDXDNA_QOS_LOW_PRIORITY: Clients that can wait indefinite amount of time for
  *                           completion.
+ *
+ * NOTE, if driver see value beyond above definition, it decides the priority of
+ * the context without error/warning.
  */
 #define	AMDXDNA_QOS_REALTIME_PRIORITY	0x100
 #define	AMDXDNA_QOS_HIGH_PRIORITY	0x180

--- a/src/shim/device.cpp
+++ b/src/shim/device.cpp
@@ -232,24 +232,6 @@ struct partition_info
 {
   using result_type = std::any;
 
-  static int
-  convert_priority(int p)
-  {
-    // Below value of cases are copy from MCDM for application porting friendly
-    switch (p) {
-      case AMDXDNA_QOS_REALTIME_PRIORITY:
-        return 0x100;
-      case AMDXDNA_QOS_HIGH_PRIORITY:
-        return 0x180;
-      case AMDXDNA_QOS_NORMAL_PRIORITY:
-        return 0x200;
-      case AMDXDNA_QOS_LOW_PRIORITY:
-        return 0x280;
-      default:
-        shim_err(EINVAL, "Invalid priority %d", p);
-    };
-  }
-
   static result_type
   get(const xrt_core::device* device, key_type key)
   {
@@ -292,7 +274,7 @@ struct partition_info
       new_entry.migrations = entry.migrations;
       new_entry.preemptions = entry.preemptions;
       new_entry.errors = entry.errors;
-      new_entry.qos.priority = convert_priority(entry.priority);
+      new_entry.qos.priority = entry.priority;
       output.push_back(std::move(new_entry));
     }
     return output;

--- a/src/shim/hwctx.cpp
+++ b/src/shim/hwctx.cpp
@@ -37,24 +37,6 @@ destroy_syncobj(const shim_xdna::pdev& dev, uint32_t hdl)
   dev.ioctl(DRM_IOCTL_SYNCOBJ_DESTROY, &dsobj);
 }
 
-int
-convert_priority(int p)
-{
-  // Below value of cases are copy from MCDM for application porting friendly
-  switch (p) {
-    case 0x100:
-      return AMDXDNA_QOS_REALTIME_PRIORITY;
-    case 0x180:
-      return AMDXDNA_QOS_HIGH_PRIORITY;
-    case 0x200:
-      return AMDXDNA_QOS_NORMAL_PRIORITY;
-    case 0x280:
-      return AMDXDNA_QOS_LOW_PRIORITY;
-    default:
-      shim_err(EINVAL, "Invalid priority %d", p);
-  };
-}
-
 }
 namespace shim_xdna {
 
@@ -159,7 +141,7 @@ init_qos_info(const qos_type& qos)
     else if (key == "frame_execution_time")
       m_qos.frame_exec_time = value;
     else if (key == "priority")
-      m_qos.priority = convert_priority(value);
+      m_qos.priority = value;
   }
 }
 

--- a/test/shim_test/hwctx.h
+++ b/test/shim_test/hwctx.h
@@ -42,7 +42,7 @@ private:
     }
     dev->record_xclbin(xclbin);
     auto xclbin_uuid = xclbin.get_uuid();
-    xrt::hw_context::qos_type qos{ {"gops", 100} };
+    xrt::hw_context::qos_type qos{ {"gops", 100}, {"priority", 0x180} };
     xrt::hw_context::access_mode mode = xrt::hw_context::access_mode::shared;
 
     m_handle = dev->create_hw_context(xclbin_uuid, qos, mode);


### PR DESCRIPTION
1. Use XRT defined QoS priority value as shim/driver interface
2. XDNA driver convert QoS priority into other value that used in driver/firmware
3. Add "priority 0x180" for all shim_test (Old shim_test cannot work with this driver)