### PR TITLE
re-enable elf test case on PHX

### DIFF
--- a/test/shim_test/dev_info.cpp
+++ b/test/shim_test/dev_info.cpp
@@ -179,7 +179,7 @@ xclbin_info xclbin_infos[] = {
     .device = npu1_device_id,
     .revision_id = npu1_revision_id,
     .ip_name2idx = {
-      { "DPU:IPUV1CNN", {0} },
+      { "DPU_ELF:IPUV1CNN", {0} },
     },
     .workspace = "local_shim_test_data/elf_txn_no_cp_npu1",
     .data = "",

--- a/test/shim_test/io.cpp
+++ b/test/shim_test/io.cpp
@@ -70,7 +70,6 @@ get_ofm_format(const std::string& config_file)
       return { 0, 0, 0 };
 
     std::map<std::string, uint32_t> conf;
-
     std::string line;
     while (std::getline(config, line)) {
         std::istringstream iss(line);
@@ -78,12 +77,6 @@ get_ofm_format(const std::string& config_file)
         if (std::getline(iss, key, '=') && std::getline(iss, value))
             conf[key] = std::stoul(value);
     }
-
-    std::cout << "OFM format:"
-      << " valid_bytes_per_section=" << conf["valid_bytes_per_section"]
-      << " section_size=" << conf["section_size"]
-      << " total_size=" << conf["total_size"]
-      << std::endl;
     return { conf["valid_bytes_per_section"], conf["section_size"], conf["total_size"] };
 }
 

--- a/test/shim_test/io_test.cpp
+++ b/test/shim_test/io_test.cpp
@@ -224,6 +224,7 @@ io_test(device::id_type id, device* dev, int total_hwq_submit, int num_cmdlist, 
   if (io_test_parameters.type != IO_TEST_NOOP_RUN) {
     for (auto& boset : bo_set) {
       boset->sync_after_run();
+      //boset->dump_content();
       boset->verify_result();
     }
   }

--- a/test/shim_test/shim_test.cpp
+++ b/test/shim_test/shim_test.cpp
@@ -649,7 +649,7 @@ std::vector<test_case> test_list {
     TEST_POSITIVE, dev_filter_is_aie2, TEST_export_import_bo, {}
   },
   test_case{ "ELF io test real kernel good run", {},
-    TEST_POSITIVE, dev_filter_is_npu4, TEST_elf_io, { IO_TEST_NORMAL_RUN, 1 }
+    TEST_POSITIVE, dev_filter_is_aie2, TEST_elf_io, { IO_TEST_NORMAL_RUN, 1 }
   },
   test_case{ "Cmd fencing (user space side)", {},
     TEST_POSITIVE, dev_filter_is_aie2, TEST_cmd_fence_host, {}
@@ -697,7 +697,7 @@ std::vector<test_case> test_list {
     TEST_POSITIVE, dev_filter_is_aie2, TEST_export_import_bo_single_proc, {}
   },
   test_case{ "multi-command ELF io test real kernel good run", {},
-    TEST_POSITIVE, dev_filter_is_npu4, TEST_elf_io, { IO_TEST_NORMAL_RUN, 3 }
+    TEST_POSITIVE, dev_filter_is_aie2, TEST_elf_io, { IO_TEST_NORMAL_RUN, 3 }
   },
   test_case{ "virtual context test", {},
     TEST_POSITIVE, dev_filter_is_aie2, TEST_create_destroy_virtual_context, { 0 }


### PR DESCRIPTION
Due to the recent code change, we do not support 5-col design on PHX by default. Unfortunately, the original ELF test case on PHX is a 5-col design, hence it was disabled. I'm adding a new ELF flow test case on PHX which is a 4-col design to re-enable the test on PHX.