### PR TITLE
Fix CR-1235087

### DIFF
--- a/src/driver/amdxdna/aie2_ctx.c
+++ b/src/driver/amdxdna/aie2_ctx.c
@@ -116,9 +116,6 @@ int aie2_ctx_connect(struct amdxdna_ctx *ctx)
 	struct amdxdna_dev *xdna = ctx->client->xdna;
 	int ret;
 
-	if (!ctx->cus)
-		return -EINVAL;
-
 	mutex_lock(&xdna->dev_handle->aie2_lock);
 	ret = aie2_hwctx_start(ctx);
 	if (ret)

--- a/src/driver/amdxdna/aie2_ctx_runqueue.c
+++ b/src/driver/amdxdna/aie2_ctx_runqueue.c
@@ -285,7 +285,6 @@ select_next_ctx(struct aie2_partition *part, struct amdxdna_ctx *ctx)
 
 		i++;
 	}
-	WARN_ON(!ret); /* ctx_cnt or hwctx_cnt mismatched with runqueue */
 
 out:
 	return ret;

--- a/src/driver/amdxdna/aie2_message.c
+++ b/src/driver/amdxdna/aie2_message.c
@@ -457,32 +457,12 @@ int aie2_register_asyn_event_msg(struct amdxdna_dev_hdl *ndev, dma_addr_t addr, 
 }
 
 /* Below messages are to hardware context mailbox channel */
-
-static int config_cu_cb(void *handle, void __iomem *data, size_t size)
-{
-	struct amdxdna_dev *xdna = handle;
-	u32 status;
-
-	if (data)
-		memcpy_fromio(&status, data, sizeof(status));
-
-	XDNA_DBG(xdna, "config cu got resp, status 0x%x", status);
-	return 0;
-}
-
 int aie2_config_cu(struct amdxdna_ctx *ctx)
 {
 	struct mailbox_channel *chann = ctx->priv->mbox_chann;
 	struct amdxdna_dev *xdna = ctx->client->xdna;
 	u32 shift = xdna->dev_info->dev_mem_buf_shift;
-	struct config_cu_req req = { 0 };
-	struct xdna_mailbox_msg msg = {
-		.send_data = (u8 *)&req,
-		.send_size = sizeof(req),
-		.handle = xdna,
-		.opcode = MSG_OP_CONFIG_CU,
-		.notify_cb = config_cu_cb,
-	};
+	DECLARE_XDNA_MSG_NO_RESP(config_cu, MSG_OP_CONFIG_CU, xdna);
 	struct drm_gem_object *gobj;
 	struct amdxdna_gem_obj *abo;
 	int ret, i;

--- a/src/driver/amdxdna/aie2_message.c
+++ b/src/driver/amdxdna/aie2_message.c
@@ -473,8 +473,8 @@ static int config_cu_cb(void *handle, void __iomem *data, size_t size)
 int aie2_config_cu(struct amdxdna_ctx *ctx)
 {
 	struct mailbox_channel *chann = ctx->priv->mbox_chann;
-	u32 shift = xdna->dev_info->dev_mem_buf_shift;
 	struct amdxdna_dev *xdna = ctx->client->xdna;
+	u32 shift = xdna->dev_info->dev_mem_buf_shift;
 	struct config_cu_req req = { 0 };
 	struct xdna_mailbox_msg msg = {
 		.send_data = (u8 *)&req,

--- a/src/driver/amdxdna/amdxdna_mailbox_helper.c
+++ b/src/driver/amdxdna/amdxdna_mailbox_helper.c
@@ -5,6 +5,18 @@
 
 #include "amdxdna_mailbox_helper.h"
 
+int xdna_msg_dummy_cb(void *handle, void __iomem *data, size_t size)
+{
+	struct amdxdna_dev *xdna = handle;
+	u32 status;
+
+	if (data)
+		memcpy_fromio(&status, data, sizeof(status));
+
+	XDNA_DBG(xdna, "Got dummy resp, status 0x%x", status);
+	return 0;
+}
+
 int xdna_msg_cb(void *handle, void __iomem *data, size_t size)
 {
 	struct xdna_notify *cb_arg = handle;

--- a/src/driver/amdxdna/amdxdna_mailbox_helper.h
+++ b/src/driver/amdxdna/amdxdna_mailbox_helper.h
@@ -37,9 +37,25 @@ struct xdna_notify {
 		.notify_cb = xdna_msg_cb,				\
 	}
 
+struct xdna_dummy_notify {
+	struct amdxdna_dev	*xdna;
+	u32			opcode;
+};
+
+#define DECLARE_XDNA_MSG_NO_RESP(name, op, xdna)			\
+	struct name##_req	req = { 0 };				\
+	struct xdna_mailbox_msg msg = {					\
+		.send_data = (u8 *)&req,				\
+		.send_size = sizeof(req),				\
+		.handle = xdna,						\
+		.opcode = op,						\
+		.notify_cb = xdna_msg_dummy_cb,				\
+	}
+
 #define XDNA_STATUS_OFFSET(name) (offsetof(struct name##_resp, status) / sizeof(u32))
 
 int xdna_msg_cb(void *handle, void __iomem *data, size_t size);
+int xdna_msg_dummy_cb(void *handle, void __iomem *data, size_t size);
 int xdna_send_msg_wait(struct amdxdna_dev *xdna, struct mailbox_channel *chann,
 		       struct xdna_mailbox_msg *msg);
 


### PR DESCRIPTION
1. config CU is not mandatory in xdna driver
2. No wait for config CU with timeout, this avoid the config cu timeout when context priority is low.