### PR TITLE
Fix failed to create symbolic link issue

### DIFF
--- a/CMake/install_preemption_libs.cmake
+++ b/CMake/install_preemption_libs.cmake
@@ -4,11 +4,34 @@ set(PREEMPT_FILE_NAME preempt_save_stx_4x8.bin)
 file(GLOB_RECURSE PREEMPT_FILE_PATH ${SEARCH_PATH}/${PREEMPT_FILE_NAME})
 if (PREEMPT_FILE_PATH)
   get_filename_component(PREEMPT_FILE_DIR ${PREEMPT_FILE_PATH} DIRECTORY)
-  #message(WARNING "Linking ${BIN_DIR}/preemption_libs to ${PREEMPT_FILE_DIR}")
+  
+  # Ensure parent directory exists
+  get_filename_component(TARGET_PARENT_DIR ${BIN_DIR} DIRECTORY)
+  if (NOT EXISTS ${TARGET_PARENT_DIR})
+    file(MAKE_DIRECTORY ${TARGET_PARENT_DIR})
+  endif()
+  
+  # Create bins directory if it doesn't exist
+  if (NOT EXISTS ${BIN_DIR})
+    file(MAKE_DIRECTORY ${BIN_DIR})
+  endif()
+
+  # Remove existing symlink if it exists
+  if (EXISTS ${BIN_DIR}/preemption_libs)
+    file(REMOVE ${BIN_DIR}/preemption_libs)
+  endif()
+
+  # Create the symlink and check for errors
   execute_process(
     COMMAND ${CMAKE_COMMAND} -E create_symlink
     ${PREEMPT_FILE_DIR} ${BIN_DIR}/preemption_libs
-    )
+    RESULT_VARIABLE SYMLINK_RESULT
+    ERROR_VARIABLE SYMLINK_ERROR
+  )
+
+  if (NOT SYMLINK_RESULT EQUAL 0)
+    message(FATAL_ERROR "Failed to create symlink: ${SYMLINK_ERROR}")
+  endif()
 else()
-  message(FATAL_ERROR "Preemption libs not found!")
+  message(FATAL_ERROR "Preemption libs not found in path: ${SEARCH_PATH}")
 endif()


### PR DESCRIPTION
## Problem
During the build process, the following error occurs:

```bash
CMake Error: failed to create symbolic link '/home/user1/xdna-driver/build/Debug//bins/preemption_libs': No such file or directory
```
The error indicates that CMake is attempting to create a symbolic link to a directory that doesn't exist. The issue is that the parent directory for the symbolic link target (`/home/user1/xdna-driver/build/Debug/bins/`) doesn't exist before the symlink creation is attempted.

Solution
This PR modifies the CMake configuration to ensure that the parent directory exists before attempting to create the symbolic link. It uses CMake's file(`MAKE_DIRECTORY`) command to create any necessary parent directories.
