### PR TITLE
VITIS-13541 Enable gemm test and minor xrt-smi fixes

### DIFF
--- a/src/driver/amdxdna/npu6_regs.c
+++ b/src/driver/amdxdna/npu6_regs.c
@@ -13,7 +13,7 @@ const struct amdxdna_dev_priv npu6_dev_priv = {
 };
 
 const struct amdxdna_dev_info dev_npu6_info = {
-	.vbnv              = "NPU Kracken",
+	.vbnv              = "NPU Krackan",
 	.dev_priv          = &npu6_dev_priv,
 	NPU4_COMMON_DEV_INFO,
 };

--- a/src/shim/device.cpp
+++ b/src/shim/device.cpp
@@ -966,12 +966,12 @@ struct xclbin_name
     case xrt_core::query::xclbin_name::type::validate_elf:
       xclbin_name = "validate_elf.xclbin";
       break;
-    // case xrt_core::query::xclbin_name::type::gemm:
-    //   xclbin_name = "gemm.xclbin";
-    //   break;
-    // case xrt_core::query::xclbin_name::type::gemm_elf:
-    //   xclbin_name = "gemm_elf.xclbin";
-    //   break;
+    case xrt_core::query::xclbin_name::type::gemm:
+      xclbin_name = "gemm.xclbin";
+      break;
+    case xrt_core::query::xclbin_name::type::gemm_elf:
+      xclbin_name = "gemm_elf.xclbin";
+      break;
     }
 
     return boost::str(boost::format("bins/%04x_%02x/%s")
@@ -1008,9 +1008,9 @@ struct sequence_name
     case xrt_core::query::sequence_name::type::tct_all_column:
       seq_name = "tct_4col.txt";
       break;
-    // case xrt_core::query::sequence_name::type::gemm_int8:
-    //   seq_name = "gemm_int8.txt";
-    //   break;
+    case xrt_core::query::sequence_name::type::gemm_int8: 
+      seq_name = "gemm_int8.txt";
+      break;
     }
 
     return boost::str(fmt % seq_name);
@@ -1050,9 +1050,9 @@ struct elf_name
     case xrt_core::query::elf_name::type::aie_reconfig_overhead:
       elf_file = "aie_reconfig_overhead.elf";
       break;
-    // case xrt_core::query::elf_name::type::gemm_int8:
-    //   elf_file = "gemm_int8.elf";
-    //   break;
+    case xrt_core::query::elf_name::type::gemm_int8:
+      elf_file = "gemm_int8.elf";
+      break;
     }
 
     return boost::str(boost::format("bins/%04x_%02x/%s")

--- a/src/shim/smi_xdna.cpp
+++ b/src/shim/smi_xdna.cpp
@@ -9,7 +9,6 @@ xrt_core::smi::subcommand
 create_validate_subcommand()
 {
   std::vector<xrt_core::smi::basic_option> validate_test_desc = {
-    {"aie-reconfig-overhead", "Run end-to-end array reconfiguration overhead through shim DMA", "hidden"},
     {"all", "All applicable validate tests will be executed (default)", "common"},
     {"cmd-chain-latency", "Run end-to-end latency test using command chaining", "hidden"},
     {"cmd-chain-throughput", "Run end-to-end throughput test using command chaining", "hidden"},

--- a/tools/info.json
+++ b/tools/info.json
@@ -1,7 +1,7 @@
 {
 	"copyright": "Copyright (C) 2023-2025 Advanced Micro Devices, Inc. All rights reserved.",
 	"xrt" : {
-		"version": "202510.2.19.170",
+		"version": "202510.2.19.175",
 		"os_rel": ["22.04", "24.04"]
 	},
 	"firmwares": [


### PR DESCRIPTION
Fixed NPU Device name to "NPU Krackan" from "NPU Kracken".
Disabled aie-reconfig-overhead test that was re-enabled accidentally from a previous PR.
Enabled gemm test, updating xrt submodule to 14103ac386a87404bbc822eedfa708516fcf67b3 to include the fix to NPU Latency and NPU Throughput Tests.

Tested on STX machine.