### PR TITLE
Context runqueue error code path fix

### DIFF
--- a/src/driver/amdxdna/aie2_ctx_runqueue.c
+++ b/src/driver/amdxdna/aie2_ctx_runqueue.c
@@ -388,6 +388,7 @@ ctx_dead:
 	part->ctx_cnt--;
 	if (ctx_is_rt(ctx))
 		part->rt_ctx_cnt--;
+	ctx->priv->part = NULL;
 }
 
 static void part_ctx_stop_wait(struct amdxdna_ctx *ctx, bool wait)


### PR DESCRIPTION
when connect context fatal error, ctx was moved out from partition, set ctx->priv->part to null