### PR TITLE
Driver selected iommu_mode for easy of use

### DIFF
--- a/src/driver/amdxdna/amdxdna_devel.h
+++ b/src/driver/amdxdna/amdxdna_devel.h
@@ -13,7 +13,6 @@
 
 #define AMDXDNA_IOMMU_PASID 0
 #define AMDXDNA_IOMMU_NO_PASID 1
-#define AMDXDNA_IOMMU_BYPASS 2
 extern int iommu_mode;
 extern bool priv_load;
 extern int start_col_index;


### PR DESCRIPTION
Why this change is required:
Recently, the xdna driver start to support Carvedout Memory (PR #460). If we combine iommu_mode and use SHMEM or Carvedout Memory. Some combination is working directly and some combination required special Linux cmdline arguments.
This makes the user interface difficult to use and not user friendly.

How to fix:
The driver remove iommu_mode module parameter. Instead, driver detect the IOMMU setting and Carvedout memory setting to set the iommu_mode internally. 

Supported Linux cmdline argument and what to expect:
``` shell
# On Linux cmdline, when amd_iommu=off is set. Must apply memmap=<size>$<start address> to reserved memory.
$ modprobe amdxdna    # This will fail to load because Carvedout memory is not used.
$ modprobe amdxdna carvedout_addr=<start address> carvedout_size=<size>   # iommu_mode = 1 and Carvedout memory

# On Linux cmdline, when amd_iommu=force_isolation is set. SHMEM and Carvedout memory are both supported
$ modprobe amdxdna     # iommu_mode = 1 and SHMEM
$ modprobe amdxdna carvedout_addr=<start address> carvedout_size=<size>  # iommu_mode = 1 and Carvedout memory

# On Linux cmdline, if there is not "amd_iommu=" arguments. SHMEM and Carvedout memory are both supported
$ modprobe amdxdna     # iommu_mode = 0 and SHMEM
$ modprobe amdxdna carvedout_addr=<start address> carvedout_size=<size>  # iommu_mode = 0 and Carvedout memory

```