### PR TITLE
amdxdna: ve2: Support Versal Edge/Gen2 embedded devices

### DIFF
--- a/src/driver/amdxdna/Kbuild
+++ b/src/driver/amdxdna/Kbuild
@@ -17,14 +17,18 @@ ccflags-y += -g -Werror
 obj-m	+= amdxdna.o
 amdxdna-y := \
 	amdxdna_ctx.o \
-	amdxdna_gem.o \
-	amdxdna_drm.o \
 	amdxdna_sysfs.o \
 	amdxdna_mailbox.o \
 	amdxdna_mailbox_helper.o \
 	amdxdna_tdr.o \
 	amdxdna_ubuf.o \
-	amdxdna_carvedout_buf.o \
+	amdxdna_carvedout_buf.o
+
+# On x86 architecture
+ifeq ($(ARCH), x86)
+amdxdna-y += \
+	amdxdna_gem.o \
+	amdxdna_drm.o \
 	aie2_solver.o \
 	aie2_smu.o \
 	aie2_psp.o \
@@ -43,6 +47,17 @@ amdxdna-y := \
 	npu5_regs.o \
 	npu6_regs.o \
 	amdxdna_pci_drv.o
+endif
+
+# On ARM64 architecture
+ifeq ($(ARCH), arm64)
+amdxdna-y += \
+	amdxdna_gem_of.o \
+	amdxdna_drm.o \
+	ve2_of.o \
+	ve2_regs.o \
+	amdxdna_of_drv.o
+endif
 
 # Helper functions for amdxdna development, but not for upstreaming
 amdxdna-y += amdxdna_devel.o

--- a/src/driver/amdxdna/Kbuild
+++ b/src/driver/amdxdna/Kbuild
@@ -17,6 +17,7 @@ ccflags-y += -g -Werror
 obj-m	+= amdxdna.o
 amdxdna-y := \
 	amdxdna_ctx.o \
+	amdxdna_drm.o \
 	amdxdna_sysfs.o \
 	amdxdna_mailbox.o \
 	amdxdna_mailbox_helper.o \
@@ -28,7 +29,6 @@ amdxdna-y := \
 ifeq ($(ARCH), x86)
 amdxdna-y += \
 	amdxdna_gem.o \
-	amdxdna_drm.o \
 	aie2_solver.o \
 	aie2_smu.o \
 	aie2_psp.o \
@@ -53,7 +53,6 @@ endif
 ifeq ($(ARCH), arm64)
 amdxdna-y += \
 	amdxdna_gem_of.o \
-	amdxdna_drm.o \
 	ve2_of.o \
 	ve2_regs.o \
 	amdxdna_of_drv.o

--- a/src/driver/amdxdna/Makefile
+++ b/src/driver/amdxdna/Makefile
@@ -25,6 +25,10 @@ ifdef AMDXDNA_DRM_USAGE
 DEFINES += -DAMDXDNA_DRM_USAGE
 endif
 
+ifeq ($(ARCH), arm64)
+DEFINES += -DAMDXDNA_OF
+endif
+
 modules:
 	$(MAKE) -C $(KERNEL_SRC) M=$(SRC_DIR) CFLAGS_MODULE="$(DEFINES)" modules
 

--- a/src/driver/amdxdna/amdxdna_devel.c
+++ b/src/driver/amdxdna/amdxdna_devel.c
@@ -189,7 +189,7 @@ void amdxdna_bo_dma_unmap(struct amdxdna_gem_obj *abo)
 
 void amdxdna_gem_dump_mm(struct amdxdna_dev *xdna)
 {
-#ifdef AMDXDNA_OF
+#if KERNEL_VERSION(6, 10, 0) > LINUX_VERSION_CODE
 	struct drm_printer p = drm_debug_printer(NULL);
 #else
 	struct drm_printer p = drm_dbg_printer(&xdna->ddev, DRM_UT_DRIVER, NULL);

--- a/src/driver/amdxdna/amdxdna_drm.h
+++ b/src/driver/amdxdna/amdxdna_drm.h
@@ -15,6 +15,9 @@
 #include <linux/workqueue.h>
 
 #include "amdxdna_ctx.h"
+#ifdef AMDXDNA_OF
+#include "amdxdna_gem_of.h"
+#endif
 #ifdef AMDXDNA_SHMEM
 #include "amdxdna_gem.h"
 #else

--- a/src/driver/amdxdna/amdxdna_drm.h
+++ b/src/driver/amdxdna/amdxdna_drm.h
@@ -16,6 +16,10 @@
 
 #include "amdxdna_ctx.h"
 #ifdef AMDXDNA_OF
+/*
+ * TODO: remove this and implement physical contiguous memory by carvedout memory
+ * supported by amdxdna_gem.h"
+ */
 #include "amdxdna_gem_of.h"
 #endif
 #ifdef AMDXDNA_SHMEM

--- a/src/driver/amdxdna/amdxdna_gem_of.c
+++ b/src/driver/amdxdna/amdxdna_gem_of.c
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Copyright (C) 2025, Advanced Micro Devices, Inc.
+ */
+
+#include <linux/dma-mapping.h>
+
+#include "drm_local/amdxdna_accel.h"
+
+#include "amdxdna_drm.h"
+#include "amdxdna_gem_of.h"
+
+/* For drm_driver->gem_create_object callback */
+struct drm_gem_object *
+amdxdna_gem_create_object_cb(struct drm_device *dev, size_t size)
+{
+	//TODO
+	return NULL;
+}

--- a/src/driver/amdxdna/amdxdna_gem_of.h
+++ b/src/driver/amdxdna/amdxdna_gem_of.h
@@ -1,0 +1,14 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+/*
+ * Copyright (C) 2025, Advanced Micro Devices, Inc.
+ */
+
+#ifndef _AMDXDNA_GEM_OF_H_
+#define _AMDXDNA_GEM_OF_H_
+
+#include <drm/drm_gem.h>
+
+struct drm_gem_object *
+amdxdna_gem_create_object_cb(struct drm_device *dev, size_t size);
+
+#endif /* _AMDXDNA_GEM_OF_H_ */

--- a/src/driver/amdxdna/amdxdna_of_drv.c
+++ b/src/driver/amdxdna/amdxdna_of_drv.c
@@ -8,7 +8,6 @@
 #include <linux/dma-mapping.h>
 #include <drm/drm_managed.h>
 
-#include "amdxdna_devel.h"
 #include "amdxdna_of_drv.h"
 
 static const struct of_device_id amdxdna_of_table[] = {

--- a/src/driver/amdxdna/amdxdna_of_drv.c
+++ b/src/driver/amdxdna/amdxdna_of_drv.c
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Copyright (C) 2025, Advanced Micro Devices, Inc.
+ */
+
+#include <linux/module.h>
+#include <linux/version.h>
+#include <linux/dma-mapping.h>
+#include <drm/drm_managed.h>
+
+#include "amdxdna_devel.h"
+#include "amdxdna_of_drv.h"
+
+static const struct of_device_id amdxdna_of_table[] = {
+	{ .compatible = "amdxdna,ve2", .data = &dev_ve2_info },
+	{ /* end of table */ }
+};
+
+MODULE_DEVICE_TABLE(of, amdxdna_of_table);
+
+static int amdxdna_of_probe(struct platform_device *pdev)
+{
+	struct device *dev = &pdev->dev;
+	const struct of_device_id *id;
+	struct amdxdna_dev *xdna;
+	int ret;
+
+	xdna = devm_drm_dev_alloc(dev, &amdxdna_drm_drv, typeof(*xdna), ddev);
+	if (IS_ERR(xdna))
+		return PTR_ERR(xdna);
+
+	id = of_match_node(amdxdna_of_table, dev->of_node);
+	if (!id) {
+		XDNA_ERR(xdna, "Match device ID not found");
+		return -EINVAL;
+	}
+
+	xdna->dev_info = (struct amdxdna_dev_info *)id->data;
+	if (!xdna->dev_info)
+		return -ENODEV;
+
+	drmm_mutex_init(&xdna->ddev, &xdna->dev_lock);
+	INIT_LIST_HEAD(&xdna->client_list);
+	platform_set_drvdata(pdev, xdna);
+
+	if (!xdna->dev_info->ops->init || !xdna->dev_info->ops->fini)
+		return -EOPNOTSUPP;
+
+	mutex_lock(&xdna->dev_lock);
+	ret = xdna->dev_info->ops->init(xdna);
+	mutex_unlock(&xdna->dev_lock);
+	if (ret) {
+		XDNA_ERR(xdna, "Hardware init failed, ret %d", ret);
+		return ret;
+	}
+
+	ret = drm_dev_register(&xdna->ddev, 0);
+	if (ret) {
+		XDNA_ERR(xdna, "DRM register failed, ret %d", ret);
+		return ret;
+	}
+
+	ret = dma_set_mask_and_coherent(&pdev->dev, DMA_BIT_MASK(64));
+	if (ret) {
+		ret = dma_set_mask_and_coherent(&pdev->dev, DMA_BIT_MASK(32));
+		if (ret) {
+			XDNA_ERR(xdna, "DMA configuration failed: 0x%x\n", ret);
+			drm_dev_put(&xdna->ddev);
+			return ret;
+		}
+
+		XDNA_WARN(xdna, "DMA configuration downgraded to 32bit Mask\n");
+	}
+
+	return 0;
+}
+
+static void amdxdna_of_remove(struct platform_device *pdev)
+{
+	struct amdxdna_dev *xdna = platform_get_drvdata(pdev);
+
+	drm_dev_unplug(&xdna->ddev);
+
+	mutex_lock(&xdna->dev_lock);
+	xdna->dev_info->ops->fini(xdna);
+	mutex_unlock(&xdna->dev_lock);
+}
+
+static struct platform_driver amdxdna_of_plat_driver = {
+	.probe		= amdxdna_of_probe,
+	.remove_new	= amdxdna_of_remove,
+	.driver		= {
+		.name	= KBUILD_MODNAME,
+		.of_match_table = amdxdna_of_table,
+	},
+};
+
+module_platform_driver(amdxdna_of_plat_driver);
+
+MODULE_LICENSE("GPL");
+MODULE_AUTHOR("XRT Team <runtimeca39d@amd.com>");
+MODULE_VERSION("0.1");
+MODULE_DESCRIPTION("amdxdna_of driver");

--- a/src/driver/amdxdna/amdxdna_of_drv.h
+++ b/src/driver/amdxdna/amdxdna_of_drv.h
@@ -1,0 +1,19 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+/*
+ * Copyright (C) 2025, Advanced Micro Devices, Inc.
+ */
+
+#ifndef _AMDXDNA_VE2_DRV_H_
+#define _AMDXDNA_VE2_DRV_H_
+
+#include <linux/platform_device.h>
+#include <linux/of.h>
+
+#include "amdxdna_drm.h"
+
+#define AMDXDNA_DRIVER_NAME "amdxdna_of"
+
+/* Add device info below */
+extern const struct amdxdna_dev_info dev_ve2_info;
+
+#endif /* _AMDXDNA_VE2_DRV_H_ */

--- a/src/driver/amdxdna/ve2_of.c
+++ b/src/driver/amdxdna/ve2_of.c
@@ -8,7 +8,7 @@
 static int ve2_init(struct amdxdna_dev *xdna)
 {
 	struct platform_device *pdev = to_platform_device(xdna->ddev.dev);
-	struct amdxdna_dev_hdl *xdna_hdl = NULL;
+	struct amdxdna_dev_hdl *xdna_hdl;
 
 	xdna_hdl = devm_kzalloc(&pdev->dev, sizeof(*xdna_hdl), GFP_KERNEL);
 	if (!xdna_hdl)
@@ -23,6 +23,7 @@ static int ve2_init(struct amdxdna_dev *xdna)
 
 static void ve2_fini(struct amdxdna_dev *xdna)
 {
+	return;
 }
 
 const struct amdxdna_dev_ops ve2_ops = {

--- a/src/driver/amdxdna/ve2_of.c
+++ b/src/driver/amdxdna/ve2_of.c
@@ -23,7 +23,6 @@ static int ve2_init(struct amdxdna_dev *xdna)
 
 static void ve2_fini(struct amdxdna_dev *xdna)
 {
-	return;
 }
 
 const struct amdxdna_dev_ops ve2_ops = {

--- a/src/driver/amdxdna/ve2_of.c
+++ b/src/driver/amdxdna/ve2_of.c
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Copyright (C) 2025, Advanced Micro Devices, Inc.
+ */
+
+#include "ve2_of.h"
+
+static int ve2_init(struct amdxdna_dev *xdna)
+{
+	struct platform_device *pdev = to_platform_device(xdna->ddev.dev);
+	struct amdxdna_dev_hdl *xdna_hdl = NULL;
+
+	xdna_hdl = devm_kzalloc(&pdev->dev, sizeof(*xdna_hdl), GFP_KERNEL);
+	if (!xdna_hdl)
+		return -ENOMEM;
+
+	xdna_hdl->xdna = xdna;
+
+	xdna->dev_handle = xdna_hdl;
+
+	return 0;
+}
+
+static void ve2_fini(struct amdxdna_dev *xdna)
+{
+}
+
+const struct amdxdna_dev_ops ve2_ops = {
+	.init		= ve2_init,
+	.fini		= ve2_fini,
+};

--- a/src/driver/amdxdna/ve2_of.h
+++ b/src/driver/amdxdna/ve2_of.h
@@ -1,0 +1,18 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+/*
+ * Copyright (C) 2025, Advanced Micro Devices, Inc.
+ */
+
+#ifndef _VE2_OF_H_
+#define _VE2_OF_H_
+
+#include "amdxdna_of_drv.h"
+
+struct amdxdna_dev_hdl {
+	struct amdxdna_dev              *xdna;
+};
+
+/* ve2_of.c */
+extern const struct amdxdna_dev_ops ve2_ops;
+
+#endif /* _VE2_OF_H_ */

--- a/src/driver/amdxdna/ve2_regs.c
+++ b/src/driver/amdxdna/ve2_regs.c
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Copyright (C) 2025, Advanced Micro Devices, Inc.
+ */
+
+#include "drm_local/amdxdna_accel.h"
+#include "ve2_of.h"
+
+const struct amdxdna_dev_info dev_ve2_info = {
+	.device_type		= AMDXDNA_DEV_TYPE_VE,
+	.ops			= &ve2_ops,
+};

--- a/src/driver/amdxdna/ve2_regs.c
+++ b/src/driver/amdxdna/ve2_regs.c
@@ -7,6 +7,6 @@
 #include "ve2_of.h"
 
 const struct amdxdna_dev_info dev_ve2_info = {
-	.device_type		= AMDXDNA_DEV_TYPE_VE,
+	.device_type		= AMDXDNA_DEV_TYPE_KMQ,
 	.ops			= &ve2_ops,
 };

--- a/src/include/uapi/drm_local/amdxdna_accel.h
+++ b/src/include/uapi/drm_local/amdxdna_accel.h
@@ -62,7 +62,6 @@ extern "C" {
 #define	AMDXDNA_DEV_TYPE_UNKNOWN	-1
 #define	AMDXDNA_DEV_TYPE_KMQ		0
 #define	AMDXDNA_DEV_TYPE_UMQ		1
-#define	AMDXDNA_DEV_TYPE_VE		2
 
 /*
  * Define priority in application's QoS.

--- a/src/include/uapi/drm_local/amdxdna_accel.h
+++ b/src/include/uapi/drm_local/amdxdna_accel.h
@@ -62,6 +62,7 @@ extern "C" {
 #define	AMDXDNA_DEV_TYPE_UNKNOWN	-1
 #define	AMDXDNA_DEV_TYPE_KMQ		0
 #define	AMDXDNA_DEV_TYPE_UMQ		1
+#define	AMDXDNA_DEV_TYPE_VE		2
 
 /*
  * Define priority in application's QoS.


### PR DESCRIPTION
-Implemented probe/remove for VE2 devices.
-Updated Makefile/Kbuild to support VE2 driver.
--Compile & build VE2 driver only on ARM64