### PR TITLE
refine context dpm level calculation

### DIFF
--- a/src/driver/amdxdna/aie2_hwctx.c
+++ b/src/driver/amdxdna/aie2_hwctx.c
@@ -15,6 +15,7 @@
 
 extern const struct drm_sched_backend_ops sched_ops;
 
+__maybe_unused
 static int aie2_alloc_resource(struct amdxdna_ctx *ctx)
 {
 	struct alloc_requests *xrs_req;
@@ -48,6 +49,7 @@ static int aie2_alloc_resource(struct amdxdna_ctx *ctx)
 	return ret;
 }
 
+__maybe_unused
 static void aie2_release_resource(struct amdxdna_ctx *ctx)
 {
 	struct amdxdna_dev *xdna;
@@ -147,16 +149,10 @@ int aie2_hwctx_start(struct amdxdna_ctx *ctx)
 		goto fini_sched;
 	}
 
-	ret = aie2_alloc_resource(ctx);
-	if (ret) {
-		XDNA_ERR(xdna, "Alloc hw resource failed, ret %d", ret);
-		goto destroy_entity;
-	}
-
 	ret = aie2_load_hwctx(ctx);
 	if (ret) {
 		XDNA_ERR(xdna, "Alloc hw resource failed, ret %d", ret);
-		goto release_resource;
+		goto destroy_entity;
 	}
 
 #ifdef AMDXDNA_DEVEL
@@ -181,8 +177,6 @@ skip:
 
 unload_hwctx:
 	aie2_unload_hwctx(ctx);
-release_resource:
-	aie2_release_resource(ctx);
 destroy_entity:
 	drm_sched_entity_destroy(&ctx->priv->entity);
 fini_sched:
@@ -197,7 +191,6 @@ void aie2_hwctx_stop(struct amdxdna_ctx *ctx)
 	drm_WARN_ON(&xdna->ddev, !mutex_is_locked(&xdna->dev_handle->aie2_lock));
 	drm_sched_entity_destroy(&ctx->priv->entity);
 	aie2_unload_hwctx(ctx);
-	aie2_release_resource(ctx);
 	wait_event(ctx->priv->job_free_waitq,
 		   (ctx->submitted == atomic64_read(&ctx->job_free_cnt)));
 	drm_sched_fini(&ctx->priv->sched);

--- a/src/driver/amdxdna/aie2_pci.h
+++ b/src/driver/amdxdna/aie2_pci.h
@@ -212,6 +212,7 @@ struct amdxdna_ctx_priv {
 	wait_queue_head_t		job_free_waitq;
 
 	u32				orig_num_col;
+	u32				req_dpm_level;
 
 	/* For context runqueue */
 	/* When there is ongoing IO, use this sem avoid runqueue disconnect ctx */
@@ -320,9 +321,11 @@ struct amdxdna_dev_hdl {
 	/*power management and clock */
 	int				pw_mode;
 	enum aie2_power_state		power_state;
+	u32				sys_eff_factor;
 	u32				dpm_level;
 	u32				dft_dpm_level;
 	u32				max_dpm_level;
+	u32				*dpm_cnt;
 	u32				clk_gating;
 	u32				npuclk_freq;
 	u32				hclk_freq;
@@ -379,6 +382,7 @@ struct amdxdna_dev_priv {
 #define COL_ALIGN_NONE   0
 #define COL_ALIGN_NATURE 1
 	u32				col_align;
+	u32				col_opc;
 	u32				mbox_dev_addr;
 	/* If mbox_size is 0, use BAR size. See MBOX_SIZE macro */
 	u32				mbox_size;
@@ -427,6 +431,9 @@ int aie2_smu_get_power_state(struct amdxdna_dev_hdl *ndev);
 int aie2_pm_init(struct amdxdna_dev_hdl *ndev);
 void aie2_pm_fini(struct amdxdna_dev_hdl *ndev);
 int aie2_pm_set_mode(struct amdxdna_dev_hdl *ndev, int target);
+#define aie2_pm_add_dpm_level(d, l) aie2_pm_set_dft_dpm_level(d, l, true)
+#define aie2_pm_del_dpm_level(d, l) aie2_pm_set_dft_dpm_level(d, l, false)
+void aie2_pm_set_dft_dpm_level(struct amdxdna_dev_hdl *ndev, u32 level, bool add);
 int npu1_get_tops(struct amdxdna_dev_hdl *ndev, u64 *max, u64 *curr);
 int npu4_get_tops(struct amdxdna_dev_hdl *ndev, u64 *max, u64 *curr);
 

--- a/src/driver/amdxdna/aie2_pm.c
+++ b/src/driver/amdxdna/aie2_pm.c
@@ -3,7 +3,13 @@
  * Copyright (C) 2024-2025, Advanced Micro Devices, Inc.
  */
 
+#include <drm/drm_managed.h>
 #include "aie2_pci.h"
+
+#define DEFAULT_SYS_EFF_FACTOR 2
+uint sys_eff_factor = DEFAULT_SYS_EFF_FACTOR;
+module_param(sys_eff_factor, int, 0444);
+MODULE_PARM_DESC(sys_eff_factor, "System efficiency factor, default 2");
 
 #define AIE2_CLK_GATING_ENABLE	1
 #define AIE2_CLK_GATING_DISABLE	0
@@ -82,6 +88,41 @@ int aie2_pm_set_mode(struct amdxdna_dev_hdl *ndev, int target)
 	return pm_set_mode(ndev, target, true);
 }
 
+void aie2_pm_set_dft_dpm_level(struct amdxdna_dev_hdl *ndev, u32 level, bool add)
+{
+	struct amdxdna_dev *xdna = ndev->xdna;
+
+	XDNA_DBG(xdna, "Default DPM %d, %s level %d", ndev->dft_dpm_level,
+		 add ? "add" : "delete", level);
+
+	mutex_lock(&ndev->aie2_lock);
+	if (unlikely(level > ndev->max_dpm_level)) {
+		level = ndev->max_dpm_level;
+		WARN_ON(1);
+	}
+
+	if (add) {
+		/* Add DPM level count */
+		ndev->dpm_cnt[level]++;
+	} else {
+		/* Delete DPM level count */
+		WARN_ON(level > ndev->dft_dpm_level);
+		WARN_ON(!ndev->dpm_cnt[level]);
+		ndev->dpm_cnt[level]--;
+	}
+
+	for (level = ndev->max_dpm_level; level > 0; level--)
+		if (ndev->dpm_cnt[level])
+			break;
+
+	XDNA_DBG(xdna, "Set default DPM to %d", level);
+	if (ndev->pw_mode == POWER_MODE_DEFAULT)
+		ndev->priv->hw_ops.set_dpm(ndev, level);
+	ndev->dft_dpm_level = level;
+
+	mutex_unlock(&ndev->aie2_lock);
+}
+
 int aie2_pm_init(struct amdxdna_dev_hdl *ndev)
 {
 	struct amdxdna_dev *xdna = ndev->xdna;
@@ -99,6 +140,9 @@ int aie2_pm_init(struct amdxdna_dev_hdl *ndev)
 
 	while (ndev->priv->dpm_clk_tbl[ndev->max_dpm_level].hclk)
 		ndev->max_dpm_level++;
+	ndev->dpm_cnt = drmm_kzalloc(&xdna->ddev, ndev->max_dpm_level * sizeof(u32), GFP_KERNEL);
+	if (!ndev->dpm_cnt)
+		return -ENOMEM;
 	ndev->max_dpm_level--;
 
 	ret = ndev->priv->hw_ops.set_dpm(ndev, ndev->max_dpm_level);
@@ -111,8 +155,21 @@ int aie2_pm_init(struct amdxdna_dev_hdl *ndev)
 
 	ndev->pw_mode = POWER_MODE_DEFAULT;
 	ndev->dft_dpm_level = ndev->max_dpm_level;
+	ndev->sys_eff_factor = sys_eff_factor;
+	if (!ndev->sys_eff_factor)
+		ndev->sys_eff_factor = DEFAULT_SYS_EFF_FACTOR;
 
 	return 0;
+}
+
+void aie2_pm_fini(struct amdxdna_dev_hdl *ndev)
+{
+	struct amdxdna_dev *xdna = ndev->xdna;
+
+	drm_WARN_ON(&xdna->ddev, !mutex_is_locked(&ndev->aie2_lock));
+
+	if (pm_set_mode(ndev, POWER_MODE_DEFAULT, false))
+		XDNA_ERR(ndev->xdna, "Can not set to default power mode");
 }
 
 int npu1_get_tops(struct amdxdna_dev_hdl *ndev, u64 *max, u64 *curr)
@@ -139,14 +196,4 @@ int npu4_get_tops(struct amdxdna_dev_hdl *ndev, u64 *max, u64 *curr)
 	*curr = (topc * hclk_freq) / 1000000;
 
 	return 0;
-}
-
-void aie2_pm_fini(struct amdxdna_dev_hdl *ndev)
-{
-	struct amdxdna_dev *xdna = ndev->xdna;
-
-	drm_WARN_ON(&xdna->ddev, !mutex_is_locked(&ndev->aie2_lock));
-
-	if (pm_set_mode(ndev, POWER_MODE_DEFAULT, false))
-		XDNA_ERR(ndev->xdna, "Can not set to default power mode");
 }

--- a/src/driver/amdxdna/npu1_regs.c
+++ b/src/driver/amdxdna/npu1_regs.c
@@ -65,6 +65,7 @@ const struct amdxdna_dev_priv npu1_dev_priv = {
 	.rt_config	= npu1_default_rt_cfg,
 	.dpm_clk_tbl	= npu1_dpm_clk_table,
 	.col_align	= COL_ALIGN_NONE,
+	.col_opc	= 2048,
 	.mbox_dev_addr  = NPU1_MBOX_BAR_BASE,
 	.mbox_size      = 0, /* Use BAR size */
 	.hwctx_limit	= 6,

--- a/src/driver/amdxdna/npu4_family.h
+++ b/src/driver/amdxdna/npu4_family.h
@@ -72,6 +72,7 @@ extern const struct amdxdna_dev_priv npu4_dev_priv;
 	.dpm_clk_tbl	= npu4_dpm_clk_table,							\
 	.priv_load_cfg = { 5, 0, AIE2_RT_CFG_INIT },						\
 	.col_align	= COL_ALIGN_NATURE,							\
+	.col_opc	= 4096,									\
 	.mbox_dev_addr  = NPU4_MBOX_BAR_BASE,							\
 	.mbox_size      = 0, /* Use BAR size */							\
 	.sram_dev_addr  = NPU4_SRAM_BAR_BASE,							\

--- a/src/include/uapi/drm_local/amdxdna_accel.h
+++ b/src/include/uapi/drm_local/amdxdna_accel.h
@@ -83,8 +83,8 @@ extern "C" {
 
 /**
  * struct qos_info - QoS information for driver.
- * @gops: Giga operations per second.
- * @fps: Frames per second.
+ * @gops: Giga operations per workload.
+ * @fps: Workload per second.
  * @dma_bandwidth: DMA bandwidtha.
  * @latency: Frame response latency.
  * @frame_exec_time: Frame execution time.


### PR DESCRIPTION
This PR move the DPM level calculation logic to aie2_ctx.c. This is the needed step of removing aie2_solver.c. I will remove all the dead code after this is merged.

1. The DPM calculation formula is unchanged
2. The max_opc from User is drop in the aie2_ctx.c. Instead, driver calculate it by "per column OPC" * "number of columns of the context"
3. If the QoS leads to invalid result. Always use Maximum DPM level
4. When context destroy, adjust DPM level. (This was missing in the aie2_solver.c)