### PR TITLE
amdxdna: ve2: Add support to create, sync, get BO IOCTLs

### DIFF
--- a/src/driver/amdxdna/Makefile
+++ b/src/driver/amdxdna/Makefile
@@ -31,7 +31,7 @@ all: $(BUILD_ROOT_DIR)
 	$(MAKE) -C $(BUILD_ROOT_DIR)/driver/$(notdir $(SRC_DIR)) modules
 
 # add EXTRA_CFLAGS='-save-temps' to keep intermedia files
-DEFINES := -DAMDXDNA_DEVEL -DAMDXDNA_SHMEM
+DEFINES := -DAMDXDNA_DEVEL
 ifdef AMDXDNA_DRM_USAGE
 DEFINES += -DAMDXDNA_DRM_USAGE
 endif

--- a/src/driver/amdxdna/amdxdna_ctx.h
+++ b/src/driver/amdxdna/amdxdna_ctx.h
@@ -20,6 +20,10 @@
 #include "amdxdna_gem_dma.h"
 #endif
 
+#ifdef AMDXDNA_OF
+#include "amdxdna_gem_of.h"
+#endif
+
 struct amdxdna_ctx_priv;
 
 enum ert_cmd_opcode {

--- a/src/driver/amdxdna/amdxdna_ctx.h
+++ b/src/driver/amdxdna/amdxdna_ctx.h
@@ -14,14 +14,10 @@
 #include <drm/gpu_scheduler.h>
 #include "drm_local/amdxdna_accel.h"
 
-#ifdef AMDXDNA_SHMEM
-#include "amdxdna_gem.h"
-#else
-#include "amdxdna_gem_dma.h"
-#endif
-
 #ifdef AMDXDNA_OF
 #include "amdxdna_gem_of.h"
+#else
+#include "amdxdna_gem.h"
 #endif
 
 struct amdxdna_ctx_priv;

--- a/src/driver/amdxdna/amdxdna_devel.c
+++ b/src/driver/amdxdna/amdxdna_devel.c
@@ -150,7 +150,7 @@ void amdxdna_mem_unmap(struct amdxdna_dev *xdna, struct amdxdna_mem *mem)
 	amdxdna_free_sgt(xdna, sgt);
 }
 
-#ifdef AMDXDNA_SHMEM
+#ifndef AMDXDNA_OF
 int amdxdna_bo_dma_map(struct amdxdna_gem_obj *abo)
 {
 	struct amdxdna_dev *xdna = to_xdna_dev(to_gobj(abo)->dev);
@@ -194,7 +194,7 @@ int amdxdna_bo_dma_map(struct amdxdna_gem_obj *abo)
 void amdxdna_bo_dma_unmap(struct amdxdna_gem_obj *abo)
 {
 }
-#endif /* AMDXDNA_SHMEM */
+#endif
 
 void amdxdna_gem_dump_mm(struct amdxdna_dev *xdna)
 {

--- a/src/driver/amdxdna/amdxdna_drm.c
+++ b/src/driver/amdxdna/amdxdna_drm.c
@@ -303,16 +303,12 @@ const struct drm_driver amdxdna_drm_drv = {
 	.ioctls = amdxdna_drm_ioctls,
 	.num_ioctls = ARRAY_SIZE(amdxdna_drm_ioctls),
 	.show_fdinfo = amdxdna_show_fdinfo,
-
-	/* For shmem object create */
 #ifdef AMDXDNA_OF
 	.gem_create_object = amdxdna_gem_create_object_cb,
-#else
-	.gem_create_object = amdxdna_gem_create_shmem_object_cb,
-#endif
-#ifdef AMDXDNA_SHMEM
-	.gem_prime_import = amdxdna_gem_prime_import,
-#else
 	.gem_prime_import_sg_table = drm_gem_dma_prime_import_sg_table,
+#else
+	/* For shmem object create */
+	.gem_create_object = amdxdna_gem_create_shmem_object_cb,
+	.gem_prime_import = amdxdna_gem_prime_import,
 #endif
 };

--- a/src/driver/amdxdna/amdxdna_drm.h
+++ b/src/driver/amdxdna/amdxdna_drm.h
@@ -21,11 +21,8 @@
  * supported by amdxdna_gem.h"
  */
 #include "amdxdna_gem_of.h"
-#endif
-#ifdef AMDXDNA_SHMEM
-#include "amdxdna_gem.h"
 #else
-#include "amdxdna_gem_dma.h"
+#include "amdxdna_gem.h"
 #endif
 #include "amdxdna_tdr.h"
 

--- a/src/driver/amdxdna/amdxdna_gem_of.c
+++ b/src/driver/amdxdna/amdxdna_gem_of.c
@@ -6,14 +6,231 @@
 #include <linux/dma-mapping.h>
 
 #include "drm_local/amdxdna_accel.h"
-
 #include "amdxdna_drm.h"
 #include "amdxdna_gem_of.h"
 
-/* For drm_driver->gem_create_object callback */
-struct drm_gem_object *
-amdxdna_gem_create_object_cb(struct drm_device *dev, size_t size)
+struct amdxdna_gem_obj *amdxdna_gem_get_obj(struct amdxdna_client *client, u32 bo_hdl, u8 bo_type)
 {
-	//TODO
+	struct amdxdna_dev *xdna = client->xdna;
+	struct amdxdna_gem_obj *abo;
+	struct drm_gem_object *gobj;
+
+	gobj = drm_gem_object_lookup(client->filp, bo_hdl);
+	if (!gobj) {
+		XDNA_DBG(xdna, "Can not find bo %d", bo_hdl);
+		return NULL;
+	}
+
+	abo = to_xdna_obj(gobj);
+	if (bo_type == AMDXDNA_BO_INVALID || abo->type == bo_type)
+		return abo;
+
+	drm_gem_object_put(gobj);
+
 	return NULL;
+}
+
+static void amdxdna_gem_dma_obj_free(struct drm_gem_object *gobj)
+{
+	struct amdxdna_dev *xdna = to_xdna_dev(gobj->dev);
+	struct amdxdna_gem_obj *abo = to_xdna_obj(gobj);
+
+	XDNA_DBG(xdna, "BO type %d xdna_addr 0x%llx", abo->type, abo->mem.dev_addr);
+	drm_gem_dma_object_free(gobj);
+}
+
+static const struct drm_gem_object_funcs amdxdna_gem_dma_funcs = {
+	.free = amdxdna_gem_dma_obj_free,
+	.print_info = drm_gem_dma_object_print_info,
+	.get_sg_table = drm_gem_dma_object_get_sg_table,
+	.vmap = drm_gem_dma_object_vmap,
+	.mmap = drm_gem_dma_object_mmap,
+	.vm_ops = &drm_gem_dma_vm_ops,
+};
+
+/* For drm_driver->gem_create_object callback */
+struct drm_gem_object *amdxdna_gem_create_object_cb(struct drm_device *dev, size_t size)
+{
+	struct amdxdna_gem_obj *abo;
+
+	abo = kzalloc(sizeof(*abo), GFP_KERNEL);
+	if (!abo)
+		return ERR_PTR(-ENOMEM);
+
+	/* The default funcs, caller should change if needed */
+	to_gobj(abo)->funcs = &amdxdna_gem_dma_funcs;
+
+	abo->type = AMDXDNA_BO_SHARE;
+	mutex_init(&abo->lock);
+
+	abo->mem.userptr = AMDXDNA_INVALID_ADDR;
+	abo->mem.dev_addr = AMDXDNA_INVALID_ADDR;
+	abo->mem.size = size;
+
+	return to_gobj(abo);
+}
+
+static struct amdxdna_gem_obj *amdxdna_drm_create_dma_bo(struct drm_device *dev,
+							 struct amdxdna_drm_create_bo *args,
+							 struct drm_file *filp)
+{
+	struct drm_gem_dma_object *dma;
+	struct amdxdna_gem_obj *abo;
+	size_t size = args->size;
+
+	/* Round up to more than 4K to ensure to allocate memory from CMA always */
+	if (size <= PAGE_SIZE)
+		size = round_up(size, 2 * PAGE_SIZE);
+
+	dma = drm_gem_dma_create(dev, size);
+	if (IS_ERR(dma))
+		return ERR_CAST(dma);
+
+	abo = to_xdna_obj(&dma->base);
+
+	abo->mem.dev_addr = dma->dma_addr;
+	abo->mem.kva = dma->vaddr;
+	abo->type = args->type;
+
+	return abo;
+}
+
+int amdxdna_drm_create_bo_ioctl(struct drm_device *dev, void *data, struct drm_file *filp)
+{
+	struct amdxdna_dev *xdna = to_xdna_dev(dev);
+	struct amdxdna_drm_create_bo *args = data;
+	struct amdxdna_gem_obj *abo;
+	int ret;
+
+	if (args->flags || !args->size) {
+		XDNA_ERR(xdna, "Invalid BO received, flags: 0x%llx, size: %llu", args->flags,
+				args->size);
+		return -EINVAL;
+	}
+
+	XDNA_DBG(xdna, "BO arg type %d size 0x%llx flags 0x%llx", args->type, args->size,
+			args->flags);
+	switch (args->type) {
+	case AMDXDNA_BO_SHARE:
+	case AMDXDNA_BO_CMD:
+	case AMDXDNA_BO_DMA:
+	case AMDXDNA_BO_DEV:
+		/* CMD and DMA are traded the same */
+		abo = amdxdna_drm_create_dma_bo(dev, args, filp);
+		break;
+	default:
+		return -EINVAL;
+	}
+	if (IS_ERR(abo))
+		return PTR_ERR(abo);
+
+	/* ready to publish object to userspace */
+	ret = drm_gem_handle_create(filp, to_gobj(abo), &args->handle);
+	if (ret) {
+		XDNA_ERR(xdna, "Create drm_gem handle failed, ret %d", ret);
+		goto put_obj;
+	}
+
+	XDNA_DBG(xdna, "BO hdl %d type %d userptr 0x%llx xdna_addr 0x%llx size 0x%lx",
+			args->handle, args->type, abo->mem.userptr,
+			abo->mem.dev_addr, abo->mem.size);
+put_obj:
+	/* Dereference object reference. Handle holds it now. */
+	drm_gem_object_put(to_gobj(abo));
+	return ret;
+}
+
+int amdxdna_drm_sync_bo_ioctl(struct drm_device *dev, void *data, struct drm_file *filp)
+{
+	struct amdxdna_dev *xdna = to_xdna_dev(dev);
+	struct amdxdna_drm_sync_bo *args = data;
+	struct amdxdna_gem_obj *abo;
+	struct drm_gem_object *gobj;
+	dma_addr_t bo_phyaddr;
+	int ret = 0;
+
+	if (!args) {
+		XDNA_ERR(xdna, "Invalid input NULL BO received");
+		return -EINVAL;
+	}
+
+	gobj = drm_gem_object_lookup(filp, args->handle);
+	if (!gobj) {
+		XDNA_ERR(xdna, "Lookup GEM object %d failed", args->handle);
+		return -ENOENT;
+	}
+
+	if ((args->offset > gobj->size) || (args->size > gobj->size) ||
+	    ((args->offset + args->size) > gobj->size)) {
+		XDNA_ERR(xdna, "Invalid BO %d requested", args->handle);
+		ret = -EINVAL;
+		goto out;
+	}
+
+	abo = to_xdna_obj(gobj);
+
+	/* For now we only support CMA memory*/
+	bo_phyaddr = (uint64_t)abo->base.dma_addr;
+	bo_phyaddr += args->offset;
+
+	if (args->direction == SYNC_DIRECT_TO_DEVICE) {
+		dma_sync_single_for_device(dev->dev, bo_phyaddr, args->size, DMA_TO_DEVICE);
+	}
+	else if (args->direction == SYNC_DIRECT_FROM_DEVICE) {
+		dma_sync_single_for_cpu(dev->dev, bo_phyaddr, args->size, DMA_FROM_DEVICE);
+	}
+	else {
+		XDNA_ERR(xdna, "Invalid direction %d requested", args->direction);
+		ret = -EINVAL;
+	}
+
+out:
+	drm_gem_object_put(gobj);
+	return ret;
+}
+
+int amdxdna_drm_get_bo_info_ioctl(struct drm_device *dev, void *data, struct drm_file *filp)
+{
+	struct amdxdna_drm_get_bo_info *args = data;
+	struct amdxdna_dev *xdna = to_xdna_dev(dev);
+	struct amdxdna_gem_obj *abo;
+	struct drm_gem_object *gobj;
+	int ret = 0;
+
+	if (args->ext_flags)
+		return -EINVAL;
+
+	gobj = drm_gem_object_lookup(filp, args->handle);
+	if (!gobj) {
+		XDNA_DBG(xdna, "Lookup GEM object %d failed", args->handle);
+		return -ENOENT;
+	}
+
+	abo = to_xdna_obj(gobj);
+	args->vaddr = abo->mem.userptr;
+	args->xdna_addr = abo->mem.dev_addr;
+	args->map_offset = drm_vma_node_offset_addr(&gobj->vma_node);
+
+	XDNA_DBG(xdna, "BO hdl %d map_offset 0x%llx vaddr 0x%llx xdna_addr 0x%llx",
+			args->handle, args->map_offset, args->vaddr, args->xdna_addr);
+
+	drm_gem_object_put(gobj);
+	return ret;
+}
+
+int amdxdna_gem_pin_nolock(struct amdxdna_gem_obj *abo)
+{
+	/* TODO: implement this */
+	return 0;
+}
+
+int amdxdna_gem_pin(struct amdxdna_gem_obj *abo)
+{
+	/* no ops */
+	return 0;
+}
+
+void amdxdna_gem_unpin(struct amdxdna_gem_obj *abo)
+{
+	/* no ops */
 }

--- a/src/driver/amdxdna/amdxdna_gem_of.c
+++ b/src/driver/amdxdna/amdxdna_gem_of.c
@@ -104,12 +104,12 @@ int amdxdna_drm_create_bo_ioctl(struct drm_device *dev, void *data, struct drm_f
 
 	if (args->flags || !args->size) {
 		XDNA_ERR(xdna, "Invalid BO received, flags: 0x%llx, size: %llu", args->flags,
-				args->size);
+			 args->size);
 		return -EINVAL;
 	}
 
 	XDNA_DBG(xdna, "BO arg type %d size 0x%llx flags 0x%llx", args->type, args->size,
-			args->flags);
+		 args->flags);
 	switch (args->type) {
 	case AMDXDNA_BO_SHARE:
 	case AMDXDNA_BO_CMD:
@@ -131,9 +131,8 @@ int amdxdna_drm_create_bo_ioctl(struct drm_device *dev, void *data, struct drm_f
 		goto put_obj;
 	}
 
-	XDNA_DBG(xdna, "BO hdl %d type %d userptr 0x%llx xdna_addr 0x%llx size 0x%lx",
-			args->handle, args->type, abo->mem.userptr,
-			abo->mem.dev_addr, abo->mem.size);
+	XDNA_DBG(xdna, "BO hdl %d type %d userptr 0x%llx xdna_addr 0x%llx size 0x%lx", args->handle,
+		 args->type, abo->mem.userptr, abo->mem.dev_addr, abo->mem.size);
 put_obj:
 	/* Dereference object reference. Handle holds it now. */
 	drm_gem_object_put(to_gobj(abo));
@@ -160,8 +159,8 @@ int amdxdna_drm_sync_bo_ioctl(struct drm_device *dev, void *data, struct drm_fil
 		return -ENOENT;
 	}
 
-	if ((args->offset > gobj->size) || (args->size > gobj->size) ||
-	    ((args->offset + args->size) > gobj->size)) {
+	if (args->offset > gobj->size || args->size > gobj->size ||
+	    (args->offset + args->size) > gobj->size) {
 		XDNA_ERR(xdna, "Invalid BO %d requested", args->handle);
 		ret = -EINVAL;
 		goto out;
@@ -175,11 +174,9 @@ int amdxdna_drm_sync_bo_ioctl(struct drm_device *dev, void *data, struct drm_fil
 
 	if (args->direction == SYNC_DIRECT_TO_DEVICE) {
 		dma_sync_single_for_device(dev->dev, bo_phyaddr, args->size, DMA_TO_DEVICE);
-	}
-	else if (args->direction == SYNC_DIRECT_FROM_DEVICE) {
+	} else if (args->direction == SYNC_DIRECT_FROM_DEVICE) {
 		dma_sync_single_for_cpu(dev->dev, bo_phyaddr, args->size, DMA_FROM_DEVICE);
-	}
-	else {
+	} else {
 		XDNA_ERR(xdna, "Invalid direction %d requested", args->direction);
 		ret = -EINVAL;
 	}
@@ -211,8 +208,8 @@ int amdxdna_drm_get_bo_info_ioctl(struct drm_device *dev, void *data, struct drm
 	args->xdna_addr = abo->mem.dev_addr;
 	args->map_offset = drm_vma_node_offset_addr(&gobj->vma_node);
 
-	XDNA_DBG(xdna, "BO hdl %d map_offset 0x%llx vaddr 0x%llx xdna_addr 0x%llx",
-			args->handle, args->map_offset, args->vaddr, args->xdna_addr);
+	XDNA_DBG(xdna, "BO hdl %d map_offset 0x%llx vaddr 0x%llx xdna_addr 0x%llx", args->handle,
+		 args->map_offset, args->vaddr, args->xdna_addr);
 
 	drm_gem_object_put(gobj);
 	return ret;

--- a/src/driver/amdxdna/amdxdna_gem_of.h
+++ b/src/driver/amdxdna/amdxdna_gem_of.h
@@ -27,12 +27,12 @@ struct amdxdna_mem {
 #define BO_SUBMIT_LOCKED	BIT(1)
 
 struct amdxdna_gem_obj {
-        struct drm_gem_dma_object	base;
-        struct amdxdna_client           *client;
-        u8                              type;
-        u64                             flags;
-        struct mutex                    lock; /* Protects: pinned, assigned_hwctx */
-        struct amdxdna_mem              mem;
+	struct drm_gem_dma_object	base;
+	struct amdxdna_client           *client;
+	u8                              type;
+	u64                             flags;
+	struct mutex                    lock; /* Protects: pinned, assigned_hwctx */
+	struct amdxdna_mem              mem;
 };
 
 #define to_gobj(obj)		(&(obj)->base.base)

--- a/src/driver/amdxdna/amdxdna_gem_of.h
+++ b/src/driver/amdxdna/amdxdna_gem_of.h
@@ -6,9 +6,57 @@
 #ifndef _AMDXDNA_GEM_OF_H_
 #define _AMDXDNA_GEM_OF_H_
 
+#include <drm/drm_file.h>
 #include <drm/drm_gem.h>
+#include <drm/drm_gem_dma_helper.h>
 
-struct drm_gem_object *
-amdxdna_gem_create_object_cb(struct drm_device *dev, size_t size);
+struct amdxdna_mem {
+	u64			userptr;
+	void			*kva;
+	u64			dev_addr;
+	size_t			size;
+	struct page		**pages;
+	u32			nr_pages;
+#ifdef AMDXDNA_DEVEL
+	struct sg_table		*sgt;
+	u64			dma_addr; /* IOVA DMA address */
+#endif
+};
+
+#define BO_SUBMIT_PINNED	BIT(0)
+#define BO_SUBMIT_LOCKED	BIT(1)
+
+struct amdxdna_gem_obj {
+        struct drm_gem_dma_object	base;
+        struct amdxdna_client           *client;
+        u8                              type;
+        u64                             flags;
+        struct mutex                    lock; /* Protects: pinned, assigned_hwctx */
+        struct amdxdna_mem              mem;
+};
+
+#define to_gobj(obj)		(&(obj)->base.base)
+#define is_import_bo(obj)	(to_gobj(obj)->import_attach)
+
+static inline struct amdxdna_gem_obj *to_xdna_obj(struct drm_gem_object *gobj)
+{
+	return container_of(gobj, struct amdxdna_gem_obj, base.base);
+}
+
+static inline void amdxdna_gem_put_obj(struct amdxdna_gem_obj *abo)
+{
+	drm_gem_object_put(to_gobj(abo));
+}
+
+struct amdxdna_gem_obj *amdxdna_gem_get_obj(struct amdxdna_client *client, u32 bo_hdl, u8 bo_type);
+int amdxdna_drm_create_bo_ioctl(struct drm_device *dev, void *data, struct drm_file *filp);
+int amdxdna_drm_get_bo_info_ioctl(struct drm_device *dev, void *data, struct drm_file *filp);
+int amdxdna_drm_sync_bo_ioctl(struct drm_device *dev, void *data, struct drm_file *filp);
+
+struct drm_gem_object *amdxdna_gem_create_object_cb(struct drm_device *dev, size_t size);
+
+int amdxdna_gem_pin_nolock(struct amdxdna_gem_obj *abo);
+int amdxdna_gem_pin(struct amdxdna_gem_obj *abo);
+void amdxdna_gem_unpin(struct amdxdna_gem_obj *abo);
 
 #endif /* _AMDXDNA_GEM_OF_H_ */


### PR DESCRIPTION
amdxdna_gem_of.* driver used for GEM BO handling on VE2.