### PR TITLE
amdxdna_accel: Add metadata structure to configure ctx's debug/log buffers

### DIFF
--- a/src/include/uapi/drm_local/amdxdna_accel.h
+++ b/src/include/uapi/drm_local/amdxdna_accel.h
@@ -175,7 +175,7 @@ enum fw_buf_type {
  * @index: uc index
  *     On aie2ps, uc index is same to column index
  *     On aie4, uc index is mapped as 0->0_A, 1->0_B, 2->1_A, 3->1_B, 4->2_A, 5->2_B
- * @size: buffer size in words for this uc
+ * @size: buffer size in bytes for this uc
  */
 struct uc_info_entry {
 	__u32 index;

--- a/src/include/uapi/drm_local/amdxdna_accel.h
+++ b/src/include/uapi/drm_local/amdxdna_accel.h
@@ -163,6 +163,41 @@ struct amdxdna_ctx_param_config_cu {
 	struct amdxdna_cu_config cu_configs[];
 };
 
+enum cert_buf_type {
+	debug_buffer = 0,
+	trace_buffer,
+	dbg_queue,
+	log_buffer
+};
+
+/**
+ * struct uc_info_entry: Holds uc index & buffer size allotment info
+ * @index: uc index
+ *     On aie2ps, uc index is same to column index
+ *     On aie4, uc index is mapped as 0->0_A, 1->0_B, 2->1_A, 3->1_B, 4->2_A, 5->2_B
+ * @size: buffer size in words for this uc
+ */
+struct uc_info_entry {
+	__u32 index;
+	__u32 size;
+};
+
+/**
+ * struct cert_log_metadata - Holds buffer configuration.
+ * @buf_type: log type set to cert
+ * @num_ucs: total ucs to config
+ * @command_id: command id used for trace
+ * @bo_handle: actual bo handle
+ * @uc_info_entry: uc index & buffer size mapping info
+ */
+struct cert_log_metadata {
+	__u8 buf_type;
+	__u8 num_ucs;
+	__u64 command_id;
+	__u64 bo_handle;
+	struct uc_info_entry uc_info[];
+};
+
 /**
  * struct amdxdna_drm_config_ctx - Configure context.
  * @handle: Context handle.

--- a/src/include/uapi/drm_local/amdxdna_accel.h
+++ b/src/include/uapi/drm_local/amdxdna_accel.h
@@ -163,7 +163,7 @@ struct amdxdna_ctx_param_config_cu {
 	struct amdxdna_cu_config cu_configs[];
 };
 
-enum cert_buf_type {
+enum fw_buf_type {
 	debug_buffer = 0,
 	trace_buffer,
 	dbg_queue,
@@ -183,14 +183,14 @@ struct uc_info_entry {
 };
 
 /**
- * struct cert_log_metadata - Holds buffer configuration.
- * @buf_type: log type set to cert
+ * struct fw_buffer_metadata - Holds buffer configuration.
+ * @buf_type: buffer type set to fw
  * @num_ucs: total ucs to config
  * @command_id: command id used for trace
  * @bo_handle: actual bo handle
  * @uc_info_entry: uc index & buffer size mapping info
  */
-struct cert_log_metadata {
+struct fw_buffer_metadata {
 	__u8 buf_type;
 	__u8 num_ucs;
 	__u64 command_id;

--- a/src/include/uapi/drm_local/amdxdna_accel.h
+++ b/src/include/uapi/drm_local/amdxdna_accel.h
@@ -163,13 +163,6 @@ struct amdxdna_ctx_param_config_cu {
 	struct amdxdna_cu_config cu_configs[];
 };
 
-enum fw_buf_type {
-	debug_buffer = 0,
-	trace_buffer,
-	dbg_queue,
-	log_buffer
-};
-
 /**
  * struct uc_info_entry: Holds uc index & buffer size allotment info
  * @index: uc index
@@ -191,8 +184,13 @@ struct uc_info_entry {
  * @uc_info_entry: uc index & buffer size mapping info
  */
 struct fw_buffer_metadata {
+#define AMDXDNA_FW_BUF_DEBUG	0
+#define AMDXDNA_FW_BUF_TRACE	1
+#define AMDXDNA_FW_BUF_DBG_Q	2
+#define AMDXDNA_FW_BUF_LOG	3
 	__u8 buf_type;
 	__u8 num_ucs;
+	__u8 pad[48];
 	__u64 command_id;
 	__u64 bo_handle;
 	struct uc_info_entry uc_info[];


### PR DESCRIPTION
Define new metadata structure for configuring hardware context at runtime