### PR TITLE
enable runtime auto suspend/resume; refine the design

### DIFF
--- a/src/driver/amdxdna/aie2_pci.c
+++ b/src/driver/amdxdna/aie2_pci.c
@@ -458,7 +458,7 @@ disable_dev:
 
 static void aie2_hw_suspend(struct amdxdna_dev *xdna)
 {
-	aie2_assign_event_trace_state(xdna->dev_handle, false);
+	//aie2_assign_event_trace_state(xdna->dev_handle, false);
 	aie2_rq_stop_all(&xdna->dev_handle->ctx_rq);
 	aie2_hw_stop(xdna);
 }
@@ -467,16 +467,20 @@ static int aie2_hw_resume(struct amdxdna_dev *xdna)
 {
 	int ret;
 
-	XDNA_INFO(xdna, "firmware resuming...");
+	XDNA_DBG(xdna, "firmware resuming...");
 	ret = aie2_hw_start(xdna);
 	if (ret) {
 		XDNA_ERR(xdna, "resume NPU firmware failed");
 		return ret;
 	}
 
-	XDNA_INFO(xdna, "context resuming...");
+	XDNA_DBG(xdna, "context resuming...");
 	aie2_rq_restart_all(&xdna->dev_handle->ctx_rq);
-	aie2_assign_event_trace_state(xdna->dev_handle, true);
+	/*
+	 * Resume should turn it back to the previous event trace state.
+	 * Not just simply turn it on.
+	 */
+	//aie2_assign_event_trace_state(xdna->dev_handle, true);
 	return 0;
 }
 

--- a/src/driver/amdxdna/aie2_pci.h
+++ b/src/driver/amdxdna/aie2_pci.h
@@ -424,6 +424,8 @@ int aie2_smu_get_power_state(struct amdxdna_dev_hdl *ndev);
 /* aie2_pm.c */
 int aie2_pm_init(struct amdxdna_dev_hdl *ndev);
 void aie2_pm_fini(struct amdxdna_dev_hdl *ndev);
+int aie2_pm_resume(struct amdxdna_dev_hdl *ndev);
+void aie2_pm_suspend(struct amdxdna_dev_hdl *ndev);
 int aie2_pm_set_mode(struct amdxdna_dev_hdl *ndev, int target);
 #define aie2_pm_add_dpm_level(d, l) aie2_pm_set_dft_dpm_level(d, l, true)
 #define aie2_pm_del_dpm_level(d, l) aie2_pm_set_dft_dpm_level(d, l, false)

--- a/src/driver/amdxdna/aie2_pm.c
+++ b/src/driver/amdxdna/aie2_pm.c
@@ -3,6 +3,7 @@
  * Copyright (C) 2024-2025, Advanced Micro Devices, Inc.
  */
 
+#include <linux/pm_runtime.h>
 #include <drm/drm_managed.h>
 #include "aie2_pci.h"
 
@@ -116,11 +117,26 @@ void aie2_pm_set_dft_dpm_level(struct amdxdna_dev_hdl *ndev, u32 level, bool add
 			break;
 
 	XDNA_DBG(xdna, "Set default DPM to %d", level);
-	if (ndev->pw_mode == POWER_MODE_DEFAULT)
+	if (ndev->pw_mode == POWER_MODE_DEFAULT && ndev->dev_status == AIE2_DEV_START)
 		ndev->priv->hw_ops.set_dpm(ndev, level);
 	ndev->dft_dpm_level = level;
 
 	mutex_unlock(&ndev->aie2_lock);
+}
+
+int aie2_pm_resume(struct amdxdna_dev_hdl *ndev)
+{
+	struct amdxdna_dev *xdna = ndev->xdna;
+
+	return pm_runtime_resume_and_get(xdna->ddev.dev);
+}
+
+void aie2_pm_suspend(struct amdxdna_dev_hdl *ndev)
+{
+	struct amdxdna_dev *xdna = ndev->xdna;
+
+	pm_runtime_mark_last_busy(xdna->ddev.dev);
+	pm_runtime_put_autosuspend(xdna->ddev.dev);
 }
 
 int aie2_pm_init(struct amdxdna_dev_hdl *ndev)

--- a/src/driver/amdxdna/amdxdna_pci_drv.c
+++ b/src/driver/amdxdna/amdxdna_pci_drv.c
@@ -17,7 +17,7 @@
 #include "amdxdna_carvedout_buf.h"
 #endif
 
-int autosuspend_ms = -1;
+int autosuspend_ms = 5000;
 module_param(autosuspend_ms, int, 0644);
 MODULE_PARM_DESC(autosuspend_ms, "runtime suspend delay in miliseconds. < 0: prevent it");
 
@@ -222,7 +222,6 @@ static int amdxdna_rpmops_suspend(struct device *dev)
 {
 	struct amdxdna_dev *xdna = pci_get_drvdata(to_pci_dev(dev));
 
-	WARN_ON(!list_empty(&xdna->client_list));
 	if (xdna->dev_info->ops->suspend)
 		xdna->dev_info->ops->suspend(xdna);
 


### PR DESCRIPTION
1. Enable runtime auto suspend in 5 seconds if there is no outstanding command
2. Resume FW / SMU when the first command is submitted instead of the old design which resume when client open
3. There is NO performance degradation with the shim_test
4. Comment out event trace in suspend/resume code path for now. I will sync up with @VinitAmd and @NishadSaraf  offline.