### PR TITLE
support unused column

### DIFF
--- a/src/driver/amdxdna/aie2_message.c
+++ b/src/driver/amdxdna/aie2_message.c
@@ -425,6 +425,7 @@ int aie2_create_context(struct amdxdna_dev_hdl *ndev, struct amdxdna_ctx *ctx,
 	req.aie_type = 1;
 	req.start_col = ctx->start_col;
 	req.num_col = ctx->num_col;
+	req.num_unused_col = ctx->num_col - ctx->priv->orig_num_col;
 	req.num_cq_pairs_requested = 1;
 	req.pasid = ctx->client->pasid;
 	req.context_priority = ctx->priv->priority + 1;

--- a/src/driver/amdxdna/aie2_msg_priv.h
+++ b/src/driver/amdxdna/aie2_msg_priv.h
@@ -134,7 +134,8 @@ struct create_ctx_req {
 	u32	aie_type;
 	u8	start_col;
 	u8	num_col;
-	u16	reserved;
+	u8	num_unused_col;
+	u8	reserved;
 	u8	num_cq_pairs_requested;
 	u8	reserved1;
 	u16	pasid;


### PR DESCRIPTION
Actually, current FW in tools/info.json doesn't support context unused column.
This PR is to verify that the new code will NOT trigger failure with old firmware.

Once this is merged, there will be a separate PR to update firmware version.