### PR TITLE
Add context suspension counter

### DIFF
--- a/src/driver/amdxdna/aie2_ctx.c
+++ b/src/driver/amdxdna/aie2_ctx.c
@@ -108,6 +108,7 @@ void aie2_ctx_disconnect(struct amdxdna_ctx *ctx, bool wait)
 		aie2_ctx_wait_for_idle(ctx);
 	mutex_lock(&xdna->dev_handle->aie2_lock);
 	aie2_hwctx_stop(ctx);
+	ctx->priv->disconn_cnt++;
 	mutex_unlock(&xdna->dev_handle->aie2_lock);
 }
 

--- a/src/driver/amdxdna/aie2_pci.c
+++ b/src/driver/amdxdna/aie2_pci.c
@@ -973,7 +973,6 @@ static int aie2_query_ctx_status(struct amdxdna_client *client,
 
 			tmp->pid = tmp_client->pid;
 			tmp->context_id = ctx->id;
-			tmp->hwctx_id = ctx->priv->id;
 			tmp->start_col = ctx->start_col;
 			tmp->num_col = ctx->num_col;
 			tmp->command_submissions = ctx->submitted;
@@ -981,7 +980,6 @@ static int aie2_query_ctx_status(struct amdxdna_client *client,
 			tmp->migrations = 0;
 			tmp->preemptions = 0;
 			tmp->errors = 0;
-			tmp->priority = ctx->qos.priority;
 
 			if (copy_to_user(&buf[hw_i], tmp, sizeof(*tmp))) {
 				ret = -EFAULT;
@@ -1291,7 +1289,7 @@ static int aie2_query_ctx_status_array(struct amdxdna_client *client,
 			tmp[hw_i].latency = ctx->qos.latency;
 			tmp[hw_i].frame_exec_time = ctx->qos.frame_exec_time;
 			tmp[hw_i].heap_usage = heap_usage;
-			tmp[hw_i].egops = 0; /* TODO: Calculate effective gops */
+			tmp[hw_i].suspensions = ctx->priv->disconn_cnt;
 
 			if (ctx->priv->status == CTX_STATE_CONNECTED)
 				tmp[hw_i].state = AMDXDNA_CTX_STATE_ACTIVE;

--- a/src/driver/amdxdna/aie2_pci.c
+++ b/src/driver/amdxdna/aie2_pci.c
@@ -577,7 +577,7 @@ static int aie2_init(struct amdxdna_dev *xdna)
 	}
 #ifdef AMDXDNA_DEVEL
 skip_pasid:
-		XDNA_INFO(xdna, "(Develop) IOMMU mode is %d", iommu_mode);
+	XDNA_INFO(xdna, "(Develop) IOMMU mode is %d", iommu_mode);
 #endif
 
 	psp_conf.fw_size = fw->size;

--- a/src/driver/amdxdna/aie2_pci.h
+++ b/src/driver/amdxdna/aie2_pci.h
@@ -219,6 +219,7 @@ struct amdxdna_ctx_priv {
 	atomic64_t			job_pending_cnt;
 	wait_queue_head_t		connect_waitq;
 	int				idle_cnt;
+	u64				disconn_cnt;
 	bool				force_yield;
 #define CTX_STATE_DISCONNECTED		0x0
 #define CTX_STATE_DISPATCHED		0x1

--- a/src/include/uapi/drm_local/amdxdna_accel.h
+++ b/src/include/uapi/drm_local/amdxdna_accel.h
@@ -464,6 +464,8 @@ struct amdxdna_drm_query_sensor {
  * @preemptions: The number of times this context has been preempted by another context in the
  *               same partition.
  * @errors: The errors for this context.
+ *
+ * !!! NOTE: Never expand this struct. Use amdxdna_drm_query_ctx_array instead. !!!
  */
 struct amdxdna_drm_query_ctx {
 	__u32 context_id;

--- a/src/include/uapi/drm_local/amdxdna_accel.h
+++ b/src/include/uapi/drm_local/amdxdna_accel.h
@@ -456,7 +456,7 @@ struct amdxdna_drm_query_sensor {
  * @context_id: The ID for this context.
  * @start_col: The starting column for the partition assigned to this context.
  * @num_col: The number of columns in the partition assigned to this context.
- * @hwctx_id: Hardware context ID.
+ * @pad: Structure padding.
  * @pid: The Process ID of the process that created this context.
  * @command_submissions: The number of commands submitted to this context.
  * @command_completions: The number of commands completed by this context.
@@ -464,20 +464,18 @@ struct amdxdna_drm_query_sensor {
  * @preemptions: The number of times this context has been preempted by another context in the
  *               same partition.
  * @errors: The errors for this context.
- * @priority: Context priority
  */
 struct amdxdna_drm_query_ctx {
 	__u32 context_id;
 	__u32 start_col;
 	__u32 num_col;
-	__u32 hwctx_id;
+	__u32 pad;
 	__s64 pid;
 	__u64 command_submissions;
 	__u64 command_completions;
 	__u64 migrations;
 	__u64 preemptions;
 	__u64 errors;
-	__u64 priority;
 };
 
 /**
@@ -633,10 +631,10 @@ struct amdxdna_drm_get_info {
  * @errors: The errors for this context.
  * @priority: Context priority.
  * @heap_usage: The usage of heap buffer of the process
+ * @suspensions: Context suspension count
  * @state: The state of context.
  * @pasid: PASID for this process
  * @gops: Giga operations per second
- * @egops: effective giga operations per second
  * @fps: Frames per second
  * @dma_bandwidth: DMA bandwidth
  * @latency: Frame response latency
@@ -655,12 +653,12 @@ struct amdxdna_drm_query_ctx_array {
 	__u64 errors;
 	__u64 priority;
 	__u64 heap_usage;
+	__u64 suspensions;
 #define AMDXDNA_CTX_STATE_IDLE		0
 #define AMDXDNA_CTX_STATE_ACTIVE	1
 	__u32 state;
 	__u32 pasid;
 	__u32 gops;
-	__u32 egops;
 	__u32 fps;
 	__u32 dma_bandwidth;
 	__u32 latency;

--- a/src/shim/device.cpp
+++ b/src/shim/device.cpp
@@ -288,7 +288,6 @@ struct partition_info
           new_entry.migrations = entry.migrations;
           new_entry.preemptions = entry.preemptions;
           new_entry.errors = entry.errors;
-          new_entry.qos.priority = entry.priority;
           output.push_back(std::move(new_entry));
         }
         return output;
@@ -329,14 +328,13 @@ struct partition_info
       new_entry.errors = entry.errors;
       new_entry.qos.priority = entry.priority;
       new_entry.qos.gops = entry.gops;
-      new_entry.qos.egops = entry.egops;
       new_entry.qos.fps = entry.fps;
       new_entry.qos.dma_bandwidth = entry.dma_bandwidth;
       new_entry.qos.latency = entry.latency;
       new_entry.qos.frame_exec_time = entry.frame_exec_time;
       new_entry.instruction_mem = entry.heap_usage;
       new_entry.pasid = entry.pasid;
-      // new_entry.suspensions = entry.suspensions;
+      new_entry.suspensions = entry.suspensions;
       output.push_back(std::move(new_entry));
     }
     return output;


### PR DESCRIPTION
1. Add context suspension counter. A user context is counted as suspension when it destroyed the FW context.
2. Some minor code cleanup change.