### PR TITLE
Release device lock if query telemetry fails

### DIFF
--- a/src/driver/amdxdna/aie2_pci.c
+++ b/src/driver/amdxdna/aie2_pci.c
@@ -1038,6 +1038,7 @@ static int aie2_query_telemetry(struct amdxdna_client *client,
 				       aligned_sz - offset, &ver);
 	if (ret) {
 		XDNA_ERR(xdna, "Get telemetry failed ret %d", ret);
+		mutex_unlock(&xdna->dev_lock);
 		goto free_buf;
 	}
 


### PR DESCRIPTION
Release device lock if query telemetry fails due error code returned from the firmware command.