### PR TITLE
Enabling temporal-sharing-overhead test on linux

### DIFF
--- a/src/shim/smi_xdna.cpp
+++ b/src/shim/smi_xdna.cpp
@@ -21,6 +21,7 @@ create_validate_subcommand()
     {"tct-all-col", "Measure average TCT processing time for all columns", "hidden"},
     {"tct-one-col", "Measure average TCT processing time for one column", "hidden"},
     {"throughput", "Run end-to-end throughput test", "common"},
+    {"temporal-sharing-overhead", "Run end-to-end temporal sharing overhead test", "hidden"},
   };
 
   std::map<std::string, std::shared_ptr<xrt_core::smi::option>> validate_suboptions;

--- a/tools/info.json
+++ b/tools/info.json
@@ -1,7 +1,7 @@
 {
 	"copyright": "Copyright (C) 2023-2025 Advanced Micro Devices, Inc. All rights reserved.",
 	"xrt" : {
-		"version": "202520.2.20.27",
+		"version": "202520.2.20.34",
 		"os_rel": ["22.04", "24.04"]
 	},
 	"firmwares": [


### PR DESCRIPTION
This PR enables the temporal-sharing-overhead test on Linux. 
Updates XRT submodule to take the latest changes related to the test.