### PR TITLE
Add support for new CMD_CHAIN_NPU opcode 0x18

### DIFF
--- a/src/driver/amdxdna/aie2_ctx.c
+++ b/src/driver/amdxdna/aie2_ctx.c
@@ -307,8 +307,10 @@ aie2_sched_job_run(struct drm_sched_job *sched_job)
 	struct amdxdna_sched_job *job = drm_job_to_xdna_job(sched_job);
 	struct amdxdna_gem_obj *cmd_abo = job->cmd_bo;
 	struct amdxdna_ctx *ctx = job->ctx;
+	enum cmd_chain_class class;
 	struct dma_fence *fence;
 	int ret = 0;
+	u32 op;
 
 	trace_xdna_job(sched_job, ctx->name, "job run", job->seq, job->opcode);
 
@@ -332,12 +334,19 @@ aie2_sched_job_run(struct drm_sched_job *sched_job)
 		goto out;
 	}
 
-	if (amdxdna_cmd_get_op(cmd_abo) == ERT_CMD_CHAIN)
-		ret = aie2_cmdlist_multi_execbuf(ctx, job, aie2_sched_cmdlist_resp_handler);
+	/*
+	 * Transaction binaries are only supported with RAI 1.5 release onwards. Below
+	 * implementation returns -EOPNOTSUPP error code for any older firmware versions.
+	 */
+	class = aie2_is_supported_msg(ctx->client->xdna->dev_handle, MSG_OP_CMD_CHAIN_NPU) ?
+		CMD_CHAIN_CLASS_PREEMPT : CMD_CHAIN_CLASS_NON_PREEMPT;
+	op = amdxdna_cmd_get_op(cmd_abo);
+	if (op == ERT_CMD_CHAIN)
+		ret = aie2_cmdlist_multi_execbuf(ctx, job, class, aie2_sched_cmdlist_resp_handler);
 	else if (force_cmdlist)
-		ret = aie2_cmdlist_single_execbuf(ctx, job, aie2_sched_cmdlist_resp_handler);
+		ret = aie2_cmdlist_single_execbuf(ctx, job, class, aie2_sched_cmdlist_resp_handler);
 	else
-		ret = aie2_execbuf(ctx, job, aie2_sched_resp_handler);
+		ret = aie2_execbuf(ctx, job, class, aie2_sched_resp_handler);
 
 out:
 	if (ret) {

--- a/src/driver/amdxdna/aie2_msg_priv.h
+++ b/src/driver/amdxdna/aie2_msg_priv.h
@@ -25,6 +25,7 @@ enum aie2_msg_opcode {
 	MSG_OP_CHAIN_EXEC_DPU              = 0x13,
 	MSG_OP_CONFIG_DEBUG_BO		   = 0x14,
 	MSG_OP_EXEC_DPU_PREEMPT		   = 0x15,
+	MSG_OP_CMD_CHAIN_NPU		   = 0x18,
 #ifdef AMDXDNA_DEVEL
 	MSG_OP_REGISTER_PDI                = 0x1,
 	MSG_OP_UNREGISTER_PDI              = 0xA,
@@ -448,6 +449,13 @@ struct stop_event_trace_resp {
 #define slot_has_space(slot, offset, payload_size)		\
 	(MAX_CHAIN_CMDBUF_SIZE >= (offset) + (payload_size) +	\
 	 sizeof(typeof(slot)))
+
+enum cmd_chain_class {
+	CMD_CHAIN_CLASS_NON_PREEMPT,
+	CMD_CHAIN_CLASS_PREEMPT,
+	CMD_CHAIN_CLASS_MAX,
+};
+
 struct cmd_chain_slot_execbuf_cf {
 	u32 cu_idx;
 	u32 arg_cnt;
@@ -465,6 +473,37 @@ struct cmd_chain_slot_dpu {
 };
 
 struct cmd_chain_req {
+	u64 buf_addr;
+	u32 buf_size;
+	u32 count;
+} __packed;
+
+enum cmd_chain_npu_type {
+	CMD_CHAIN_NPU_TYPE_NON_ELF	= 0x1,
+	CMD_CHAIN_NPU_TYPE_PARTIAL_ELF	= 0x2,
+	CMD_CHAIN_NPU_TYPE_PREEMPT	= 0x3,
+	CMD_CHAIN_NPU_TYPE_MAX
+};
+
+struct cmd_chain_slot_npu {
+	union {
+		enum cmd_chain_npu_type type;
+		u32 type_u32;
+	};
+	u64 inst_buf_addr;
+	u64 save_buf_addr;
+	u64 restore_buf_addr;
+	u32 inst_size;
+	u32 save_size;
+	u32 restore_size;
+	u32 inst_prop_cnt;
+	u32 cu_idx;
+	u32 arg_cnt;
+	u32 args[] __counted_by(arg_cnt);
+} __packed;
+
+struct cmd_chain_npu_req {
+	u64 reserved;
 	u64 buf_addr;
 	u32 buf_size;
 	u32 count;

--- a/src/driver/amdxdna/aie2_pci.h
+++ b/src/driver/amdxdna/aie2_pci.h
@@ -17,6 +17,7 @@
 #include <drm/gpu_scheduler.h>
 
 #include "drm_local/amdxdna_accel.h"
+#include "aie2_msg_priv.h"
 #include "amdxdna_pci_drv.h"
 #include "amdxdna_ctx.h"
 #include "amdxdna_gem.h"
@@ -463,6 +464,7 @@ void aie2_config_event_trace(struct amdxdna_dev_hdl *ndev, u32 enable,
 void aie2_assign_event_trace_state(struct amdxdna_dev_hdl *ndev, bool state);
 
 /* aie2_message.c */
+bool aie2_is_supported_msg(struct amdxdna_dev_hdl *ndev, enum aie2_msg_opcode opcode);
 int aie2_suspend_fw(struct amdxdna_dev_hdl *ndev);
 int aie2_resume_fw(struct amdxdna_dev_hdl *ndev);
 int aie2_set_runtime_cfg(struct amdxdna_dev_hdl *ndev, u32 type, u64 value);
@@ -500,13 +502,13 @@ int aie2_legacy_config_cu(struct amdxdna_ctx *ctx);
 #endif
 
 int aie2_config_cu(struct amdxdna_ctx *ctx);
-int aie2_execbuf(struct amdxdna_ctx *ctx, struct amdxdna_sched_job *job,
+int aie2_execbuf(struct amdxdna_ctx *ctx, struct amdxdna_sched_job *job, enum cmd_chain_class class,
 		 int (*notify_cb)(void *, void __iomem *, size_t));
 int aie2_cmdlist_single_execbuf(struct amdxdna_ctx *ctx,
-				struct amdxdna_sched_job *job,
+				struct amdxdna_sched_job *job, enum cmd_chain_class class,
 				int (*notify_cb)(void *, void __iomem *, size_t));
 int aie2_cmdlist_multi_execbuf(struct amdxdna_ctx *ctx,
-			       struct amdxdna_sched_job *job,
+			       struct amdxdna_sched_job *job, enum cmd_chain_class class,
 			       int (*notify_cb)(void *, void __iomem *, size_t));
 int aie2_sync_bo(struct amdxdna_ctx *ctx, struct amdxdna_sched_job *job,
 		 int (*notify_cb)(void *, void __iomem *, size_t));

--- a/src/driver/amdxdna/npu1_regs.c
+++ b/src/driver/amdxdna/npu1_regs.c
@@ -58,12 +58,18 @@ const struct dpm_clk_freq npu1_dpm_clk_table[] = {
 	{ 0 }
 };
 
+const struct msg_op_ver npu1_msg_op_tbl[] = {
+	{ 8, MSG_OP_CMD_CHAIN_NPU },
+	{ 0 },
+};
+
 const struct amdxdna_dev_priv npu1_dev_priv = {
 	.fw_path        = "amdnpu/1502_00/npu.dev.sbin",
 	.protocol_major = 5,
 	.protocol_minor = 7,
 	.rt_config	= npu1_default_rt_cfg,
 	.dpm_clk_tbl	= npu1_dpm_clk_table,
+	.optional_msg	= npu1_msg_op_tbl,
 	.col_opc	= 2048,
 	.mbox_dev_addr  = NPU1_MBOX_BAR_BASE,
 	.mbox_size      = 0, /* Use BAR size */

--- a/src/driver/amdxdna/npu4_regs.c
+++ b/src/driver/amdxdna/npu4_regs.c
@@ -24,6 +24,7 @@ const struct rt_cfg_ver npu4_rt_cfg_tbl[] = {
 };
 
 const struct msg_op_ver npu4_msg_op_tbl[] = {
+	{ 15, MSG_OP_CMD_CHAIN_NPU },
 	{ 15, MSG_OP_UPDATE_PROPERTY },
 	{ 0 },
 };

--- a/test/shim_test/io.cpp
+++ b/test/shim_test/io.cpp
@@ -326,6 +326,8 @@ sync_before_run()
     case IO_TEST_BO_RESTORE_INSTRUCTION:
     case IO_TEST_BO_PARAMETERS:
     case IO_TEST_BO_MC_CODE:
+    case IO_TEST_BO_CTRL_PKT_PM:
+    case IO_TEST_BO_SCRATCH_PAD:
       ibo->tbo->get()->sync(buffer_handle::direction::host2device, ibo->tbo->size(), 0);
       break;
     default:

--- a/test/shim_test/shim_test.cpp
+++ b/test/shim_test/shim_test.cpp
@@ -735,9 +735,9 @@ std::vector<test_case> test_list {
     TEST_POSITIVE, dev_filter_is_aie2, TEST_create_destroy_device, {}
   },
   // Disable for now. Require changes in XRT for argument patching.
-  //test_case{ "multi-command preempt ELF io test real kernel good run", {},
-  //  TEST_POSITIVE, dev_filter_is_npu4, TEST_preempt_elf_io, { IO_TEST_NORMAL_RUN, 1 }
-  //},
+  test_case{ "multi-command preempt ELF io test real kernel good run", {},
+    TEST_POSITIVE, dev_filter_is_npu4, TEST_preempt_elf_io, { IO_TEST_NORMAL_RUN, 8 }
+  },
 };
 
 // Test case executor implementation


### PR DESCRIPTION
Added support for the new CMD_CHAIN_NPU opcode 0x18, categorized under CMD_CHAIN_CLASS_PREEMPT. The new opcode enables control code execution for DPU sequence, non-ELF, and ELF full-ELF transactions. Firmware compatibility measures ensure fallback to non-preemptive class for firmware command chaining before RAI 1.5.
While testing, uncovered a bug with old opcode 0x13, which causes the mailbox channels to go in a bad state. This has been mitigated by failing early in pre-RAI 1.5 firmware versions. These changes have been validated on Strix and Phoenix devices against RAI 1.0 and RAI 1.5 firmware versions.