### PR TITLE
The buffer for MGMT FW cannot span 64MB boundary

### DIFF
--- a/src/driver/amdxdna/aie2_ctx.c
+++ b/src/driver/amdxdna/aie2_ctx.c
@@ -53,7 +53,7 @@ void aie2_dump_ctx(struct amdxdna_ctx *ctx)
 	struct amdxdna_dev *xdna = ctx->client->xdna;
 	struct app_health_report_v1 *report;
 	struct amdxdna_dev_hdl *ndev;
-	const size_t size = 0x1000;
+	const size_t size = SZ_4M;
 	u64 comp = ctx->completed;
 	u64 sub = ctx->submitted;
 	dma_addr_t dma_addr;
@@ -70,6 +70,7 @@ void aie2_dump_ctx(struct amdxdna_ctx *ctx)
 		return;
 	}
 
+	WARN_ONCE(!IS_ALIGNED(dma_addr, SZ_4M), "app health buffer needs to be 4M aligned");
 	drm_clflush_virt_range(buff, size); /* device can access */
 	mutex_lock(&ndev->aie2_lock);
 	ret = aie2_get_app_health(ndev, ctx->priv->id, dma_addr, size);

--- a/src/driver/amdxdna/aie2_error.c
+++ b/src/driver/amdxdna/aie2_error.c
@@ -302,10 +302,11 @@ int aie2_error_async_events_alloc(struct amdxdna_dev_hdl *ndev)
 {
 	struct amdxdna_dev *xdna = ndev->xdna;
 	u32 total_col = ndev->total_col;
-	u32 total_size = ASYNC_BUF_SIZE * total_col;
 	struct async_events *events;
+	u32 total_size = SZ_4M;
 	int i, ret;
 
+	WARN_ON(ASYNC_BUF_SIZE * total_col > SZ_4M);
 	events = kzalloc(struct_size(events, event, total_col), GFP_KERNEL);
 	if (!events)
 		return -ENOMEM;

--- a/src/driver/amdxdna/aie2_message.c
+++ b/src/driver/amdxdna/aie2_message.c
@@ -548,6 +548,7 @@ int aie2_query_aie_status(struct amdxdna_dev_hdl *ndev, char __user *buf,
 	unsigned long ctx_id;
 	dma_addr_t dma_addr;
 	u32 aie_bitmap = 0;
+	size_t buff_sz;
 	u8 *buff_addr;
 	int ret, idx;
 
@@ -556,8 +557,7 @@ int aie2_query_aie_status(struct amdxdna_dev_hdl *ndev, char __user *buf,
 		return -EFAULT;
 	}
 
-	buff_addr = dma_alloc_noncoherent(xdna->ddev.dev, size, &dma_addr,
-					  DMA_FROM_DEVICE, GFP_KERNEL);
+	buff_addr = aie2_mgmt_buff_alloc(ndev, size, &buff_sz, &dma_addr);
 	if (!buff_addr)
 		return -ENOMEM;
 
@@ -604,7 +604,7 @@ int aie2_query_aie_status(struct amdxdna_dev_hdl *ndev, char __user *buf,
 	*cols_filled = aie_bitmap;
 
 fail:
-	dma_free_noncoherent(xdna->ddev.dev, size, buff_addr, dma_addr, DMA_FROM_DEVICE);
+	aie2_mgmt_buff_free(ndev, buff_sz, buff_addr, dma_addr);
 	return ret;
 }
 

--- a/src/driver/amdxdna/aie2_pci.c
+++ b/src/driver/amdxdna/aie2_pci.c
@@ -998,8 +998,7 @@ static int aie2_query_telemetry(struct amdxdna_client *client,
 {
 	struct amdxdna_drm_query_telemetry_header header, *tmp;
 	struct amdxdna_dev *xdna = client->xdna;
-	const int total_size = SZ_4M;
-	size_t aligned_sz, offset;
+	size_t aligned_sz, buff_sz, offset;
 	struct aie_version ver;
 	dma_addr_t dma_addr;
 	void *buff;
@@ -1016,13 +1015,10 @@ static int aie2_query_telemetry(struct amdxdna_client *client,
 	}
 
 	aligned_sz = PAGE_ALIGN(args->buffer_size);
-	buff = dma_alloc_noncoherent(xdna->ddev.dev, total_size, &dma_addr,
-				     DMA_FROM_DEVICE, GFP_KERNEL);
+	buff = aie2_mgmt_buff_alloc(xdna->dev_handle, aligned_sz, &buff_sz, &dma_addr);
 	if (!buff)
 		return -ENOMEM;
 
-	WARN_ONCE(!IS_ALIGNED(dma_addr, SZ_4M), "telemetry buffer needs to be 4M aligned");
-	WARN_ON(aligned_sz > total_size);
 	memset(buff, 0, aligned_sz);
 
 	drm_clflush_virt_range(buff, aligned_sz); /* device can access */
@@ -1059,7 +1055,7 @@ static int aie2_query_telemetry(struct amdxdna_client *client,
 		ret = -EFAULT;
 
 free_buf:
-	dma_free_noncoherent(xdna->ddev.dev, total_size, buff, dma_addr, DMA_FROM_DEVICE);
+	aie2_mgmt_buff_free(xdna->dev_handle, buff_sz, buff, dma_addr);
 	return ret;
 }
 
@@ -1441,6 +1437,55 @@ static int aie2_set_state(struct amdxdna_client *client, struct amdxdna_drm_set_
 	mutex_unlock(&xdna->dev_handle->aie2_lock);
 
 	return ret;
+}
+
+#define SPAN_64M_BOUNDARY(addr, size) \
+	((((unsigned long)(addr) & ((SZ_64M) - 1)) + (size)) > (SZ_64M))
+void *aie2_mgmt_buff_alloc(struct amdxdna_dev_hdl *ndev, size_t size, size_t *aligned_sz,
+			   dma_addr_t *dma_handle)
+{
+	struct amdxdna_dev *xdna = ndev->xdna;
+	void *buf;
+
+	size = PAGE_ALIGN(size);
+	*aligned_sz = roundup_pow_of_two(size);
+	/* TODO: This workaround a FW issue. Remove this later */
+	*aligned_sz *= 2;
+
+	/*
+	 * Note: We test the behavior of dma_alloc_noncoherent() on 6.13 kernel.
+	 * 1. This function eventually goes to __alloc_frozen_pages_noprof().
+	 * 2. The maximum size is 4MB (limited by MAX_PAGE_ORDER 10), otherwise
+	 * this will return NULL pointer.
+	 * 3. For valid size, this function returns physical contiguous memory.
+	 *
+	 * Thoughts, if there is requirement for larger than 4MB physical
+	 * contiguous memory, consider allocate buffer from carvedout memory?
+	 */
+	buf = dma_alloc_noncoherent(xdna->ddev.dev, *aligned_sz, dma_handle,
+				    DMA_BIDIRECTIONAL, GFP_KERNEL);
+	if (!buf)
+		return NULL;
+
+	/*
+	 * FW doesn't allow buffer spans 64MB boundary.
+	 * Satisfied this by below two facts,
+	 * 1. The aligned_sz is power of 2 pages
+	 * 2. dma_alloc_noncoherent() should return size aligned dma_handle.
+	 *
+	 * If any of above changed, you will see WARN_ON.
+	 */
+	WARN_ON(SPAN_64M_BOUNDARY(*dma_handle, *aligned_sz));
+
+	return buf;
+}
+
+void aie2_mgmt_buff_free(struct amdxdna_dev_hdl *ndev, size_t aligned_sz,
+			 void *vaddr, dma_addr_t dma_handle)
+{
+	struct amdxdna_dev *xdna = ndev->xdna;
+
+	dma_free_noncoherent(xdna->ddev.dev, aligned_sz, vaddr, dma_handle, DMA_FROM_DEVICE);
 }
 
 const struct amdxdna_dev_ops aie2_ops = {

--- a/src/driver/amdxdna/aie2_pci.h
+++ b/src/driver/amdxdna/aie2_pci.h
@@ -411,6 +411,10 @@ int aie2_runtime_cfg(struct amdxdna_dev_hdl *ndev,
 extern uint aie2_control_flags;
 extern const struct amdxdna_dev_ops aie2_ops;
 int aie2_check_protocol(struct amdxdna_dev_hdl *ndev, u32 fw_major, u32 fw_minor);
+void *aie2_mgmt_buff_alloc(struct amdxdna_dev_hdl *ndev, size_t size, size_t *aligned_sz,
+			   dma_addr_t *dma_handle);
+void aie2_mgmt_buff_free(struct amdxdna_dev_hdl *ndev, size_t aligned_sz,
+			 void *vaddr, dma_addr_t dma_handle);
 
 /* aie2_smu.c */
 int aie2_smu_start(struct amdxdna_dev_hdl *ndev);


### PR DESCRIPTION
This is a fix for AIESW-3960. The FW required all buffers used on mgmt channel to be 4MB aligned and not span 64MB boundary.

The solution of this PR is not perfect. It simply over-allocated 4MB buffer with dma_alloc_noncoherent() API, without considering the actual needs of the buffer (It only needs a few pages). 

DMA APIs doesn't provide alignment to the caller. So, maybe still need more efforts to investigate what is the best approach.

This PR can be a quick fix for 1.5 release.