### PR TITLE
Resolving command dependency in SHIM

### DIFF
--- a/src/shim/buffer.cpp
+++ b/src/shim/buffer.cpp
@@ -2,7 +2,7 @@
 // Copyright (C) 2025, Advanced Micro Devices, Inc. All rights reserved.
 
 // Disable debug print in this file.
-#undef XDNA_SHIM_DEBUG
+//#undef XDNA_SHIM_DEBUG
 
 #include "buffer.h"
 #include "shim_debug.h"

--- a/src/shim/buffer.cpp
+++ b/src/shim/buffer.cpp
@@ -2,7 +2,7 @@
 // Copyright (C) 2025, Advanced Micro Devices, Inc. All rights reserved.
 
 // Disable debug print in this file.
-//#undef XDNA_SHIM_DEBUG
+#undef XDNA_SHIM_DEBUG
 
 #include "buffer.h"
 #include "shim_debug.h"

--- a/src/shim/buffer.cpp
+++ b/src/shim/buffer.cpp
@@ -427,10 +427,9 @@ get_arg_bo_ids() const
 
 void
 cmd_buffer::
-enqueued(uint64_t seq)
+mark_enqueued() const
 {
   std::unique_lock<std::mutex> lg(m_submission_lock);
-  m_cmd_seq = seq;
   m_submitted = false;
 }
 
@@ -445,11 +444,10 @@ wait_for_submitted() const
 
 void
 cmd_buffer::
-submitted(uint64_t seq) const
+mark_submitted(uint64_t seq) const
 {
   std::unique_lock<std::mutex> lg(m_submission_lock);
-  if (seq != m_cmd_seq)
-    shim_err(EINVAL, "Submitted seq not matching enqueue seq!");
+  m_cmd_seq = seq;
   m_submitted = true;
   m_submission_cv.notify_all();
 }

--- a/src/shim/buffer.h
+++ b/src/shim/buffer.h
@@ -122,14 +122,11 @@ public:
   bind_at(size_t pos, const buffer_handle* bh, size_t offset, size_t size) override;
 
 public:
-  // Today, sequence order is decided once enqueued.
   void
-  enqueued(uint64_t seq);
+  mark_enqueued() const;
 
-  // Passing in sequence number in HW queue.
-  // Should be the same as seq when enqueued.
   void
-  submitted(uint64_t seq) const;
+  mark_submitted(uint64_t seq) const;
 
   // Returning final sequence number in HW queue, which can be waited on.
   uint64_t
@@ -139,7 +136,8 @@ public:
   get_arg_bo_ids() const override;
 
 private:
-  uint64_t m_cmd_seq = 0;
+  // Valid only when m_submitted is true.
+  mutable uint64_t m_cmd_seq = 0;
   std::map< size_t, std::set<bo_id> > m_args_map;
   mutable std::mutex m_args_map_lock;
 

--- a/src/shim/fence.cpp
+++ b/src/shim/fence.cpp
@@ -186,7 +186,7 @@ const std::string
 fence::
 describe() const
 {
-  return std::to_string(m_syncobj_hdl) + "@" + std::to_string(m_state + 1);
+  return std::to_string(m_syncobj_hdl) + "@" + std::to_string(get_next_state());
 }
 
 }

--- a/src/shim/fence.h
+++ b/src/shim/fence.h
@@ -36,11 +36,8 @@ public:
   signal() const override;
 
 public:
-  void
-  submit_wait(const hwctx& ctx) const;
-
-  void
-  submit_signal(const hwctx& ctx) const;
+  const std::string
+  describe() const;
 
 private:
   uint64_t
@@ -48,9 +45,6 @@ private:
 
   uint64_t
   signal_next_state() const;
-
-  void
-  save_cookies(std::unique_ptr<platform_cookie> cookie) const;
 
   const pdev& m_pdev;
   const std::unique_ptr<xrt_core::shared_handle> m_import;
@@ -63,9 +57,6 @@ private:
   static constexpr uint64_t initial_state = 0;
   // Ever incrementing at each wait/signal
   mutable uint64_t m_state = initial_state;
-  // Keep track of all async waiting threads so that they can be joined
-  // when fence goes away. They do not affect fence's running state.
-  mutable std::vector< std::unique_ptr<platform_cookie> > m_cookies;
 };
 
 }

--- a/src/shim/fence.h
+++ b/src/shim/fence.h
@@ -37,10 +37,10 @@ public:
 
 public:
   void
-  submit_wait(xrt_core::hwctx_handle::slot_id) const;
+  submit_wait(const hwctx& ctx) const;
 
   void
-  submit_signal(xrt_core::hwctx_handle::slot_id) const;
+  submit_signal(const hwctx& ctx) const;
 
 private:
   uint64_t
@@ -48,6 +48,9 @@ private:
 
   uint64_t
   signal_next_state() const;
+
+  void
+  save_cookies(std::unique_ptr<platform_cookie> cookie) const;
 
   const pdev& m_pdev;
   const std::unique_ptr<xrt_core::shared_handle> m_import;
@@ -57,9 +60,12 @@ private:
   mutable std::mutex m_lock;
   // Set once at first signal
   mutable bool m_signaled = false;
-  // Ever incrementing at each wait/signal
   static constexpr uint64_t initial_state = 0;
+  // Ever incrementing at each wait/signal
   mutable uint64_t m_state = initial_state;
+  // Keep track of all async waiting threads so that they can be joined
+  // when fence goes away. They do not affect fence's running state.
+  mutable std::vector< std::unique_ptr<platform_cookie> > m_cookies;
 };
 
 }

--- a/src/shim/fence.h
+++ b/src/shim/fence.h
@@ -39,13 +39,19 @@ public:
   const std::string
   describe() const;
 
+  uint64_t
+  next_wait_state() const;
+
+  uint64_t
+  next_signal_state() const;
+
+  void
+  wait(uint64_t state) const;
+
+  void
+  signal(uint64_t state) const;
+
 private:
-  uint64_t
-  wait_next_state() const;
-
-  uint64_t
-  signal_next_state() const;
-
   const pdev& m_pdev;
   const std::unique_ptr<xrt_core::shared_handle> m_import;
   uint32_t m_syncobj_hdl;

--- a/src/shim/host/platform_host.cpp
+++ b/src/shim/host/platform_host.cpp
@@ -255,36 +255,6 @@ submit_cmd(submit_cmd_arg& cmd_arg) const
 
 void
 platform_drv_host::
-submit_dep(submit_sig_dep_arg& cmd_arg) const
-{
-  wait_syncobj_available(dev_fd(), cmd_arg.syncobj_handle, cmd_arg.timepoint);
-
-  amdxdna_drm_exec_cmd arg = {};
-  arg.ctx = cmd_arg.ctx_handle;
-  arg.type = AMDXDNA_CMD_SUBMIT_DEPENDENCY;
-  arg.cmd_handles = reinterpret_cast<uintptr_t>(&cmd_arg.syncobj_handle);
-  arg.args = reinterpret_cast<uintptr_t>(&cmd_arg.timepoint);
-  arg.cmd_count = 1;
-  arg.arg_count = 1;
-  ioctl(dev_fd(), DRM_IOCTL_AMDXDNA_EXEC_CMD, &arg);
-}
-
-void
-platform_drv_host::
-submit_sig(submit_sig_dep_arg& cmd_arg) const
-{
-  amdxdna_drm_exec_cmd arg = {};
-  arg.ctx = cmd_arg.ctx_handle;
-  arg.type = AMDXDNA_CMD_SUBMIT_SIGNAL;
-  arg.cmd_handles = cmd_arg.syncobj_handle;
-  arg.args = cmd_arg.timepoint;
-  arg.cmd_count = 1;
-  arg.arg_count = 1;
-  ioctl(dev_fd(), DRM_IOCTL_AMDXDNA_EXEC_CMD, &arg);
-}
-
-void
-platform_drv_host::
 wait_cmd_ioctl(wait_cmd_arg& cmd_arg) const
 {
   amdxdna_drm_wait_cmd wcmd = {

--- a/src/shim/host/platform_host.h
+++ b/src/shim/host/platform_host.h
@@ -45,12 +45,6 @@ private:
   submit_cmd(submit_cmd_arg& arg) const override;
 
   void
-  submit_dep(submit_sig_dep_arg& arg) const override;
-
-  void
-  submit_sig(submit_sig_dep_arg& arg) const override;
-
-  void
   wait_cmd_ioctl(wait_cmd_arg& arg) const override;
 
   void

--- a/src/shim/host/platform_host.h
+++ b/src/shim/host/platform_host.h
@@ -45,13 +45,16 @@ private:
   submit_cmd(submit_cmd_arg& arg) const override;
 
   void
-  submit_dep(submit_dep_arg& arg) const override;
+  submit_dep(submit_sig_dep_arg& arg) const override;
 
   void
-  submit_sig(submit_sig_arg& arg) const override;
+  submit_sig(submit_sig_dep_arg& arg) const override;
 
   void
-  wait_cmd(wait_cmd_arg& arg) const override;
+  wait_cmd_ioctl(wait_cmd_arg& arg) const override;
+
+  void
+  wait_cmd_syncobj(wait_cmd_arg& arg) const override;
 
   void
   get_info(amdxdna_drm_get_info& arg) const override;
@@ -61,24 +64,6 @@ private:
 
   void
   set_state(amdxdna_drm_set_state& arg) const override;
-
-  void
-  create_syncobj(create_destroy_syncobj_arg& arg) const override;
-
-  void
-  destroy_syncobj(create_destroy_syncobj_arg& arg) const override;
-
-  void
-  export_syncobj(export_import_syncobj_arg& arg) const override;
-
-  void
-  import_syncobj(export_import_syncobj_arg& arg) const override;
-
-  void
-  signal_syncobj(signal_syncobj_arg& arg) const override;
-
-  void
-  wait_syncobj(wait_syncobj_arg& arg) const override;
 };
 
 }

--- a/src/shim/hwctx.cpp
+++ b/src/shim/hwctx.cpp
@@ -41,7 +41,7 @@ xclbin_parser(const xrt::xclbin& xclbin)
     shim_err(EINVAL, "No valid DPU kernel found in xclbin");
   m_ops_per_cycle = aie_partition.ops_per_cycle;
   m_column_cnt = aie_partition.ncol;
-  print_info();
+  //print_info();
 }
 
 xclbin_parser::

--- a/src/shim/hwq.cpp
+++ b/src/shim/hwq.cpp
@@ -23,7 +23,7 @@ hwq::
     std::unique_lock<std::mutex> lock(m_mutex);
     m_pending_thread_stop = true;
   }
-  m_pending_consumer_cv.notify_all();
+  m_pending_consumer_cv.notify_one();
   m_pending_thread.join();
 }
 
@@ -109,7 +109,7 @@ push_to_pending_queue(std::unique_lock<std::mutex>& lock,
   c.m_cmd = cmd;
   c.m_last_seq = m_last_seq;
   m_pending_producer++;
-  m_pending_consumer_cv.notify_all();
+  m_pending_consumer_cv.notify_one();
 }
 
 void

--- a/src/shim/hwq.cpp
+++ b/src/shim/hwq.cpp
@@ -117,10 +117,11 @@ hwq::
 submit_command(xrt_core::buffer_handle *cmd)
 {
   std::unique_lock<std::mutex> lock(m_mutex);
+  ++m_last_seq;
   auto boh = static_cast<cmd_buffer*>(cmd);
+  shim_debug("Enqueuing command (%ld)", m_last_seq);
   push_to_pending_queue(lock, boh, pending_cmd_type::io);
-  boh->enqueued(++m_last_seq);
-  shim_debug("Enqueued command (%ld)", m_last_seq);
+  boh->enqueued(m_last_seq);
 }
 
 void
@@ -129,7 +130,7 @@ submit_wait(const xrt_core::fence_handle* f)
 {
   std::unique_lock<std::mutex> lock(m_mutex);
   auto fh = static_cast<const fence*>(f);
-  shim_debug("Submitting wait fence %s", fh->describe().c_str());
+  shim_debug("Enqueuing wait fence %s", fh->describe().c_str());
   push_to_pending_queue(lock, fh, pending_cmd_type::wait);
 }
 
@@ -139,7 +140,7 @@ submit_signal(const xrt_core::fence_handle* f)
 {
   std::unique_lock<std::mutex> lock(m_mutex);
   auto fh = static_cast<const fence*>(f);
-  shim_debug("Submitting signal fence %s", fh->describe().c_str());
+  shim_debug("Enqueuing signal fence %s", fh->describe().c_str());
   push_to_pending_queue(lock, fh, pending_cmd_type::signal);
 }
 

--- a/src/shim/hwq.cpp
+++ b/src/shim/hwq.cpp
@@ -135,7 +135,7 @@ submit_wait(const xrt_core::fence_handle* f)
 {
   std::unique_lock<std::mutex> lock(m_mutex);
   auto fh = static_cast<const fence*>(f);
-  shim_debug("Enqueuing wait fence %s", fh->describe().c_str());
+  shim_debug("Enqueuing wait fence %s after command %ld", fh->describe().c_str(), m_last_seq);
   push_to_pending_queue(lock, fh, fh->next_wait_state(), pending_cmd_type::wait);
 }
 
@@ -145,7 +145,7 @@ submit_signal(const xrt_core::fence_handle* f)
 {
   std::unique_lock<std::mutex> lock(m_mutex);
   auto fh = static_cast<const fence*>(f);
-  shim_debug("Enqueuing signal fence %s", fh->describe().c_str());
+  shim_debug("Enqueuing signal fence %s after command %ld", fh->describe().c_str(), m_last_seq);
   push_to_pending_queue(lock, fh, fh->next_signal_state(), pending_cmd_type::signal);
 }
 

--- a/src/shim/hwq.h
+++ b/src/shim/hwq.h
@@ -8,6 +8,7 @@
 #include "hwctx.h"
 #include "buffer.h"
 #include "core/common/shim/hwqueue_handle.h"
+#include <thread>
 
 namespace shim_xdna {
 
@@ -54,8 +55,51 @@ protected:
   wait_command(uint64_t seq, uint32_t timeout_ms) const;
 
 private:
-  virtual void
-  issue_command(cmd_buffer *) = 0;
+  enum class pending_cmd_type
+  {
+    io,
+    signal,
+    wait,
+  };
+  struct pending_cmd {
+    pending_cmd_type m_type;
+    const void* m_cmd = nullptr;
+    uint64_t m_last_seq;
+  };
+
+  virtual uint64_t
+  issue_command(const cmd_buffer *) = 0;
+
+  bool
+  pending_queue_empty() const;
+
+  bool
+  pending_queue_full() const;
+
+  uint64_t
+  pending_queue_consumer_idx() const;
+
+  uint64_t
+  pending_queue_producer_idx() const;
+
+  void
+  process_pending_queue();
+
+  void
+  push_to_pending_queue(std::unique_lock<std::mutex>& lock,
+    const void *cmd, pending_cmd_type type);
+
+  std::mutex m_mutex;
+  const uint64_t INVALID_SEQ = 0xffffffffffffffff;
+  uint64_t m_last_seq = INVALID_SEQ;
+
+  std::thread m_pending_thread;
+  bool m_pending_thread_stop = false;
+  std::array<pending_cmd, 1> m_pending;
+  std::condition_variable m_pending_producer_cv;
+  std::condition_variable m_pending_consumer_cv;
+  uint64_t m_pending_consumer = 0;
+  uint64_t m_pending_producer = 0;
 };
 
 }

--- a/src/shim/hwq.h
+++ b/src/shim/hwq.h
@@ -48,14 +48,12 @@ public:
 
 protected:
   const pdev& m_pdev;
-  xrt_core::hwctx_handle::slot_id m_ctx_id = AMDXDNA_INVALID_CTX_HANDLE;
+  const hwctx* m_ctx = nullptr;
 
   int
   wait_command(uint64_t seq, uint32_t timeout_ms) const;
 
 private:
-  uint32_t m_syncobj = 0;
-
   virtual void
   issue_command(cmd_buffer *) = 0;
 };

--- a/src/shim/hwq.h
+++ b/src/shim/hwq.h
@@ -64,6 +64,7 @@ private:
   struct pending_cmd {
     pending_cmd_type m_type;
     const void* m_cmd = nullptr;
+    uint64_t m_fence_state;
     uint64_t m_last_seq;
   };
 
@@ -87,19 +88,19 @@ private:
 
   void
   push_to_pending_queue(std::unique_lock<std::mutex>& lock,
-    const void *cmd, pending_cmd_type type);
+    const void *cmd, uint64_t fence_state, pending_cmd_type type);
 
   std::mutex m_mutex;
   const uint64_t INVALID_SEQ = 0xffffffffffffffff;
   uint64_t m_last_seq = INVALID_SEQ;
 
-  std::thread m_pending_thread;
   bool m_pending_thread_stop = false;
   std::array<pending_cmd, 1> m_pending;
   std::condition_variable m_pending_producer_cv;
   std::condition_variable m_pending_consumer_cv;
   uint64_t m_pending_consumer = 0;
   uint64_t m_pending_producer = 0;
+  std::thread m_pending_thread;
 };
 
 }

--- a/src/shim/kmq/hwctx.cpp
+++ b/src/shim/kmq/hwctx.cpp
@@ -48,7 +48,7 @@ hwctx_kmq(const device& device, const xrt::xclbin& xclbin, const qos_type& qos)
     cf.cu_func = xp.get_cu_func(i);
   }
 
-  print_cu_config(cu_conf_param);
+  //print_cu_config(cu_conf_param);
 
   config_ctx_cu_config_arg arg = {
     .ctx_handle = get_slotidx(),

--- a/src/shim/kmq/hwq.cpp
+++ b/src/shim/kmq/hwq.cpp
@@ -22,7 +22,7 @@ hwq_kmq::
 issue_command(cmd_buffer *cmd_bo)
 {
   submit_cmd_arg ecmd = {
-    .ctx_handle = m_ctx_id,
+    .ctx_handle = m_ctx->get_slotidx(),
     .cmd_bo = cmd_bo->id(),
     .arg_bos = cmd_bo->get_arg_bo_ids(),
   };

--- a/src/shim/kmq/hwq.cpp
+++ b/src/shim/kmq/hwq.cpp
@@ -27,6 +27,7 @@ issue_command(const cmd_buffer *cmd_bo)
     .arg_bos = cmd_bo->get_arg_bo_ids(),
   };
   m_pdev.drv_ioctl(drv_ioctl_cmd::submit_cmd, &ecmd);
+  shim_debug("Submitted command (%ld)", ecmd.seq);
   return ecmd.seq;
 }
 

--- a/src/shim/kmq/hwq.cpp
+++ b/src/shim/kmq/hwq.cpp
@@ -17,9 +17,9 @@ hwq_kmq::
   shim_debug("Destroying KMQ HW queue");
 }
 
-void
+uint64_t
 hwq_kmq::
-issue_command(cmd_buffer *cmd_bo)
+issue_command(const cmd_buffer *cmd_bo)
 {
   submit_cmd_arg ecmd = {
     .ctx_handle = m_ctx->get_slotidx(),
@@ -27,18 +27,14 @@ issue_command(cmd_buffer *cmd_bo)
     .arg_bos = cmd_bo->get_arg_bo_ids(),
   };
   m_pdev.drv_ioctl(drv_ioctl_cmd::submit_cmd, &ecmd);
-
-  auto seq = ecmd.seq;
-  cmd_bo->set_cmd_seq(seq);
-  shim_debug("Submitted command (%ld)", seq);
+  return ecmd.seq;
 }
 
 bo_id
 hwq_kmq::
 get_queue_bo() const
 {
-  bo_id ret = { AMDXDNA_INVALID_BO_HANDLE, AMDXDNA_INVALID_BO_HANDLE };
-  return ret;
+  return { AMDXDNA_INVALID_BO_HANDLE, AMDXDNA_INVALID_BO_HANDLE };
 }
 
 }

--- a/src/shim/kmq/hwq.h
+++ b/src/shim/kmq/hwq.h
@@ -18,8 +18,8 @@ public:
   get_queue_bo() const override;
 
 private:
-  void
-  issue_command(cmd_buffer *) override;
+  uint64_t
+  issue_command(const cmd_buffer *) override;
 };
 
 }

--- a/src/shim/platform.cpp
+++ b/src/shim/platform.cpp
@@ -193,12 +193,6 @@ drv_ioctl(drv_ioctl_cmd cmd, void* cmd_arg) const
   case drv_ioctl_cmd::submit_cmd:
     submit_cmd(*static_cast<submit_cmd_arg*>(cmd_arg));
     break;
-  case drv_ioctl_cmd::submit_dep:
-    submit_dep(*static_cast<submit_sig_dep_arg*>(cmd_arg));
-    break;
-  case drv_ioctl_cmd::submit_sig:
-    submit_sig(*static_cast<submit_sig_dep_arg*>(cmd_arg));
-    break;
   case drv_ioctl_cmd::wait_cmd_ioctl:
     wait_cmd_ioctl(*static_cast<wait_cmd_arg*>(cmd_arg));
     break;

--- a/src/shim/platform.h
+++ b/src/shim/platform.h
@@ -16,16 +16,6 @@
 
 namespace shim_xdna {
 
-// Can be returned to caller for resource tracking.
-// Resource tracked needs to be implemented in inherited class.
-// Object can't be reused. When it becomes invalid, it stays invalid for ever.
-// Caller may delete object at any time, if it is not valid.
-class platform_cookie {
-public:
-  virtual bool
-  is_valid() const = 0;
-};
-
 enum class drv_ioctl_cmd {
   create_ctx,
   destroy_ctx,

--- a/src/shim/platform.h
+++ b/src/shim/platform.h
@@ -39,8 +39,6 @@ enum class drv_ioctl_cmd {
   import_bo,
 
   submit_cmd,
-  submit_dep,
-  submit_sig,
   wait_cmd_ioctl,
   wait_cmd_syncobj,
 
@@ -133,14 +131,6 @@ struct submit_cmd_arg {
   bo_id cmd_bo;
   const std::set<bo_id>& arg_bos;
   uint64_t seq;
-};
-
-struct submit_sig_dep_arg {
-  uint32_t ctx_handle;
-  uint32_t ctx_syncobj_handle;
-  uint32_t syncobj_handle;
-  uint64_t timepoint;
-  std::unique_ptr<platform_cookie> cookie;
 };
 
 struct wait_cmd_arg {
@@ -259,14 +249,6 @@ private:
 
   virtual void
   submit_cmd(submit_cmd_arg& arg) const
-  { shim_not_supported_err(__func__); }
-
-  virtual void
-  submit_dep(submit_sig_dep_arg& arg) const
-  { shim_not_supported_err(__func__); }
-
-  virtual void
-  submit_sig(submit_sig_dep_arg& arg) const
   { shim_not_supported_err(__func__); }
 
   virtual void

--- a/src/shim/platform.h
+++ b/src/shim/platform.h
@@ -16,6 +16,16 @@
 
 namespace shim_xdna {
 
+// Can be returned to caller for resource tracking.
+// Resource tracked needs to be implemented in inherited class.
+// Object can't be reused. When it becomes invalid, it stays invalid for ever.
+// Caller may delete object at any time, if it is not valid.
+class platform_cookie {
+public:
+  virtual bool
+  is_valid() const = 0;
+};
+
 enum class drv_ioctl_cmd {
   create_ctx,
   destroy_ctx,
@@ -31,7 +41,8 @@ enum class drv_ioctl_cmd {
   submit_cmd,
   submit_dep,
   submit_sig,
-  wait_cmd,
+  wait_cmd_ioctl,
+  wait_cmd_syncobj,
 
   get_info,
   get_info_array,
@@ -46,7 +57,9 @@ enum class drv_ioctl_cmd {
 };
 
 struct bo_id {
+  // In non-VM case, not valid. In VM case, DRM BO handle in guest
   uint32_t res_id = AMDXDNA_INVALID_BO_HANDLE;
+  // In non-VM case, DRM BO handle. In VM case, DRM BO handle in host
   uint32_t handle = AMDXDNA_INVALID_BO_HANDLE;
   bool operator<(const bo_id& other) const
   { return std::tie(handle, res_id) < std::tie(other.handle, other.res_id); }
@@ -122,21 +135,19 @@ struct submit_cmd_arg {
   uint64_t seq;
 };
 
-struct submit_dep_arg {
+struct submit_sig_dep_arg {
   uint32_t ctx_handle;
-  uint32_t count;
-  const uint32_t *sync_objs;
-  const uint64_t *sync_points;
-};
-
-struct submit_sig_arg {
-  uint32_t ctx_handle;
-  uint32_t sync_obj;
+  uint32_t ctx_syncobj_handle;
+  uint32_t syncobj_handle;
   uint64_t timepoint;
+  std::unique_ptr<platform_cookie> cookie;
 };
 
 struct wait_cmd_arg {
-  uint32_t ctx_handle;
+  union {
+    uint32_t ctx_handle;
+    uint32_t ctx_syncobj_handle;
+  };
   uint32_t timeout_ms;
   uint64_t seq;
 };
@@ -157,8 +168,8 @@ struct signal_syncobj_arg {
 
 struct wait_syncobj_arg {
   uint32_t handle;
-  uint64_t timepoint;
   uint32_t timeout_ms;
+  uint64_t timepoint;
 };
 
 class platform_drv
@@ -185,9 +196,21 @@ public:
   std::shared_ptr<const drv>
   get_pdrv() const;
 
+  static int64_t
+  timeout_ms2abs_ns(int64_t timeout_ms);
+
 protected:
   int
   dev_fd() const;
+
+  virtual void
+  wait_syncobj(wait_syncobj_arg& arg) const;
+
+  virtual void
+  destroy_syncobj(create_destroy_syncobj_arg& arg) const;
+
+  virtual void
+  signal_syncobj(signal_syncobj_arg& arg) const;
 
 private:
   std::shared_ptr<const drv> m_driver;
@@ -239,15 +262,19 @@ private:
   { shim_not_supported_err(__func__); }
 
   virtual void
-  submit_dep(submit_dep_arg& arg) const
+  submit_dep(submit_sig_dep_arg& arg) const
   { shim_not_supported_err(__func__); }
 
   virtual void
-  submit_sig(submit_sig_arg& arg) const
+  submit_sig(submit_sig_dep_arg& arg) const
   { shim_not_supported_err(__func__); }
 
   virtual void
-  wait_cmd(wait_cmd_arg& arg) const
+  wait_cmd_ioctl(wait_cmd_arg& arg) const
+  { shim_not_supported_err(__func__); }
+
+  virtual void
+  wait_cmd_syncobj(wait_cmd_arg& arg) const
   { shim_not_supported_err(__func__); }
 
   virtual void
@@ -263,28 +290,13 @@ private:
   { shim_not_supported_err(__func__); }
 
   virtual void
-  create_syncobj(create_destroy_syncobj_arg& arg) const
-  { shim_not_supported_err(__func__); }
+  create_syncobj(create_destroy_syncobj_arg& arg) const;
 
   virtual void
-  destroy_syncobj(create_destroy_syncobj_arg& arg) const
-  { shim_not_supported_err(__func__); }
+  export_syncobj(export_import_syncobj_arg& arg) const;
 
   virtual void
-  export_syncobj(export_import_syncobj_arg& arg) const
-  { shim_not_supported_err(__func__); }
-
-  virtual void
-  import_syncobj(export_import_syncobj_arg& arg) const
-  { shim_not_supported_err(__func__); }
-
-  virtual void
-  signal_syncobj(signal_syncobj_arg& arg) const
-  { shim_not_supported_err(__func__); }
-
-  virtual void
-  wait_syncobj(wait_syncobj_arg& arg) const
-  { shim_not_supported_err(__func__); }
+  import_syncobj(export_import_syncobj_arg& arg) const;
 };
 
 }

--- a/src/shim/umq/hwq.cpp
+++ b/src/shim/umq/hwq.cpp
@@ -185,7 +185,6 @@ reserve_slot()
   auto h = get_header_ptr();
 
   do {
-    std::unique_lock<std::mutex> lock(m_mutex);
     if (h->write_index < h->read_index) {
       shim_err(EINVAL, "Queue read before write! read_index=0x%lx, write_index=0x%lx",
         h->read_index, h->write_index);
@@ -197,7 +196,6 @@ reserve_slot()
     } else {
       queue_full = true;
     }
-    lock.unlock();
 
     if (queue_full) {
       shim_debug("Queue is full, wait for next available slot");
@@ -345,9 +343,9 @@ fill_slot_and_send(volatile struct host_queue_packet *pkt, size_t size)
   *m_mapped_doorbell = 0;
 }
 
-void
+uint64_t
 hwq_umq::
-issue_command(cmd_buffer *cmd_bo)
+issue_command(const cmd_buffer *cmd_bo)
 {
   auto cmd = reinterpret_cast<ert_start_kernel_cmd *>(cmd_bo->vaddr());
 
@@ -369,9 +367,7 @@ issue_command(cmd_buffer *cmd_bo)
   // Completion signal area has to be a full WORD, we utilze the command_bo
   uint64_t comp = cmd_bo->paddr() + offsetof(ert_start_kernel_cmd, header);
 
-  auto seq = issue_exec_buf(ffs(cmd->cu_mask) - 1, dpu_data, comp);
-  cmd_bo->set_cmd_seq(seq);
-  shim_debug("Submitted command (%ld)", seq);
+  return issue_exec_buf(ffs(cmd->cu_mask) - 1, dpu_data, comp);
 }
 
 void

--- a/src/shim/umq/hwq.cpp
+++ b/src/shim/umq/hwq.cpp
@@ -367,7 +367,9 @@ issue_command(const cmd_buffer *cmd_bo)
   // Completion signal area has to be a full WORD, we utilze the command_bo
   uint64_t comp = cmd_bo->paddr() + offsetof(ert_start_kernel_cmd, header);
 
-  return issue_exec_buf(ffs(cmd->cu_mask) - 1, dpu_data, comp);
+  auto seq = issue_exec_buf(ffs(cmd->cu_mask) - 1, dpu_data, comp);
+  shim_debug("Submitted command (%ld)", seq);
+  return seq;
 }
 
 void

--- a/src/shim/umq/hwq.h
+++ b/src/shim/umq/hwq.h
@@ -39,10 +39,8 @@ private:
 
   volatile uint32_t *m_mapped_doorbell = nullptr;
 
-  std::mutex m_mutex;
-
-  void
-  issue_command(cmd_buffer *) override;
+  uint64_t
+  issue_command(const cmd_buffer *) override;
 
   void
   dump() const;

--- a/src/shim/virtio/amdxdna_proto.h
+++ b/src/shim/virtio/amdxdna_proto.h
@@ -9,35 +9,32 @@
 #include "drm_hw.h"
 
 enum amdxdna_ccmd {
-    AMDXDNA_CCMD_NOP = 1,
-    AMDXDNA_CCMD_INIT,
-    AMDXDNA_CCMD_CREATE_BO,
-    AMDXDNA_CCMD_DESTROY_BO,
-    AMDXDNA_CCMD_CREATE_CTX,
-    AMDXDNA_CCMD_DESTROY_CTX,
-    AMDXDNA_CCMD_CONFIG_CTX,
-    AMDXDNA_CCMD_EXEC_CMD,
-    AMDXDNA_CCMD_WAIT_CMD,
-    AMDXDNA_CCMD_GET_LAST_SEQ,
-    AMDXDNA_CCMD_ADD_SYNCOBJ,
-    AMDXDNA_CCMD_SIG_SYNCOBJ,
+	AMDXDNA_CCMD_NOP = 1,
+	AMDXDNA_CCMD_INIT,
+	AMDXDNA_CCMD_CREATE_BO,
+	AMDXDNA_CCMD_DESTROY_BO,
+	AMDXDNA_CCMD_CREATE_CTX,
+	AMDXDNA_CCMD_DESTROY_CTX,
+	AMDXDNA_CCMD_CONFIG_CTX,
+	AMDXDNA_CCMD_EXEC_CMD,
+	AMDXDNA_CCMD_WAIT_CMD,
 };
 
 #ifdef __cplusplus
-#define AMDXDNA_CCMD(_cmd, _len) {          \
-    .cmd = AMDXDNA_CCMD_##_cmd,             \
-    .len = (_len),                          \
+#define AMDXDNA_CCMD(_cmd, _len) {		\
+	.cmd = AMDXDNA_CCMD_##_cmd,		\
+	.len = (_len),				\
 }
 #else
-#define AMDXDNA_CCMD(_cmd, _len) (struct vdrm_ccmd_req){    \
-    .cmd = MSM_CCMD_##_cmd,                                 \
-    .len = (_len),                                          \
+#define AMDXDNA_CCMD(_cmd, _len) (struct vdrm_ccmd_req){	\
+	.cmd = MSM_CCMD_##_cmd,					\
+	.len = (_len),						\
 }
 #endif
 
 struct amdxdna_ccmd_rsp {
-    struct vdrm_ccmd_rsp base;
-    int32_t ret;
+	struct vdrm_ccmd_rsp base;
+	int32_t ret;
 };
 static_assert(sizeof(struct amdxdna_ccmd_rsp) == 8, "bug");
 
@@ -45,45 +42,46 @@ static_assert(sizeof(struct amdxdna_ccmd_rsp) == 8, "bug");
  * AMDXDNA_CCMD_NOP
  */
 struct amdxdna_ccmd_nop_req {
-    struct vdrm_ccmd_req hdr;
+	struct vdrm_ccmd_req hdr;
 };
 
 /*
  * AMDXDNA_CCMD_INIT
  */
 struct amdxdna_ccmd_init_req {
-    struct vdrm_ccmd_req hdr;
-    uint32_t rsp_res_id;
-    uint32_t _pad;
+	struct vdrm_ccmd_req hdr;
+	uint32_t rsp_res_id;
+	uint32_t _pad;
 };
 DEFINE_CAST(vdrm_ccmd_req, amdxdna_ccmd_init_req)
 
 /*
  * AMDXDNA_CCMD_CREATE_BO
  */
+
 struct amdxdna_ccmd_create_bo_req {
-    struct vdrm_ccmd_req hdr;
-    uint32_t res_id;
-    uint32_t bo_type;
-    uint64_t size;
-    uint64_t map_align;
-    uint32_t _pad;
+	struct vdrm_ccmd_req hdr;
+	uint32_t res_id;
+	uint32_t bo_type;
+	uint64_t size;
+	uint64_t map_align;
+	uint32_t _pad;
 };
 DEFINE_CAST(vdrm_ccmd_req, amdxdna_ccmd_create_bo_req)
 
 struct amdxdna_ccmd_create_bo_rsp {
-    struct amdxdna_ccmd_rsp hdr;
-    uint64_t xdna_addr;
-    uint32_t handle;
+	struct amdxdna_ccmd_rsp hdr;
+	uint64_t xdna_addr;
+	uint32_t handle;
 };
 
 /*
  * AMDXDNA_CCMD_DESTROY_BO
  */
 struct amdxdna_ccmd_destroy_bo_req {
-    struct vdrm_ccmd_req hdr;
-    uint32_t handle;
-    uint32_t _pad;
+	struct vdrm_ccmd_req hdr;
+	uint32_t handle;
+	uint32_t _pad;
 };
 DEFINE_CAST(vdrm_ccmd_req, amdxdna_ccmd_destroy_bo_req)
 
@@ -91,30 +89,30 @@ DEFINE_CAST(vdrm_ccmd_req, amdxdna_ccmd_destroy_bo_req)
  * AMDXDNA_CCMD_CREATE_CTX
  */
 struct amdxdna_ccmd_create_ctx_req {
-    struct vdrm_ccmd_req hdr;
-    struct amdxdna_qos_info qos_info;
-    uint32_t umq_blob_id;
-    uint32_t log_buf_blob_id;
-    uint32_t max_opc;
-    uint32_t num_tiles;
-    uint32_t mem_size;
-    uint32_t _pad;
+	struct vdrm_ccmd_req hdr;
+	struct amdxdna_qos_info qos_info;
+	uint32_t umq_blob_id;
+	uint32_t log_buf_blob_id;
+	uint32_t max_opc;
+	uint32_t num_tiles;
+	uint32_t mem_size;
+	uint32_t _pad;
 };
 DEFINE_CAST(vdrm_ccmd_req, amdxdna_ccmd_create_ctx_req)
 
 struct amdxdna_ccmd_create_ctx_rsp {
-    struct amdxdna_ccmd_rsp hdr;
-    uint32_t handle;
-    uint32_t syncobj_hdl;
+	struct amdxdna_ccmd_rsp hdr;
+	uint32_t handle;
+	uint32_t syncobj_hdl;
 };
 
 /*
  * AMDXDNA_CCMD_DESTROY_CTX
  */
 struct amdxdna_ccmd_destroy_ctx_req {
-    struct vdrm_ccmd_req hdr;
-    uint32_t handle;
-    uint32_t syncobj_hdl;
+	struct vdrm_ccmd_req hdr;
+	uint32_t handle;
+	uint32_t syncobj_hdl;
 };
 DEFINE_CAST(vdrm_ccmd_req, amdxdna_ccmd_destroy_ctx_req)
 
@@ -122,12 +120,12 @@ DEFINE_CAST(vdrm_ccmd_req, amdxdna_ccmd_destroy_ctx_req)
  * AMDXDNA_CCMD_CONFIG_CTX
  */
 struct amdxdna_ccmd_config_ctx_req {
-    struct vdrm_ccmd_req hdr;
-    uint32_t handle;
-    uint32_t _pad;
-    uint32_t param_type;
-    uint32_t param_val_size;
-    uint64_t param_val[];
+	struct vdrm_ccmd_req hdr;
+	uint32_t handle;
+	uint32_t _pad;
+	uint32_t param_type;
+	uint32_t param_val_size;
+	uint64_t param_val[];
 };
 DEFINE_CAST(vdrm_ccmd_req, amdxdna_ccmd_config_ctx_req)
 
@@ -135,70 +133,30 @@ DEFINE_CAST(vdrm_ccmd_req, amdxdna_ccmd_config_ctx_req)
  * AMDXDNA_CCMD_EXEC_CMD
  */
 struct amdxdna_ccmd_exec_cmd_req {
-    struct vdrm_ccmd_req hdr;
-    uint32_t ctx_handle;
-    uint32_t type;
-    uint32_t cmd_count;
-    uint32_t arg_count;
-    uint32_t arg_offset; /* number of dwords from the cmds_n_args[0] */
-    uint32_t cmds_n_args[];
+	struct vdrm_ccmd_req hdr;
+	uint32_t ctx_handle;
+	uint32_t type;
+	uint32_t cmd_count;
+	uint32_t arg_count;
+	uint32_t arg_offset; /* number of dwords from the cmds_n_args[0] */
+	uint32_t cmds_n_args[];
 };
 DEFINE_CAST(vdrm_ccmd_req, amdxdna_ccmd_exec_cmd_req)
 
 struct amdxdna_ccmd_exec_cmd_rsp {
-    struct amdxdna_ccmd_rsp hdr;
-    uint64_t seq;
+	struct amdxdna_ccmd_rsp hdr;
+	uint64_t seq;
 };
 
 /*
  * AMDXDNA_CCMD_WAIT_CMD
  */
 struct amdxdna_ccmd_wait_cmd_req {
-    struct vdrm_ccmd_req hdr;
-    uint64_t seq;
-    uint32_t syncobj_hdl;
-    uint32_t _pad;
+	struct vdrm_ccmd_req hdr;
+	uint64_t seq;
+	uint32_t syncobj_hdl;
+	uint32_t _pad;
 };
 DEFINE_CAST(vdrm_ccmd_req, amdxdna_ccmd_wait_cmd_req)
-
-/*
- * AMDXDNA_CCMD_get_last_seq_req
- */
-struct amdxdna_ccmd_get_last_seq_req {
-    struct vdrm_ccmd_req hdr;
-    uint32_t syncobj_hdl;
-    uint32_t _pad;
-};
-DEFINE_CAST(vdrm_ccmd_req, amdxdna_ccmd_get_last_seq_req)
-
-struct amdxdna_ccmd_get_last_seq_rsp {
-    struct amdxdna_ccmd_rsp hdr;
-    uint64_t seq;
-};
-
-/*
- * AMDXDNA_CCMD_ADD_SYNCOBJ
- */
-struct amdxdna_ccmd_add_syncobj_req {
-    struct vdrm_ccmd_req hdr;
-    uint32_t ctx_handle;
-    uint32_t _pad;
-};
-DEFINE_CAST(vdrm_ccmd_req, amdxdna_ccmd_add_syncobj_req)
-
-struct amdxdna_ccmd_add_syncobj_rsp {
-    struct amdxdna_ccmd_rsp hdr;
-    uint32_t syncobj_hdl;
-};
-
-/*
- * AMDXDNA_CCMD_SIG_SYNCOBJ
- */
-struct amdxdna_ccmd_sig_syncobj_req {
-    struct vdrm_ccmd_req hdr;
-    uint32_t syncobj_hdl;
-    uint32_t _pad;
-};
-DEFINE_CAST(vdrm_ccmd_req, amdxdna_ccmd_sig_syncobj_req)
 
 #endif /* AMDXDNA_PROTO_H_ */

--- a/src/shim/virtio/amdxdna_proto.h
+++ b/src/shim/virtio/amdxdna_proto.h
@@ -9,32 +9,35 @@
 #include "drm_hw.h"
 
 enum amdxdna_ccmd {
-	AMDXDNA_CCMD_NOP = 1,
-	AMDXDNA_CCMD_INIT,
-	AMDXDNA_CCMD_CREATE_BO,
-	AMDXDNA_CCMD_DESTROY_BO,
-	AMDXDNA_CCMD_CREATE_CTX,
-	AMDXDNA_CCMD_DESTROY_CTX,
-	AMDXDNA_CCMD_CONFIG_CTX,
-	AMDXDNA_CCMD_EXEC_CMD,
-	AMDXDNA_CCMD_WAIT_CMD,
+    AMDXDNA_CCMD_NOP = 1,
+    AMDXDNA_CCMD_INIT,
+    AMDXDNA_CCMD_CREATE_BO,
+    AMDXDNA_CCMD_DESTROY_BO,
+    AMDXDNA_CCMD_CREATE_CTX,
+    AMDXDNA_CCMD_DESTROY_CTX,
+    AMDXDNA_CCMD_CONFIG_CTX,
+    AMDXDNA_CCMD_EXEC_CMD,
+    AMDXDNA_CCMD_WAIT_CMD,
+    AMDXDNA_CCMD_GET_LAST_SEQ,
+    AMDXDNA_CCMD_ADD_SYNCOBJ,
+    AMDXDNA_CCMD_SIG_SYNCOBJ,
 };
 
 #ifdef __cplusplus
-#define AMDXDNA_CCMD(_cmd, _len) {		\
-	.cmd = AMDXDNA_CCMD_##_cmd,		\
-	.len = (_len),				\
+#define AMDXDNA_CCMD(_cmd, _len) {          \
+    .cmd = AMDXDNA_CCMD_##_cmd,             \
+    .len = (_len),                          \
 }
 #else
-#define AMDXDNA_CCMD(_cmd, _len) (struct vdrm_ccmd_req){	\
-	.cmd = MSM_CCMD_##_cmd,					\
-	.len = (_len),						\
+#define AMDXDNA_CCMD(_cmd, _len) (struct vdrm_ccmd_req){    \
+    .cmd = MSM_CCMD_##_cmd,                                 \
+    .len = (_len),                                          \
 }
 #endif
 
 struct amdxdna_ccmd_rsp {
-	struct vdrm_ccmd_rsp base;
-	int32_t ret;
+    struct vdrm_ccmd_rsp base;
+    int32_t ret;
 };
 static_assert(sizeof(struct amdxdna_ccmd_rsp) == 8, "bug");
 
@@ -42,46 +45,45 @@ static_assert(sizeof(struct amdxdna_ccmd_rsp) == 8, "bug");
  * AMDXDNA_CCMD_NOP
  */
 struct amdxdna_ccmd_nop_req {
-	struct vdrm_ccmd_req hdr;
+    struct vdrm_ccmd_req hdr;
 };
 
 /*
  * AMDXDNA_CCMD_INIT
  */
 struct amdxdna_ccmd_init_req {
-	struct vdrm_ccmd_req hdr;
-	uint32_t rsp_res_id;
-	uint32_t _pad;
+    struct vdrm_ccmd_req hdr;
+    uint32_t rsp_res_id;
+    uint32_t _pad;
 };
 DEFINE_CAST(vdrm_ccmd_req, amdxdna_ccmd_init_req)
 
 /*
  * AMDXDNA_CCMD_CREATE_BO
  */
-
 struct amdxdna_ccmd_create_bo_req {
-	struct vdrm_ccmd_req hdr;
-	uint32_t res_id;
-	uint32_t bo_type;
-	uint64_t size;
-	uint64_t map_align;
-	uint32_t _pad;
+    struct vdrm_ccmd_req hdr;
+    uint32_t res_id;
+    uint32_t bo_type;
+    uint64_t size;
+    uint64_t map_align;
+    uint32_t _pad;
 };
 DEFINE_CAST(vdrm_ccmd_req, amdxdna_ccmd_create_bo_req)
 
 struct amdxdna_ccmd_create_bo_rsp {
-	struct amdxdna_ccmd_rsp hdr;
-	uint64_t xdna_addr;
-	uint32_t handle;
+    struct amdxdna_ccmd_rsp hdr;
+    uint64_t xdna_addr;
+    uint32_t handle;
 };
 
 /*
  * AMDXDNA_CCMD_DESTROY_BO
  */
 struct amdxdna_ccmd_destroy_bo_req {
-	struct vdrm_ccmd_req hdr;
-	uint32_t handle;
-	uint32_t _pad;
+    struct vdrm_ccmd_req hdr;
+    uint32_t handle;
+    uint32_t _pad;
 };
 DEFINE_CAST(vdrm_ccmd_req, amdxdna_ccmd_destroy_bo_req)
 
@@ -89,30 +91,30 @@ DEFINE_CAST(vdrm_ccmd_req, amdxdna_ccmd_destroy_bo_req)
  * AMDXDNA_CCMD_CREATE_CTX
  */
 struct amdxdna_ccmd_create_ctx_req {
-	struct vdrm_ccmd_req hdr;
-	struct amdxdna_qos_info qos_info;
-	uint32_t umq_blob_id;
-	uint32_t log_buf_blob_id;
-	uint32_t max_opc;
-	uint32_t num_tiles;
-	uint32_t mem_size;
-	uint32_t _pad;
+    struct vdrm_ccmd_req hdr;
+    struct amdxdna_qos_info qos_info;
+    uint32_t umq_blob_id;
+    uint32_t log_buf_blob_id;
+    uint32_t max_opc;
+    uint32_t num_tiles;
+    uint32_t mem_size;
+    uint32_t _pad;
 };
 DEFINE_CAST(vdrm_ccmd_req, amdxdna_ccmd_create_ctx_req)
 
 struct amdxdna_ccmd_create_ctx_rsp {
-	struct amdxdna_ccmd_rsp hdr;
-	uint32_t handle;
-	uint32_t syncobj_hdl;
+    struct amdxdna_ccmd_rsp hdr;
+    uint32_t handle;
+    uint32_t syncobj_hdl;
 };
 
 /*
  * AMDXDNA_CCMD_DESTROY_CTX
  */
 struct amdxdna_ccmd_destroy_ctx_req {
-	struct vdrm_ccmd_req hdr;
-	uint32_t handle;
-	uint32_t syncobj_hdl;
+    struct vdrm_ccmd_req hdr;
+    uint32_t handle;
+    uint32_t syncobj_hdl;
 };
 DEFINE_CAST(vdrm_ccmd_req, amdxdna_ccmd_destroy_ctx_req)
 
@@ -120,12 +122,12 @@ DEFINE_CAST(vdrm_ccmd_req, amdxdna_ccmd_destroy_ctx_req)
  * AMDXDNA_CCMD_CONFIG_CTX
  */
 struct amdxdna_ccmd_config_ctx_req {
-	struct vdrm_ccmd_req hdr;
-	uint32_t handle;
-	uint32_t _pad;
-	uint32_t param_type;
-	uint32_t param_val_size;
-	uint64_t param_val[];
+    struct vdrm_ccmd_req hdr;
+    uint32_t handle;
+    uint32_t _pad;
+    uint32_t param_type;
+    uint32_t param_val_size;
+    uint64_t param_val[];
 };
 DEFINE_CAST(vdrm_ccmd_req, amdxdna_ccmd_config_ctx_req)
 
@@ -133,30 +135,70 @@ DEFINE_CAST(vdrm_ccmd_req, amdxdna_ccmd_config_ctx_req)
  * AMDXDNA_CCMD_EXEC_CMD
  */
 struct amdxdna_ccmd_exec_cmd_req {
-	struct vdrm_ccmd_req hdr;
-	uint32_t ctx_handle;
-	uint32_t type;
-	uint32_t cmd_count;
-	uint32_t arg_count;
-	uint32_t arg_offset; /* number of dwords from the cmds_n_args[0] */
-	uint32_t cmds_n_args[];
+    struct vdrm_ccmd_req hdr;
+    uint32_t ctx_handle;
+    uint32_t type;
+    uint32_t cmd_count;
+    uint32_t arg_count;
+    uint32_t arg_offset; /* number of dwords from the cmds_n_args[0] */
+    uint32_t cmds_n_args[];
 };
 DEFINE_CAST(vdrm_ccmd_req, amdxdna_ccmd_exec_cmd_req)
 
 struct amdxdna_ccmd_exec_cmd_rsp {
-	struct amdxdna_ccmd_rsp hdr;
-	uint64_t seq;
+    struct amdxdna_ccmd_rsp hdr;
+    uint64_t seq;
 };
 
 /*
  * AMDXDNA_CCMD_WAIT_CMD
  */
 struct amdxdna_ccmd_wait_cmd_req {
-	struct vdrm_ccmd_req hdr;
-	uint64_t seq;
-	uint32_t syncobj_hdl;
-	uint32_t _pad;
+    struct vdrm_ccmd_req hdr;
+    uint64_t seq;
+    uint32_t syncobj_hdl;
+    uint32_t _pad;
 };
 DEFINE_CAST(vdrm_ccmd_req, amdxdna_ccmd_wait_cmd_req)
+
+/*
+ * AMDXDNA_CCMD_get_last_seq_req
+ */
+struct amdxdna_ccmd_get_last_seq_req {
+    struct vdrm_ccmd_req hdr;
+    uint32_t syncobj_hdl;
+    uint32_t _pad;
+};
+DEFINE_CAST(vdrm_ccmd_req, amdxdna_ccmd_get_last_seq_req)
+
+struct amdxdna_ccmd_get_last_seq_rsp {
+    struct amdxdna_ccmd_rsp hdr;
+    uint64_t seq;
+};
+
+/*
+ * AMDXDNA_CCMD_ADD_SYNCOBJ
+ */
+struct amdxdna_ccmd_add_syncobj_req {
+    struct vdrm_ccmd_req hdr;
+    uint32_t ctx_handle;
+    uint32_t _pad;
+};
+DEFINE_CAST(vdrm_ccmd_req, amdxdna_ccmd_add_syncobj_req)
+
+struct amdxdna_ccmd_add_syncobj_rsp {
+    struct amdxdna_ccmd_rsp hdr;
+    uint32_t syncobj_hdl;
+};
+
+/*
+ * AMDXDNA_CCMD_SIG_SYNCOBJ
+ */
+struct amdxdna_ccmd_sig_syncobj_req {
+    struct vdrm_ccmd_req hdr;
+    uint32_t syncobj_hdl;
+    uint32_t _pad;
+};
+DEFINE_CAST(vdrm_ccmd_req, amdxdna_ccmd_sig_syncobj_req)
 
 #endif /* AMDXDNA_PROTO_H_ */

--- a/src/shim/virtio/platform_virtio.cpp
+++ b/src/shim/virtio/platform_virtio.cpp
@@ -2,7 +2,7 @@
 // Copyright (C) 2025, Advanced Micro Devices, Inc. All rights reserved.
 
 // Disable debug print in this file.
-//#undef XDNA_SHIM_DEBUG
+#undef XDNA_SHIM_DEBUG
 
 #include "../shim_debug.h"
 #include "drm_local/amdxdna_accel.h"

--- a/src/shim/virtio/platform_virtio.cpp
+++ b/src/shim/virtio/platform_virtio.cpp
@@ -1,6 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (C) 2025, Advanced Micro Devices, Inc. All rights reserved.
 
+// Disable debug print in this file.
+//#undef XDNA_SHIM_DEBUG
+
 #include "../shim_debug.h"
 #include "drm_local/amdxdna_accel.h"
 #include "amdxdna_proto.h"

--- a/src/shim/virtio/platform_virtio.h
+++ b/src/shim/virtio/platform_virtio.h
@@ -86,20 +86,6 @@ private:
 
   void
   import_bo(import_bo_arg& arg) const override;
-
-  void
-  wait_and_signal_host(uint32_t syncobj, uint64_t timepoint,
-    uint32_t host_syncobj) const;
-
-  void
-  wait_and_signal_guest(uint32_t ctx_syncobj, uint64_t cmd_seq,
-    uint32_t syncobj, uint64_t timepoint) const;
-
-  void
-  submit_dep(submit_sig_dep_arg& arg) const override;
-
-  void
-  submit_sig(submit_sig_dep_arg& arg) const override;
 };
 
 }

--- a/src/shim/virtio/platform_virtio.h
+++ b/src/shim/virtio/platform_virtio.h
@@ -79,7 +79,7 @@ private:
   submit_cmd(submit_cmd_arg& arg) const override;
 
   void
-  wait_syncobj(wait_syncobj_arg& arg) const override;
+  wait_cmd_syncobj(wait_cmd_arg& arg) const override;
 
   void
   export_bo(export_bo_arg& arg) const override;
@@ -87,6 +87,19 @@ private:
   void
   import_bo(import_bo_arg& arg) const override;
 
+  void
+  wait_and_signal_host(uint32_t syncobj, uint64_t timepoint,
+    uint32_t host_syncobj) const;
+
+  void
+  wait_and_signal_guest(uint32_t ctx_syncobj, uint64_t cmd_seq,
+    uint32_t syncobj, uint64_t timepoint) const;
+
+  void
+  submit_dep(submit_sig_dep_arg& arg) const override;
+
+  void
+  submit_sig(submit_sig_dep_arg& arg) const override;
 };
 
 }

--- a/test/shim_test/cmd_fence.cpp
+++ b/test/shim_test/cmd_fence.cpp
@@ -133,13 +133,14 @@ private:
     hw_ctx hwctx{dev.get()};
     auto hwq = hwctx.get()->get_hw_queue();
 
-    io_test_bo_set boset{dev.get()};
     try {
       hwq->submit_signal(fence.get());
     } catch(...) {
       fence->signal();
       throw;
     }
+
+    io_test_bo_set boset{dev.get()};
     boset.run(wfences, sfences, false);
     boset.run(wfences, sfences, false);
 

--- a/test/shim_test/io.cpp
+++ b/test/shim_test/io.cpp
@@ -523,6 +523,7 @@ run(const std::vector<xrt_core::fence_handle*>& wait_fences,
   hwq->submit_command(chdl);
   for (const auto& fence : signal_fences)
     hwq->submit_signal(fence);
+  //sleep(1);
   hwq->wait_command(chdl, 5000);
   auto cpkt = reinterpret_cast<ert_start_kernel_cmd *>(cbo->map());
   if (cpkt->state != ERT_CMD_STATE_COMPLETED)

--- a/test/shim_test/io.cpp
+++ b/test/shim_test/io.cpp
@@ -523,7 +523,6 @@ run(const std::vector<xrt_core::fence_handle*>& wait_fences,
   hwq->submit_command(chdl);
   for (const auto& fence : signal_fences)
     hwq->submit_signal(fence);
-  //sleep(1);
   hwq->wait_command(chdl, 5000);
   auto cpkt = reinterpret_cast<ert_start_kernel_cmd *>(cbo->map());
   if (cpkt->state != ERT_CMD_STATE_COMPLETED)

--- a/test/shim_test/io.cpp
+++ b/test/shim_test/io.cpp
@@ -5,7 +5,7 @@
 #include "hwctx.h"
 #include "exec_buf.h"
 #include "io_config.h"
-#include "core/common/aiebu/src/cpp/aiebu/src/include/aiebu_assembler.h"
+#include "core/common/aiebu/src/cpp/include/aiebu/aiebu_assembler.h"
 
 #include <string>
 #include <regex>

--- a/test/shim_test/shim_test.cpp
+++ b/test/shim_test/shim_test.cpp
@@ -788,8 +788,8 @@ run_test(int id, const test_case& test, bool force, const device::id_type& num_o
   if (skipped)
     result = "skipped";
   else
-    result = failed ? "\x1b[5m\x1b[31mFAILED\x1b[0m" : "passed";
-  std::cout << "====== " << id << ": " << test.name << " " << result << "  =====" << std::endl;
+    result = failed ? "\x1b[5m\x1b[31mFAILED\x1b[0m" : "passed ";
+  std::cout << "====== " << id << ": " << test.name << " " << result << " =====" << std::endl;
 
   if (skipped)
     test_skipped++;


### PR DESCRIPTION
This PR implement command dependency signaling and waiting in SHIM. For doing this, we have to create a queue in SHIM and launch a thread for serving the queue in SHIM.
Future clean up:
1. Remove DRM scheduler in driver since we have a scheduler (queue + thread) in SHIM already.
2. Skip the queue if there is no dependency needs to be resolved and push the command directly to driver.
3. The queue length is 1 slot today. Might consider enlarging the queue if it impacts performance.