### PR TITLE
Enable force preemption shim test

### DIFF
--- a/test/shim_test/exec_buf.h
+++ b/test/shim_test/exec_buf.h
@@ -145,10 +145,10 @@ public:
     }
     std::cout << std::setfill(' ') << std::setw(0) << std::dec << std::endl;
 
-    std::cout << "Dumping ctrl_text arguement list:\n";
+    std::cout << "Dumping ctrl_text argument list:\n";
     for (auto& [arg_name, arg_addr] : m_ctrl_text_args)
       std::cout << "{ " << arg_name << ", 0x" << std::hex << arg_addr << std::dec << " }\n";
-    std::cout << "Dumping save_restore arguement list:\n";
+    std::cout << "Dumping save_restore argument list:\n";
     for (auto& [arg_name, arg_addr] : m_save_restore_args)
       std::cout << "{ " << arg_name << ", 0x" << std::hex << arg_addr << std::dec << " }\n";
   }

--- a/test/shim_test/io.cpp
+++ b/test/shim_test/io.cpp
@@ -5,7 +5,7 @@
 #include "hwctx.h"
 #include "exec_buf.h"
 #include "io_config.h"
-#include "core/common/aiebu/src/cpp/aiebu/src/include/aiebu_assembler.h"
+#include "core/common/aiebu/src/cpp/include/aiebu/aiebu_assembler.h"
 
 #include <string>
 #include <regex>
@@ -13,6 +13,8 @@
 using namespace xrt_core;
 
 namespace {
+
+std::unique_ptr<aiebu::aiebu_assembler> asp = nullptr;
 
 std::array io_test_bo_type_names {
   "IO_TEST_BO_CMD",
@@ -89,8 +91,6 @@ get_ofm_format(const std::string& config_file)
 xrt::elf
 txn2elf(std::vector<char>& txn_buf, std::vector<char>& pm_ctrlpkt)
 {
-  std::unique_ptr<aiebu::aiebu_assembler> asp = nullptr;
-
   if (pm_ctrlpkt.size()) {
     std::vector<char> buffer2 = {};
     std::vector<char> patch_json = {};
@@ -128,6 +128,65 @@ txn_file2elf(const std::string& ml_txn, const std::string& pm_ctrlpkt)
   if (pm_ctrlpkt_size)
     read_data_from_bin(pm_ctrlpkt, 0, pm_ctrlpkt_size, reinterpret_cast<int*>(pm_ctrlpkt_buf.data()));
   return txn2elf(txn_buf, pm_ctrlpkt_buf);
+}
+
+unsigned long
+get_fine_preemption_checkpoints(const xrt::elf elf)
+{
+  unsigned long count = 0;
+  std::ostringstream out;
+  size_t pos = 0;
+
+  asp->get_report(out);
+  std::string report = out.str();
+
+  // Find occurrences of XAIE_IO_PREEMPT in the string
+  while ((pos = report.find("XAIE_IO_PREEMPT", pos)) != std::string::npos) {
+      pos += std::string("XAIE_IO_PREEMPT").length();
+      std::istringstream stream(report.substr(pos));
+      int value;
+      stream >> value;
+      count += value;
+  }
+
+  if (!count)
+    throw std::runtime_error("Preemptible kernel must have atleast 1 preemption checkpoint");
+
+  return count;
+}
+
+std::vector<std::pair<int, uint64_t>>
+get_fine_preemption_counters(device *dev)
+{
+  std::vector<std::pair<int, uint64_t>> counters;
+
+  const auto telemetry = device_query<query::rtos_telemetry>(dev);
+  for (auto& task : telemetry) {
+    auto user_tid = task.preemption_data.slot_index;
+    auto value = task.preemption_data.preemption_checkpoint_event;
+
+    counters.emplace_back(user_tid, value);
+  }
+  return counters;
+}
+
+int
+force_fine_preemption(device *dev, bool control)
+{
+  try {
+    device_update<query::preemption>(dev, static_cast<uint32_t>(control));
+  }
+  catch (const std::runtime_error& e) {
+    if (errno == EACCES) {
+      std::cerr << "User doesn't have admin privilege. Skipping force preemption.\n";
+      return -1;
+    }
+  }
+  catch (...) {
+    throw std::runtime_error("Caught an unknown exception.");
+  }
+
+  return 0;
 }
 
 } // namespace
@@ -223,7 +282,6 @@ elf_io_test_bo_set::
 elf_io_test_bo_set(device* dev, const std::string& xclbin_name) :
   io_test_bo_set_base(dev, xclbin_name)
   , m_elf(txn_file2elf(m_local_data_path + "/ml_txn.bin", m_local_data_path + "/pm_ctrlpkt.bin"))
-  , m_type(get_kernel_type(dev, xclbin_name.c_str()))
 {
   std::string file;
 
@@ -241,24 +299,6 @@ elf_io_test_bo_set(device* dev, const std::string& xclbin_name) :
       if (ibo.size == 0)
         throw std::runtime_error("instruction size cannot be 0");
       alloc_bo(ibo, m_dev, type);
-      break;
-    case IO_TEST_BO_SAVE_INSTRUCTION:
-      // Save instruction buffer is required for preemption kernel
-      if (m_type == KERNEL_TYPE_TXN_PREEMPT) {
-        ibo.size = exec_buf::get_ctrl_code_size(m_elf, xrt_core::patcher::buf_type::preempt_save);
-        if (ibo.size == 0)
-          throw std::runtime_error("save instruction size cannot be 0");
-        alloc_bo(ibo, m_dev, type);
-      }
-      break;
-    case IO_TEST_BO_RESTORE_INSTRUCTION:
-      // Restore instruction buffer is required for preemption kernel
-      if (m_type == KERNEL_TYPE_TXN_PREEMPT) {
-        ibo.size = exec_buf::get_ctrl_code_size(m_elf, xrt_core::patcher::buf_type::preempt_restore);
-        if (ibo.size == 0)
-          throw std::runtime_error("restore instruction size cannot be 0");
-        alloc_bo(ibo, m_dev, type);
-      }
       break;
     case IO_TEST_BO_INPUT:
       file = m_local_data_path + "/ifm.bin";
@@ -293,20 +333,99 @@ elf_io_test_bo_set(device* dev, const std::string& xclbin_name) :
         init_bo(ibo, file);
       }
       break;
+    case IO_TEST_BO_SAVE_INSTRUCTION:
+    case IO_TEST_BO_RESTORE_INSTRUCTION:
     case IO_TEST_BO_SCRATCH_PAD:
-      // Scratch pad buffer is required for preemption kernel
-      if (m_type == KERNEL_TYPE_TXN_PREEMPT) {
-        // Only support mem tile size for NPU4
-        const size_t mem_tile_sz = 512 * 1024;
-        ibo.size = mem_tile_sz * get_column_size(m_local_data_path + "/" + xclbin_name);
-        alloc_bo(ibo, m_dev, type);
-      }
+      // Save, restore instruction and scratch pad buffer is required for preemption kernel
       break;
     default:
       throw std::runtime_error("unknown BO type");
       break;
     }
   }
+}
+
+elf_preempt_io_test_bo_set::
+elf_preempt_io_test_bo_set(device* dev, const std::string& xclbin_name) :
+  io_test_bo_set_base(dev, xclbin_name)
+  , m_elf(txn_file2elf(m_local_data_path + "/ml_txn.bin", m_local_data_path + "/pm_ctrlpkt.bin"))
+  , m_total_fine_preemption_checkpoints(get_fine_preemption_checkpoints(m_elf))
+{
+  std::string file;
+
+  for (int i = 0; i < IO_TEST_BO_MAX_TYPES; i++) {
+    auto& ibo = m_bo_array[i];
+    auto type = static_cast<io_test_bo_type>(i);
+
+    switch(type) {
+    case IO_TEST_BO_CMD:
+      ibo.size = 0x1000;
+      alloc_bo(ibo, m_dev, type);
+      break;
+    case IO_TEST_BO_INSTRUCTION:
+      ibo.size = exec_buf::get_ctrl_code_size(m_elf, xrt_core::patcher::buf_type::ctrltext);
+      if (ibo.size == 0)
+        throw std::runtime_error("instruction size cannot be 0");
+      alloc_bo(ibo, m_dev, type);
+      break;
+    case IO_TEST_BO_SAVE_INSTRUCTION:
+      ibo.size = exec_buf::get_ctrl_code_size(m_elf, xrt_core::patcher::buf_type::preempt_save);
+      if (ibo.size == 0)
+        throw std::runtime_error("save instruction size cannot be 0");
+      alloc_bo(ibo, m_dev, type);
+      break;
+    case IO_TEST_BO_RESTORE_INSTRUCTION:
+      ibo.size = exec_buf::get_ctrl_code_size(m_elf, xrt_core::patcher::buf_type::preempt_restore);
+      if (ibo.size == 0)
+        throw std::runtime_error("restore instruction size cannot be 0");
+      alloc_bo(ibo, m_dev, type);
+      break;
+    case IO_TEST_BO_INPUT:
+      file = m_local_data_path + "/ifm.bin";
+      ibo.size = get_bin_size(file);
+      alloc_bo(ibo, m_dev, type);
+      init_bo(ibo, file);
+      break;
+    case IO_TEST_BO_PARAMETERS:
+      file = m_local_data_path + "/wts.bin";
+      ibo.size = get_bin_size(file);
+      // May not have wts.bin
+      if (ibo.size) {
+        alloc_bo(ibo, m_dev, type);
+        init_bo(ibo, file);
+      }
+      break;
+    case IO_TEST_BO_OUTPUT:
+      file = m_local_data_path + "/ofm.bin";
+      ibo.size = get_bin_size(file);
+      alloc_bo(ibo, m_dev, type);
+      break;
+    case IO_TEST_BO_INTERMEDIATE:
+    case IO_TEST_BO_MC_CODE:
+      // No need for intermediate/mc_code BO
+      break;
+    case IO_TEST_BO_CTRL_PKT_PM:
+      file = m_local_data_path + "/pm_ctrlpkt.bin";
+      ibo.size = get_bin_size(file);
+      // May not have pm_ctrlpkt.bin
+      if (ibo.size) {
+        alloc_bo(ibo, m_dev, type);
+        init_bo(ibo, file);
+      }
+      break;
+    case IO_TEST_BO_SCRATCH_PAD: {
+      // Only support mem tile size for NPU4
+      const size_t mem_tile_sz = 512 * 1024;
+
+      ibo.size = mem_tile_sz * get_column_size(m_local_data_path + "/" + xclbin_name);
+      alloc_bo(ibo, m_dev, type);
+      break;
+    }
+    default:
+      throw std::runtime_error("Unknown BO type");
+    }
+  }
+  ++m_total_cmds;
 }
 
 void
@@ -381,58 +500,76 @@ elf_io_test_bo_set::
 init_cmd(xrt_core::cuidx_type idx, bool dump)
 {
   auto dev_id = device_query<query::pcie_device>(m_dev);
-  uint32_t cmd;
+  uint32_t cmd = ERT_START_NPU;
 
-  switch (m_type) {
-  case KERNEL_TYPE_TXN:
-    cmd = ERT_START_NPU;
-    break;
-  case KERNEL_TYPE_TXN_PREEMPT:
-    cmd = ERT_START_NPU_PREEMPT;
-    break;
-  default:
-    throw std::runtime_error(std::string("Unknown kernel type: ") + std::to_string(m_type));
-  }
   exec_buf ebuf(*m_bo_array[IO_TEST_BO_CMD].tbo.get(), cmd);
   ebuf.set_cu_idx(idx);
-
-  if (m_type == KERNEL_TYPE_TXN_PREEMPT) {
-    ebuf.add_ctrl_bo(
-      *m_bo_array[IO_TEST_BO_INSTRUCTION].tbo.get(),
-      *m_bo_array[IO_TEST_BO_SAVE_INSTRUCTION].tbo.get(),
-      *m_bo_array[IO_TEST_BO_RESTORE_INSTRUCTION].tbo.get()
-    );
-  } else {
-    ebuf.add_ctrl_bo(*m_bo_array[IO_TEST_BO_INSTRUCTION].tbo.get());
-  }
-
+  ebuf.add_ctrl_bo(*m_bo_array[IO_TEST_BO_INSTRUCTION].tbo.get());
   ebuf.add_arg_64(3);
   ebuf.add_arg_64(0);
   ebuf.add_arg_32(0);
   ebuf.add_arg_bo(*m_bo_array[IO_TEST_BO_INPUT].tbo.get());
-  if (m_type == KERNEL_TYPE_TXN)
-    ebuf.add_arg_bo(*m_bo_array[IO_TEST_BO_PARAMETERS].tbo.get());
-  else
-    ebuf.add_arg_64(0);
+  ebuf.add_arg_bo(*m_bo_array[IO_TEST_BO_PARAMETERS].tbo.get());
   ebuf.add_arg_bo(*m_bo_array[IO_TEST_BO_OUTPUT].tbo.get());
   ebuf.add_arg_64(0);
   ebuf.add_arg_64(0);
-  if (m_type == KERNEL_TYPE_TXN_PREEMPT) {
-    ebuf.add_arg_bo(*m_bo_array[IO_TEST_BO_CTRL_PKT_PM].tbo.get(), "ctrlpkt-pm-0");
-    ebuf.add_arg_bo(*m_bo_array[IO_TEST_BO_CTRL_PKT_PM].tbo.get(), "ctrlpkt-pm-1");
-    ebuf.add_scratchpad_bo(*m_bo_array[IO_TEST_BO_SCRATCH_PAD].tbo.get());
-  }
   if (dump)
     ebuf.dump();
 
   ebuf.patch_ctrl_code(*m_bo_array[IO_TEST_BO_INSTRUCTION].tbo.get(),
     xrt_core::patcher::buf_type::ctrltext, m_elf);
-  if (m_type == KERNEL_TYPE_TXN_PREEMPT) {
-    ebuf.patch_ctrl_code(*m_bo_array[IO_TEST_BO_SAVE_INSTRUCTION].tbo.get(),
-      xrt_core::patcher::buf_type::preempt_save, m_elf);
-    ebuf.patch_ctrl_code(*m_bo_array[IO_TEST_BO_RESTORE_INSTRUCTION].tbo.get(),
-      xrt_core::patcher::buf_type::preempt_restore, m_elf);
+}
+
+void
+elf_preempt_io_test_bo_set::
+init_cmd(xrt_core::cuidx_type idx, bool dump)
+{
+  auto dev_id = device_query<query::pcie_device>(m_dev);
+  uint32_t cmd = ERT_START_NPU_PREEMPT;
+
+  exec_buf ebuf(*m_bo_array[IO_TEST_BO_CMD].tbo.get(), cmd);
+  ebuf.set_cu_idx(idx);
+  ebuf.add_ctrl_bo(
+    *m_bo_array[IO_TEST_BO_INSTRUCTION].tbo.get(),
+    *m_bo_array[IO_TEST_BO_SAVE_INSTRUCTION].tbo.get(),
+    *m_bo_array[IO_TEST_BO_RESTORE_INSTRUCTION].tbo.get()
+  );
+  ebuf.add_arg_64(3);
+  ebuf.add_arg_64(0);
+  ebuf.add_arg_32(0);
+  ebuf.add_arg_bo(*m_bo_array[IO_TEST_BO_INPUT].tbo.get());
+  ebuf.add_arg_64(0);
+  ebuf.add_arg_bo(*m_bo_array[IO_TEST_BO_OUTPUT].tbo.get());
+  ebuf.add_arg_64(0);
+  ebuf.add_arg_64(0);
+  ebuf.add_arg_bo(*m_bo_array[IO_TEST_BO_CTRL_PKT_PM].tbo.get(), "ctrlpkt-pm-0");
+  ebuf.add_arg_bo(*m_bo_array[IO_TEST_BO_CTRL_PKT_PM].tbo.get(), "ctrlpkt-pm-1");
+  ebuf.add_scratchpad_bo(*m_bo_array[IO_TEST_BO_SCRATCH_PAD].tbo.get());
+  if (dump)
+    ebuf.dump();
+
+  ebuf.patch_ctrl_code(*m_bo_array[IO_TEST_BO_INSTRUCTION].tbo.get(),
+    xrt_core::patcher::buf_type::ctrltext, m_elf);
+  ebuf.patch_ctrl_code(*m_bo_array[IO_TEST_BO_SAVE_INSTRUCTION].tbo.get(),
+    xrt_core::patcher::buf_type::preempt_save, m_elf);
+  ebuf.patch_ctrl_code(*m_bo_array[IO_TEST_BO_RESTORE_INSTRUCTION].tbo.get(),
+    xrt_core::patcher::buf_type::preempt_restore, m_elf);
+
+  if (force_fine_preemption(m_dev, true))
+    return;
+
+  const auto info = device_query<query::aie_partition_info>(m_dev);
+  auto pid = getpid();
+
+  for (auto& partition: info) {
+    if (partition.pid == pid)
+      m_user_tid = std::stoi(partition.metadata.id);
   }
+
+  if (m_user_tid == -1)
+    throw std::runtime_error("Invalid user task ID!");
+
+  m_fine_preemptions = get_fine_preemption_counters(m_dev);
 }
 
 // For debug only
@@ -489,6 +626,57 @@ verify_result()
   }
   if (count)
     throw std::runtime_error(std::to_string(count) + " bytes result mismatch!!!");
+}
+
+void
+elf_preempt_io_test_bo_set::
+verify_result()
+{
+  auto bo_ofm = m_bo_array[IO_TEST_BO_OUTPUT].tbo;
+  auto ofm_p = reinterpret_cast<char*>(bo_ofm->map());
+  auto sz = bo_ofm->size();
+
+  std::vector<char> buf_ofm_golden(sz);
+  auto ofm_golden_p = reinterpret_cast<char*>(buf_ofm_golden.data());
+  read_data_from_bin(m_local_data_path + "/ofm.bin", 0, sz, reinterpret_cast<int*>(ofm_golden_p));
+
+  auto [ valid_per_sec, sec_size, total_size ] = get_ofm_format(m_local_data_path + "/ofm_format.ini");
+  if (total_size == 0)
+    valid_per_sec = sec_size = total_size = sz;
+  size_t count = 0;
+  for (size_t i = 0; i < total_size; i += sec_size) {
+    for (size_t j = i; j < i + valid_per_sec; j++) {
+      if (ofm_p[i] != ofm_golden_p[i])
+        count++;
+    }
+  }
+  if (count)
+    throw std::runtime_error(std::to_string(count) + " bytes result mismatch!!!");
+
+  if (force_fine_preemption(m_dev, false))
+    return;
+
+  std::vector<std::pair<int, uint64_t>> post_run = get_fine_preemption_counters(m_dev);
+  uint64_t fine_preemption_count;
+  int hw_ctx_id = -1;
+
+  // Find the HW Context ID for the current user TID
+  for (auto i =  0; i < post_run.size(); i++) {
+    auto tid = post_run[i].first;
+
+    if (tid == m_user_tid) {
+      fine_preemption_count = post_run[i].second;
+      hw_ctx_id = i;
+      break;
+    }
+  }
+
+  if (hw_ctx_id == -1)
+    throw std::runtime_error("Invalid hw context ID");
+
+  auto delta = fine_preemption_count - m_fine_preemptions.at(hw_ctx_id).second;
+  if (m_total_fine_preemption_checkpoints * m_total_cmds != delta)
+    throw std::runtime_error("All cmds failed to preempt!");
 }
 
 const char *

--- a/test/shim_test/io.h
+++ b/test/shim_test/io.h
@@ -87,7 +87,7 @@ public:
   io_test_bo_set(device *dev);
 
   void
-  init_cmd(xrt_core::cuidx_type idx, bool dump) override; 
+  init_cmd(xrt_core::cuidx_type idx, bool dump) override;
 
   void
   verify_result() override;
@@ -99,14 +99,36 @@ public:
   elf_io_test_bo_set(device *dev, const std::string& xclbin_name);
 
   void
-  init_cmd(xrt_core::cuidx_type idx, bool dump) override; 
+  init_cmd(xrt_core::cuidx_type idx, bool dump) override;
 
   void
   verify_result() override;
 
 private:
   const xrt::elf m_elf;
-  const kernel_type m_type;
+};
+
+class elf_preempt_io_test_bo_set : public io_test_bo_set_base
+{
+public:
+  elf_preempt_io_test_bo_set(device *dev, const std::string& xclbin_name);
+
+  ~elf_preempt_io_test_bo_set() {
+    --m_total_cmds;
+  }
+
+  void
+  init_cmd(xrt_core::cuidx_type idx, bool dump) override;
+
+  void
+  verify_result() override;
+
+private:
+  const xrt::elf m_elf;
+  int m_user_tid = -1;
+  std::vector<std::pair<int, uint64_t>> m_fine_preemptions;
+  unsigned long m_total_fine_preemption_checkpoints;
+  static unsigned long m_total_cmds;
 };
 
 #endif // _SHIMTEST_IO_H_

--- a/test/shim_test/shim_test.cpp
+++ b/test/shim_test/shim_test.cpp
@@ -734,7 +734,6 @@ std::vector<test_case> test_list {
   test_case{ "Create and destroy devices", {},
     TEST_POSITIVE, dev_filter_is_aie2, TEST_create_destroy_device, {}
   },
-  // Disable for now. Require changes in XRT for argument patching.
   test_case{ "multi-command preempt ELF io test real kernel good run", {},
     TEST_POSITIVE, dev_filter_is_npu4, TEST_preempt_elf_io, { IO_TEST_NORMAL_RUN, 8 }
   },
@@ -899,10 +898,10 @@ main(int argc, char **argv)
       if (xclbin) {
         xclbin_path = optarg;
         std::cout << "Using xclbin file: " << xclbin_path << std::endl;
-	      break;
+        break;
       } else {
         std::cout << "Failed to open xclbin file: " << optarg << std::endl;
-	      return 1;
+        return 1;
       }
     }
     case 'k': {


### PR DESCRIPTION
This change adds functionality to validate preemptible kernels at each preemption point by enabling force preemption for a privileged user. Unprivileged user test will continue to validate the test compute output, without force preempting at each preemption point. Added functionality validates telemetry, force preemption, aiebu preemptible ELF generation, and runlist preemption code paths.