### PR TITLE
Fix xrt-smi advanced test order

### DIFF
--- a/src/shim/smi_xdna.cpp
+++ b/src/shim/smi_xdna.cpp
@@ -21,8 +21,8 @@ create_validate_subcommand()
     {"tct-all-col", "Measure average TCT processing time for all columns", "hidden"},
     {"tct-one-col", "Measure average TCT processing time for one column", "hidden"},
     {"throughput", "Run end-to-end throughput test", "common"},
-    {"preemption-overhead", "Measure preemption overhead at noop and memtile levels", "hidden"},
     {"temporal-sharing-overhead", "Run end-to-end temporal sharing overhead test", "hidden"},
+    {"preemption-overhead", "Measure preemption overhead at noop and memtile levels", "hidden"},
   };
 
   std::map<std::string, std::shared_ptr<xrt_core::smi::option>> validate_suboptions;


### PR DESCRIPTION
Swap the order of preemption-overhead and temporal-sharing-overhead tests to match MCDM.