### PR TITLE
[Branch 1.5] fix parition not able to shrink issue; fix a memory corruption issue (#581)

### DIFF
--- a/src/driver/amdxdna/aie2_ctx_runqueue.c
+++ b/src/driver/amdxdna/aie2_ctx_runqueue.c
@@ -718,17 +718,14 @@ static bool should_update_parts(struct aie2_ctx_rq *rq)
 	if (rq->paused && !part_ctx)
 		return true;
 
-	/*
-	 * The counter of partition cols is zero.
-	 * Trimming partition is needed.
-	 */
-	if (!rq->col_arr[part_col])
-		return true;
+	rq->max_cols = xdna->dev_handle->total_col;
+	while (rq->max_cols) {
+		if (rq->ctx_width_resv[rq->max_cols])
+			break;
 
-	/*
-	 * When max cols not equals to partition cols,
-	 * it needs to update partition cols to new max cols.
-	 */
+		rq->max_cols--;
+	}
+
 	if (rq->max_cols != part_col)
 		return true;
 
@@ -767,7 +764,6 @@ static void rq_parts_work(struct work_struct *work)
 	struct amdxdna_ctx *ctx;
 	struct amdxdna_ctx *tmp;
 	struct aie2_ctx_rq *rq;
-	u32 part_col;
 	int i;
 
 	rq = container_of(work, struct aie2_ctx_rq, parts_work);
@@ -782,18 +778,6 @@ static void rq_parts_work(struct work_struct *work)
 	if (handle_busy_ctxs(rq)) {
 		XDNA_DBG(xdna, "Wait for disconneting active contexts");
 		goto out;
-	}
-
-	part_col = get_part_cols(&rq->parts[0]);
-	if (rq->max_cols == part_col) {
-		/* Find out the next maximum column in records */
-		for (i = rq->max_cols; i > 0; i--) {
-			if (!rq->col_arr[i])
-				continue;
-
-			rq->max_cols = i;
-			break;
-		}
 	}
 
 	for (i = 0; i < rq->num_parts; i++)
@@ -1060,6 +1044,66 @@ void aie2_rq_submit_exit(struct amdxdna_ctx *ctx)
 	up_read(&ctx->priv->io_sem);
 }
 
+static bool
+aie2_enable_special_case(struct aie2_ctx_rq *rq, struct amdxdna_ctx *ctx)
+{
+	struct amdxdna_dev_hdl *ndev;
+	struct amdxdna_dev *xdna;
+
+	ndev = ctx_rq_to_ndev(rq);
+	xdna = ndev->xdna;
+	/*
+	 * Enable special case support when,
+	 * 1. The first column of the device is non-zero.
+	 * 2. The columns of context and device are the same.
+	 *
+	 * After spacial case support is enabled,
+	 * 1. Other context doesn't use all columns will fail to create.
+	 */
+	if (!xdna->dev_info->first_col) {
+		XDNA_DBG(xdna, "First column of the device is zero");
+		return false;
+	}
+
+	if (ctx->priv->orig_num_col != ndev->total_col) {
+		XDNA_DBG(xdna, "Context not the same as device total");
+		return false;
+	}
+
+	if (rq->ctx_cnt) {
+		XDNA_DBG(xdna, "Other context is running");
+		return false;
+	}
+
+	WARN_ON(!rq->start_col);
+	rq->start_col_orig = rq->start_col;
+	rq->start_col = 0;
+	rq->total_cols = ndev->total_col - rq->start_col;
+	XDNA_DBG(xdna, "Special case support enabled");
+
+	return true;
+}
+
+static void
+aie2_disable_special_case(struct aie2_ctx_rq *rq)
+{
+	struct amdxdna_dev_hdl *ndev;
+	struct amdxdna_dev *xdna;
+
+	ndev = ctx_rq_to_ndev(rq);
+	xdna = ndev->xdna;
+	if (!rq->start_col_orig)
+		return;
+
+	if (rq->ctx_cnt)
+		return;
+
+	rq->start_col = rq->start_col_orig;
+	rq->total_cols = ndev->total_col - rq->start_col;
+	rq->start_col_orig = 0;
+	XDNA_DBG(xdna, "Special case support disabled");
+}
+
 int aie2_rq_add(struct aie2_ctx_rq *rq, struct amdxdna_ctx *ctx)
 {
 	struct amdxdna_dev *xdna;
@@ -1089,11 +1133,19 @@ int aie2_rq_add(struct aie2_ctx_rq *rq, struct amdxdna_ctx *ctx)
 	}
 
 	num_col = ctx->priv->orig_num_col;
-	if (num_col > rq->total_cols) {
-		XDNA_ERR(xdna, "Require %d columns exceed %d",
-			 num_col, rq->total_cols);
-		ret = -ENOSPC;
+	if (rq->start_col_orig && num_col != rq->total_cols) {
+		XDNA_ERR(xdna, "Special context is running");
+		ret = -EBUSY;
 		goto error;
+	}
+
+	if (num_col > rq->total_cols) {
+		if (!aie2_enable_special_case(rq, ctx)) {
+			XDNA_ERR(xdna, "Require %d columns exceed %d",
+				 num_col, rq->total_cols);
+			ret = -ENOSPC;
+			goto error;
+		}
 	}
 
 	INIT_WORK(&ctx->dispatch_work, rq_dispatch_work);
@@ -1103,16 +1155,12 @@ int aie2_rq_add(struct aie2_ctx_rq *rq, struct amdxdna_ctx *ctx)
 	ctx->priv->should_block = false;
 	qos_to_rq_prio(ctx);
 
-	rq->col_arr[num_col]++;
+	rq->ctx_width_resv[num_col]++;
 	list_add_tail(&ctx->entry, &rq->disconn_list);
 	rq->ctx_cnt++;
 
-	if (num_col > rq->max_cols) {
-		rq->max_cols = num_col;
-		wait_parts = true;
-	}
-
-	if (!rq->ctx_cnt && num_col < rq->max_cols)
+	/* Expand partition is needed*/
+	if (num_col > rq->max_cols)
 		wait_parts = true;
 
 	if (ctx_is_rt(ctx)) {
@@ -1142,7 +1190,6 @@ void aie2_rq_del(struct aie2_ctx_rq *rq, struct amdxdna_ctx *ctx)
 	struct amdxdna_dev *xdna;
 	bool wait_parts = false;
 	u32 num_col;
-	int i;
 
 	xdna = ctx_rq_to_xdna_dev(rq);
 	mutex_lock(&xdna->dev_lock);
@@ -1159,16 +1206,12 @@ void aie2_rq_del(struct aie2_ctx_rq *rq, struct amdxdna_ctx *ctx)
 	}
 
 	num_col = ctx->priv->orig_num_col;
-	rq->col_arr[num_col]--;
-	if (!rq->col_arr[rq->max_cols]) {
-		for (i = rq->max_cols; i > 0; i--) {
-			if (!rq->col_arr[i])
-				continue;
+	rq->ctx_width_resv[num_col]--;
+	/* Shrink partition is needed */
+	if (!rq->ctx_width_resv[rq->max_cols])
+		wait_parts = true;
 
-			wait_parts = true;
-			break;
-		}
-	}
+	aie2_disable_special_case(rq);
 
 	if (wait_parts) {
 		list_add_tail(&ctx->parts_work_entry, &rq->parts_work_waitq);
@@ -1223,13 +1266,22 @@ int aie2_rq_init(struct aie2_ctx_rq *rq)
 	if (!rq->parts)
 		return -ENOMEM;
 
-	rq->col_arr = kcalloc(ndev->total_col, sizeof(*rq->col_arr), GFP_KERNEL);
-	if (!rq->col_arr)
+	rq->ctx_width_resv = kcalloc(ndev->total_col + 1, sizeof(*rq->ctx_width_resv), GFP_KERNEL);
+	if (!rq->ctx_width_resv)
 		goto free_parts;
+
+	/*
+	 * For temporal shared only device, hardcoding the all columns counter
+	 * to be 1.
+	 * 1. There will be only 1 partition to use all available columns.
+	 * 2. All contexts will expand and there will be no shrinking.
+	 */
+	if (ndev->priv->temporal_only)
+		rq->ctx_width_resv[rq->total_cols] = 1;
 
 	rq->work_q = alloc_ordered_workqueue("ctx_runqueue", 0);
 	if (!rq->work_q)
-		goto free_col_arr;
+		goto free_ctx_width_resv;
 
 	INIT_WORK(&rq->parts_work, rq_parts_work);
 	INIT_LIST_HEAD(&rq->parts_work_waitq);
@@ -1239,8 +1291,8 @@ int aie2_rq_init(struct aie2_ctx_rq *rq)
 
 	return 0;
 
-free_col_arr:
-	kfree(rq->col_arr);
+free_ctx_width_resv:
+	kfree(rq->ctx_width_resv);
 free_parts:
 	kfree(rq->parts);
 	return -ENOMEM;
@@ -1249,7 +1301,7 @@ free_parts:
 void aie2_rq_fini(struct aie2_ctx_rq *rq)
 {
 	destroy_workqueue(rq->work_q);
-	kfree(rq->col_arr);
+	kfree(rq->ctx_width_resv);
 	kfree(rq->parts);
 }
 

--- a/src/driver/amdxdna/aie2_pci.h
+++ b/src/driver/amdxdna/aie2_pci.h
@@ -281,6 +281,7 @@ struct aie2_ctx_rq {
 	u32			hwctx_limit;
 	u32			start_col;
 	u32			total_cols;
+	u32			start_col_orig;
 
 	struct workqueue_struct	*work_q;
 	struct work_struct	parts_work;
@@ -297,7 +298,7 @@ struct aie2_ctx_rq {
 	u32			num_parts;
 	u32			ctx_cnt;
 	u32			rt_ctx_cnt;
-	int			*col_arr;
+	int			*ctx_width_resv;
 	u32			max_cols;
 };
 
@@ -385,6 +386,7 @@ struct amdxdna_dev_priv {
 	u32				mbox_size;
 	u32				hwctx_limit; /* Hardware determine */
 	u32				ctx_limit; /* Driver determine */
+	u32				temporal_only;
 	u32				sram_dev_addr;
 	struct aie2_bar_off_pair	sram_offs[SRAM_MAX_INDEX];
 	struct aie2_bar_off_pair	psp_regs_off[PSP_MAX_REGS];

--- a/src/driver/amdxdna/npu1_regs.c
+++ b/src/driver/amdxdna/npu1_regs.c
@@ -75,6 +75,7 @@ const struct amdxdna_dev_priv npu1_dev_priv = {
 	.mbox_size      = 0, /* Use BAR size */
 	.hwctx_limit	= 6,
 	.ctx_limit	= 6,
+	.temporal_only	= 0,
 	.sram_dev_addr  = NPU1_SRAM_BAR_BASE,
 	.sram_offs      = {
 		DEFINE_BAR_OFFSET(MBOX_CHANN_OFF, NPU1_SRAM, MPNPU_SRAM_X2I_MAILBOX_0),

--- a/src/driver/amdxdna/npu4_family.h
+++ b/src/driver/amdxdna/npu4_family.h
@@ -77,6 +77,7 @@ extern const struct amdxdna_dev_priv npu4_dev_priv;
 	.sram_dev_addr  = NPU4_SRAM_BAR_BASE,							\
 	.hwctx_limit	= 16,									\
 	.ctx_limit	= 32,									\
+	.temporal_only	= 1,									\
 	.sram_offs      = {									\
 		DEFINE_BAR_OFFSET(MBOX_CHANN_OFF, NPU4_SRAM, MPNPU_SRAM_X2I_MAILBOX_0),		\
 		DEFINE_BAR_OFFSET(FW_ALIVE_OFF,   NPU4_SRAM, MPNPU_SRAM_X2I_MAILBOX_15),	\


### PR DESCRIPTION
Backport #581 to 1.5 branch with below fixes for EDGEML-10749 

------ 
* fix partition not able to shrink issue; fix a memory corruption issue
* Shrink partition only when context was destroyed; If all contexts are destroyed, shrink partition to 1 column
* Let update partition worker find out the max column. rq_add() and rq_dev() just udpate the col array counter
* for npu4, force temporal sharing
* auto detect special case on NPU1; rename col_arr to ctx_width_resv

---------