### PR TITLE
EDGEML-10861 launch polld should be at the end of create mailbox

### DIFF
--- a/src/driver/amdxdna/amdxdna_mailbox.c
+++ b/src/driver/amdxdna/amdxdna_mailbox.c
@@ -1006,11 +1006,19 @@ struct mailbox *xdna_mailbox_create(struct device *dev,
 	spin_lock_init(&mb->mbox_lock);
 	INIT_LIST_HEAD(&mb->chann_list);
 	INIT_LIST_HEAD(&mb->poll_chann_list);
+	init_waitqueue_head(&mb->poll_wait);
+	mb->sent_msg = false;
+
+#if defined(CONFIG_DEBUG_FS)
+	INIT_LIST_HEAD(&mb->res_records);
+#endif /* CONFIG_DEBUG_FS */
 
 	/*
 	 * The polld kthread will only wakeup and handle those
-	 * MB_CHANNEL_USER_POLL channels. If no thing to do, polld should
+	 * MB_CHANNEL_USER_POLL channels. If nothing to do, polld should
 	 * just sleep. It is a per device kthread.
+	 *
+	 * Note: make sure polld is the last thing to initialize.
 	 */
 	mb->polld = kthread_run(mailbox_polld, mb, MAILBOX_NAME);
 	if (IS_ERR(mb->polld)) {
@@ -1018,12 +1026,6 @@ struct mailbox *xdna_mailbox_create(struct device *dev,
 		kfree(mb);
 		return NULL;
 	}
-	init_waitqueue_head(&mb->poll_wait);
-	mb->sent_msg = false;
-
-#if defined(CONFIG_DEBUG_FS)
-	INIT_LIST_HEAD(&mb->res_records);
-#endif /* CONFIG_DEBUG_FS */
 
 	return mb;
 }


### PR DESCRIPTION
There is a race here when kthread polld launched but poll_wait is not initialized. This PR is to fix this issue.