### PR TITLE
A workaround for large heap buffer allocation

### DIFF
--- a/test/shim_test/io_test.cpp
+++ b/test/shim_test/io_test.cpp
@@ -59,6 +59,7 @@ alloc_and_init_bo_set(device* dev, const char *xclbin)
   if (io_test_parameters.type == IO_TEST_NOOP_RUN) {
     // Preparing no-op kernel's special control code
     size_t sz = 32 * sizeof(int32_t);
+    //size_t sz = 0x100000 * 128; // 128 MB
     auto tbo = std::make_shared<bo>(dev, sz, XCL_BO_FLAGS_CACHEABLE);
     bos[IO_TEST_BO_INSTRUCTION].tbo = tbo;
     std::memset(tbo->map(), 0, sz);

--- a/test/shim_test/shim_test.cpp
+++ b/test/shim_test/shim_test.cpp
@@ -782,6 +782,9 @@ std::vector<test_case> test_list {
   test_case{ "io test real kernel bad run for health report", {},
     TEST_POSITIVE, dev_filter_is_npu4, TEST_io, { IO_TEST_BAD_RUN_REPORT_CTX_PC, 1 }
   },
+  //test_case{ "io test no-op kernel good run", {},
+  //  TEST_POSITIVE, dev_filter_is_aie2, TEST_io, { IO_TEST_NOOP_RUN, 1 }
+  //},
 };
 
 // Test case executor implementation


### PR DESCRIPTION
The workaround is when heap BO size large than 64MB,
1. Allocate small dev BO in the first bank, where bank size is 64MB.
2. Allocate large dev BO start from the second bank.

The threshold of the small and large buffer is 64MB. Hack shim_test noop test to verify the code. 
The debug print in dmesg shows expected xdna_addr for dev BOs.