### PR TITLE
hmm invalidate should wait forever

### DIFF
--- a/src/driver/amdxdna/aie2_ctx.c
+++ b/src/driver/amdxdna/aie2_ctx.c
@@ -1066,17 +1066,11 @@ int aie2_cmd_wait(struct amdxdna_ctx *ctx, u64 seq, u32 timeout)
 void aie2_hmm_invalidate(struct amdxdna_gem_obj *abo, unsigned long cur_seq)
 {
 	struct drm_gem_object *gobj = to_gobj(abo);
-	long ret;
 
 	/*
 	 * Must wait forever, otherwise, memory was unmapped then FW might crash.
 	 * In case FW not response, TDR will terminal context execution and unref all BOs.
-	 * This loop will eventually exit.
 	 */
-	while (1) {
-		ret = dma_resv_wait_timeout(gobj->resv, DMA_RESV_USAGE_BOOKKEEP,
-					    true, MAX_SCHEDULE_TIMEOUT);
-		if (ret > 0)
-			break; /* Success */
-	}
+	dma_resv_wait_timeout(gobj->resv, DMA_RESV_USAGE_BOOKKEEP,
+			      false /* non-interruptible */, MAX_SCHEDULE_TIMEOUT);
 }

--- a/src/driver/amdxdna/aie2_ctx_runqueue.c
+++ b/src/driver/amdxdna/aie2_ctx_runqueue.c
@@ -922,6 +922,9 @@ void aie2_rq_restart_all(struct aie2_ctx_rq *rq)
 
 	xdna = ctx_rq_to_xdna_dev(rq);
 	mutex_lock(&xdna->dev_lock);
+	if (rq->paused)
+		queue_work(rq->work_q, &rq->parts_work);
+
 	for (i = 0; i < rq->num_parts; i++) {
 		part = &rq->parts[i];
 		queue_work(rq->work_q, &part->sched_work);


### PR DESCRIPTION
Based on dma_resv_wait_timeout() document, "Returns -ERESTARTSYS if interrupted, 0 if the wait timed out, or greater than zero on success."

aie2_hmm_invalidate() should only exit the loop on success.