### PR TITLE
Remove the dependancy of AIE_METADATA instead use AIE_TRACE_METADATA

### DIFF
--- a/src/shim_ve2/xdna_aie_array.cpp
+++ b/src/shim_ve2/xdna_aie_array.cpp
@@ -174,7 +174,7 @@ xdna_aie_array::
 get_driver_config_hwctx(const xrt_core::device* device, const xdna_hwctx* hwctx)
 {
   auto xclbin_uuid = hwctx ? hwctx->get_xclbin_uuid() : xrt::uuid();
-  auto data = device->get_axlf_section(AIE_METADATA, xclbin_uuid);
+  auto data = device->get_axlf_section(AIE_TRACE_METADATA, xclbin_uuid);
   if (!data.first || !data.second)
     return {};
 

--- a/src/shim_ve2/xdna_hwctx.cpp
+++ b/src/shim_ve2/xdna_hwctx.cpp
@@ -68,7 +68,7 @@ get_partition_info_main(const xrt_core::device* device,const pt::ptree& aie_meta
 partition_info
 get_partition_info_hw(const xrt_core::device* device, const xrt::uuid xclbin_uuid, uint32_t hw_context_id)
 {
-  auto data = device->get_axlf_section(AIE_METADATA, xclbin_uuid);
+  auto data = device->get_axlf_section(AIE_TRACE_METADATA, xclbin_uuid);
   if (!data.first || !data.second)
     return {};
 
@@ -110,7 +110,7 @@ xdna_hwctx(const device_xdna& dev, const xrt::xclbin& xclbin, const xrt::hw_cont
   m_info = get_partition_info_hw(&m_device, xclbin.get_uuid(), arg.handle);
   set_doorbell(arg.umq_doorbell);
 
-  auto data = m_device.get_axlf_section(AIE_METADATA, xclbin.get_uuid());
+  auto data = m_device.get_axlf_section(AIE_TRACE_METADATA, xclbin.get_uuid());
   if (data.first && data.second)
     m_aie_array = std::make_shared<xdna_aie_array>(&m_device, this);
 


### PR DESCRIPTION
Removing the dependancy of AIE_METADATA  in xclbin , instead use AIE_TRACE_METADATA to get the aie parition info data for the purpose of XDP profiling.