### PR TITLE
Added firmware query version to the telluride shim

### DIFF
--- a/tools/info.json
+++ b/tools/info.json
@@ -1,7 +1,7 @@
 {
 	"copyright": "Copyright (C) 2023-2025 Advanced Micro Devices, Inc. All rights reserved.",
 	"xrt" : {
-		"version": "202520.2.20.63",
+		"version": "202520.2.20.70",
 		"os_rel": ["22.04", "24.04"]
 	},
 	"firmwares": [


### PR DESCRIPTION
1. Added firmware query version to the telluride shim
2. Modified existing firmware query in xdna shim.
3. Required [changes](https://github.com/Xilinx/XRT/commit/53f0c575007521872bfdd073a031525bd79f343c) from XRT is merged to master.
4. Tested by builind and running tests on telluride.