### PR TITLE
disable userptr BO real kernel test

### DIFF
--- a/test/shim_test/io_test.cpp
+++ b/test/shim_test/io_test.cpp
@@ -424,7 +424,7 @@ TEST_preempt_elf_io(device::id_type id, std::shared_ptr<device>& sdev, const std
 void
 TEST_io_with_ubuf_bo(device::id_type id, std::shared_ptr<device>& sdev, arg_type& arg)
 {
-  io_test_bo_set boset{sdev.get(), true};
+  io_test_bo_set boset{sdev.get(), false};
   boset.run();
 }
 


### PR DESCRIPTION
This PR disables user pointer bo real kernel test (test case 62) for now until we can run it reliably.