### PR TITLE
Returning device id in the bdf instead of hardcoding

### DIFF
--- a/src/shim_ve2/xdna_device.cpp
+++ b/src/shim_ve2/xdna_device.cpp
@@ -66,7 +66,7 @@ struct bdf
   static result_type
   get(const xrt_core::device* device, key_type)
   {
-    return std::make_tuple(0,0,0,0);
+    return std::make_tuple(0,0,0,device->get_device_id());
   }
 
 };


### PR DESCRIPTION
Returning device id in the bdf instead of hardcoding