### PR TITLE
shim: device: add pci device handle to device class

### DIFF
--- a/src/shim/device.cpp
+++ b/src/shim/device.cpp
@@ -1444,6 +1444,7 @@ device::
 device(const pdev& pdev, handle_type shim_handle, id_type device_id)
   : noshim<xrt_core::device_pcie>{shim_handle, device_id, !pdev.m_is_mgmt}
   , m_pdev(pdev)
+  , m_pcidev_handle(xrt_core::pci::get_dev(device_id,is_userpf()))
 {
   m_pdev.open();
   shim_debug("Created device (%s) ...", m_pdev.m_sysfs_name.c_str());

--- a/src/shim/device.h
+++ b/src/shim/device.h
@@ -16,6 +16,11 @@ class device : public xrt_core::noshim<xrt_core::device_pcie>
 private:
   const pdev& m_pdev; // The pcidev that this device object is created from
 
+  // The shared pointer to the pcidev which this device is created from
+  // Hold the shared pointer in this object to make sure the underline pdev
+  // will not be released until this object is released.
+  std::shared_ptr<xrt_core::pci::dev> m_pcidev_handle;
+
   // Private look up function for concrete query::request
   const xrt_core::query::request&
   lookup_query(xrt_core::query::key_type query_key) const override;


### PR DESCRIPTION
Add pci device handle which is a shared pointer to xrt_core::pci::dev, which is the underline PCIe device to make sure the pci device will not get released before the shim_xdna device is released, otherwise, the application can get crash as shim_xdna will access xrt_core::pci::dev when it is closing the device.

At the moment, there is an issue if I keep create a `xrt::device` and keep it in global space, when application is complete, the cleanup sequence can release the `xrt_core::pci::dev` before releasing `xrt::device` which needs to access `xrt_core::pci::dev` during closing. This will result in segfault or invalid access or double free errors. here is the example:
```
#include <iostream>
std::shared_ptr<xrt::device> device;
int main(void)
{
  unsigned int device_index = 0;
  device = std::make_shared<xrt::device>(device_index);
  if (!device) {
    std::cout << "ERROR: faield to create device." << std::endl;
    return -1;
  }
  return 0;
}
```
The same issue happens if we put the `xrt::bo` to global space as releasing `xrt::bo` also needs to access `xrt_core::pci:dev`.