### PR TITLE
Add helper APIs to manage management buffer

### DIFF
--- a/src/driver/amdxdna/aie2_pci.c
+++ b/src/driver/amdxdna/aie2_pci.c
@@ -1014,9 +1014,9 @@ static int aie2_query_telemetry(struct amdxdna_client *client,
 {
 	struct amdxdna_drm_query_telemetry_header header, *tmp;
 	struct amdxdna_dev *xdna = client->xdna;
-	size_t aligned_sz, buff_sz, offset;
+	struct aie2_mgmt_dma_hdl mgmt_hdl;
 	struct aie_version ver;
-	dma_addr_t dma_addr;
+	size_t size, offset;
 	void *buff;
 	int ret, i;
 
@@ -1030,26 +1030,36 @@ static int aie2_query_telemetry(struct amdxdna_client *client,
 		return -EFAULT;
 	}
 
-	aligned_sz = PAGE_ALIGN(args->buffer_size);
-	buff = aie2_mgmt_buff_alloc(xdna->dev_handle, aligned_sz, &buff_sz, &dma_addr);
+	header.map_num_elements = xdna->dev_handle->ctx_rq.hwctx_limit;
+	offset = struct_size(&header, map, header.map_num_elements);
+	if (args->buffer_size < offset)
+		return -EINVAL;
+
+	/*
+	 * struct amdxdna_drm_query_telemetry_header sized bytes are reserved for metadata shared
+	 * between the driver and shim. Rest is for the data shared between the firmware and shim
+	 */
+	size = args->buffer_size - offset;
+
+	buff = aie2_mgmt_buff_alloc(xdna->dev_handle, &mgmt_hdl, size, DMA_FROM_DEVICE);
 	if (!buff)
 		return -ENOMEM;
 
-	memset(buff, 0, aligned_sz);
+	memset(buff, 0, size);
+	aie2_mgmt_buff_clflush(&mgmt_hdl);
 
-	drm_clflush_virt_range(buff, aligned_sz); /* device can access */
-
-	/* Reserve enough space for the driver to copy context map in the user buffer */
-	header.map_num_elements = xdna->dev_handle->ctx_rq.hwctx_limit;
-	offset = struct_size(&header, map, header.map_num_elements);
-	ret = aie2_query_aie_telemetry(xdna->dev_handle, header.type, dma_addr + offset,
-				       aligned_sz - offset, &ver);
+	ret = aie2_query_aie_telemetry(xdna->dev_handle, &mgmt_hdl, header.type, size, &ver);
 	if (ret) {
 		XDNA_ERR(xdna, "Get telemetry failed ret %d", ret);
 		goto free_buf;
 	}
 
-	tmp = (struct amdxdna_drm_query_telemetry_header *)buff;
+	tmp = kzalloc(offset, GFP_KERNEL);
+	if (!tmp) {
+		ret = -ENOMEM;
+		goto free_buf;
+	}
+
 	tmp->map_num_elements = header.map_num_elements;
 	tmp->type = header.type;
 	tmp->major = ver.major;
@@ -1064,14 +1074,19 @@ static int aie2_query_telemetry(struct amdxdna_client *client,
 		}
 	}
 
-	print_hex_dump_debug("telemetry: ", DUMP_PREFIX_OFFSET, 16, 4, buff,
-			     aligned_sz, false);
+	print_hex_dump_debug("telemetry: ", DUMP_PREFIX_OFFSET, 16, 4, buff, size, false);
 
-	if (copy_to_user(u64_to_user_ptr(args->buffer), buff, args->buffer_size))
+	if (copy_to_user(u64_to_user_ptr(args->buffer), tmp, offset)) {
+		ret = -EFAULT;
+		goto free_buf;
+	}
+
+	if (copy_to_user(u64_to_user_ptr(args->buffer + offset), buff, size))
 		ret = -EFAULT;
 
 free_buf:
-	aie2_mgmt_buff_free(xdna->dev_handle, buff_sz, buff, dma_addr);
+	kfree(tmp);
+	aie2_mgmt_buff_free(&mgmt_hdl);
 	return ret;
 }
 
@@ -1455,53 +1470,76 @@ static int aie2_set_state(struct amdxdna_client *client, struct amdxdna_drm_set_
 	return ret;
 }
 
-#define SPAN_64M_BOUNDARY(addr, size) \
-	((((unsigned long)(addr) & ((SZ_64M) - 1)) + (size)) > (SZ_64M))
-void *aie2_mgmt_buff_alloc(struct amdxdna_dev_hdl *ndev, size_t size, size_t *aligned_sz,
-			   dma_addr_t *dma_handle)
+void *aie2_mgmt_buff_alloc(struct amdxdna_dev_hdl *ndev, struct aie2_mgmt_dma_hdl *mgmt_hdl,
+			   size_t size, enum dma_data_direction dir)
 {
 	struct amdxdna_dev *xdna = ndev->xdna;
-	void *buf;
 
-	size = PAGE_ALIGN(size);
-	*aligned_sz = roundup_pow_of_two(size);
-	/* TODO: This workaround a FW issue. Remove this later */
-	*aligned_sz *= 2;
-
-	/*
-	 * Note: We test the behavior of dma_alloc_noncoherent() on 6.13 kernel.
-	 * 1. This function eventually goes to __alloc_frozen_pages_noprof().
-	 * 2. The maximum size is 4MB (limited by MAX_PAGE_ORDER 10), otherwise
-	 * this will return NULL pointer.
-	 * 3. For valid size, this function returns physical contiguous memory.
-	 *
-	 * Thoughts, if there is requirement for larger than 4MB physical
-	 * contiguous memory, consider allocate buffer from carvedout memory?
-	 */
-	buf = dma_alloc_noncoherent(xdna->ddev.dev, *aligned_sz, dma_handle,
-				    DMA_BIDIRECTIONAL, GFP_KERNEL);
-	if (!buf)
+	if (!size)
 		return NULL;
 
 	/*
-	 * FW doesn't allow buffer spans 64MB boundary.
-	 * Satisfied this by below two facts,
-	 * 1. The aligned_sz is power of 2 pages
-	 * 2. dma_alloc_noncoherent() should return size aligned dma_handle.
-	 *
-	 * If any of above changed, you will see WARN_ON.
+	 * The aligned size calculation is implemented to work around a known firmware issue that
+	 * can cause the system to hang. By aligning the size to the nearest power of two and then
+	 * doubling it, we ensure that the memory allocation is compatible with the firmware's
+	 * requirements, thus preventing potential system instability.
 	 */
-	WARN_ON(SPAN_64M_BOUNDARY(*dma_handle, *aligned_sz));
+	mgmt_hdl->aligned_size = PAGE_ALIGN(size);
+	mgmt_hdl->aligned_size = roundup_pow_of_two(mgmt_hdl->aligned_size);
+	mgmt_hdl->aligned_size *= 2;
 
-	return buf;
+	/*
+	 * The behavior of dma_alloc_noncoherent() was tested on the 6.13 kernel.
+	 * 1. This function eventually calls __alloc_frozen_pages_noprof().
+	 * 2. The maximum allocatable size is 4MB, constrained by MAX_PAGE_ORDER 10.
+	 *    Exceeding this limit results in a NULL pointer return.
+	 * 3. For valid sizes, this function provides physically contiguous memory.
+	 *
+	 * If there is a requirement for physical contiguous memory larger than 4MB,
+	 * consider allocating the buffer from carved-out memory.
+	 */
+	mgmt_hdl->vaddr = dma_alloc_noncoherent(xdna->ddev.dev, mgmt_hdl->aligned_size,
+						&mgmt_hdl->dma_hdl, dir, GFP_KERNEL);
+	if (!mgmt_hdl->vaddr)
+		return NULL;
+
+	mgmt_hdl->size = size;
+	mgmt_hdl->xdna = xdna;
+	mgmt_hdl->dir = dir;
+
+	return mgmt_hdl->vaddr;
 }
 
-void aie2_mgmt_buff_free(struct amdxdna_dev_hdl *ndev, size_t aligned_sz,
-			 void *vaddr, dma_addr_t dma_handle)
+void aie2_mgmt_buff_clflush(struct aie2_mgmt_dma_hdl *mgmt_hdl)
 {
-	struct amdxdna_dev *xdna = ndev->xdna;
+	/*
+	 * After flushing the buffer and handing it over to the device,
+	 * the user must wait for the device to complete its operations and return
+	 * control before attempting to write to the buffer again.
+	 */
+	drm_clflush_virt_range(mgmt_hdl->vaddr, mgmt_hdl->size);
+}
 
-	dma_free_noncoherent(xdna->ddev.dev, aligned_sz, vaddr, dma_handle, DMA_FROM_DEVICE);
+dma_addr_t aie2_mgmt_buff_get_dma_addr(struct aie2_mgmt_dma_hdl *mgmt_hdl)
+{
+	if (!mgmt_hdl->aligned_size)
+		return 0;
+
+	return mgmt_hdl->dma_hdl;
+}
+
+void *aie2_mgmt_buff_get_cpu_addr(struct aie2_mgmt_dma_hdl *mgmt_hdl)
+{
+	if (!mgmt_hdl->aligned_size)
+		return ERR_PTR(-EINVAL);
+
+	return mgmt_hdl->vaddr;
+}
+
+void aie2_mgmt_buff_free(struct aie2_mgmt_dma_hdl *mgmt_hdl)
+{
+	dma_free_noncoherent(mgmt_hdl->xdna->ddev.dev, mgmt_hdl->aligned_size, mgmt_hdl->vaddr,
+			     mgmt_hdl->dma_hdl, mgmt_hdl->dir);
 }
 
 const struct amdxdna_dev_ops aie2_ops = {

--- a/src/driver/amdxdna/aie2_pci.h
+++ b/src/driver/amdxdna/aie2_pci.h
@@ -400,6 +400,15 @@ struct amdxdna_dev_priv {
 #endif
 };
 
+struct aie2_mgmt_dma_hdl {
+	struct amdxdna_dev		*xdna;
+	enum dma_data_direction		dir;
+	void				*vaddr;
+	dma_addr_t			dma_hdl;
+	size_t				size;
+	size_t				aligned_size;
+};
+
 extern const struct amdxdna_dev_ops aie2_ops;
 
 static inline void aie2_calc_intr_reg(struct xdna_mailbox_chann_info *info)
@@ -417,10 +426,12 @@ int aie2_runtime_cfg(struct amdxdna_dev_hdl *ndev,
 extern uint aie2_control_flags;
 extern const struct amdxdna_dev_ops aie2_ops;
 int aie2_check_protocol(struct amdxdna_dev_hdl *ndev, u32 fw_major, u32 fw_minor);
-void *aie2_mgmt_buff_alloc(struct amdxdna_dev_hdl *ndev, size_t size, size_t *aligned_sz,
-			   dma_addr_t *dma_handle);
-void aie2_mgmt_buff_free(struct amdxdna_dev_hdl *ndev, size_t aligned_sz,
-			 void *vaddr, dma_addr_t dma_handle);
+void *aie2_mgmt_buff_alloc(struct amdxdna_dev_hdl *ndev, struct aie2_mgmt_dma_hdl *mgmt_hdl,
+			   size_t size, enum dma_data_direction dir);
+void aie2_mgmt_buff_clflush(struct aie2_mgmt_dma_hdl *mgmt_hdl);
+dma_addr_t aie2_mgmt_buff_get_dma_addr(struct aie2_mgmt_dma_hdl *mgmt_hdl);
+void *aie2_mgmt_buff_get_cpu_addr(struct aie2_mgmt_dma_hdl *mgmt_hdl);
+void aie2_mgmt_buff_free(struct aie2_mgmt_dma_hdl *mgmt_hdl);
 
 /* aie2_smu.c */
 int aie2_smu_start(struct amdxdna_dev_hdl *ndev);
@@ -487,10 +498,10 @@ int aie2_update_prop_time_quota(struct amdxdna_dev_hdl *ndev,
 				struct amdxdna_ctx *ctx, u32 us);
 int aie2_check_protocol_version(struct amdxdna_dev_hdl *ndev);
 int aie2_assign_mgmt_pasid(struct amdxdna_dev_hdl *ndev, u16 pasid);
-int aie2_query_aie_telemetry(struct amdxdna_dev_hdl *ndev, u32 type, dma_addr_t addr,
-			     u32 size, struct aie_version *version);
-int aie2_get_app_health(struct amdxdna_dev_hdl *ndev, u32 context_id,
-			dma_addr_t addr, u32 size);
+int aie2_query_aie_telemetry(struct amdxdna_dev_hdl *ndev, struct aie2_mgmt_dma_hdl *mgmt_hdl,
+			     u32 type, u32 size, struct aie_version *version);
+int aie2_get_app_health(struct amdxdna_dev_hdl *ndev, struct aie2_mgmt_dma_hdl *mgmt_hdl,
+			u32 context_id, u32 size);
 int aie2_query_aie_version(struct amdxdna_dev_hdl *ndev, struct aie_version *version);
 int aie2_query_aie_metadata(struct amdxdna_dev_hdl *ndev, struct aie_metadata *metadata);
 int aie2_query_aie_firmware_version(struct amdxdna_dev_hdl *ndev,
@@ -503,7 +514,7 @@ int aie2_create_context(struct amdxdna_dev_hdl *ndev, struct amdxdna_ctx *ctx,
 int aie2_destroy_context(struct amdxdna_dev_hdl *ndev, struct amdxdna_ctx *ctx);
 int aie2_map_host_buf(struct amdxdna_dev_hdl *ndev, u32 context_id, u64 addr, u64 size);
 int aie2_query_aie_status(struct amdxdna_dev_hdl *ndev, char *buf, u32 size, u32 *cols_filled);
-int aie2_register_asyn_event_msg(struct amdxdna_dev_hdl *ndev, dma_addr_t addr, u32 size,
+int aie2_register_asyn_event_msg(struct amdxdna_dev_hdl *ndev, struct aie2_mgmt_dma_hdl *mgmt_hdl,
 				 void *handle, int (*cb)(void*, void __iomem *, size_t));
 int aie2_self_test(struct amdxdna_dev_hdl *ndev);
 #ifdef AMDXDNA_DEVEL

--- a/src/shim/device.cpp
+++ b/src/shim/device.cpp
@@ -610,8 +610,6 @@ struct telemetry
     }
     case key_type::rtos_telemetry:
     {
-      amdxdna_drm_query_ctx* data;
-      const uint32_t output_size = 256 * sizeof(*data);
       query::rtos_telemetry::result_type output;
 
       auto device_id = sysfs_fcn<uint16_t>::get(get_pcidev(device), "", "device");
@@ -994,7 +992,7 @@ struct runner{
   static std::any
   get(const xrt_core::device* /*device*/, key_type key)
   {
-    throw xrt_core::query::no_such_key(key, "Not implemented"); 
+    throw xrt_core::query::no_such_key(key, "Not implemented");
   }
 
   static std::any


### PR DESCRIPTION
Add helper APIs to manage management buffer to limit the scope of implemented driver workaround to a known firmware issue. Align existing management buffer allocation to utilize these APIs.