### PR TITLE
change back _ctx to _hwctx

### DIFF
--- a/src/driver/amdxdna/aie2_ctx.c
+++ b/src/driver/amdxdna/aie2_ctx.c
@@ -679,7 +679,7 @@ void aie2_ctx_fini(struct amdxdna_ctx *ctx)
 
 static int aie2_ctx_cu_config(struct amdxdna_ctx *ctx, void *buf, u32 size)
 {
-	struct amdxdna_ctx_param_config_cu *config = buf;
+	struct amdxdna_hwctx_param_config_cu *config = buf;
 	struct amdxdna_dev *xdna = ctx->client->xdna;
 	u32 total_size;
 	int ret;
@@ -798,11 +798,11 @@ int aie2_ctx_config(struct amdxdna_ctx *ctx, u32 type, u64 value, void *buf, u32
 	struct amdxdna_dev *xdna = ctx->client->xdna;
 
 	switch (type) {
-	case DRM_AMDXDNA_CTX_CONFIG_CU:
+	case DRM_AMDXDNA_HWCTX_CONFIG_CU:
 		return aie2_ctx_cu_config(ctx, buf, size);
-	case DRM_AMDXDNA_CTX_ASSIGN_DBG_BUF:
+	case DRM_AMDXDNA_HWCTX_ASSIGN_DBG_BUF:
 		return aie2_ctx_attach_debug_bo(ctx, (u32)value);
-	case DRM_AMDXDNA_CTX_REMOVE_DBG_BUF:
+	case DRM_AMDXDNA_HWCTX_REMOVE_DBG_BUF:
 		return aie2_ctx_detach_debug_bo(ctx, (u32)value);
 	default:
 		XDNA_DBG(xdna, "Not supported type %d", type);

--- a/src/driver/amdxdna/aie2_debugfs.c
+++ b/src/driver/amdxdna/aie2_debugfs.c
@@ -663,9 +663,9 @@ static int aie2_ioctl_id_show(struct seq_file *m, void *unused)
 #define drm_ioctl_id_seq_print(_name) \
 seq_printf(m, "%ld:%s\n", _name, #_name)
 
-	drm_ioctl_id_seq_print(DRM_IOCTL_AMDXDNA_CREATE_CTX);
-	drm_ioctl_id_seq_print(DRM_IOCTL_AMDXDNA_DESTROY_CTX);
-	drm_ioctl_id_seq_print(DRM_IOCTL_AMDXDNA_CONFIG_CTX);
+	drm_ioctl_id_seq_print(DRM_IOCTL_AMDXDNA_CREATE_HWCTX);
+	drm_ioctl_id_seq_print(DRM_IOCTL_AMDXDNA_DESTROY_HWCTX);
+	drm_ioctl_id_seq_print(DRM_IOCTL_AMDXDNA_CONFIG_HWCTX);
 	drm_ioctl_id_seq_print(DRM_IOCTL_AMDXDNA_CREATE_BO);
 	drm_ioctl_id_seq_print(DRM_IOCTL_AMDXDNA_GET_BO_INFO);
 	drm_ioctl_id_seq_print(DRM_IOCTL_AMDXDNA_SYNC_BO);

--- a/src/driver/amdxdna/aie2_pci.c
+++ b/src/driver/amdxdna/aie2_pci.c
@@ -942,9 +942,9 @@ static int aie2_query_sensors(struct amdxdna_client *client,
 static int aie2_query_ctx_status(struct amdxdna_client *client,
 				 struct amdxdna_drm_get_info *args)
 {
-	struct amdxdna_drm_query_ctx __user *buf;
+	struct amdxdna_drm_query_hwctx __user *buf;
 	struct amdxdna_dev *xdna = client->xdna;
-	struct amdxdna_drm_query_ctx *tmp;
+	struct amdxdna_drm_query_hwctx *tmp;
 	struct amdxdna_client *tmp_client;
 	struct amdxdna_ctx *ctx;
 	unsigned long ctx_id;
@@ -1236,8 +1236,8 @@ static int aie2_get_info(struct amdxdna_client *client, struct amdxdna_drm_get_i
 static int aie2_query_ctx_status_array(struct amdxdna_client *client,
 				       struct amdxdna_drm_get_info_array *args)
 {
-	struct amdxdna_drm_query_ctx_array __user *buf;
-	struct amdxdna_drm_query_ctx_array *tmp;
+	struct amdxdna_drm_query_hwctx_array __user *buf;
+	struct amdxdna_drm_query_hwctx_array *tmp;
 	struct amdxdna_dev *xdna = client->xdna;
 	int idx, ctx_limit, ctx_cnt, min, i;
 	struct amdxdna_client *tmp_client;
@@ -1302,9 +1302,9 @@ static int aie2_query_ctx_status_array(struct amdxdna_client *client,
 			tmp[hw_i].suspensions = ctx->priv->disconn_cnt;
 
 			if (ctx->priv->active)
-				tmp[hw_i].state = AMDXDNA_CTX_STATE_ACTIVE;
+				tmp[hw_i].state = AMDXDNA_HWCTX_STATE_ACTIVE;
 			else
-				tmp[hw_i].state = AMDXDNA_CTX_STATE_IDLE;
+				tmp[hw_i].state = AMDXDNA_HWCTX_STATE_IDLE;
 
 			hw_i++;
 		}

--- a/src/driver/amdxdna/amdxdna_ctx.c
+++ b/src/driver/amdxdna/amdxdna_ctx.c
@@ -71,7 +71,7 @@ static void amdxdna_ctx_destroy_rcu(struct amdxdna_ctx *ctx, struct srcu_struct 
 /*
  * This should be called in flush() and remove(). DO NOT call in other syscalls.
  * This guarantee that when ctx and resources will be released, if user
- * doesn't call amdxdna_drm_destroy_ctx_ioctl.
+ * doesn't call amdxdna_drm_destroy_hwctx_ioctl.
  */
 void amdxdna_ctx_remove_all(struct amdxdna_client *client)
 {
@@ -86,10 +86,10 @@ void amdxdna_ctx_remove_all(struct amdxdna_client *client)
 	}
 }
 
-int amdxdna_drm_create_ctx_ioctl(struct drm_device *dev, void *data, struct drm_file *filp)
+int amdxdna_drm_create_hwctx_ioctl(struct drm_device *dev, void *data, struct drm_file *filp)
 {
 	struct amdxdna_client *client = filp->driver_priv;
-	struct amdxdna_drm_create_ctx *args = data;
+	struct amdxdna_drm_create_hwctx *args = data;
 	struct amdxdna_dev *xdna = to_xdna_dev(dev);
 	struct amdxdna_ctx *ctx;
 	int ret, idx;
@@ -166,10 +166,10 @@ exit:
 	return ret;
 }
 
-int amdxdna_drm_destroy_ctx_ioctl(struct drm_device *dev, void *data, struct drm_file *filp)
+int amdxdna_drm_destroy_hwctx_ioctl(struct drm_device *dev, void *data, struct drm_file *filp)
 {
 	struct amdxdna_client *client = filp->driver_priv;
-	struct amdxdna_drm_destroy_ctx *args = data;
+	struct amdxdna_drm_destroy_hwctx *args = data;
 	struct amdxdna_dev *xdna = to_xdna_dev(dev);
 	struct amdxdna_ctx *ctx;
 	int ret, idx;
@@ -199,10 +199,10 @@ out:
 	return ret;
 }
 
-int amdxdna_drm_config_ctx_ioctl(struct drm_device *dev, void *data, struct drm_file *filp)
+int amdxdna_drm_config_hwctx_ioctl(struct drm_device *dev, void *data, struct drm_file *filp)
 {
 	struct amdxdna_client *client = filp->driver_priv;
-	struct amdxdna_drm_config_ctx *args = data;
+	struct amdxdna_drm_config_hwctx *args = data;
 	struct amdxdna_dev *xdna = to_xdna_dev(dev);
 	struct amdxdna_ctx *ctx;
 	int ret, idx;
@@ -217,7 +217,7 @@ int amdxdna_drm_config_ctx_ioctl(struct drm_device *dev, void *data, struct drm_
 	buf_size = args->param_val_size;
 
 	switch (args->param_type) {
-	case DRM_AMDXDNA_CTX_CONFIG_CU:
+	case DRM_AMDXDNA_HWCTX_CONFIG_CU:
 		/* For those types that param_val is pointer */
 		if (buf_size > PAGE_SIZE) {
 			XDNA_ERR(xdna, "Config CU param buffer too large");
@@ -234,8 +234,8 @@ int amdxdna_drm_config_ctx_ioctl(struct drm_device *dev, void *data, struct drm_
 		}
 
 		break;
-	case DRM_AMDXDNA_CTX_ASSIGN_DBG_BUF:
-	case DRM_AMDXDNA_CTX_REMOVE_DBG_BUF:
+	case DRM_AMDXDNA_HWCTX_ASSIGN_DBG_BUF:
+	case DRM_AMDXDNA_HWCTX_REMOVE_DBG_BUF:
 		/* For those types that param_val is a value */
 		buf = NULL;
 		buf_size = 0;
@@ -538,7 +538,7 @@ static int amdxdna_drm_submit_execbuf(struct amdxdna_client *client,
 	}
 
 	ret = amdxdna_cmd_submit(client, OP_USER, cmd_bo_hdl, arg_bo_hdls,
-				 args->arg_count, NULL, NULL, 0, args->ctx, &args->seq);
+				 args->arg_count, NULL, NULL, 0, args->hwctx, &args->seq);
 
 free_cmd_bo_hdls:
 	kfree(arg_bo_hdls);
@@ -589,7 +589,7 @@ static int amdxdna_drm_submit_dependency(struct amdxdna_client *client,
 
 	ret = amdxdna_cmd_submit(client, OP_NOOP, AMDXDNA_INVALID_BO_HANDLE, NULL, 0,
 				 syncobj_hdls, syncobj_pts, syncobj_cnt,
-				 args->ctx, &args->seq);
+				 args->hwctx, &args->seq);
 
 done:
 	kfree(argbuf);
@@ -607,7 +607,7 @@ static int amdxdna_drm_submit_signal(struct amdxdna_client *client,
 	struct dma_fence *ofence = NULL;
 	u64 syncobj_pt = args->args;
 	struct drm_syncobj *syncobj;
-	u32 ctx_hdl = args->ctx;
+	u32 ctx_hdl = args->hwctx;
 	struct amdxdna_ctx *ctx;
 	int ret = 0;
 	int idx;
@@ -739,12 +739,12 @@ int amdxdna_drm_wait_cmd_ioctl(struct drm_device *dev, void *data, struct drm_fi
 		return ret;
 
 	XDNA_DBG(xdna, "PID %d ctx %d timeout set %d ms for cmd %lld",
-		 client->pid, args->ctx, args->timeout, args->seq);
+		 client->pid, args->hwctx, args->timeout, args->seq);
 
-	ret = amdxdna_cmd_wait(client, args->ctx, args->seq, args->timeout);
+	ret = amdxdna_cmd_wait(client, args->hwctx, args->seq, args->timeout);
 
 	XDNA_DBG(xdna, "PID %d ctx %d cmd %lld wait finished, ret %d",
-		 client->pid, args->ctx, args->seq, ret);
+		 client->pid, args->hwctx, args->seq, ret);
 
 	amdxdna_pm_suspend_put(dev->dev);
 	return ret;

--- a/src/driver/amdxdna/amdxdna_ctx.h
+++ b/src/driver/amdxdna/amdxdna_ctx.h
@@ -131,7 +131,7 @@ struct amdxdna_ctx {
 	u32				doorbell_offset;
 
 	struct amdxdna_qos_info		     qos;
-	struct amdxdna_ctx_param_config_cu *cus;
+	struct amdxdna_hwctx_param_config_cu *cus;
 
 	/* Submitted, completed, freed job counter */
 	u64				submitted;
@@ -283,9 +283,9 @@ int amdxdna_cmd_submit(struct amdxdna_client *client, u32 opcode,
 int amdxdna_cmd_wait(struct amdxdna_client *client, u32 ctx_hdl,
 		     u64 seq, u32 timeout);
 
-int amdxdna_drm_create_ctx_ioctl(struct drm_device *dev, void *data, struct drm_file *filp);
-int amdxdna_drm_config_ctx_ioctl(struct drm_device *dev, void *data, struct drm_file *filp);
-int amdxdna_drm_destroy_ctx_ioctl(struct drm_device *dev, void *data, struct drm_file *filp);
+int amdxdna_drm_create_hwctx_ioctl(struct drm_device *dev, void *data, struct drm_file *filp);
+int amdxdna_drm_config_hwctx_ioctl(struct drm_device *dev, void *data, struct drm_file *filp);
+int amdxdna_drm_destroy_hwctx_ioctl(struct drm_device *dev, void *data, struct drm_file *filp);
 int amdxdna_drm_submit_cmd_ioctl(struct drm_device *dev, void *data, struct drm_file *filp);
 int amdxdna_drm_wait_cmd_ioctl(struct drm_device *dev, void *data, struct drm_file *filp);
 

--- a/src/driver/amdxdna/amdxdna_drm.c
+++ b/src/driver/amdxdna/amdxdna_drm.c
@@ -234,9 +234,9 @@ exit:
 
 static const struct drm_ioctl_desc amdxdna_drm_ioctls[] = {
 	/* Context */
-	DRM_IOCTL_DEF_DRV(AMDXDNA_CREATE_CTX, amdxdna_drm_create_ctx_ioctl, 0),
-	DRM_IOCTL_DEF_DRV(AMDXDNA_DESTROY_CTX, amdxdna_drm_destroy_ctx_ioctl, 0),
-	DRM_IOCTL_DEF_DRV(AMDXDNA_CONFIG_CTX, amdxdna_drm_config_ctx_ioctl, 0),
+	DRM_IOCTL_DEF_DRV(AMDXDNA_CREATE_HWCTX, amdxdna_drm_create_hwctx_ioctl, 0),
+	DRM_IOCTL_DEF_DRV(AMDXDNA_DESTROY_HWCTX, amdxdna_drm_destroy_hwctx_ioctl, 0),
+	DRM_IOCTL_DEF_DRV(AMDXDNA_CONFIG_HWCTX, amdxdna_drm_config_hwctx_ioctl, 0),
 	/* BO */
 	DRM_IOCTL_DEF_DRV(AMDXDNA_CREATE_BO, amdxdna_drm_create_bo_ioctl, 0),
 	DRM_IOCTL_DEF_DRV(AMDXDNA_GET_BO_INFO, amdxdna_drm_get_bo_info_ioctl, 0),

--- a/src/include/uapi/drm_local/amdxdna_accel.h
+++ b/src/include/uapi/drm_local/amdxdna_accel.h
@@ -47,9 +47,9 @@ extern "C" {
  * We don't have extension now. The extension struct will define in the future.
  */
 
-#define	DRM_AMDXDNA_CREATE_CTX		0
-#define	DRM_AMDXDNA_DESTROY_CTX		1
-#define	DRM_AMDXDNA_CONFIG_CTX		2
+#define	DRM_AMDXDNA_CREATE_HWCTX		0
+#define	DRM_AMDXDNA_DESTROY_HWCTX		1
+#define	DRM_AMDXDNA_CONFIG_HWCTX		2
 #define	DRM_AMDXDNA_CREATE_BO		3
 #define	DRM_AMDXDNA_GET_BO_INFO		4
 #define	DRM_AMDXDNA_SYNC_BO		5
@@ -102,7 +102,7 @@ struct amdxdna_qos_info {
 };
 
 /**
- * struct amdxdna_drm_create_ctx - Create context.
+ * struct amdxdna_drm_create_hwctx - Create context.
  * @ext: MBZ.
  * @ext_flags: MBZ.
  * @qos_p: Address of QoS info.
@@ -115,7 +115,7 @@ struct amdxdna_qos_info {
  * @handle: Returned context handle.
  * @syncobj_handle: The drm timeline syncobj handle for command completion notification.
  */
-struct amdxdna_drm_create_ctx {
+struct amdxdna_drm_create_hwctx {
 	__u64 ext;
 	__u64 ext_flags;
 	__u64 qos_p;
@@ -130,11 +130,11 @@ struct amdxdna_drm_create_ctx {
 };
 
 /**
- * struct amdxdna_drm_destroy_ctx - Destroy context.
+ * struct amdxdna_drm_destroy_hwctx - Destroy context.
  * @handle: Context handle.
  * @pad: Structure padding.
  */
-struct amdxdna_drm_destroy_ctx {
+struct amdxdna_drm_destroy_hwctx {
 	__u32 handle;
 	__u32 pad;
 };
@@ -152,12 +152,12 @@ struct amdxdna_cu_config {
 };
 
 /**
- * struct amdxdna_ctx_param_config_cu - configuration for CUs in context
+ * struct amdxdna_hwctx_param_config_cu - configuration for CUs in context
  * @num_cus: Number of CUs to configure.
  * @pad: Structure padding.
  * @cu_configs: Array of CU configurations of struct amdxdna_cu_config.
  */
-struct amdxdna_ctx_param_config_cu {
+struct amdxdna_hwctx_param_config_cu {
 	__u16 num_cus;
 	__u16 pad[3];
 	struct amdxdna_cu_config cu_configs[];
@@ -197,7 +197,7 @@ struct fw_buffer_metadata {
 };
 
 /**
- * struct amdxdna_drm_config_ctx - Configure context.
+ * struct amdxdna_drm_config_hwctx - Configure context.
  * @handle: Context handle.
  * @param_type: Specifies the structure passed in via param_val.
  * @param_val: A structure specified by the param_type struct member.
@@ -208,11 +208,11 @@ struct fw_buffer_metadata {
  * Note: if the param_val is a pointer pointing to a buffer, the maximum size
  * of the buffer is 4KiB(PAGE_SIZE).
  */
-struct amdxdna_drm_config_ctx {
+struct amdxdna_drm_config_hwctx {
 	__u32 handle;
-#define DRM_AMDXDNA_CTX_CONFIG_CU	0
-#define DRM_AMDXDNA_CTX_ASSIGN_DBG_BUF	1
-#define DRM_AMDXDNA_CTX_REMOVE_DBG_BUF	2
+#define DRM_AMDXDNA_HWCTX_CONFIG_CU	0
+#define DRM_AMDXDNA_HWCTX_ASSIGN_DBG_BUF	1
+#define DRM_AMDXDNA_HWCTX_REMOVE_DBG_BUF	2
 	__u32 param_type;
 	__u64 param_val;
 	__u32 param_val_size;
@@ -315,7 +315,7 @@ struct amdxdna_drm_sync_bo {
 struct amdxdna_drm_exec_cmd {
 	__u64 ext;
 	__u64 ext_flags;
-	__u32 ctx;
+	__u32 hwctx;
 #define	AMDXDNA_CMD_SUBMIT_EXEC_BUF	0
 #define	AMDXDNA_CMD_SUBMIT_DEPENDENCY	1
 #define	AMDXDNA_CMD_SUBMIT_SIGNAL	2
@@ -337,7 +337,7 @@ struct amdxdna_drm_exec_cmd {
  * Wait a command specified by seq to be completed.
  */
 struct amdxdna_drm_wait_cmd {
-	__u32 ctx;
+	__u32 hwctx;
 	__u32 timeout;
 	__u64 seq;
 };
@@ -452,7 +452,7 @@ struct amdxdna_drm_query_sensor {
 };
 
 /**
- * struct amdxdna_drm_query_ctx - The data for single context.
+ * struct amdxdna_drm_query_hwctx - The data for single context.
  * @context_id: The ID for this context.
  * @start_col: The starting column for the partition assigned to this context.
  * @num_col: The number of columns in the partition assigned to this context.
@@ -467,7 +467,7 @@ struct amdxdna_drm_query_sensor {
  *
  * !!! NOTE: Never expand this struct. Use amdxdna_drm_query_ctx_array instead. !!!
  */
-struct amdxdna_drm_query_ctx {
+struct amdxdna_drm_query_hwctx {
 	__u32 context_id;
 	__u32 start_col;
 	__u32 num_col;
@@ -603,7 +603,7 @@ struct amdxdna_drm_query_telemetry_header {
 	__u32 minor;
 	__u32 type;
 	__u32 map_num_elements;
-	__u32 map[] __counted_by(map_num_elements);
+	__u32 map[];
 };
 
 /**
@@ -657,7 +657,7 @@ struct amdxdna_drm_get_info {
  * @latency: Frame response latency
  * @frame_exec_time: Frame execution time
  */
-struct amdxdna_drm_query_ctx_array {
+struct amdxdna_drm_query_hwctx_array {
 	__u32 context_id;
 	__u32 start_col;
 	__u32 num_col;
@@ -671,8 +671,8 @@ struct amdxdna_drm_query_ctx_array {
 	__u64 priority;
 	__u64 heap_usage;
 	__u64 suspensions;
-#define AMDXDNA_CTX_STATE_IDLE		0
-#define AMDXDNA_CTX_STATE_ACTIVE	1
+#define AMDXDNA_HWCTX_STATE_IDLE	0
+#define AMDXDNA_HWCTX_STATE_ACTIVE	1
 	__u32 state;
 	__u32 pasid;
 	__u32 gops;
@@ -726,17 +726,17 @@ struct amdxdna_drm_set_state {
 	__u64 buffer; /* in */
 };
 
-#define DRM_IOCTL_AMDXDNA_CREATE_CTX \
-	DRM_IOWR(DRM_COMMAND_BASE + DRM_AMDXDNA_CREATE_CTX, \
-		 struct amdxdna_drm_create_ctx)
+#define DRM_IOCTL_AMDXDNA_CREATE_HWCTX \
+	DRM_IOWR(DRM_COMMAND_BASE + DRM_AMDXDNA_CREATE_HWCTX, \
+		 struct amdxdna_drm_create_hwctx)
 
-#define DRM_IOCTL_AMDXDNA_DESTROY_CTX \
-	DRM_IOWR(DRM_COMMAND_BASE + DRM_AMDXDNA_DESTROY_CTX, \
-		 struct amdxdna_drm_destroy_ctx)
+#define DRM_IOCTL_AMDXDNA_DESTROY_HWCTX \
+	DRM_IOWR(DRM_COMMAND_BASE + DRM_AMDXDNA_DESTROY_HWCTX, \
+		 struct amdxdna_drm_destroy_hwctx)
 
-#define DRM_IOCTL_AMDXDNA_CONFIG_CTX \
-	DRM_IOWR(DRM_COMMAND_BASE + DRM_AMDXDNA_CONFIG_CTX, \
-		 struct amdxdna_drm_config_ctx)
+#define DRM_IOCTL_AMDXDNA_CONFIG_HWCTX \
+	DRM_IOWR(DRM_COMMAND_BASE + DRM_AMDXDNA_CONFIG_HWCTX, \
+		 struct amdxdna_drm_config_hwctx)
 
 #define DRM_IOCTL_AMDXDNA_CREATE_BO \
 	DRM_IOWR(DRM_COMMAND_BASE + DRM_AMDXDNA_CREATE_BO, \

--- a/src/shim/device.cpp
+++ b/src/shim/device.cpp
@@ -234,7 +234,7 @@ struct partition_info
     if (key != key_type::aie_partition_info)
       throw xrt_core::query::no_such_key(key, "Not implemented");
 
-    amdxdna_drm_query_ctx_array* data;
+    amdxdna_drm_query_hwctx_array* data;
     const uint32_t output_size = 32 * sizeof(*data);
 
     std::vector<char> payload(output_size);
@@ -254,7 +254,7 @@ struct partition_info
     } catch (const xrt_core::system_error& e) {
       if (e.get_code() == -EINVAL) {
         // If ioctl not supported, use legacy ioctl.
-        amdxdna_drm_query_ctx* legacy_data;
+        amdxdna_drm_query_hwctx* legacy_data;
         const uint32_t legacy_output_size = 256 * sizeof(*legacy_data);
         std::vector<char> legacy_payload(legacy_output_size);
         amdxdna_drm_get_info legacy_arg = {
@@ -335,7 +335,7 @@ struct partition_info
       new_entry.instruction_mem = entry.heap_usage;
       new_entry.pasid = entry.pasid;
       new_entry.suspensions = entry.suspensions;
-      new_entry.is_suspended = entry.state == AMDXDNA_CTX_STATE_IDLE;
+      new_entry.is_suspended = entry.state == AMDXDNA_HWCTX_STATE_IDLE;
       output.push_back(std::move(new_entry));
     }
     return output;

--- a/src/shim/kmq/hwctx.cpp
+++ b/src/shim/kmq/hwctx.cpp
@@ -8,7 +8,7 @@ namespace {
 
 // For debug only
 void
-print_cu_config(amdxdna_ctx_param_config_cu *config)
+print_cu_config(amdxdna_hwctx_param_config_cu *config)
 {
   auto n = config->num_cus;
   auto conf = config->cu_configs;
@@ -27,8 +27,8 @@ hwctx_kmq(const device& device, const xrt::xclbin& xclbin, const qos_type& qos)
 {
   xclbin_parser xp(xclbin);
   std::vector<char> cu_conf_param_buf(
-    sizeof(amdxdna_ctx_param_config_cu) + xp.get_num_cus() * sizeof(amdxdna_cu_config));
-  auto cu_conf_param = reinterpret_cast<amdxdna_ctx_param_config_cu *>(cu_conf_param_buf.data());
+    sizeof(amdxdna_hwctx_param_config_cu) + xp.get_num_cus() * sizeof(amdxdna_cu_config));
+  auto cu_conf_param = reinterpret_cast<amdxdna_hwctx_param_config_cu *>(cu_conf_param_buf.data());
 
   cu_conf_param->num_cus = xp.get_num_cus();
   xcl_bo_flags f = {};

--- a/src/shim/virtio/platform_virtio.cpp
+++ b/src/shim/virtio/platform_virtio.cpp
@@ -487,13 +487,13 @@ config_ctx_cu_config(config_ctx_cu_config_arg& arg) const
 {
   std::vector<char> cu_conf_param_buf(sizeof(amdxdna_ccmd_config_ctx_req) + arg.conf_buf.size());
   auto cu_conf_req = reinterpret_cast<amdxdna_ccmd_config_ctx_req *>(cu_conf_param_buf.data());
-  auto cu_conf_param = reinterpret_cast<amdxdna_ctx_param_config_cu *>(cu_conf_req->param_val);
+  auto cu_conf_param = reinterpret_cast<amdxdna_hwctx_param_config_cu *>(cu_conf_req->param_val);
 
   cu_conf_req->hdr.cmd = AMDXDNA_CCMD_CONFIG_CTX;
   cu_conf_req->hdr.len = cu_conf_param_buf.size();
   cu_conf_req->hdr.rsp_off = 0;
   cu_conf_req->handle = arg.ctx_handle;
-  cu_conf_req->param_type = DRM_AMDXDNA_CTX_CONFIG_CU;
+  cu_conf_req->param_type = DRM_AMDXDNA_HWCTX_CONFIG_CU;
   cu_conf_req->param_val_size = cu_conf_req->hdr.len - sizeof(amdxdna_ccmd_config_ctx_req);
   std::memcpy(cu_conf_param_buf.data() + sizeof(amdxdna_ccmd_config_ctx_req),
     arg.conf_buf.data(), arg.conf_buf.size());


### PR DESCRIPTION
To unify with upstream driver uapi, check _ctx back to _hwctx.  When the context creation success, the required hardware resources are reserved. So it makes sense to use hwctx.