### PR TITLE
moving to latest xrt for ve2 fixes

### DIFF
--- a/tools/info.json
+++ b/tools/info.json
@@ -1,7 +1,7 @@
 {
 	"copyright": "Copyright (C) 2023-2025 Advanced Micro Devices, Inc. All rights reserved.",
 	"xrt" : {
-		"version": "202520.2.20.85",
+		"version": "202520.2.20.90",
 		"os_rel": ["22.04", "24.04"]
 	},
 	"firmwares": [


### PR DESCRIPTION
Moving to latest XRT for ve2 fixes. Need below change for ve2
https://github.com/Xilinx/XRT/pull/9066
