### PR TITLE
ve2: updating buffer allocation logic to support cma allocation from multiple regions

### DIFF
--- a/src/driver/amdxdna/amdxdna_gem_of.c
+++ b/src/driver/amdxdna/amdxdna_gem_of.c
@@ -98,7 +98,7 @@ static struct drm_gem_dma_object *amdxdna_cma_create(struct drm_device *dev, siz
 
 	gem_obj->funcs = &amdxdna_gem_dma_funcs;
 
-	//manually init the drm gem obj
+	/* manually init the drm gem obj */
 	ret = drm_gem_object_init(dev, gem_obj, size);
 	if (ret)
 		goto error;


### PR DESCRIPTION
EDF/Vitis Common CED contains multiple DDR (or LPDDR) memory banks, this pr is to support DMA access to any of the memory banks. This pr has the initial changes to support this feature. 
Updated the logic to allocate buffers with dma_alloc_coherent() instead of directly using drm_gem_dma_create(). This update is required to support https://jira.xilinx.com/browse/VITIS-15145