### PR TITLE
Update xrt submodule for xrt-smi minor fixes

### DIFF
--- a/tools/info.json
+++ b/tools/info.json
@@ -1,7 +1,7 @@
 {
 	"copyright": "Copyright (C) 2023-2025 Advanced Micro Devices, Inc. All rights reserved.",
 	"xrt" : {
-		"version": "202520.2.20.109",
+		"version": "202520.2.20.115",
 		"os_rel": ["22.04", "24.04"]
 	},
 	"firmwares": [


### PR DESCRIPTION
Update xrt submodule to version 2.20.115 to include fixes for error handling and aie-partitions report.

Associated commit hash in XRT is d0a52f1392cef651344d818e3be9fa014862da7d