### PR TITLE
[XRT-SMI] Shim changes to support context health report

### DIFF
--- a/src/shim/smi_xdna.cpp
+++ b/src/shim/smi_xdna.cpp
@@ -71,7 +71,8 @@ config_gen_xdna::create_examine_subcommand()
     {"platform", "Platforms flashed on the device", "common"},
     {"telemetry", "Telemetry data for the device", "hidden"},
     {"preemption", "Preemption telemetry data for the device", "hidden"},
-    {"clocks", "Clock frequency information", "hidden"}
+    {"clocks", "Clock frequency information", "hidden"},
+    {"context-health", "Log to console context health information", "hidden"},
   };
 
   std::map<std::string, std::shared_ptr<option>> examine_suboptions; 

--- a/tools/info.json
+++ b/tools/info.json
@@ -1,7 +1,7 @@
 {
 	"copyright": "Copyright (C) 2023-2025 Advanced Micro Devices, Inc. All rights reserved.",
 	"xrt" : {
-		"version": "202520.2.20.119",
+		"version": "202520.2.20.121",
 		"os_rel": ["22.04", "24.04"]
 	},
 	"firmwares": [


### PR DESCRIPTION
This PR updates the xdna shim to add shim side changes to support context health report.
xrt-smi commands : 
**xrt-smi examine -r context-health --advanced** --> All active contexts
**xrt-smi examine -r context-health --advanced --element watch --element pid=1920087 --element ctx_id=5** --> filtered by <ctx_id,pid>
Output : 
```
---------------------------
[0000:c5:00.1] : NPU Strix
---------------------------
Starting Context Health Watch Mode (Press Ctrl+C to exit)
Update interval: 1 second
=======================================================
  Context Health Information:
    |Txn Op Idx  |Ctx PC      |Fatal Err Type  |Fatal Err Ex Type  |Fatal Err Ex PC  |Fatal App Module  |
    |------------|------------|----------------|-------------------|-----------------|------------------|
    |0xffffffff  |0xdeadbeef  |0x0             |0x0                |0x0              |0x0               |

(Press Ctrl+C to exit watch mode | Last update: Wed Aug 20 19:17:07 2025 GMT)^C
```