### PR TITLE
XDNA driver cache last async error and provide ioctl to enable user to get the async error

### DIFF
--- a/src/driver/amdxdna/Kbuild
+++ b/src/driver/amdxdna/Kbuild
@@ -26,7 +26,8 @@ amdxdna-y := \
 	amdxdna_mgmt.o \
 	amdxdna_tdr.o \
 	amdxdna_ubuf.o \
-	amdxdna_carvedout_buf.o
+	amdxdna_carvedout_buf.o \
+	amdxdna_error.o
 
 amdxdna-$(OFT_CONFIG_AMDXDNA_PCI) += \
 	amdxdna_gem.o \

--- a/src/driver/amdxdna/aie2_error.c
+++ b/src/driver/amdxdna/aie2_error.c
@@ -54,10 +54,13 @@ enum aie_error_category {
 
 /* Don't pack, unless XAIE side changed */
 struct aie_error {
-	__u8			row;
-	__u8			col;
-	__u32			mod_type;
-	__u8			event_id;
+	u8			row;
+	u8			col;
+	u16			reserved_0;
+	u32			mod_type;
+	u8			event_id;
+	u8			reserved_1;
+	u16			reserved_2;
 };
 
 struct aie_err_info {
@@ -70,6 +73,16 @@ struct aie_err_info {
 struct aie_event_category {
 	u8			event_id;
 	enum aie_error_category category;
+};
+
+struct aie_cat_xrt_err_num {
+	enum aie_error_category category;
+	enum xrt_error_num xrt_num;
+};
+
+struct aie_mod_xrt_err_mod {
+	enum aie_module_type mod_type;
+	enum xrt_error_module xrt_mod;
 };
 
 #define EVENT_CATEGORY(id, cat) { id, cat }
@@ -132,6 +145,43 @@ static const struct aie_event_category aie_ml_shim_tile_event_cat[] = {
 	EVENT_CATEGORY(74U, AIE_ERROR_LOCK),
 };
 
+static const struct aie_cat_xrt_err_num aie_cat_err_num_map[] = {
+	{ AIE_ERROR_SATURATION, XRT_ERROR_NUM_AIE_SATURATION },
+	{ AIE_ERROR_FP, XRT_ERROR_NUM_AIE_FP },
+	{ AIE_ERROR_STREAM, XRT_ERROR_NUM_AIE_STREAM },
+	{ AIE_ERROR_ACCESS, XRT_ERROR_NUM_AIE_ACCESS },
+	{ AIE_ERROR_BUS, XRT_ERROR_NUM_AIE_BUS },
+	{ AIE_ERROR_INSTRUCTION, XRT_ERROR_NUM_AIE_INSTRUCTION },
+	{ AIE_ERROR_ECC, XRT_ERROR_NUM_AIE_ECC },
+	{ AIE_ERROR_LOCK, XRT_ERROR_NUM_AIE_LOCK },
+	{ AIE_ERROR_DMA, XRT_ERROR_NUM_AIE_DMA },
+	{ AIE_ERROR_MEM_PARITY, XRT_ERROR_NUM_AIE_MEM_PARITY },
+};
+
+static const struct aie_mod_xrt_err_mod aie_mod_xrt_err_mod_map[] = {
+	{ AIE_MEM_MOD, XRT_ERROR_MODULE_AIE_MEMORY },
+	{ AIE_CORE_MOD, XRT_ERROR_MODULE_AIE_CORE },
+	{ AIE_PL_MOD, XRT_ERROR_MODULE_AIE_PL },
+};
+
+static enum xrt_error_module aie_get_xrt_error_mod(enum aie_module_type mod_type)
+{
+	for (int i = 0; i < ARRAY_SIZE(aie_mod_xrt_err_mod_map); i++) {
+		if (aie_mod_xrt_err_mod_map[i].mod_type == mod_type)
+			return aie_mod_xrt_err_mod_map[i].xrt_mod;
+	}
+	return XRT_ERROR_MODULE_UNKNOWN;
+}
+
+static enum xrt_error_num aie_err_cat_get_xrt_err_num(enum aie_error_category cat)
+{
+	for (int i = 0; i < ARRAY_SIZE(aie_cat_err_num_map); i++) {
+		if (aie_cat_err_num_map[i].category == cat)
+			return aie_cat_err_num_map[i].xrt_num;
+	}
+	return XRT_ERROR_NUM_UNKNOWN;
+}
+
 static enum aie_error_category
 aie_get_error_category(u8 row, u8 event_id, enum aie_module_type mod_type)
 {
@@ -171,6 +221,31 @@ aie_get_error_category(u8 row, u8 event_id, enum aie_module_type mod_type)
 	return AIE_ERROR_UNKNOWN;
 }
 
+static void aie2_async_errors_cache(struct amdxdna_dev_hdl *ndev, void *err_info, u32 num_err)
+{
+	struct amdxdna_async_error *record = &ndev->async_errs_cache.err;
+	u64 current_time_us = ktime_to_us(ktime_get_real());
+	struct aie_error *errs = err_info;
+	enum xrt_error_module xrt_err_mod;
+	enum xrt_error_num err_num;
+	struct aie_error *err;
+	u64 err_code;
+
+	/* Cache the last async error only */
+	err = &errs[num_err - 1];
+	err_num = aie_err_cat_get_xrt_err_num(aie_get_error_category(err->row, err->event_id,
+								     err->mod_type));
+	xrt_err_mod = aie_get_xrt_error_mod(err->mod_type);
+	err_code = XRT_ERROR_CODE_BUILD(err_num, XRT_ERROR_DRIVER_AIE,
+					XRT_ERROR_SEVERITY_CRITICAL, xrt_err_mod,
+					XRT_ERROR_CLASS_AIE);
+
+	mutex_lock(&ndev->async_errs_cache.lock);
+	record->ts_us = current_time_us;
+	record->err_code = err_code;
+	mutex_unlock(&ndev->async_errs_cache.lock);
+}
+
 static u32 aie2_error_backtrack(struct amdxdna_dev_hdl *ndev, void *err_info, u32 num_err)
 {
 	struct aie_error *errs = err_info;
@@ -195,8 +270,6 @@ static u32 aie2_error_backtrack(struct amdxdna_dev_hdl *ndev, void *err_info, u3
 
 		err_col |= (1 << err->col);
 	}
-
-	/* TODO: Send AIE error to EDAC system */
 
 	return err_col;
 }
@@ -259,6 +332,8 @@ static void aie2_error_worker(struct work_struct *err_work)
 		XDNA_WARN(xdna, "Did not get error column");
 		return;
 	}
+
+	aie2_async_errors_cache(e->ndev, info->payload, info->err_cnt);
 
 	mutex_lock(&xdna->dev_handle->aie2_lock);
 	/* Re-sent this event to firmware */
@@ -351,4 +426,34 @@ free_buf:
 free_events:
 	kfree(events);
 	return ret;
+}
+
+/**
+ * amdxdna_error_async_cache_init - Initialize async error cache
+ * @ndev: XDNA device handle for async errors cache initialization
+ * Return: 0 for success.
+ */
+int aie2_error_async_cache_init(struct amdxdna_dev_hdl *ndev)
+{
+	return amdxdna_error_async_cache_init(&ndev->async_errs_cache);
+}
+
+/**
+ * amdxdna_aie2_get_last_async_error - Retrieve the last asynchronous error information.
+ * @xdna: Pointer to the xdna structure.
+ * @num_errs: in/out, Number of error structures to populate.
+ * @errors_ret: async errors information array to return
+ *
+ * This function obtains the most recent asynchronous error that occurred
+ * in the AIE2 subsystem and populates the provided error information structure.
+ * It is typically used for error handling and diagnostics in the driver.
+ * Today, only one last async error is cached. And thus, this function will only
+ * return 1 last async error.
+ *
+ * Return: 0 on success, negative error code on failure.
+ */
+int aie2_error_get_last_async(struct amdxdna_dev *xdna, u32 num_errs, void *errors_ret)
+{
+	return amdxdna_error_get_last_async(xdna, &xdna->dev_handle->async_errs_cache, num_errs,
+										errors_ret);
 }

--- a/src/driver/amdxdna/aie2_pci.c
+++ b/src/driver/amdxdna/aie2_pci.c
@@ -600,6 +600,12 @@ skip_pasid:
 		ret = -ENOMEM;
 		goto disable_sva;
 	}
+
+	ret = aie2_error_async_cache_init(ndev);
+	if (ret) {
+		XDNA_ERR(xdna, "failed to init async error cache, ret %d", ret);
+		goto disable_sva;
+	}
 	xdna->dev_handle = ndev;
 
 	ret = aie2_hw_start(xdna);
@@ -1363,6 +1369,13 @@ static int aie2_get_array(struct amdxdna_client *client, struct amdxdna_drm_get_
 		ret = aie2_query_ctx_status_array(client, tmp, input.pid, input.context_id);
 		if (ret)
 			goto exit;
+
+		break;
+	case DRM_AMDXDNA_HW_LAST_ASYNC_ERR:
+		ret = aie2_error_get_last_async(xdna, args->num_element, tmp);
+		if (ret < 0)
+			goto exit;
+		ctx_cnt = ret;
 
 		break;
 	default:

--- a/src/driver/amdxdna/aie2_pci.h
+++ b/src/driver/amdxdna/aie2_pci.h
@@ -20,6 +20,7 @@
 #include "aie2_msg_priv.h"
 #include "amdxdna_pci_drv.h"
 #include "amdxdna_ctx.h"
+#include "amdxdna_error.h"
 #include "amdxdna_gem.h"
 #include "amdxdna_mailbox.h"
 #include "amdxdna_pm.h"
@@ -370,6 +371,8 @@ struct amdxdna_dev_hdl {
 	struct aie2_ctx_rq		ctx_rq;
 
 	u32				tdr_status;
+
+	struct amdxdna_async_err_cache	async_errs_cache; // For async error event cache
 };
 
 #define DEFINE_BAR_OFFSET(reg_name, bar, reg_addr) \
@@ -476,6 +479,8 @@ int aie2_error_async_events_alloc(struct amdxdna_dev_hdl *ndev);
 void aie2_error_async_events_free(struct amdxdna_dev_hdl *ndev);
 int aie2_error_async_events_send(struct amdxdna_dev_hdl *ndev);
 int aie2_error_async_msg_thread(void *data);
+int aie2_error_async_cache_init(struct amdxdna_dev_hdl *ndev);
+int aie2_error_get_last_async(struct amdxdna_dev *xdna, u32 num_errs, void *errors);
 
 /* aie2_message.c */
 bool aie2_is_supported_msg(struct amdxdna_dev_hdl *ndev, enum aie2_msg_opcode opcode);

--- a/src/driver/amdxdna/aie2_smu.c
+++ b/src/driver/amdxdna/aie2_smu.c
@@ -25,22 +25,6 @@ static int aie2_smu_exec(struct amdxdna_dev_hdl *ndev, u32 reg_cmd,
 
 	WARN_ON(!mutex_is_locked(&ndev->aie2_lock));
 
-#ifdef AMDXDNA_DEVEL
-	/*
-	 * This is not a fix in the driver, it's just an internal debug helper.
-	 *
-	 * PMFW as system level firmware, uses SMU register write/read commands to provide power
-	 * management services for many component devices including NPU. When SMU does register
-	 * write, it must be in idle state, although xdna driver uses aie2_lock mutex to serialize
-	 * its SMU commands, there might be chances that other device drivers cause SMU busy.
-	 *
-	 * Prior to register write, check SMU status first and log warning if busy.
-	 */
-	resp = readl(SMU_REG(ndev, SMU_RESP_REG));
-	if (!resp)
-		XDNA_WARN(ndev->xdna, "reg write while smu still busy, smu_resp_reg 0x%x", resp);
-#endif
-
 	writel(0, SMU_REG(ndev, SMU_RESP_REG));
 	writel(reg_arg, SMU_REG(ndev, SMU_ARG_REG));
 	writel(reg_cmd, SMU_REG(ndev, SMU_CMD_REG));

--- a/src/driver/amdxdna/amdxdna_error.c
+++ b/src/driver/amdxdna/amdxdna_error.c
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Copyright (C) 2025, Advanced Micro Devices, Inc.
+ */
+
+#include "amdxdna_error.h"
+#include "drm_local/amdxdna_accel.h"
+
+/**
+ * amdxdna_error_async_cache_init - Initialize async error cache
+ * @err_cache: error cache pointer to initialize
+ * Return: 0 for success.
+ */
+int amdxdna_error_async_cache_init(struct amdxdna_async_err_cache *err_cache)
+{
+	mutex_init(&err_cache->lock);
+	return 0;
+}
+
+/**
+ * amdxdna_aie2_get_last_async_error - Retrieve the last asynchronous error information.
+ * @xdna: Pointer to the xdna structure, it is used when printing function related information
+ * @err_cache: async errors cache
+ * @num_errs: Number of error structures to populate.
+ * @errors: errors array for returning errors information.
+ *
+ * This function obtains the most recent asynchronous error that occurred
+ * in the xdna subsystem and populates the provided error information structure.
+ * It is typically used for error handling and diagnostics in the driver.
+ * Today, only one last async error is cached. And thus, this function will only
+ * return 1 last async error.
+ *
+ * Return: 0 on success, negative error code on failure.
+ */
+int amdxdna_error_get_last_async(struct amdxdna_dev *xdna,
+				 struct amdxdna_async_err_cache *err_cache, u32 num_errs,
+				 void *errors)
+{
+	struct amdxdna_async_error *cached_last_err = &err_cache->err;
+
+	if (num_errs == 0 || !errors) {
+		XDNA_ERR(xdna,
+			 "get last async failed due to invalid input num_errors or empty errors array.");
+		return -EINVAL;
+	}
+
+	/* Retrieve the last async error information */
+	mutex_lock(&err_cache->lock);
+	if (!cached_last_err->err_code)
+		return 0;
+
+	memcpy(errors, cached_last_err, sizeof(*cached_last_err));
+	mutex_unlock(&err_cache->lock);
+
+	return 1;
+}

--- a/src/driver/amdxdna/amdxdna_error.h
+++ b/src/driver/amdxdna/amdxdna_error.h
@@ -1,0 +1,129 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+/*
+ * Copyright (C) 2025, Advanced Micro Devices, Inc.
+ */
+
+#ifndef _AMDXDNA_ERROR_H_
+#define _AMDXDNA_ERROR_H_
+
+#include "amdxdna_drm.h"
+#include <drm_local/amdxdna_accel.h>
+#include <linux/types.h>
+#include <linux/mutex.h>
+
+/**
+ * XRT error code layout
+ *
+ * This layout is internal to XRT (akin to a POSIX error code).
+ *
+ * The error code is populated by driver and consumed by XRT
+ * implementation where it is translated into an actual error / info /
+ * warning that is propagated to the end user.
+ *
+ * 63 - 48  47 - 40   39 - 32   31 - 24   23 - 16    15 - 0
+ * --------------------------------------------------------
+ * |    |    |    |    |    |    |    |    |    |    |----| xrt error number
+ * |    |    |    |    |    |    |    |    |----|---------- xrt error driver
+ * |    |    |    |    |    |    |----|-------------------- xrt error severity
+ * |    |    |    |    |----|------------------------------ xrt error module
+ * |    |    |----|---------------------------------------- xrt error class
+ * |----|-------------------------------------------------- reserved
+ *
+ */
+
+#define XRT_ERROR_NUM_MASK		0xFFFFUL
+#define XRT_ERROR_NUM_SHIFT		0
+#define XRT_ERROR_DRIVER_MASK		0xFUL
+#define XRT_ERROR_DRIVER_SHIFT		16
+#define XRT_ERROR_SEVERITY_MASK		0xFUL
+#define XRT_ERROR_SEVERITY_SHIFT	24
+#define XRT_ERROR_MODULE_MASK		0xFUL
+#define XRT_ERROR_MODULE_SHIFT		32
+#define XRT_ERROR_CLASS_MASK		0xFUL
+#define XRT_ERROR_CLASS_SHIFT		40
+
+#define	XRT_ERROR_CODE_BUILD(num, driver, severity, module, eclass) \
+	((((num) & XRT_ERROR_NUM_MASK) << XRT_ERROR_NUM_SHIFT) | \
+	(((driver) & XRT_ERROR_DRIVER_MASK) << XRT_ERROR_DRIVER_SHIFT) | \
+	(((severity) & XRT_ERROR_SEVERITY_MASK) << XRT_ERROR_SEVERITY_SHIFT) | \
+	(((module) & XRT_ERROR_MODULE_MASK) << XRT_ERROR_MODULE_SHIFT) | \
+	(((eclass) & XRT_ERROR_CLASS_MASK) << XRT_ERROR_CLASS_SHIFT))
+
+#define XRT_ERROR_NUM(code) (((code) >> XRT_ERROR_NUM_SHIFT) & XRT_ERROR_NUM_MASK)
+#define XRT_ERROR_DRIVER(code) (((code) >> XRT_ERROR_DRIVER_SHIFT) & XRT_ERROR_DRIVER_MASK)
+#define XRT_ERROR_SEVERITY(code) (((code) >> XRT_ERROR_SEVERITY_SHIFT) & XRT_ERROR_SEVERITY_MASK)
+#define XRT_ERROR_MODULE(code) (((code) >> XRT_ERROR_MODULE_SHIFT) & XRT_ERROR_MODULE_MASK)
+#define XRT_ERROR_CLASS(code) (((code) >> XRT_ERROR_CLASS_SHIFT) & XRT_ERROR_CLASS_MASK)
+
+/**
+ * xrt_error_num - XRT specific error numbers
+ */
+enum xrt_error_num {
+	XRT_ERROR_NUM_FIRWWALL_TRIP = 1,
+	XRT_ERROR_NUM_TEMP_HIGH,
+	XRT_ERROR_NUM_AIE_SATURATION,
+	XRT_ERROR_NUM_AIE_FP,
+	XRT_ERROR_NUM_AIE_STREAM,
+	XRT_ERROR_NUM_AIE_ACCESS,
+	XRT_ERROR_NUM_AIE_BUS,
+	XRT_ERROR_NUM_AIE_INSTRUCTION,
+	XRT_ERROR_NUM_AIE_ECC,
+	XRT_ERROR_NUM_AIE_LOCK,
+	XRT_ERROR_NUM_AIE_DMA,
+	XRT_ERROR_NUM_AIE_MEM_PARITY,
+	XRT_ERROR_NUM_KDS_CU,
+	XRT_ERROR_NUM_KDS_EXEC,
+	XRT_ERROR_NUM_UNKNOWN
+};
+
+enum xrt_error_driver {
+	XRT_ERROR_DRIVER_XOCL = 1,
+	XRT_ERROR_DRIVER_XCLMGMT,
+	XRT_ERROR_DRIVER_ZOCL,
+	XRT_ERROR_DRIVER_AIE,
+	XRT_ERROR_DRIVER_UNKNOWN
+};
+
+enum xrt_error_severity {
+	XRT_ERROR_SEVERITY_EMERGENCY = 1,
+	XRT_ERROR_SEVERITY_ALERT,
+	XRT_ERROR_SEVERITY_CRITICAL,
+	XRT_ERROR_SEVERITY_ERROR,
+	XRT_ERROR_SEVERITY_WARNING,
+	XRT_ERROR_SEVERITY_NOTICE,
+	XRT_ERROR_SEVERITY_INFO,
+	XRT_ERROR_SEVERITY_DEBUG,
+	XRT_ERROR_SEVERITY_UNKNOWN
+};
+
+enum xrt_error_module {
+	XRT_ERROR_MODULE_FIREWALL = 1,
+	XRT_ERROR_MODULE_CMC,
+	XRT_ERROR_MODULE_AIE_CORE,
+	XRT_ERROR_MODULE_AIE_MEMORY,
+	XRT_ERROR_MODULE_AIE_SHIM,
+	XRT_ERROR_MODULE_AIE_NOC,
+	XRT_ERROR_MODULE_AIE_PL,
+	XRT_ERROR_MODULE_UNKNOWN
+};
+
+enum xrt_error_class {
+	XRT_ERROR_CLASS_FIRST_ENTRY = 1,
+	XRT_ERROR_CLASS_SYSTEM = XRT_ERROR_CLASS_FIRST_ENTRY,
+	XRT_ERROR_CLASS_AIE,
+	XRT_ERROR_CLASS_HARDWARE,
+	XRT_ERROR_CLASS_UNKNOWN,
+	XRT_ERROR_CLASS_LAST_ENTRY = XRT_ERROR_CLASS_UNKNOWN
+};
+
+struct amdxdna_async_err_cache {
+	struct amdxdna_async_error err; /* last async error which can be queried from userspace */
+	struct mutex lock; /* protects access to the error cache */
+};
+
+int amdxdna_error_async_cache_init(struct amdxdna_async_err_cache *err_cache);
+int amdxdna_error_get_last_async(struct amdxdna_dev *xdna,
+				 struct amdxdna_async_err_cache *err_cache, u32 num_errs,
+				 void *errors);
+
+#endif /* _AMDXDNA_ERROR_H_ */

--- a/src/include/uapi/drm_local/amdxdna_accel.h
+++ b/src/include/uapi/drm_local/amdxdna_accel.h
@@ -696,6 +696,24 @@ struct amdxdna_drm_hwctx_entry {
 };
 
 /**
+ * struct amdxdna_async_error - XDNA async error structure
+ * @err_code: error code, ErrorNum + Driver + Severity + Module + Class
+ *            Refer to amdxnda_xrt_error.h for error code encoding details
+ * @ts_us: timestamp in us
+ * @ex_err_code: extra error code
+ * @reserved0: reserved field
+ * @reserved1: reserved field
+ *
+ * This structure definition refers to XRT error code definition
+ */
+struct amdxdna_async_error {
+	__u64 err_code;
+	__u64 ts_us;
+	__u64 ex_err_code;
+	__u64 reserved0;
+};
+
+/**
  * struct amdxdna_drm_get_array - Get some information from the AIE hardware, return array.
  * @param: Specifies the structure passed in the buffer.
  * @element_size: Size of each element in the array.
@@ -705,6 +723,7 @@ struct amdxdna_drm_hwctx_entry {
 struct amdxdna_drm_get_array {
 #define DRM_AMDXDNA_HW_CONTEXT_ALL	0
 #define DRM_AMDXDNA_HW_CONTEXT_BY_ID	1
+#define DRM_AMDXDNA_HW_LAST_ASYNC_ERR	2	/* Get last async error */
 	__u32 param; /* in */
 	__u32 element_size; /* in/out */
 #define AMDXDNA_MAX_NUM_ELEMENT			1024

--- a/src/shim/device.cpp
+++ b/src/shim/device.cpp
@@ -10,6 +10,7 @@
 
 #include "core/common/query_requests.h"
 #include "core/include/ert.h"
+#include "core/include/xclerr_int.h"
 #include <sys/syscall.h>
 #include <algorithm>
 #include <libgen.h>
@@ -450,6 +451,45 @@ struct context_health_info {
 
       auto* data = reinterpret_cast<amdxdna_drm_hwctx_entry*>(payload.data());
       output.push_back(fill_health_entry(*data));
+    }
+    return output;
+  }
+};
+
+struct xocl_errors
+{
+  using result_type = std::any;
+
+  static result_type
+  get(const xrt_core::device* device, key_type key)
+  {
+    if (key != key_type::xocl_errors)
+      throw xrt_core::query::no_such_key(key, "Not implemented");
+
+    // Query all contexts
+    amdxdna_async_error* data;
+    const uint32_t drv_output = 32 * sizeof(*data);
+    std::vector<char> payload(drv_output);
+    amdxdna_drm_get_array arg = {
+      .param = DRM_AMDXDNA_HW_LAST_ASYNC_ERR,
+      .element_size = sizeof(*data),
+      .num_element = 32,
+      .buffer = reinterpret_cast<uintptr_t>(payload.data())
+    };
+
+    auto& pci_dev_impl = get_pcidev_impl(device);
+    uint32_t data_size = 0;
+    pci_dev_impl.drv_ioctl(shim_xdna::drv_ioctl_cmd::get_info_array, &arg);
+    data_size = arg.num_element;
+    data = reinterpret_cast<decltype(data)>(payload.data());
+
+    query::xocl_errors::result_type output(sizeof(xcl_errors));
+    xcl_errors *out_xcl_errors = reinterpret_cast<xcl_errors*>(output.data());
+    out_xcl_errors->num_err = arg.num_element;
+    for (uint32_t i = 0; i < arg.num_element; i++) {
+      out_xcl_errors->errors[i].err_code = data[i].err_code;
+      out_xcl_errors->errors[i].ts = data[i].ts_us;
+      out_xcl_errors->errors[i].ex_error_code = data[i].ex_err_code;
     }
     return output;
   }
@@ -1628,6 +1668,7 @@ static void
 initialize_query_table()
 {
   emplace_func0_request<query::aie_partition_info,             partition_info>();
+  emplace_func0_request<query::xocl_errors,                    xocl_errors>();
   emplace_func1_request<query::context_health_info,           context_health_info>();
   emplace_func0_request<query::aie_status_version,             aie_info>();
   emplace_func0_request<query::aie_tiles_stats,                aie_info>();

--- a/test/shim_test/io.h
+++ b/test/shim_test/io.h
@@ -151,4 +151,23 @@ public:
   verify_result() override;
 };
 
+class async_error_io_test_bo_set : public io_test_bo_set_base
+{
+public:
+  async_error_io_test_bo_set(device *dev);
+
+  void
+  init_cmd(xrt_core::cuidx_type idx, bool dump) override;
+
+  void
+  run() override;
+
+  void
+  verify_result() override;
+private:
+  uint64_t m_expect_err_code;
+  uint64_t m_last_err_timestamp;
+  static const std::map<uint32_t, enum xrtErrorNum> m_shim_event_err_num_map;
+};
+
 #endif // _SHIMTEST_IO_H_

--- a/test/shim_test/io_test.cpp
+++ b/test/shim_test/io_test.cpp
@@ -488,3 +488,12 @@ TEST_io_timeout(device::id_type id, std::shared_ptr<device>& sdev, arg_type& arg
   boset.verify_result();
 }
 
+void
+TEST_async_error_io(device::id_type id, std::shared_ptr<device>& sdev, arg_type& arg)
+{
+  async_error_io_test_bo_set async_error_io_test_bo_set{sdev.get()};
+  // verification is inside run()
+  async_error_io_test_bo_set.run();
+  // Run again to check if we can catch newly generated async error
+  async_error_io_test_bo_set.run();
+}

--- a/test/shim_test/shim_test.cpp
+++ b/test/shim_test/shim_test.cpp
@@ -45,6 +45,7 @@ void TEST_export_import_bo(device::id_type, std::shared_ptr<device>&, arg_type&)
 void TEST_export_import_bo_single_proc(device::id_type, std::shared_ptr<device>&, arg_type&);
 void TEST_io(device::id_type, std::shared_ptr<device>&, arg_type&);
 void TEST_io_timeout(device::id_type, std::shared_ptr<device>&, arg_type&);
+void TEST_async_error_io(device::id_type id, std::shared_ptr<device>& sdev, arg_type& arg);
 void TEST_io_latency(device::id_type, std::shared_ptr<device>&, arg_type&);
 void TEST_io_throughput(device::id_type, std::shared_ptr<device>&, arg_type&);
 void TEST_io_runlist_latency(device::id_type, std::shared_ptr<device>&, arg_type&);
@@ -692,8 +693,8 @@ std::vector<test_case> test_list {
     TEST_POSITIVE, dev_filter_is_aie2, TEST_create_destroy_hw_queue, {}
   },
   // Keep bad run before normal run to test recovery of hw ctx
-  test_case{ "io test real kernel bad run", {},
-    TEST_NEGATIVE, dev_filter_is_aie2, TEST_io, { IO_TEST_BAD_RUN, 1 }
+  test_case{ "io test async error", {},
+    TEST_POSITIVE, dev_filter_is_npu4, TEST_async_error_io, {}
   },
   test_case{ "io test real kernel good run", {},
     TEST_POSITIVE, dev_filter_is_aie2, TEST_io, { IO_TEST_NORMAL_RUN, 1 }


### PR DESCRIPTION
This patch set cache the last async error event signaled from hardware and encode the error from firmware error event information to userspace runtime library format.

Added a type of get array ioctl to enable user to get the last async error from the driver.

shim async error is added to test this case. This test use DPU sequence flow to request firmware to write to AIE event register to raise an async error event. The test will call get array ioctl to get the last async error compared it with the expected encoded error code, and then run the test again to check if new async error is cached.