### PR TITLE
Fix hangs while quering HW context report

### DIFF
--- a/src/driver/amdxdna/aie2_message.c
+++ b/src/driver/amdxdna/aie2_message.c
@@ -684,6 +684,19 @@ int aie2_register_asyn_event_msg(struct amdxdna_dev_hdl *ndev, struct aie2_mgmt_
 	return xdna_mailbox_send_msg(ndev->mgmt_chann, &msg, TX_TIMEOUT);
 }
 
+void aie2_reset_app_health_report(struct app_health_report *r)
+{
+	if (!r)
+		return;
+
+	r->fatal_info.exception_type = AIE2_APP_HEALTH_RESET_FATAL_INFO;
+	r->fatal_info.exception_pc = AIE2_APP_HEALTH_RESET_FATAL_INFO;
+	r->fatal_info.app_module = AIE2_APP_HEALTH_RESET_FATAL_INFO;
+	r->fatal_info.fatal_type = AIE2_APP_HEALTH_RESET_FATAL_INFO;
+	r->txn_op_id = AIE2_APP_HEALTH_RESET_TXN_OP_ID;
+	r->ctx_pc = AIE2_APP_HEALTH_RESET_CTX_PC;
+}
+
 int aie2_get_app_health(struct amdxdna_dev_hdl *ndev, struct aie2_mgmt_dma_hdl *mgmt_hdl,
 			u32 context_id, u32 size)
 {

--- a/src/driver/amdxdna/aie2_pci.c
+++ b/src/driver/amdxdna/aie2_pci.c
@@ -1272,14 +1272,9 @@ static int aie2_query_ctx_status_array(struct amdxdna_client *client,
 							  ctx->priv->id, sizeof(*r));
 				mutex_unlock(&xdna->dev_handle->aie2_lock);
 				if (ret)
-					return ret;
+					aie2_reset_app_health_report(r);
 			} else {
-				r->fatal_info.exception_type = AIE2_APP_HEALTH_RESET_FATAL_INFO;
-				r->fatal_info.exception_pc = AIE2_APP_HEALTH_RESET_FATAL_INFO;
-				r->fatal_info.app_module = AIE2_APP_HEALTH_RESET_FATAL_INFO;
-				r->fatal_info.fatal_type = AIE2_APP_HEALTH_RESET_FATAL_INFO;
-				r->txn_op_id = AIE2_APP_HEALTH_RESET_TXN_OP_ID;
-				r->ctx_pc = AIE2_APP_HEALTH_RESET_CTX_PC;
+				aie2_reset_app_health_report(r);
 			}
 
 			tmp[hw_i].fatal_error_exception_type = r->fatal_info.exception_type;

--- a/src/driver/amdxdna/aie2_pci.h
+++ b/src/driver/amdxdna/aie2_pci.h
@@ -500,6 +500,7 @@ int aie2_query_aie_telemetry(struct amdxdna_dev_hdl *ndev, struct aie2_mgmt_dma_
 			     u32 type, u32 size, struct aie_version *version);
 int aie2_get_app_health(struct amdxdna_dev_hdl *ndev, struct aie2_mgmt_dma_hdl *mgmt_hdl,
 			u32 context_id, u32 size);
+void aie2_reset_app_health_report(struct app_health_report *r);
 int aie2_query_aie_version(struct amdxdna_dev_hdl *ndev, struct aie_version *version);
 int aie2_query_aie_metadata(struct amdxdna_dev_hdl *ndev, struct aie_metadata *metadata);
 int aie2_query_aie_firmware_version(struct amdxdna_dev_hdl *ndev,


### PR DESCRIPTION
Fix hangs while quering HW context report on platforms that do not support app health.