### PR TITLE
Make FW log parser device specific

### DIFF
--- a/src/driver/amdxdna/aie2_pci.c
+++ b/src/driver/amdxdna/aie2_pci.c
@@ -1599,6 +1599,7 @@ const struct amdxdna_dev_ops aie2_ops = {
 	.debugfs		= aie2_debugfs_init,
 	.fw_log_init		= aie2_fw_log_init,
 	.fw_log_fini		= aie2_fw_log_fini,
+	.fw_log_parse		= aie2_fw_log_parse,
 	.get_aie_info		= aie2_get_info,
 	.get_aie_array		= aie2_get_array,
 	.set_aie_state		= aie2_set_state,

--- a/src/driver/amdxdna/aie2_pci.h
+++ b/src/driver/amdxdna/aie2_pci.h
@@ -436,6 +436,7 @@ void *aie2_mgmt_buff_get_cpu_addr(struct aie2_mgmt_dma_hdl *mgmt_hdl);
 void aie2_mgmt_buff_free(struct aie2_mgmt_dma_hdl *mgmt_hdl);
 int aie2_fw_log_init(struct amdxdna_dev *xdna, size_t size, u8 level);
 int aie2_fw_log_fini(struct amdxdna_dev *xdna);
+void aie2_fw_log_parse(struct amdxdna_dev *xdna, char *buffer, size_t size);
 
 /* aie2_smu.c */
 int aie2_smu_start(struct amdxdna_dev_hdl *ndev);

--- a/src/driver/amdxdna/amdxdna_drm.h
+++ b/src/driver/amdxdna/amdxdna_drm.h
@@ -64,6 +64,7 @@ struct amdxdna_dev_ops {
 	void (*debugfs)(struct amdxdna_dev *xdna);
 	int (*fw_log_init)(struct amdxdna_dev *xdna, size_t size, u8 level);
 	int (*fw_log_fini)(struct amdxdna_dev *xdna);
+	void (*fw_log_parse)(struct amdxdna_dev *xdna, char *buffer, size_t size);
 
 	/* Below device ops are called by IOCTL */
 	int (*ctx_init)(struct amdxdna_ctx *ctx);


### PR DESCRIPTION
FW log buffer format may vary based on the device generation. Make the parser logic device specific.