### PR TITLE
moving to latest xrt for import/export bo fix across xdna-ve2 & zocl

### DIFF
--- a/tools/info.json
+++ b/tools/info.json
@@ -1,7 +1,7 @@
 {
 	"copyright": "Copyright (C) 2023-2025 Advanced Micro Devices, Inc. All rights reserved.",
 	"xrt" : {
-		"version": "202520.2.20.152",
+		"version": "202520.2.20.153",
 		"os_rel": ["22.04", "24.04"]
 	},
 	"firmwares": [


### PR DESCRIPTION
There is an issue in zocl which is causing an issue with import/export across these two drivers.
Fixed the issue and zocl and updating commit id