### PR TITLE
[Updated bo type to AMDXDNA_BO_SHARE for ve2

### DIFF
--- a/src/shim_ve2/xdna_bo.cpp
+++ b/src/shim_ve2/xdna_bo.cpp
@@ -118,8 +118,6 @@ xdna_bo(const device_xdna& device, xrt_core::hwctx_handle::slot_id ctx_id,
   , m_map_offset(0)
 {
   alloc_bo();
-  if (m_type == AMDXDNA_BO_SHARE)
-    sync(direction::host2device, size, 0);
 
   xcl_bo_flags xflags{ m_flags };
   if (xflags.use == XRT_BO_USE_DEBUG || xflags.use == XRT_BO_USE_DTRACE ||
@@ -334,7 +332,7 @@ config(const xrt_core::hwctx_handle* ctx, const std::map<uint32_t, size_t>& buf_
   auto mdata_size = sizeof(struct fw_buffer_metadata) + total_cols * sizeof(struct uc_info_entry);
 
   auto xdev = static_cast<const device_xdna*>(m_core_device);
-  xdna_bo mdata_bo = xdna_bo(*xdev, ctx_id, mdata_size, XCL_BO_FLAGS_CACHEABLE, AMDXDNA_BO_DEV);
+  xdna_bo mdata_bo = xdna_bo(*xdev, ctx_id, mdata_size, XCL_BO_FLAGS_CACHEABLE, AMDXDNA_BO_SHARE);
   init_metadata_buffer(mdata_bo, boh, total_cols, xflags.use, buf_sizes, true);
 
   shim_debug("Configuring BO %d on ctx: %d", boh, ctx_id);
@@ -360,7 +358,7 @@ attach_to_ctx(uint32_t flag)
 
   auto mdata_size = sizeof(struct fw_buffer_metadata) + total_cols * sizeof(struct uc_info_entry);
   auto xdev = static_cast<const device_xdna*>(m_core_device);
-  xdna_bo mdata_bo = xdna_bo(*xdev, m_owner_ctx_id, mdata_size, XCL_BO_FLAGS_CACHEABLE, AMDXDNA_BO_DEV);
+  xdna_bo mdata_bo = xdna_bo(*xdev, m_owner_ctx_id, mdata_size, XCL_BO_FLAGS_CACHEABLE, AMDXDNA_BO_SHARE);
   init_metadata_buffer(mdata_bo, boh, total_cols, flag, buf_sizes, true);
   shim_debug("Attaching drm_bo %d to ctx: %d", boh, m_owner_ctx_id);
   config_drm_bo(m_edev, m_owner_ctx_id, mdata_bo.get_drm_bo_handle(), mdata_size, true);
@@ -376,7 +374,7 @@ detach_from_ctx(uint32_t flag)
   auto boh = get_drm_bo_handle();
   auto mdata_size = sizeof(struct fw_buffer_metadata);
   auto xdev = static_cast<const device_xdna*>(m_core_device);
-  xdna_bo mdata_bo = xdna_bo(*xdev, m_owner_ctx_id, mdata_size, XCL_BO_FLAGS_CACHEABLE, AMDXDNA_BO_DEV);
+  xdna_bo mdata_bo = xdna_bo(*xdev, m_owner_ctx_id, mdata_size, XCL_BO_FLAGS_CACHEABLE, AMDXDNA_BO_SHARE);
   init_metadata_buffer(mdata_bo, 0, 0, flag, std::map<uint32_t, size_t>{}, false);
   shim_debug("Detaching drm_bo %d from ctx: %d", boh, m_owner_ctx_id);
   config_drm_bo(m_edev, m_owner_ctx_id, mdata_bo.get_drm_bo_handle(), mdata_size, false);

--- a/src/shim_ve2/xdna_device.cpp
+++ b/src/shim_ve2/xdna_device.cpp
@@ -55,9 +55,8 @@ flag_to_type(uint64_t bo_flags)
   switch (boflags) {
   case XCL_BO_FLAGS_NONE:
   case XCL_BO_FLAGS_HOST_ONLY:
-    return AMDXDNA_BO_SHARE;
   case XCL_BO_FLAGS_CACHEABLE:
-    return AMDXDNA_BO_DEV;
+    return AMDXDNA_BO_SHARE;
   case XCL_BO_FLAGS_EXECBUF:
     return AMDXDNA_BO_CMD;
   default:


### PR DESCRIPTION
Updated the bo type for ve2 from AMDXDNA_BO_DEV to AMDXDNA_BO_SHARE to align with ve2 usecases (eg. log buffer, etc)
And also removed the hardcoded bo sync().
Tested all the ve2 hw tests and all are passing including log_buf test.