### PR TITLE
test: shim: add read async error multi times in multi threads

### DIFF
--- a/test/shim_test/io_test.cpp
+++ b/test/shim_test/io_test.cpp
@@ -3,6 +3,7 @@
 
 #include "io.h"
 #include "hwctx.h"
+#include "multi_threads.h"
 #include "speed.h"
 #include "dev_info.h"
 #include "io_param.h"
@@ -497,3 +498,43 @@ TEST_async_error_io(device::id_type id, std::shared_ptr<device>& sdev, arg_type&
   // Run again to check if we can catch newly generated async error
   async_error_io_test_bo_set.run();
 }
+
+/**
+ * This test is to test if t here is deadlock in reading async error ioctl
+ */
+static void TEST_async_error_continue_read(device::id_type id, std::shared_ptr<device>& sdev,
+                                           arg_type& arg)
+{
+  auto devptr = sdev.get();
+  auto must_error = arg[0];
+  xrtErrorTime last_err_timestamp;
+
+  constexpr uint32_t iters = 2;
+  for (uint32_t i = 0; i < iters; i++) {
+    auto buf = device_query<query::xocl_errors>(devptr);
+    if (buf.empty())
+      throw std::runtime_error("async error multithread failed, buffer is null.");
+
+    auto ect = query::xocl_errors::to_value(buf, XRT_ERROR_CLASS_AIE);
+    xrtErrorTime err_timestamp;
+    xrtErrorCode err_code;
+    std::tie(err_code, err_timestamp) = ect;
+    if (must_error && !err_code)
+      throw std::runtime_error("async error multithread failed, expect error, but no error.");
+
+    if (i && (err_timestamp != last_err_timestamp)) {
+      std::stringstream ss;
+      ss << "async error continuous read failed, timestamp different: " << err_timestamp
+         << ", " << last_err_timestamp << ".";
+      throw std::runtime_error(ss.str());
+    }
+    last_err_timestamp = err_timestamp;
+  }
+}
+
+void TEST_async_error_multi(device::id_type id, std::shared_ptr<device>& sdev, arg_type& arg)
+{
+  multi_thread threads(10, TEST_async_error_continue_read);
+  threads.run_test(id, sdev, arg);
+}
+

--- a/test/shim_test/shim_test.cpp
+++ b/test/shim_test/shim_test.cpp
@@ -46,6 +46,7 @@ void TEST_export_import_bo_single_proc(device::id_type, std::shared_ptr<device>&
 void TEST_io(device::id_type, std::shared_ptr<device>&, arg_type&);
 void TEST_io_timeout(device::id_type, std::shared_ptr<device>&, arg_type&);
 void TEST_async_error_io(device::id_type id, std::shared_ptr<device>& sdev, arg_type& arg);
+void TEST_async_error_multi(device::id_type id, std::shared_ptr<device>& sdev, arg_type& arg);
 void TEST_io_latency(device::id_type, std::shared_ptr<device>&, arg_type&);
 void TEST_io_throughput(device::id_type, std::shared_ptr<device>&, arg_type&);
 void TEST_io_runlist_latency(device::id_type, std::shared_ptr<device>&, arg_type&);
@@ -638,6 +639,11 @@ std::vector<test_case> test_list {
   test_case{ "query(rom_fpga_name)", {},
     TEST_NEGATIVE, dev_filter_xdna, TEST_query_userpf<query::rom_fpga_name>, {}
   },
+  // get async error in multi thread before running any other tests
+  // there may or may not be async error.
+  test_case{ "get async error in multithread - INITIAL", {},
+    TEST_POSITIVE, dev_filter_is_aie2, TEST_async_error_multi, {false}
+  },
   //test_case{ "non_xdna_userpf: query(rom_vbnv)", {},
   //  TEST_POSITIVE, dev_filter_not_xdna, TEST_query_userpf<query::rom_vbnv>, {}
   //},
@@ -827,6 +833,10 @@ std::vector<test_case> test_list {
   //},
   test_case{ "multi-command preempt full ELF io test real kernel good run", {},
     TEST_POSITIVE, dev_filter_is_npu4, TEST_preempt_full_elf_io, { IO_TEST_FORCE_PREEMPTION, 8 }
+  },
+  // get async error in multi thread after async error has raised.
+  test_case{ "get async error in multithread - HAS ASYNC ERROR", {},
+    TEST_POSITIVE, dev_filter_is_npu4, TEST_async_error_multi, {true}
   },
 };
 


### PR DESCRIPTION
Add test case to read async errors multiple times in multiple threads.

To test async error read when there is no errors, we will need to run the test after xdna module is probed and before any runs launched on the hardware.