### PR TITLE
test: shim: add instruction code invalid address access test

### DIFF
--- a/test/shim_test/io.h
+++ b/test/shim_test/io.h
@@ -140,6 +140,8 @@ class elf_io_timeout_test_bo_set : public io_test_bo_set_base
 {
 public:
   elf_io_timeout_test_bo_set(device *dev, const std::string& xclbin_name);
+  elf_io_timeout_test_bo_set(device *dev, const std::string& xclbin_name,
+                             const std::string& elf_name, uint32_t exp_txn_op_idx);
 
   void
   init_cmd(xrt_core::cuidx_type idx, bool dump) override;
@@ -149,6 +151,9 @@ public:
 
   void
   verify_result() override;
+
+private:
+  uint32_t m_expect_txn_op_idx;
 };
 
 class async_error_io_test_bo_set : public io_test_bo_set_base

--- a/test/shim_test/io_test.cpp
+++ b/test/shim_test/io_test.cpp
@@ -538,3 +538,14 @@ void TEST_async_error_multi(device::id_type id, std::shared_ptr<device>& sdev, a
   threads.run_test(id, sdev, arg);
 }
 
+void
+TEST_instr_invalid_addr_io(device::id_type id, std::shared_ptr<device>& sdev, arg_type& arg)
+{
+  elf_io_timeout_test_bo_set invalid_addr_txn_set{sdev.get(), "timeout.xclbin",
+                                                  "instr_invalid_addr.elf", 0xFFFFFFFF};
+  // verification is inside run()
+  invalid_addr_txn_set.run();
+
+  std::vector<uint64_t> params = {IO_TEST_NORMAL_RUN, 1};
+  elf_io(id, sdev, params, "design.xclbin");
+}

--- a/test/shim_test/shim_test.cpp
+++ b/test/shim_test/shim_test.cpp
@@ -47,6 +47,7 @@ void TEST_io(device::id_type, std::shared_ptr<device>&, arg_type&);
 void TEST_io_timeout(device::id_type, std::shared_ptr<device>&, arg_type&);
 void TEST_async_error_io(device::id_type id, std::shared_ptr<device>& sdev, arg_type& arg);
 void TEST_async_error_multi(device::id_type id, std::shared_ptr<device>& sdev, arg_type& arg);
+void TEST_instr_invalid_addr_io(device::id_type id, std::shared_ptr<device>& sdev, arg_type& arg);
 void TEST_io_latency(device::id_type, std::shared_ptr<device>&, arg_type&);
 void TEST_io_throughput(device::id_type, std::shared_ptr<device>&, arg_type&);
 void TEST_io_runlist_latency(device::id_type, std::shared_ptr<device>&, arg_type&);
@@ -704,6 +705,9 @@ std::vector<test_case> test_list {
   },
   test_case{ "io test real kernel good run", {},
     TEST_POSITIVE, dev_filter_is_aie2, TEST_io, { IO_TEST_NORMAL_RUN, 1 }
+  },
+  test_case{ "io test with intruction code invalid address access", {},
+    TEST_POSITIVE, dev_filter_is_npu4, TEST_instr_invalid_addr_io, {}
   },
   test_case{ "measure no-op kernel latency", {},
     TEST_POSITIVE, dev_filter_is_aie2, TEST_io_latency, { IO_TEST_NOOP_RUN, IO_TEST_IOCTL_WAIT, 32000 }


### PR DESCRIPTION
Add test case to have instruction code access invalid address we should expect timeout and then, if we start a good run, the good run should finish properly.
