### PR TITLE
Properly support exporting and importing BO in the same process

### DIFF
--- a/src/shim/buffer.cpp
+++ b/src/shim/buffer.cpp
@@ -104,8 +104,8 @@ type_to_name(int type, uint64_t flags)
       return std::string("AMDXDNA_BO_UC_LOG");
     else if (xcl_bo_flags{flags}.use == XRT_BO_USE_DEBUG_QUEUE)
       return std::string("AMDXDNA_BO_UC_DEBUG_QUEUE");
-    //else if (xcl_bo_flags{flags}.use == XRT_BO_USE_UC_DEBUG)
-    //  return std::string("AMDXDNA_BO_UC_DEBUG_BUF");
+    else if (xcl_bo_flags{flags}.use == XRT_BO_USE_UC_DEBUG)
+      return std::string("AMDXDNA_BO_UC_DEBUG_BUF");
     return std::string("AMDXDNA_BO_SHARE");
   case AMDXDNA_BO_DEV_HEAP:
     return std::string("AMDXDNA_BO_DEV_HEAP");
@@ -266,14 +266,14 @@ alloc(const pdev *dev, uint64_t dev_offset, size_t size)
 //
 
 drm_bo::
-drm_bo(const pdev& pdev, size_t size, int type)
+drm_bo(const pdev& pdev, size_t size, uint32_t type)
   : m_pdev(pdev), m_size(size)
 {
   auto align = bo_addr_align(type);
-  create_bo_arg arg = {
-    .type = type,
-    .size = m_size,
+  bo_info arg = {
     .xdna_addr_align = (align == 1 ? 0 : align), 
+    .size = m_size,
+    .type = type,
   };
   m_pdev.create_drm_bo(&arg);
   m_id = arg.bo;
@@ -285,9 +285,9 @@ drm_bo::
 drm_bo(const pdev& pdev, size_t size, void *uptr)
   : m_pdev(pdev), m_size(size)
 {
-  create_uptr_bo_arg arg = {
-    .buf = uptr,
+  bo_info arg = {
     .size = m_size,
+    .vaddr = uptr,
   };
   m_pdev.drv_ioctl(drv_ioctl_cmd::create_uptr_bo, &arg);
   m_id = arg.bo;
@@ -303,33 +303,20 @@ drm_bo(const pdev& pdev, xrt_core::shared_handle::export_handle ehdl)
     .fd = ehdl,
   };
   m_pdev.drv_ioctl(drv_ioctl_cmd::import_bo, &arg);
-  m_size = arg.size;
-  m_id = arg.bo;
-  m_xdna_addr = arg.xdna_addr;
-  m_map_offset = arg.map_offset;
+  m_size = arg.boinfo.size;
+  m_id = arg.boinfo.bo;
+  m_xdna_addr = arg.boinfo.xdna_addr;
+  m_map_offset = arg.boinfo.map_offset;
 }
 
 drm_bo::
 ~drm_bo()
 {
   m_vaddr.reset();
-
-  try {
-    destroy_bo_arg arg = {
-      .bo = m_id,
-    };
-    m_pdev.drv_ioctl(drv_ioctl_cmd::destroy_bo, &arg);
-  } catch (const xrt_core::system_error& e) {
-    // In case BO is exported and imported in the same process, the same BO
-    // could be destroyed twice (once by exported BO, and once by imported BO).
-    // The last BO destroy will see EINVAL error. Ignore it.
-    if (e.get_code() != EINVAL) {
-      std::cout << "Failed to destroy DRM BO "
-        << std::to_string(m_id.handle)
-        << ": " << e.what()
-        << std::endl;
-    }
-  }
+  destroy_bo_arg arg = {
+    .bo = m_id,
+  };
+  m_pdev.drv_ioctl(drv_ioctl_cmd::destroy_bo, &arg);
 }
 
 //

--- a/src/shim/buffer.h
+++ b/src/shim/buffer.h
@@ -35,7 +35,7 @@ private:
 
 class drm_bo {
 public:
-  drm_bo(const pdev& pdev, size_t size, int type);
+  drm_bo(const pdev& pdev, size_t size, uint32_t type);
   drm_bo(const pdev& pdev, size_t size, void *uptr);
   drm_bo(const pdev& pdev, xrt_core::shared_handle::export_handle ehdl);
   ~drm_bo();

--- a/src/shim/host/platform_host.cpp
+++ b/src/shim/host/platform_host.cpp
@@ -265,20 +265,9 @@ import_bo(import_bo_arg& bo_arg) const
   carg.fd = bo_arg.fd;
   ioctl(dev_fd(), DRM_IOCTL_PRIME_FD_TO_HANDLE, &carg);
 
-  bo_info info;
-  auto bo_exist = true;
-  try {
-    load_bo_info(carg.handle, info);
-  } catch (const xrt_core::system_error& e) {
-    if (e.get_code() != ENOENT)
-      throw;
-    bo_exist = false;
-  }
-  if (bo_exist) {
-    // Found existing BO, just use the info.
-    bo_arg.boinfo = info;
+  // Found existing BO, just use the saved info.
+  if (load_bo_info(carg.handle, bo_arg.boinfo))
     return;
-  }
 
   amdxdna_drm_get_bo_info iarg = {};
   iarg.handle = carg.handle;

--- a/src/shim/host/platform_host.cpp
+++ b/src/shim/host/platform_host.cpp
@@ -291,6 +291,8 @@ import_bo(import_bo_arg& bo_arg) const
   bo_arg.boinfo.type = AMDXDNA_BO_SHARE;
   bo_arg.boinfo.size = lseek(bo_arg.fd, 0, SEEK_END);
   lseek(bo_arg.fd, 0, SEEK_SET);
+
+  save_bo_info(carg.handle, bo_arg.boinfo);
 }
 
 void

--- a/src/shim/host/platform_host.cpp
+++ b/src/shim/host/platform_host.cpp
@@ -192,7 +192,7 @@ create_drm_bo(void *uva_tbl, size_t size, int type) const
 
 void
 platform_drv_host::
-create_bo(create_bo_arg& bo_arg) const
+create_bo(bo_info& bo_arg) const
 {
   bo_arg.bo.res_id = AMDXDNA_INVALID_BO_HANDLE;
   std::tie(bo_arg.bo.handle, bo_arg.xdna_addr, bo_arg.map_offset) =
@@ -201,14 +201,14 @@ create_bo(create_bo_arg& bo_arg) const
 
 void
 platform_drv_host::
-create_uptr_bo(create_uptr_bo_arg& bo_arg) const
+create_uptr_bo(bo_info& bo_arg) const
 {
   alignas(amdxdna_drm_va_tbl)
   char buf[sizeof(amdxdna_drm_va_tbl) + sizeof(amdxdna_drm_va_entry)];
   auto tbl = reinterpret_cast<amdxdna_drm_va_tbl*>(buf);
   tbl->udma_fd = -1;
   tbl->num_entries = 1;
-  tbl->va_entries[0].vaddr = reinterpret_cast<uintptr_t>(bo_arg.buf);
+  tbl->va_entries[0].vaddr = reinterpret_cast<uintptr_t>(bo_arg.vaddr);
   tbl->va_entries[0].len = page_roundup(bo_arg.size);
 
   bo_arg.bo.res_id = AMDXDNA_INVALID_BO_HANDLE;
@@ -263,13 +263,13 @@ import_bo(import_bo_arg& bo_arg) const
   amdxdna_drm_get_bo_info iarg = {};
   iarg.handle = carg.handle;
   ioctl(dev_fd(), DRM_IOCTL_AMDXDNA_GET_BO_INFO, &iarg);
-  bo_arg.bo.handle = carg.handle;
-  bo_arg.bo.res_id = AMDXDNA_INVALID_BO_HANDLE;
-  bo_arg.xdna_addr = iarg.xdna_addr;
-  bo_arg.vaddr = to_ptr(iarg.vaddr);
-  bo_arg.map_offset = iarg.map_offset;
-  bo_arg.type = AMDXDNA_BO_SHARE;
-  bo_arg.size = lseek(bo_arg.fd, 0, SEEK_END);
+  bo_arg.boinfo.bo.handle = carg.handle;
+  bo_arg.boinfo.bo.res_id = AMDXDNA_INVALID_BO_HANDLE;
+  bo_arg.boinfo.xdna_addr = iarg.xdna_addr;
+  bo_arg.boinfo.vaddr = to_ptr(iarg.vaddr);
+  bo_arg.boinfo.map_offset = iarg.map_offset;
+  bo_arg.boinfo.type = AMDXDNA_BO_SHARE;
+  bo_arg.boinfo.size = lseek(bo_arg.fd, 0, SEEK_END);
   lseek(bo_arg.fd, 0, SEEK_SET);
 }
 

--- a/src/shim/host/platform_host.h
+++ b/src/shim/host/platform_host.h
@@ -27,10 +27,10 @@ private:
   config_ctx_debug_bo(config_ctx_debug_bo_arg& arg) const override;
 
   void
-  create_bo(create_bo_arg& arg) const override;
+  create_bo(bo_info& arg) const override;
 
   void
-  create_uptr_bo(create_uptr_bo_arg& arg) const override;
+  create_uptr_bo(bo_info& arg) const override;
 
   void
   destroy_bo(destroy_bo_arg& arg) const override;

--- a/src/shim/kmq/pcidev.cpp
+++ b/src/shim/kmq/pcidev.cpp
@@ -70,7 +70,7 @@ is_umq() const
 
 void
 pdev_kmq::
-create_drm_bo(create_bo_arg *arg) const
+create_drm_bo(bo_info *arg) const
 {
   if (arg->type != AMDXDNA_BO_DEV) {
     drv_ioctl(drv_ioctl_cmd::create_bo, arg);

--- a/src/shim/kmq/pcidev.h
+++ b/src/shim/kmq/pcidev.h
@@ -29,7 +29,7 @@ public:
   is_umq() const override;
 
   void
-  create_drm_bo(create_bo_arg *arg) const override;
+  create_drm_bo(bo_info *arg) const override;
 
 private:
   // Alloc'ed on first open and freed on last close

--- a/src/shim/pcidev.cpp
+++ b/src/shim/pcidev.cpp
@@ -36,7 +36,7 @@ void
 pdev::
 open() const
 {
-  const std::lock_guard<std::mutex> lock(m_lock);
+  const std::lock_guard<std::mutex> lock(m_open_close_lock);
 
   if (m_dev_users == 0) {
     m_driver->drv_open(m_sysfs_name);
@@ -54,7 +54,7 @@ void
 pdev::
 close() const
 {
-  const std::lock_guard<std::mutex> lock(m_lock);
+  const std::lock_guard<std::mutex> lock(m_open_close_lock);
 
   --m_dev_users;
   if (m_dev_users == 0) {

--- a/src/shim/pcidev.h
+++ b/src/shim/pcidev.h
@@ -78,7 +78,7 @@ public:
   is_umq() const = 0;
 
   virtual void
-  create_drm_bo(create_bo_arg *arg) const = 0;
+  create_drm_bo(bo_info *arg) const = 0;
 
 private:
   virtual void
@@ -88,7 +88,8 @@ private:
   on_last_close() const = 0;
 
   mutable int m_dev_users = 0;
-  mutable std::mutex m_lock;
+  mutable std::mutex m_open_close_lock;
+
   std::shared_ptr<const platform_drv> m_driver;
 };
 

--- a/src/shim/platform.cpp
+++ b/src/shim/platform.cpp
@@ -187,10 +187,10 @@ drv_ioctl(drv_ioctl_cmd cmd, void* cmd_arg) const
     config_ctx_debug_bo(*static_cast<config_ctx_debug_bo_arg*>(cmd_arg));
     break;
   case drv_ioctl_cmd::create_bo:
-    create_bo(*static_cast<create_bo_arg*>(cmd_arg));
+    create_bo(*static_cast<bo_info*>(cmd_arg));
     break;
   case drv_ioctl_cmd::create_uptr_bo:
-    create_uptr_bo(*static_cast<create_uptr_bo_arg*>(cmd_arg));
+    create_uptr_bo(*static_cast<bo_info*>(cmd_arg));
     break;
   case drv_ioctl_cmd::destroy_bo:
     destroy_bo(*static_cast<destroy_bo_arg*>(cmd_arg));

--- a/src/shim/platform.cpp
+++ b/src/shim/platform.cpp
@@ -258,6 +258,9 @@ save_bo_info(uint32_t key, bo_info& info) const
 {
   const std::lock_guard<std::mutex> lock(m_drm_bo_map_lock);
 
+  if (key == AMDXDNA_INVALID_BO_HANDLE)
+    return;
+
   if (m_drm_bo_map.find(key) != m_drm_bo_map.end())
     shim_err(EEXIST, "BO info for %d already exists", key);
   m_drm_bo_map[key] = { 1, info };
@@ -269,6 +272,9 @@ delete_bo_info(uint32_t key) const
 {
   const std::lock_guard<std::mutex> lock(m_drm_bo_map_lock);
   bool erased;
+
+  if (key == AMDXDNA_INVALID_BO_HANDLE)
+    return true;
 
   auto it = m_drm_bo_map.find(key);
   if (it == m_drm_bo_map.end())
@@ -285,7 +291,7 @@ delete_bo_info(uint32_t key) const
   return erased;
 }
 
-void
+bool
 platform_drv::
 load_bo_info(uint32_t key, bo_info& info) const
 {
@@ -293,10 +299,11 @@ load_bo_info(uint32_t key, bo_info& info) const
 
   auto it = m_drm_bo_map.find(key);
   if (it == m_drm_bo_map.end())
-    shim_err(ENOENT, "BO info for %d not found", key);
+    return false;
 
   it->second.first++;
   info = it->second.second;
+  return true;
 }
 
 }

--- a/src/shim/platform.h
+++ b/src/shim/platform.h
@@ -212,7 +212,7 @@ protected:
   bool
   delete_bo_info(uint32_t key) const;
 
-  void
+  bool
   load_bo_info(uint32_t key, bo_info& info) const;
 
 private:

--- a/src/shim/platform.h
+++ b/src/shim/platform.h
@@ -206,6 +206,15 @@ protected:
   virtual void
   signal_syncobj(signal_syncobj_arg& arg) const;
 
+  void
+  save_bo_info(uint32_t key, bo_info& info) const;
+
+  bool
+  delete_bo_info(uint32_t key) const;
+
+  void
+  load_bo_info(uint32_t key, bo_info& info) const;
+
 private:
   std::shared_ptr<const drv> m_driver;
 
@@ -223,7 +232,7 @@ private:
   // the bo is destroyed will cause the driver bo to be freed while
   // other bo intances may still be in-use in shim.
   mutable std::mutex m_drm_bo_map_lock;
-  std::map<uint32_t, bo_info> m_drm_bo_map;
+  mutable std::map< uint32_t, std::pair<int, bo_info> > m_drm_bo_map;
 
   std::string
   get_dev_node(const std::string& sysfs_name);

--- a/src/shim/umq/pcidev.cpp
+++ b/src/shim/umq/pcidev.cpp
@@ -49,7 +49,7 @@ is_umq() const
 
 void
 pdev_umq::
-create_drm_bo(create_bo_arg *arg) const
+create_drm_bo(bo_info *arg) const
 {
   drv_ioctl(drv_ioctl_cmd::create_bo, arg);
 }

--- a/src/shim/umq/pcidev.h
+++ b/src/shim/umq/pcidev.h
@@ -27,7 +27,7 @@ public:
   is_umq() const override;
 
   void
-  create_drm_bo(create_bo_arg *arg) const override;
+  create_drm_bo(bo_info *arg) const override;
 
 private:
   virtual void

--- a/src/shim/virtio/platform_virtio.cpp
+++ b/src/shim/virtio/platform_virtio.cpp
@@ -713,6 +713,8 @@ import_bo(import_bo_arg& bo_arg) const
   bo_arg.boinfo.map_offset = map_offset;
   bo_arg.boinfo.type = AMDXDNA_BO_SHARE;
   bo_arg.boinfo.size = size;
+
+  save_bo_info(gboh, bo_arg.boinfo);
 }
 
 }

--- a/src/shim/virtio/platform_virtio.cpp
+++ b/src/shim/virtio/platform_virtio.cpp
@@ -463,7 +463,7 @@ host_bo_free(uint32_t host_hdl) const
 
 void
 platform_drv_virtio::
-create_bo(create_bo_arg& arg) const
+create_bo(bo_info& arg) const
 {
   bo_id id;
   auto fd = dev_fd();
@@ -685,13 +685,13 @@ import_bo(import_bo_arg& bo_arg) const
   uint64_t map_offset = AMDXDNA_INVALID_ADDR;
   map_offset = drm_bo_get_map_offset(fd, gboh);
 
-  bo_arg.bo.handle = hboh;
-  bo_arg.bo.res_id = gboh;
-  bo_arg.xdna_addr = xdna_addr;
-  bo_arg.vaddr = nullptr;
-  bo_arg.map_offset = map_offset;
-  bo_arg.type = AMDXDNA_BO_SHARE;
-  bo_arg.size = size;
+  bo_arg.boinfo.bo.handle = hboh;
+  bo_arg.boinfo.bo.res_id = gboh;
+  bo_arg.boinfo.xdna_addr = xdna_addr;
+  bo_arg.boinfo.vaddr = nullptr;
+  bo_arg.boinfo.map_offset = map_offset;
+  bo_arg.boinfo.type = AMDXDNA_BO_SHARE;
+  bo_arg.boinfo.size = size;
 }
 
 }

--- a/src/shim/virtio/platform_virtio.cpp
+++ b/src/shim/virtio/platform_virtio.cpp
@@ -484,12 +484,17 @@ create_bo(bo_info& arg) const
     drm_bo_free(fd, arg.bo.res_id);
     throw;
   }
+
+  save_bo_info(arg.bo.res_id, arg);
 }
 
 void
 platform_drv_virtio::
 destroy_bo(destroy_bo_arg& arg) const
 {
+  if (!delete_bo_info(arg.bo.res_id))
+    return;
+
   host_bo_free(arg.bo.handle);
   drm_bo_free(dev_fd(), arg.bo.res_id);
 }
@@ -671,6 +676,22 @@ import_bo(import_bo_arg& bo_arg) const
   ioctl(fd, DRM_IOCTL_PRIME_FD_TO_HANDLE, &carg);
   auto gboh = carg.handle;
 
+  bo_info info;
+  auto bo_exist = true;
+  try {
+    load_bo_info(gboh, info);
+  } catch (const xrt_core::system_error& e) {
+    if (e.get_code() != ENOENT)
+      throw;
+    bo_exist = false;
+  }
+  if (bo_exist) {
+    // Found existing BO, just use the info.
+    bo_arg.boinfo = info;
+    return;
+  }
+
+  // New BO is created.
   auto [ resource, size ] = drm_bo_get_info(fd, gboh);
 
   uint32_t hboh = AMDXDNA_INVALID_BO_HANDLE;

--- a/src/shim/virtio/platform_virtio.h
+++ b/src/shim/virtio/platform_virtio.h
@@ -66,7 +66,7 @@ private:
   host_bo_free(uint32_t host_hdl) const;
 
   void
-  create_bo(create_bo_arg& arg) const override;
+  create_bo(bo_info& arg) const override;
 
   void
   destroy_bo(destroy_bo_arg& arg) const override;


### PR DESCRIPTION
When importing a BO which is exported from the same process, driver will return the same BO handle. In SHIM, the exported BO and imported one are two different BOs referring to the same BO in driver. To make sure, when one of the BO is destroyed, we don't delete the BO in driver since the other is still in-use, SHIM will maintain a reference counter to the BO in driver, which will be deleted until all BOs in SHIM are gone.

Tested in both bare metal and virtio environments.