### PR TITLE
Update get async error ioctl to return only 0 for success case

### DIFF
--- a/src/driver/amdxdna/aie2_error.c
+++ b/src/driver/amdxdna/aie2_error.c
@@ -434,23 +434,3 @@ int aie2_error_async_cache_init(struct amdxdna_dev_hdl *ndev)
 {
 	return amdxdna_error_async_cache_init(&ndev->async_errs_cache);
 }
-
-/**
- * amdxdna_aie2_get_last_async_error - Retrieve the last asynchronous error information.
- * @xdna: Pointer to the xdna structure.
- * @num_errs: in/out, Number of error structures to populate.
- * @errors_ret: async errors information array to return
- *
- * This function obtains the most recent asynchronous error that occurred
- * in the AIE2 subsystem and populates the provided error information structure.
- * It is typically used for error handling and diagnostics in the driver.
- * Today, only one last async error is cached. And thus, this function will only
- * return 1 last async error.
- *
- * Return: 0 on success, negative error code on failure.
- */
-int aie2_error_get_last_async(struct amdxdna_dev *xdna, u32 num_errs, void *errors_ret)
-{
-	return amdxdna_error_get_last_async(xdna, &xdna->dev_handle->async_errs_cache, num_errs,
-										errors_ret);
-}

--- a/src/driver/amdxdna/aie2_pci.h
+++ b/src/driver/amdxdna/aie2_pci.h
@@ -466,7 +466,6 @@ void aie2_error_async_events_free(struct amdxdna_dev_hdl *ndev);
 int aie2_error_async_events_send(struct amdxdna_dev_hdl *ndev);
 int aie2_error_async_msg_thread(void *data);
 int aie2_error_async_cache_init(struct amdxdna_dev_hdl *ndev);
-int aie2_error_get_last_async(struct amdxdna_dev *xdna, u32 num_errs, void *errors);
 
 /* aie2_message.c */
 bool aie2_is_supported_msg(struct amdxdna_dev_hdl *ndev, enum aie2_msg_opcode opcode);


### PR DESCRIPTION
This patch has two changes:
 * returns 0 only in when get async error success
 * restructure aie2 get array ioctl implementation to split get async
    error information implementation and get other hardware context
    information implementation.
* remove aie2_error get async error implementation as it is just
   a very thin wrapper which is not necessary.
* specify only one elment to get async error information in shim layer