### PR TITLE
Minor tweaks to build xdna-driver UMD for upstreaming with XRT

### DIFF
--- a/CMake/native.cmake
+++ b/CMake/native.cmake
@@ -1,0 +1,36 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (C) 2025, Advanced Micro Devices, Inc. All rights reserved.
+
+# For native xdna-driver builds, XRT headers and link library
+# comes from xdna-driver's XRT submodule.
+
+# By default, build/build.sh downloads binaries to build/amdxdna_bins/
+# Absolute path, cannot be used in install command as destination.
+set(AMDXDNA_BINS_DIR ${CMAKE_BINARY_DIR}/../amdxdna_bins)
+
+if(XDNA_VE2)
+
+include(${CMAKE_CURRENT_SOURCE_DIR}/CMake/xrt_ve2.cmake)
+add_subdirectory(src)
+
+else(XDNA_VE2)
+
+# Bring in xrt git submodule before include any local directories
+include(${CMAKE_CURRENT_SOURCE_DIR}/CMake/xrt.cmake)
+set(XRT_SUBMOD_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/xrt)
+set(XRT_SUBMOD_BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/xrt)
+
+# Upstreaming pkg will not have access to .git which is required for version.cmake
+if(NOT SKIP_KMOD)
+  include(${CMAKE_CURRENT_SOURCE_DIR}/CMake/version.cmake)
+endif()
+
+include(${CMAKE_CURRENT_SOURCE_DIR}/CMake/pkg.cmake)
+
+add_subdirectory(src)
+
+if(NOT SKIP_KMOD)
+  add_subdirectory(test)
+endif()
+
+endif(XDNA_VE2)

--- a/CMake/upstream.cmake
+++ b/CMake/upstream.cmake
@@ -1,0 +1,11 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (C) 2025, Advanced Micro Devices, Inc. All rights reserved.
+if (POLICY CMP0177)
+  cmake_policy(SET CMP0177 NEW)
+endif()
+
+# When building for upstream, only shim plugin library is built
+# XRT is part of the upstreaming project and provides the headers
+# and targets needed by xdna plugin
+set(XRT_PLUGIN_VERSION_STRING ${XRT_VERSION_STRING})
+add_subdirectory(src/shim)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,33 +30,8 @@ message("-- XDNA_PKG_DATA_DIR=${XDNA_PKG_DATA_DIR}")
 message("-- XDNA_PKG_FW_DIR=${XDNA_PKG_FW_DIR}")
 message("-- XDNA_BIN_DIR=${XDNA_BIN_DIR}")
 
-# By default, build/build.sh downloads binaries to build/amdxdna_bins/
-# Absolute path, cannot be used in install command as destination.
-set(AMDXDNA_BINS_DIR ${CMAKE_BINARY_DIR}/../amdxdna_bins)
-
-if(XDNA_VE2)
-
-include(${CMAKE_CURRENT_SOURCE_DIR}/CMake/xrt_ve2.cmake)
-add_subdirectory(src)
-
-else(XDNA_VE2)
-
-# Bring in xrt git submodule before include any local directories
-include(${CMAKE_CURRENT_SOURCE_DIR}/CMake/xrt.cmake)
-set(XRT_SUBMOD_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/xrt)
-set(XRT_SUBMOD_BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/xrt)
-
-# Upstreaming pkg will not have access to .git which is required for version.cmake
-if(NOT SKIP_KMOD)
-  include(${CMAKE_CURRENT_SOURCE_DIR}/CMake/version.cmake)
+if (XRT_UPSTREAM)
+  include(CMake/upstream.cmake)
+else()
+  include(CMake/native.cmake)
 endif()
-
-include(${CMAKE_CURRENT_SOURCE_DIR}/CMake/pkg.cmake)
-
-add_subdirectory(src)
-
-if(NOT SKIP_KMOD)
-  add_subdirectory(test)
-endif()
-
-endif(XDNA_VE2)


### PR DESCRIPTION
Refactor CMake such that upstreaming builds only the XDNA UMD plugin library while using XRT as provided by upstream project.

When building for upstreaming, it is assume that a top-level project provides XRT headers and targets as needed when building the xdna driver plugin library.

This changes in this PR simply disables the XRT part of xdna-driver when XRT_UPSTREAM is defined.

No changes for native xdna-driver builds.