### PR TITLE
Ve2 runner to archive migration

### DIFF
--- a/src/shim_ve2/CMakeLists.txt
+++ b/src/shim_ve2/CMakeLists.txt
@@ -36,6 +36,13 @@ install (TARGETS ${XDNA_VE2_TARGET}
   LIBRARY DESTINATION ${XRT_INSTALL_LIB_DIR}
   )
 
-install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/Runner/
-	DESTINATION ${CMAKE_INSTALL_DATADIR}/amdxdna/
+set(vtd_file "${CMAKE_CURRENT_BINARY_DIR}/xrt_smi_ve2.ar")
+
+file(DOWNLOAD
+  "https://github.com/Xilinx/VTD/raw/b935283f0ff7a5b68cc87cf1139eef83f344a208/archive/ve2/xrt_smi_ve2.a"
+  "${vtd_file}"
+)
+
+install(FILES "${vtd_file}"
+  DESTINATION ${CMAKE_INSTALL_DATADIR}/amdxdna/bins/
 )

--- a/src/shim_ve2/xdna_device.cpp
+++ b/src/shim_ve2/xdna_device.cpp
@@ -336,41 +336,16 @@ struct firmware_version
     return output;
   }
 };
-struct runner
+
+struct archive_path
 {
-    static std::any
-    get(const xrt_core::device* /*device*/, key_type key)
-    {
-      throw xrt_core::query::no_such_key(key, "Not implemented");
-    }
+  using result_type = query::archive_path::result_type;
 
-    static std::any
-    get(const xrt_core::device* device, key_type key, const std::any& param)
-    {
-      if (key != key_type::runner)
-        throw xrt_core::query::no_such_key(key, "Not implemented");
-
-      std::string file_name;
-      std::string path;
-      const auto runner_type = std::any_cast<xrt_core::query::runner::type>(param);
-      switch (runner_type) {
-      case xrt_core::query::runner::type::latency_path:
-        path = get_shim_data_dir() + std::string("latency/");
-        break;
-      case xrt_core::query::runner::type::latency_recipe:
-        file_name = "latency/recipe_latency.json";
-        break;
-      case xrt_core::query::runner::type::latency_profile:
-        file_name = "latency/profile_latency.json";
-        break;
-      }
-
-      if (!path.empty())
-          return get_shim_data_dir() + path;
-
-      return get_shim_data_dir() + boost::str(boost::format("%s")
-        % file_name);
-    }
+  static result_type
+  get(const xrt_core::device* device, key_type key)
+  {
+        return std::string(get_shim_data_dir() + "bins/xrt_smi_ve2.ar");
+  }
 };
 
 struct total_cols
@@ -629,8 +604,8 @@ initialize_query_table()
   emplace_func0_request<query::rom_vbnv,                dev_info>();
   emplace_func0_request<query::device_class,            dev_info>();
   emplace_func0_request<query::total_cols,              total_cols>();
+  emplace_func0_request<query::archive_path,            archive_path>();
   emplace_func1_request<query::firmware_version,        firmware_version>();
-  emplace_func1_request<query::runner,                  runner>();
   emplace_func4_request<query::xrt_smi_config,          xrt_smi_config>();
   emplace_func4_request<query::xrt_smi_lists,           xrt_smi_lists>();
 }


### PR DESCRIPTION
Archive files with the .a extension are not supported as part of /usr/... because the dwarfsrc files package attempts to extract debug symbols even though it's not an ELF binary.
Since this archive is part of XRT, we **cannot skip** the entire package from any checks. Therefore, the archive is downloaded as an ar extension package to avoid being scanned by QA checks.

This has been tested on the Telluride board using the generated Image/rootfs with these changes.

```
amd-edf:/home/amd-edf# xrt-smi validate -d 0
open : DEV name  /dev/accel/accel0
Validate Device           : [0000:00:00.0]
    Platform              : Telluride
    Power Mode            : Default
-------------------------------------------------------------------------------
Test 1 [0000:00:00.0]     : latency 
    Details               : Average latency: 31.0 us                            
    Test Status           : [PASSED]
-------------------------------------------------------------------------------
```



Currently, only the latency test is added. We will include more test cases once the corresponding ELF binaries and XCLBINs are ready.