### PR TITLE
amdxdna: ve2: update firmware version retrieval design

### DIFF
--- a/src/driver/amdxdna/ve2_fw.c
+++ b/src/driver/amdxdna/ve2_fw.c
@@ -10,9 +10,8 @@
 #include "ve2_mgmt.h"
 #include "ve2_fw.h"
 
-int ve2_store_firmware_version(struct amdxdna_dev_hdl *xdna_hdl, struct device *xaie_dev)
+int ve2_store_firmware_version(struct ve2_firmware_version *c_version, struct device *xaie_dev)
 {
-	struct amdxdna_dev *xdna = xdna_hdl->xdna;
 	struct ve2_firmware_version *version;
 	int ret = 0;
 
@@ -23,19 +22,19 @@ int ve2_store_firmware_version(struct amdxdna_dev_hdl *xdna_hdl, struct device *
 	ret = ve2_partition_read(xaie_dev, 0, 0, VE2_PROG_DATA_MEMORY_OFF + VE2_CERT_VERSION_OFF,
 				 VE2_CERT_VERSION_SIZE, version);
 	if (ret < 0) {
-		XDNA_ERR(xdna, "aie_partition_read failed with ret %d\n", ret);
 		kfree(version);
 		return ret;
 	}
 
-	memcpy(&xdna_hdl->fw_version, version, sizeof(*version));
-	XDNA_INFO(xdna, "CERT major: %u\n", xdna_hdl->fw_version.major);
-	XDNA_INFO(xdna, "CERT minor: %u\n", xdna_hdl->fw_version.minor);
-	XDNA_INFO(xdna, "CERT git hash: %s\n", xdna_hdl->fw_version.git_hash);
-	XDNA_INFO(xdna, "CERT git hash date: %s\n", xdna_hdl->fw_version.date);
+	c_version->major = version->major;
+	c_version->minor = version->minor;
+	strscpy(c_version->git_hash, version->git_hash, VE2_FW_HASH_STRING_LENGTH);
+	c_version->git_hash[VE2_FW_HASH_STRING_LENGTH - 1] = '\0';
+	strscpy(c_version->date, version->date, VE2_FW_DATE_STRING_LENGTH);
+	c_version->date[VE2_FW_DATE_STRING_LENGTH - 1] = '\0';
 	kfree(version);
 
-	return ret;
+	return 0;
 }
 
 static int get_firmware_status(struct amdxdna_dev *xdna, struct device *aie_dev,

--- a/src/driver/amdxdna/ve2_fw.h
+++ b/src/driver/amdxdna/ve2_fw.h
@@ -30,7 +30,7 @@ struct ve2_firmware_status {
 	u32 misc_status;
 };
 
-int ve2_store_firmware_version(struct amdxdna_dev_hdl *xdna_hdl, struct device *xaie_dev);
+int ve2_store_firmware_version(struct ve2_firmware_version *c_version, struct device *xaie_dev);
 int ve2_get_firmware_status(struct amdxdna_ctx *hwctx);
 
 #endif /* _VE2_FW_H_ */

--- a/src/driver/amdxdna/ve2_of.c
+++ b/src/driver/amdxdna/ve2_of.c
@@ -61,7 +61,15 @@ static int ve2_load_fw(struct amdxdna_dev_hdl *xdna_hdl)
 	}
 	XDNA_INFO(xdna, "aie load cert complete");
 
-	ve2_store_firmware_version(xdna_hdl, xaie_dev);
+	ret = ve2_store_firmware_version(&xdna_hdl->fw_version, xaie_dev);
+	if (ret < 0) {
+		XDNA_ERR(xdna, "cert status read failed with err %d", ret);
+		goto teardown;
+	}
+	XDNA_INFO(xdna, "CERT major: %d\n", xdna_hdl->fw_version.major);
+	XDNA_INFO(xdna, "CERT minor: %d\n", xdna_hdl->fw_version.minor);
+	XDNA_INFO(xdna, "CERT git hash: %s\n", xdna_hdl->fw_version.git_hash);
+	XDNA_INFO(xdna, "CERT git hash date: %s\n", xdna_hdl->fw_version.date);
 
 teardown:
 	aie_partition_teardown(xaie_dev);

--- a/src/driver/amdxdna/ve2_of.h
+++ b/src/driver/amdxdna/ve2_of.h
@@ -73,6 +73,7 @@ struct amdxdna_ctx_command_fifo {
 struct amdxdna_ctx_priv {
 	u32				start_col;
 	u32				num_col;
+	u32				state;
 	struct device			*aie_dev;
 	struct aie_partition_init_args	*args;
 	struct ve2_hsa_queue		hwctx_hsa_queue;


### PR DESCRIPTION
-Add hwctx state in ve2 driver
-Use amdxdna core API amdxdna_gem_dev_addr() for accessing device address