### PR TITLE
Added throughput testcase to ve2

### DIFF
--- a/src/shim_ve2/CMakeLists.txt
+++ b/src/shim_ve2/CMakeLists.txt
@@ -39,7 +39,7 @@ install (TARGETS ${XDNA_VE2_TARGET}
 set(vtd_file "${CMAKE_CURRENT_BINARY_DIR}/xrt_smi_ve2.ar")
 
 file(DOWNLOAD
-  "https://github.com/Xilinx/VTD/raw/b935283f0ff7a5b68cc87cf1139eef83f344a208/archive/ve2/xrt_smi_ve2.a"
+  "https://github.com/Xilinx/VTD/raw/7473843b9eb88ca83498f0498e905db913886572/archive/ve2/xrt_smi_ve2.a"
   "${vtd_file}"
 )
 

--- a/src/shim_ve2/smi_ve2.cpp
+++ b/src/shim_ve2/smi_ve2.cpp
@@ -9,7 +9,8 @@ xrt_core::smi::subcommand
 create_validate_subcommand()
 {
   std::vector<xrt_core::smi::basic_option> validate_test_desc = {
-   {"latency", "Run end-to-end latency test", "common"}
+   {"latency", "Run end-to-end latency test", "common"},
+   {"throughput", "Run end-to-end throughput test", "common"}
   };
 
   std::map<std::string, std::shared_ptr<xrt_core::smi::option>> validate_suboptions;


### PR DESCRIPTION
Added throughput testcase to ve2
Tested on hw by running xrt-smi validate -d 0
```
amd-edf:/home/amd-edf# xrt-smi validate -d 0
open : DEV name  /dev/accel/accel0
Validate Device           : [0000:00:00.0]
    Platform              : Telluride
    Power Mode            : Default
-------------------------------------------------------------------------------
Test 1 [0000:00:00.0]     : latency 
    Details               : Average latency: 31.0 us                            
    Test Status           : [PASSED]
-------------------------------------------------------------------------------
Test 3 [0000:00:00.0]     : throughput 
    Details               : Average throughput: 11735.0 op/s                    
    Test Status           : [PASSED]
-------------------------------------------------------------------------------
Validation completed. Please run the command '--verbose' option for more details
```