### PR TITLE
Updated smi_ve2.cpp to run cmd_chain_latency and cmd_chain_throughput

### DIFF
--- a/src/shim_ve2/CMakeLists.txt
+++ b/src/shim_ve2/CMakeLists.txt
@@ -39,7 +39,7 @@ install (TARGETS ${XDNA_VE2_TARGET}
 set(vtd_file "${CMAKE_CURRENT_BINARY_DIR}/xrt_smi_ve2.ar")
 
 file(DOWNLOAD
-  "https://github.com/Xilinx/VTD/raw/7473843b9eb88ca83498f0498e905db913886572/archive/ve2/xrt_smi_ve2.a"
+  "https://github.com/Xilinx/VTD/raw/66cd853d8c2002e9059a749fbbd34b58cc8674da/archive/ve2/xrt_smi_ve2.a"
   "${vtd_file}"
 )
 

--- a/src/shim_ve2/smi_ve2.cpp
+++ b/src/shim_ve2/smi_ve2.cpp
@@ -9,6 +9,9 @@ xrt_core::smi::subcommand
 create_validate_subcommand()
 {
   std::vector<xrt_core::smi::basic_option> validate_test_desc = {
+   {"all", "All applicable validate tests will be executed (default)", "common"},
+   {"cmd-chain-latency", "Run end-to-end latency test using command chaining", "hidden"},
+   {"cmd-chain-throughput", "Run end-to-end throughput test using command chaining", "hidden"},
    {"latency", "Run end-to-end latency test", "common"},
    {"throughput", "Run end-to-end throughput test", "common"}
   };


### PR DESCRIPTION
Updated smi_ve2.cpp to run cmd_chain_latency and cmd_chain_throughput

xrt-smi validate --advanced -r all -d 0

```amd-edf:/home/amd-edf/ve2/cmd_chain_latency# xrt-smi validate --advanced -r all -d 0
open : DEV name  /dev/accel/accel0
Validate Device           : [0000:00:00.0]
    Platform              : Telluride
    Power Mode            : Default
-------------------------------------------------------------------------------
Test 1 [0000:00:00.0]     : cmd-chain-latency 
    Details               : Average latency: 316.0 us                           
    Test Status           : [PASSED]
-------------------------------------------------------------------------------
Test 3 [0000:00:00.0]     : cmd-chain-throughput 
    Details               : Average throughput: 3156.0 ops/s                    
    Test Status           : [PASSED]
-------------------------------------------------------------------------------
Test 5 [0000:00:00.0]     : latency 
    Details               : Average latency: 31.0 us                            
    Test Status           : [PASSED]
-------------------------------------------------------------------------------
Test 7 [0000:00:00.0]     : throughput 
    Details               : Average throughput: 11161.0 op/s                    
    Test Status           : [PASSED]
-------------------------------------------------------------------------------
Validation completed. Please run the command '--verbose' option for more details
amd-edf:/home/amd-edf/ve2/cmd_chain_latency# [vek385-3] Systest#
```