### PR TITLE
Revert "ve2: Read cert's cmd completion status and set it (#830)"

### DIFF
--- a/src/driver/amdxdna/ve2_hwctx.c
+++ b/src/driver/amdxdna/ve2_hwctx.c
@@ -755,6 +755,10 @@ int ve2_cmd_wait(struct amdxdna_ctx *hwctx, u64 seq, u32 timeout)
 		}
 
 		/*
+		 * amdxdna_cmd_set_state(job->cmd_bo,
+		 *                       priv_ctx->hwctx_hsa_queue.hq_complete.hqc_mem[seq]);
+		 */
+		/*
 		 * below check need to be removed once we have a clean solution
 		 * to use completion signal
 		 */
@@ -778,8 +782,7 @@ int ve2_cmd_wait(struct amdxdna_ctx *hwctx, u64 seq, u32 timeout)
 			hwctx->health_reported = true;
 			amdxdna_cmd_set_state(job->cmd_bo, ERT_CMD_STATE_TIMEOUT);
 		} else {
-			amdxdna_cmd_set_state(job->cmd_bo,
-					      priv_ctx->hwctx_hsa_queue.hq_complete.hqc_mem[seq]);
+			amdxdna_cmd_set_state(job->cmd_bo, ERT_CMD_STATE_COMPLETED);
 		}
 
 		ve2_hwctx_job_release(hwctx, job);


### PR DESCRIPTION
This reverts commit f99cb012b8ae4ad455ec29f2a63765b4f96da003.
xrt-smi validate -d 0 command is failing with this commit 