### PR TITLE
dpt: use system_percpu_wq for newer kernel versions > 6.18

### DIFF
--- a/src/driver/amdxdna/amdxdna_dpt.c
+++ b/src/driver/amdxdna/amdxdna_dpt.c
@@ -187,7 +187,7 @@ static irqreturn_t dpt_irq_handler(int irq, void *data)
 	/* Clear the interrupt */
 	writel(0, dpt->io_base + dpt->msi_address);
 
-#if KERNEL_VERSION(6, 17, 0) > LINUX_VERSION_CODE
+#if KERNEL_VERSION(6, 18, 0) > LINUX_VERSION_CODE
 	queue_work(system_wq, &dpt->work);
 #else
 	queue_work(system_percpu_wq, &dpt->work);
@@ -264,7 +264,7 @@ static void amdxdna_dpt_timer(struct timer_list *t)
 {
 	struct amdxdna_dpt *dpt = container_of(t, struct amdxdna_dpt, timer);
 
-#if KERNEL_VERSION(6, 17, 0) > LINUX_VERSION_CODE
+#if KERNEL_VERSION(6, 18, 0) > LINUX_VERSION_CODE
 	queue_work(system_wq, &dpt->work);
 #else
 	queue_work(system_percpu_wq, &dpt->work);


### PR DESCRIPTION
Generated Ubuntu kernel headers 6.17.1 do not include `system_percpu_wq` related changes, which are part of mainline.

$ cat /usr/src/linux-headers-6.17.1+/include/linux/workqueue.h | grep "extern struct workqueue_struct" extern struct workqueue_struct *system_wq;
extern struct workqueue_struct *system_highpri_wq; extern struct workqueue_struct *system_long_wq;
extern struct workqueue_struct *system_unbound_wq; extern struct workqueue_struct *system_freezable_wq; extern struct workqueue_struct *system_power_efficient_wq; extern struct workqueue_struct *system_freezable_power_efficient_wq; extern struct workqueue_struct *system_bh_wq;
extern struct workqueue_struct *system_bh_highpri_wq;

Verified that Ubuntu headers linux-headers-6.17.6 include `system_percpu_wq` so lets start using the new wq after 6.18