### PR TITLE
Fixing the gem_prime_import. Avoiding double free to avoid crash

### DIFF
--- a/src/driver/amdxdna/amdxdna_gem.c
+++ b/src/driver/amdxdna/amdxdna_gem.c
@@ -863,7 +863,7 @@ amdxdna_gem_prime_import(struct drm_device *dev, struct dma_buf *dma_buf)
 		ret = amdxdna_bo_dma_map(abo);
 		if (ret) {
 			drm_gem_object_put(gobj);
-			goto fail_unmap;
+			return ERR_PTR(ret);
 		}
 	}
 #endif


### PR DESCRIPTION
This pr fixes the crash due to double free of user ptr BOs if amdxdna_bo_dma_map() fails means if the user ptr BOs are not contiguous.

Earlier amdxdna_gem_prime_import() used to double free if amdxdna_bo_dma_map()'s contiguous check fails. drm_gem_object_put() will trigger the amdxdna_gem_shmem_obj_free() which already triggers the dma_buf_unmap_attachment_unlocked()/dma_buf_detach()/dma_buf_put(). 

In this fix just after putting the gem obj, im just returning the ERR_PTR.