### PR TITLE
Revert "Fixing the gem_prime_import. Avoiding double free to avoid crash"

### DIFF
--- a/src/driver/amdxdna/amdxdna_gem.c
+++ b/src/driver/amdxdna/amdxdna_gem.c
@@ -863,7 +863,7 @@ amdxdna_gem_prime_import(struct drm_device *dev, struct dma_buf *dma_buf)
 		ret = amdxdna_bo_dma_map(abo);
 		if (ret) {
 			drm_gem_object_put(gobj);
-			return ERR_PTR(ret);
+			goto fail_unmap;
 		}
 	}
 #endif


### PR DESCRIPTION
Reverts amd/xdna-driver#852