### PR TITLE
fixing multi thread related issues in ve2

### DIFF
--- a/src/shim_ve2/xdna_device.cpp
+++ b/src/shim_ve2/xdna_device.cpp
@@ -670,26 +670,27 @@ device_xdna::
 create_hw_context(const xrt::uuid& xclbin_uuid, const xrt::hw_context::qos_type& qos,
 		  xrt::hw_context::access_mode mode) const
 {
-  m_uuid = xclbin_uuid.to_string(); // maintaining uuid in device class
   auto mutable_qos = qos; // Create a local copy
 
   //if qos already has priority parameter, then dont overwrite with access_mode
   if (mutable_qos.find("priority") == mutable_qos.end()) {
-  
+
     if (mode == xrt::hw_context::access_mode::exclusive)
       mutable_qos["priority"] = AMDXDNA_QOS_REALTIME_PRIORITY;
     else
       mutable_qos["priority"] = AMDXDNA_QOS_NORMAL_PRIORITY;
 
   }
+  auto xclbin = get_xclbin(xclbin_uuid);
+  std::memcpy((&m_uuid), xclbin.get_uuid().get(), sizeof(xuid_t));
 
-  auto hwctx_obj = std::make_unique<xdna_hwctx>(*this, get_xclbin(xclbin_uuid), mutable_qos);
+  auto hwctx_obj = std::make_unique<xdna_hwctx>(this, xclbin, mutable_qos);
 
   auto data = get_axlf_section(AIE_METADATA, xclbin_uuid);
 
   if (data.first && data.second)
   {
-    device_xdna* non_const_this = const_cast<device_xdna*>(this); 
+    device_xdna* non_const_this = const_cast<device_xdna*>(this);
     non_const_this->register_aie_array(hwctx_obj.get());
   }
   return hwctx_obj;
@@ -712,7 +713,7 @@ create_hw_context(uint32_t partition_size,
       mutable_qos["priority"] = AMDXDNA_QOS_NORMAL_PRIORITY;
 
   }
-  auto hwctx_obj = std::make_unique<xdna_hwctx>(*this, partition_size, mutable_qos);
+  auto hwctx_obj = std::make_unique<xdna_hwctx>(this, partition_size, mutable_qos);
   // TODO : Get AIE_METADATA info from ELF and register aie array
 
   return hwctx_obj;

--- a/src/shim_ve2/xdna_device.h
+++ b/src/shim_ve2/xdna_device.h
@@ -87,19 +87,19 @@ public:
   int
   get_info(xclDeviceInfo2 *info) const;
 
-  std::shared_ptr<xdna_aie_array> 
+  std::shared_ptr<xdna_aie_array>
   get_aie_array();
 
-  void 
+  void
   register_aie_array(const xdna_hwctx* hwctx_obj);
 
-  bool 
+  bool
   is_aie_registered();
 
   std::string
   get_uuid() const
   {
-    return m_uuid;
+    return m_uuid.to_string();
   }
 
 private:
@@ -109,7 +109,7 @@ private:
   const xrt_core::query::request&
   lookup_query(xrt_core::query::key_type query_key) const override;
   std::shared_ptr<xdna_aie_array> m_aie_array;
-  mutable std::string m_uuid;
+  mutable xrt::uuid m_uuid;
 
 };
 

--- a/src/shim_ve2/xdna_hwctx.h
+++ b/src/shim_ve2/xdna_hwctx.h
@@ -26,9 +26,9 @@ class xdna_hwq; // forward declaration
 class xdna_hwctx : public xrt_core::hwctx_handle
 {
 public:
-  xdna_hwctx(const device_xdna& dev, const xrt::xclbin& xclbin, const xrt::hw_context::qos_type& qos);
+  xdna_hwctx(const device_xdna* dev, const xrt::xclbin& xclbin, const xrt::hw_context::qos_type& qos);
 
-  xdna_hwctx(const device_xdna& dev, uint32_t partition_size, const xrt::hw_context::qos_type& qos);
+  xdna_hwctx(const device_xdna* dev, uint32_t partition_size, const xrt::hw_context::qos_type& qos);
 
   ~xdna_hwctx();
 
@@ -88,9 +88,10 @@ public:
   std::shared_ptr<xdna_aie_array>
   get_aie_array();
 
-protected:
-  const device_xdna&
+  device_xdna*
   get_device();
+
+protected:
 
   struct cu_info {
     std::string m_name;
@@ -114,7 +115,7 @@ protected:
   fini_log_buf();
 
 private:
-  const device_xdna& m_device;
+  device_xdna* m_device;
   slot_id m_handle = AMDXDNA_INVALID_CTX_HANDLE;
   amdxdna_qos_info m_qos = {};
   std::vector<cu_info> m_cu_info;

--- a/src/shim_ve2/xdna_hwq.h
+++ b/src/shim_ve2/xdna_hwq.h
@@ -14,7 +14,9 @@ namespace shim_xdna_edge {
 class xdna_hwq : public xrt_core::hwqueue_handle
 {
 public:
-  xdna_hwq(const device_xdna& device);
+  xdna_hwq(const device_xdna* device);
+  xdna_hwq() = default;
+  virtual ~xdna_hwq(){};
 
   void
   submit_command(xrt_core::buffer_handle *) override;
@@ -53,8 +55,7 @@ public:
   get_queue_bo();
 
 private:
-  const xdna_hwctx *m_hwctx;
-  std::shared_ptr<xdna_edgedev> m_edev;
+  xdna_hwctx *m_hwctx;
   uint32_t m_queue_boh;
 };
 


### PR DESCRIPTION
There are couple of issues in current shim_ve2 which are causing below issues.
1) make_unique returns same memory due to the xdna_hwq constructor
2) uuid is being copied from reference which is causing failure in destructor.