### PR TITLE
Makefile changes required to display amdxdna driver version

### DIFF
--- a/src/driver/amdxdna/Makefile
+++ b/src/driver/amdxdna/Makefile
@@ -37,10 +37,15 @@ ifeq ($(XDNA_BUS_TYPE), of)
 DEFINES += -DAMDXDNA_OF
 endif
 
-GIT_HASH := $(shell git rev-parse HEAD)
+# Driver version
+XDNA_DRIVER_VERSION ?= 2.21.0
+XDNA_DATE ?= $(shell date +%Y%m%d)
+XDNA_HASH ?= $(shell git rev-parse HEAD)
+
 ifndef MODULE_VER_STR
-MODULE_VER_STR := $(GIT_HASH)
+MODULE_VER_STR := $(XDNA_DRIVER_VERSION)_$(XDNA_DATE),$(XDNA_HASH)
 endif
+
 DEFINES += -DMODULE_VER_STR='\"$(MODULE_VER_STR)\"'
 
 modules:


### PR DESCRIPTION
Makefile changes are required to display the AMD XDNA driver version.

The version.cmake and CMakeLists.txt files are not available when building the amdxdna driver for edge cases, as we directly run the Makefile present in the driver. This makes the macros unavailable. Therefore, we added commands to the corresponding macro and updated it to use MODULE_VERSION(), which maintains the version in /sys/module/driver/version files. This version is fetched by XRT to display in the xrt-smi examine report.

Please refer to this PR: https://github.com/Xilinx/XRT/pull/9430 for details on how XRT_DRIVER_VERSION is maintained in zocl.

Tested by running xrt-smi examine on the Telluride board
```
XRT
  Version              : 2.21.0
  Branch               : HEAD
  Hash                 : 042a967bd865c7d932ccf5808827a3b98dc7a308
  Hash Date            : 2025-11-12 19:13:36
  amdxdna              : 2.21.0_20251112, e56379dd493ebdc3b74228fa8404439ce0395263
  zocl                 : 2.21.0, 042a967bd865c7d932ccf5808827a3b98dc7a308
  UC Firmware Version  : 0.17, c76d3a76981106a614e3eeda6b268059fc75957d
  UC Build Date        : 2025-10-25

Device(s) Present
|BDF             |Shell  |Logic UUID  |Device ID     |Device Ready*  |
|----------------|-------|------------|--------------|---------------|
|[0000:00:00.1]  |edge   |0x0         |user(inst=0)  |Yes            |


* Devices that are not ready will have reduced functionality when using XRT tools
|BDF             |Name       |
|----------------|-----------|
|[0000:00:00.0]  |Telluride  |


amd-edf:/home/amd-edf# 
```
