### PR TITLE
amdxdna: Fix kernel crash during command timeout cleanup

### DIFF
--- a/src/driver/amdxdna/ve2_hwctx.c
+++ b/src/driver/amdxdna/ve2_hwctx.c
@@ -918,9 +918,32 @@ void ve2_hwctx_fini(struct amdxdna_ctx *hwctx)
 {
 	struct amdxdna_client *client = hwctx->client;
 	struct amdxdna_dev *xdna = client->xdna;
+	struct amdxdna_ctx_priv *nhwctx = hwctx->priv;
+	struct amdxdna_mgmtctx *mgmtctx;
 	struct amdxdna_sched_job *job;
 	int idx;
 
+	if (enable_polling)
+		del_timer_sync(&hwctx->priv->event_timer);
+
+	/*
+	 * Clear active_ctx FIRST to prevent IRQ handler from queueing new work,
+	 * then cancel any pending work to ensure no work is accessing this context
+	 */
+	mgmtctx = &xdna->dev_handle->ve2_mgmtctx[nhwctx->start_col];
+	spin_lock(&mgmtctx->ctx_lock);
+	if (mgmtctx->active_ctx == hwctx)
+		mgmtctx->active_ctx = NULL;
+	spin_unlock(&mgmtctx->ctx_lock);
+
+	/* Now cancel any pending work - it will see active_ctx as NULL and bail out */
+	if (mgmtctx->mgmtctx_workq)
+		cancel_work_sync(&mgmtctx->sched_work);
+
+	/*
+	 * Release jobs first to decrement BO refcounts, but they may not
+	 * be freed immediately if the application still holds references
+	 */
 	for (idx = 0; idx < HWCTX_MAX_CMDS; idx++) {
 		job = hwctx->priv->pending[idx];
 		if (!job)
@@ -928,9 +951,6 @@ void ve2_hwctx_fini(struct amdxdna_ctx *hwctx)
 
 		ve2_hwctx_job_release(hwctx, job);
 	}
-
-	if (enable_polling)
-		del_timer_sync(&hwctx->priv->event_timer);
 
 	if (verbosity >= VERBOSITY_LEVEL_DBG)
 		ve2_get_firmware_status(hwctx);

--- a/src/driver/amdxdna/ve2_mgmt.c
+++ b/src/driver/amdxdna/ve2_mgmt.c
@@ -468,6 +468,13 @@ static void ve2_scheduler_work(struct work_struct *work)
 		container_of(work, struct amdxdna_mgmtctx, sched_work);
 
 	spin_lock(&mgmtctx->ctx_lock);
+
+	/* Check if context is being destroyed */
+	if (!mgmtctx->active_ctx || !mgmtctx->active_ctx->priv) {
+		spin_unlock(&mgmtctx->ctx_lock);
+		return;
+	}
+
 	/*
 	 * 3 case possible:
 	 * 1. it was completion interrupt but idle/queue_not_empty bit was set as cert moved forward
@@ -587,11 +594,13 @@ static void ve2_irq_handler(u32 partition_id, void *cb_arg)
 
 	if (get_ctx_read_index(hwctx, &read_index)) {
 		XDNA_ERR(xdna, "Failed to get read index");
+		spin_unlock_irqrestore(&mgmtctx->ctx_lock, flags);
 		return;
 	}
 
 	if (get_ctx_write_index(hwctx, &write_index)) {
 		XDNA_ERR(xdna, "Failed to get write index");
+		spin_unlock_irqrestore(&mgmtctx->ctx_lock, flags);
 		return;
 	}
 
@@ -612,8 +621,10 @@ static void ve2_irq_handler(u32 partition_id, void *cb_arg)
 
 	spin_unlock_irqrestore(&mgmtctx->ctx_lock, flags);
 
-	if (ve2_check_idle_or_queue_not_empty(mgmtctx) ||
-	    ve2_check_misc_interrupt(mgmtctx))
+	/* Only queue work if workqueue is still valid and there's work to do */
+	if (mgmtctx->mgmtctx_workq &&
+	    (ve2_check_idle_or_queue_not_empty(mgmtctx) ||
+	     ve2_check_misc_interrupt(mgmtctx)))
 		queue_work(mgmtctx->mgmtctx_workq, &mgmtctx->sched_work);
 }
 
@@ -657,6 +668,7 @@ static int ve2_create_mgmt_partition(struct amdxdna_dev *xdna,
 		mgmtctx->args.num_tiles = 0;
 		nhwctx->args = &mgmtctx->args;
 		nhwctx->aie_dev = mgmtctx->mgmt_aiedev;
+		spin_lock_init(&mgmtctx->ctx_lock);
 		INIT_LIST_HEAD(&mgmtctx->ctx_command_fifo_head);
 		/* Create workqueue for scheduling the command */
 		mgmtctx->mgmtctx_workq = create_workqueue("ve2_mgmtctx_scheduler");
@@ -795,17 +807,25 @@ int ve2_mgmt_destroy_partition(struct amdxdna_ctx *hwctx)
 
 	mgmtctx = &xdna->dev_handle->ve2_mgmtctx[start_col];
 	if (load_act.release_aie_part) {
+		struct workqueue_struct *wq = NULL;
+
 		for (u32 col = 0; col < num_col; col++)
 			cert_clear_partition(xdna, nhwctx->aie_dev, col);
-
-		aie_partition_teardown(nhwctx->aie_dev);
-		aie_partition_release(nhwctx->aie_dev);
 
 		spin_lock(&mgmtctx->ctx_lock);
 		/* Update the active context as partition doesn't exists any more */
 		mgmtctx->active_ctx = NULL;
+		/* Save workqueue pointer and clear it before partition teardown */
+		wq = mgmtctx->mgmtctx_workq;
+		mgmtctx->mgmtctx_workq = NULL;
 		spin_unlock(&mgmtctx->ctx_lock);
-		destroy_workqueue(mgmtctx->mgmtctx_workq);
+
+		/* Destroy workqueue BEFORE partition teardown to avoid memory corruption */
+		if (wq)
+			destroy_workqueue(wq);
+
+		aie_partition_teardown(nhwctx->aie_dev);
+		aie_partition_release(nhwctx->aie_dev);
 	} else {
 		spin_lock(&mgmtctx->ctx_lock);
 		if (mgmtctx->active_ctx == hwctx)


### PR DESCRIPTION
Fix multiple race conditions and synchronization issues causing kernel crashes during hardware context cleanup after command timeouts.
Root causes:
- Workqueue pointer corruption from aie_partition_teardown()
- Race between IRQ handler and cleanup code accessing freed resources
- Outstanding DMA transactions during partition teardown 

Key fixes:
- Initialize spinlock and add NULL checks for workqueue
- Destroy workqueue BEFORE partition teardown to prevent corruption
- Clear active_ctx before canceling work to stop new work from queuing
- Fix missing spinlock unlocks on error paths Test results: Command timeout cleanup now completes without crashes, system immediately ready for subsequent tests.