### PR TITLE
fix non-zero column memory read/write

### DIFF
--- a/src/driver/amdxdna/ve2_debug.c
+++ b/src/driver/amdxdna/ve2_debug.c
@@ -304,7 +304,7 @@ static int ve2_aie_read(struct amdxdna_client *client, struct amdxdna_drm_get_ar
 		return -ENOMEM;
 
 	/* Read from AIE memory */
-	ret = ve2_partition_read(aie_dev, footer.col , footer.row, footer.addr,
+	ret = ve2_partition_read(aie_dev, footer.col, footer.row, footer.addr,
 				 footer.size, local_buf);
 	if (ret < 0) {
 		XDNA_ERR(xdna, "Error in AIE memory read operation, err: %d\n", ret);


### PR DESCRIPTION
This PR fixes incorrect column number calculations in AIE memory read/write operations. The hardware context's start column offset was being incorrectly added to the footer column value, which has now been removed.

Key changes:

Removed hwctx->start_col offset from column parameter in ve2_partition_write() call
Removed hwctx->start_col offset from column parameter in ve2_partition_read() call 