### PR TITLE
Using new cert release name

### DIFF
--- a/src/driver/amdxdna/ve2_regs.c
+++ b/src/driver/amdxdna/ve2_regs.c
@@ -7,7 +7,7 @@
 #include "ve2_of.h"
 
 const struct amdxdna_dev_priv ve2_dev_priv = {
-	.fw_path	= "amdnpu/cert_ve2.elf",
+	.fw_path	= "amdnpu/release_cert_ve2.elf",
 	.hwctx_limit	= 255,
 	.ctx_limit	= 255,
 };


### PR DESCRIPTION
This PR updates the firmware file path to use a new release naming convention.

Key Changes:

Firmware path renamed from cert_ve2.elf to release_cert_ve2.elf