### PR TITLE
dpt: Add on-demand timer with reference counting

### DIFF
--- a/src/driver/amdxdna/amdxdna_dpt.h
+++ b/src/driver/amdxdna/amdxdna_dpt.h
@@ -39,7 +39,6 @@ struct amdxdna_dpt {
 	struct amdxdna_dev		*xdna;
 	struct amdxdna_mgmt_dma_hdl	*dma_hdl;
 	struct wait_queue_head		wait;
-	bool				polling;
 	struct work_struct		work;
 	struct timer_list		timer;
 	void			__iomem *io_base;
@@ -47,6 +46,7 @@ struct amdxdna_dpt {
 	u32				msi_idx;
 	u32				msi_address;
 	u64				tail;
+	atomic_t			timer_users;
 
 	/* Below members are required only until dumping to dmesg is supported */
 	bool				dump_to_dmesg;


### PR DESCRIPTION
- Add atomic_t refcount to track waiting requests and dump_to_dmesg enables
- Remove polling flag, use refcount as single source of truth for timer control
- Timer set up once during init, deleted during fini
- Timer only rearms when refcount > 0
- Supports continuous polling via module params (poll_fw_log/poll_fw_trace)
- Fix coding style: break long lines, remove extra blank lines