### PR TITLE
Stop doing DPU sequence no-op, use ELF no-op instead

### DIFF
--- a/test/shim_test/dev_info.cpp
+++ b/test/shim_test/dev_info.cpp
@@ -285,6 +285,29 @@ xclbin_info xclbin_infos[] = {
     .data = "",
     .type = KERNEL_TYPE_TXN,
   },
+  {
+    .name = "nop.xclbin",
+    .device = npu4_device_id,
+    .revision_id = npu_any_revision_id,
+    .ip_name2idx = {
+      { "DPU:IPUV1CNN", {1} },
+    },
+    .workspace = "local_shim_test_data/elf_no_op_npu4",
+    .data = "",
+    .type = KERNEL_TYPE_TXN,
+  },
+  {
+    .name = "nop.xclbin",
+    .device = npu1_device_id,
+    .revision_id = npu1_revision_id,
+    .ip_name2idx = {
+      { "DPU:IPUV1CNN", {1} },
+    },
+    .workspace = "local_shim_test_data/elf_no_op_npu1",
+    .data = "",
+    .type = KERNEL_TYPE_TXN,
+  },
+
 };
 
 }

--- a/test/shim_test/shim_test.cpp
+++ b/test/shim_test/shim_test.cpp
@@ -868,9 +868,6 @@ std::vector<test_case> test_list {
   test_case{ "Multi context IO test 3 (npu1)", {},
     TEST_POSITIVE, dev_filter_is_npu1, TEST_multi_context_io_test, { 6 }
   },
-  //test_case{ "Multi context IO test 4 (npu1)", {},
-  //  TEST_POSITIVE, dev_filter_is_npu1, TEST_multi_context_io_test, { 10 }
-  //},
   test_case{ "Multi context IO test 1 (npu4)", {},
     TEST_POSITIVE, dev_filter_is_npu4, TEST_multi_context_io_test, { 2 }
   },


### PR DESCRIPTION
Switching from DPU sequence no-op to ELF TXN no-op will make sure the performance numbers are aligned with xrt-smi validate.