### PR TITLE
Fix pointer arithmetic bug in copy_array_to/from_user

### DIFF
--- a/src/driver/amdxdna/amdxdna_drm.c
+++ b/src/driver/amdxdna/amdxdna_drm.c
@@ -183,10 +183,10 @@ int amdxdna_drm_copy_array_to_user(struct amdxdna_drm_get_array *tgt,
 	int i;
 
 	for (i = 0; i < min_num; i++) {
-		buf += i * tgt->element_size;
-		array += i * element_size;
 		if (copy_to_user(buf, array, min_sz))
 			return -EFAULT;
+		buf += tgt->element_size;
+		array += element_size;
 	}
 	tgt->num_element = min_num;
 	tgt->element_size = min_sz;
@@ -206,10 +206,10 @@ int amdxdna_drm_copy_array_from_user(struct amdxdna_drm_get_array *src,
 	int i;
 
 	for (i = 0; i < min_num; i++) {
-		buf += i * src->element_size;
-		array += i * element_size;
 		if (copy_from_user(array, buf, min_sz))
 			return -EFAULT;
+		buf += src->element_size;
+		array += element_size;
 	}
 	return 0;
 }


### PR DESCRIPTION
The loop was incrementing pointers by i*element_size on each iteration, causing cumulative offset growth instead of linear.