### PR TITLE
fixing hw_context config issue in ve2

### DIFF
--- a/src/driver/amdxdna/ve2_mgmt.c
+++ b/src/driver/amdxdna/ve2_mgmt.c
@@ -156,7 +156,7 @@ int ve2_xrs_request(struct amdxdna_dev *xdna, struct amdxdna_ctx *hwctx)
 	struct solver_state *xrs = xdna->dev_handle->xrs_hdl;
 	struct xrs_action_load load_act = {0};
 	struct amdxdna_ctx_priv *nhwctx = NULL;
-	struct amdxdna_mgmtctx  *mgmtctx = NULL;
+	struct amdxdna_mgmtctx *mgmtctx = NULL;
 	struct alloc_requests *xrs_req;
 	int ret;
 


### PR DESCRIPTION
fixing hw_context config issue in ve2. 
Below PR broke the hw context configuration
https://github.com/amd/xdna-driver/pull/896/files 
