### PR TITLE
Add AIE coredump support

### DIFF
--- a/src/driver/amdxdna/aie2_msg_priv.h
+++ b/src/driver/amdxdna/aie2_msg_priv.h
@@ -9,48 +9,49 @@
 #include <linux/uuid.h>
 
 enum aie2_msg_opcode {
-	MSG_OP_CREATE_CONTEXT              = 0x2,
-	MSG_OP_DESTROY_CONTEXT             = 0x3,
+	MSG_OP_CREATE_CONTEXT			= 0x2,
+	MSG_OP_DESTROY_CONTEXT			= 0x3,
 #ifdef AMDXDNA_DEVEL
-	MSG_OP_GET_TELEMETRY               = 0x4,
+	MSG_OP_GET_TELEMETRY			= 0x4,
 #endif
-	MSG_OP_SYNC_BO			   = 0x7,
-	MSG_OP_EXECUTE_BUFFER_CF           = 0xC,
-	MSG_OP_QUERY_COL_STATUS            = 0xD,
-	MSG_OP_QUERY_AIE_TILE_INFO         = 0xE,
-	MSG_OP_QUERY_AIE_VERSION           = 0xF,
-	MSG_OP_EXEC_DPU                    = 0x10,
-	MSG_OP_CONFIG_CU                   = 0x11,
-	MSG_OP_CHAIN_EXEC_BUFFER_CF        = 0x12,
-	MSG_OP_CHAIN_EXEC_DPU              = 0x13,
-	MSG_OP_CONFIG_DEBUG_BO		   = 0x14,
-	MSG_OP_EXEC_DPU_PREEMPT		   = 0x15,
-	MSG_OP_EXEC_NPU			   = 0x17,
-	MSG_OP_CHAIN_EXEC_NPU		   = 0x18,
+	MSG_OP_SYNC_BO				= 0x7,
+	MSG_OP_EXECUTE_BUFFER_CF		= 0xC,
+	MSG_OP_QUERY_COL_STATUS			= 0xD,
+	MSG_OP_QUERY_AIE_TILE_INFO		= 0xE,
+	MSG_OP_QUERY_AIE_VERSION		= 0xF,
+	MSG_OP_EXEC_DPU				= 0x10,
+	MSG_OP_CONFIG_CU			= 0x11,
+	MSG_OP_CHAIN_EXEC_BUFFER_CF		= 0x12,
+	MSG_OP_CHAIN_EXEC_DPU			= 0x13,
+	MSG_OP_CONFIG_DEBUG_BO			= 0x14,
+	MSG_OP_EXEC_DPU_PREEMPT			= 0x15,
+	MSG_OP_EXEC_NPU				= 0x17,
+	MSG_OP_CHAIN_EXEC_NPU			= 0x18,
 #ifdef AMDXDNA_DEVEL
-	MSG_OP_REGISTER_PDI                = 0x1,
-	MSG_OP_UNREGISTER_PDI              = 0xA,
-	MSG_OP_LEGACY_CONFIG_CU            = 0xB,
+	MSG_OP_REGISTER_PDI			= 0x1,
+	MSG_OP_UNREGISTER_PDI			= 0xA,
+	MSG_OP_LEGACY_CONFIG_CU			= 0xB,
 #endif
 	MSG_OP_MAX_XRT_OPCODE,
-	MSG_OP_SUSPEND                     = 0x101,
-	MSG_OP_RESUME                      = 0x102,
-	MSG_OP_ASSIGN_MGMT_PASID           = 0x103,
-	MSG_OP_INVOKE_SELF_TEST            = 0x104,
-	MSG_OP_MAP_HOST_BUFFER             = 0x106,
-	MSG_OP_GET_FIRMWARE_VERSION        = 0x108,
-	MSG_OP_SET_RUNTIME_CONFIG          = 0x10A,
-	MSG_OP_GET_RUNTIME_CONFIG          = 0x10B,
-	MSG_OP_REGISTER_ASYNC_EVENT_MSG    = 0x10C,
-	MSG_OP_START_FW_TRACE              = 0x10F,
-	MSG_OP_STOP_FW_TRACE               = 0x110,
-	MSG_OP_SET_FW_TRACE_CATEGORIES     = 0x111,
-	MSG_OP_UPDATE_PROPERTY             = 0x113,
-	MSG_OP_GET_APP_HEALTH              = 0x114,
-	MSG_OP_ADD_HOST_BUFFER             = 0x115,
-	MSG_OP_CONFIG_FW_LOG		   = 0x116,
+	MSG_OP_SUSPEND				= 0x101,
+	MSG_OP_RESUME				= 0x102,
+	MSG_OP_ASSIGN_MGMT_PASID		= 0x103,
+	MSG_OP_INVOKE_SELF_TEST			= 0x104,
+	MSG_OP_MAP_HOST_BUFFER			= 0x106,
+	MSG_OP_GET_FIRMWARE_VERSION		= 0x108,
+	MSG_OP_SET_RUNTIME_CONFIG		= 0x10A,
+	MSG_OP_GET_RUNTIME_CONFIG		= 0x10B,
+	MSG_OP_REGISTER_ASYNC_EVENT_MSG		= 0x10C,
+	MSG_OP_START_FW_TRACE			= 0x10F,
+	MSG_OP_STOP_FW_TRACE			= 0x110,
+	MSG_OP_SET_FW_TRACE_CATEGORIES		= 0x111,
+	MSG_OP_UPDATE_PROPERTY			= 0x113,
+	MSG_OP_GET_APP_HEALTH			= 0x114,
+	MSG_OP_ADD_HOST_BUFFER			= 0x115,
+	MSG_OP_CONFIG_FW_LOG			= 0x116,
+	MSG_OP_GET_COREDUMP			= 0x119,
 	MSG_OP_MAX_DRV_OPCODE,
-	MSG_OP_GET_PROTOCOL_VERSION        = 0x301,
+	MSG_OP_GET_PROTOCOL_VERSION		= 0x301,
 	MSG_OP_MAX_OPCODE
 };
 
@@ -737,5 +738,23 @@ struct rt_cfg_ver {
 	u32			fw_minor;
 	u32			type;
 };
+
+struct buffer_list {
+	u64			buf_addr;
+	u32			buf_size;
+	u32			reserved;
+} __packed;
+
+struct get_coredump_req {
+	u32			context_id;
+	u32			num_bufs;
+	u64			list_addr;
+} __packed;
+
+struct get_coredump_resp {
+	enum			aie2_msg_status status;
+	u32			required_buffer_size;
+	u32			reserved[7];
+} __packed;
 
 #endif /* _AIE2_MSG_PRIV_H_ */

--- a/src/driver/amdxdna/aie2_pci.c
+++ b/src/driver/amdxdna/aie2_pci.c
@@ -1328,6 +1328,198 @@ exit:
 	return ret;
 }
 
+/*
+ * Returns true if caller is root (CAP_SYS_ADMIN) or, when root_only is false,
+ * if the caller owns the context.
+ */
+static bool amdxdna_ctx_access_allowed(struct amdxdna_ctx *ctx, bool root_only)
+{
+	struct amdxdna_dev *xdna = ctx->client->xdna;
+	bool is_admin = capable(CAP_SYS_ADMIN);
+	bool is_owner;
+
+	if (root_only) {
+		XDNA_DBG(xdna, "Access check (root only): is_admin=%d", is_admin);
+		return is_admin;
+	}
+
+	is_owner = uid_eq(current_euid(), ctx->client->uid);
+	XDNA_DBG(xdna, "Access check: is_admin=%d is_owner=%d", is_admin, is_owner);
+
+	return is_admin || is_owner;
+}
+
+static int aie2_get_coredump(struct amdxdna_client *client, struct amdxdna_drm_get_array *args)
+{
+	struct amdxdna_drm_aie_coredump config = {};
+	struct amdxdna_mgmt_dma_hdl **data_hdls = NULL;
+	struct amdxdna_mgmt_dma_hdl *list_hdl = NULL;
+	struct amdxdna_dev *xdna = client->xdna;
+	struct amdxdna_dev_hdl *ndev = xdna->dev_handle;
+	struct amdxdna_client *tmp_client;
+	struct amdxdna_ctx *hwctx = NULL;
+	struct buffer_list *buf_list;
+	unsigned long hwctx_id;
+	u32 total_size;
+	size_t list_size;
+	u32 offset = 0;
+	void __user *buf;
+	u32 num_bufs;
+	u32 buf_size;
+	int ret = 0;
+	int idx, i;
+
+	buf_size = args->num_element * args->element_size;
+	buf = u64_to_user_ptr(args->buffer);
+	if (!access_ok(buf, buf_size)) {
+		XDNA_ERR(xdna, "Failed to access buffer, element num %d size 0x%x",
+			 args->num_element, args->element_size);
+		return -EFAULT;
+	}
+
+	if (buf_size < sizeof(config)) {
+		XDNA_ERR(xdna, "Insufficient buffer size: 0x%x", buf_size);
+		return -ENOSPC;
+	}
+
+	ret = amdxdna_drm_copy_array_from_user(args, &config, sizeof(config), 1);
+	if (ret) {
+		XDNA_ERR(xdna, "Failed to copy config from user");
+		return ret;
+	}
+
+	XDNA_DBG(xdna, "AIE Coredump request for context_id=%u pid=%llu",
+		 config.context_id, config.pid);
+
+	/* Search and validate if context coredump can be fetched for given PID and context ID */
+	mutex_lock(&xdna->dev_lock);
+	list_for_each_entry(tmp_client, &xdna->client_list, node) {
+		struct amdxdna_ctx *hw_ctx;
+
+		idx = srcu_read_lock(&tmp_client->ctx_srcu);
+		amdxdna_for_each_ctx(tmp_client, hwctx_id, hw_ctx) {
+			if (config.context_id == hwctx_id && config.pid == hw_ctx->client->pid) {
+				hwctx = hw_ctx;
+				break;
+			}
+		}
+		srcu_read_unlock(&tmp_client->ctx_srcu, idx);
+		if (hwctx)
+			break;
+	}
+
+	if (!hwctx) {
+		mutex_unlock(&xdna->dev_lock);
+		XDNA_ERR(xdna, "Context %u for pid %llu not found", config.context_id, config.pid);
+		return -EINVAL;
+	}
+
+	/* Check if caller is root or owns the context */
+	if (!amdxdna_ctx_access_allowed(hwctx, false)) {
+		mutex_unlock(&xdna->dev_lock);
+		XDNA_ERR(xdna, "Permission denied for context %u", config.context_id);
+		return -EPERM;
+	}
+
+	num_bufs = ndev->metadata.rows * hwctx->priv->orig_num_col;
+	total_size = num_bufs * SZ_1M;
+
+	if (buf_size < total_size) {
+		mutex_unlock(&xdna->dev_lock);
+		XDNA_DBG(xdna, "Insufficient buffer size %u, need %u", buf_size, total_size);
+		args->element_size = total_size;
+		return -ENOSPC;
+	}
+
+	list_size = max_t(size_t, num_bufs * sizeof(struct buffer_list), SZ_8K);
+	list_hdl = amdxdna_mgmt_buff_alloc(xdna, list_size, DMA_TO_DEVICE);
+	if (IS_ERR(list_hdl)) {
+		mutex_unlock(&xdna->dev_lock);
+		XDNA_ERR(xdna, "Failed to allocate buffer list");
+		return PTR_ERR(list_hdl);
+	}
+
+	buf_list = amdxdna_mgmt_buff_get_cpu_addr(list_hdl, 0);
+	if (IS_ERR(buf_list)) {
+		mutex_unlock(&xdna->dev_lock);
+		XDNA_ERR(xdna, "Failed to get CPU address for buffer list");
+		ret = PTR_ERR(buf_list);
+		goto free_list_hdl;
+	}
+	memset(buf_list, 0, list_size);
+
+	/* Allocate array to track data buffer handles */
+	data_hdls = kcalloc(num_bufs, sizeof(*data_hdls), GFP_KERNEL);
+	if (!data_hdls) {
+		mutex_unlock(&xdna->dev_lock);
+		ret = -ENOMEM;
+		goto free_list_hdl;
+	}
+
+	for (i = 0; i < num_bufs; i++) {
+		void *buf_addr;
+
+		data_hdls[i] = amdxdna_mgmt_buff_alloc(xdna, SZ_1M, DMA_FROM_DEVICE);
+		if (IS_ERR(data_hdls[i])) {
+			XDNA_ERR(xdna, "Failed to allocate data buffer %d", i);
+			ret = PTR_ERR(data_hdls[i]);
+			data_hdls[i] = NULL;
+			mutex_unlock(&xdna->dev_lock);
+			goto free_data_hdls;
+		}
+
+		buf_addr = amdxdna_mgmt_buff_get_cpu_addr(data_hdls[i], 0);
+		if (IS_ERR(buf_addr)) {
+			ret = PTR_ERR(buf_addr);
+			mutex_unlock(&xdna->dev_lock);
+			goto free_data_hdls;
+		}
+		memset(buf_addr, 0, SZ_1M);
+		amdxdna_mgmt_buff_clflush(data_hdls[i], 0, 0);
+
+		buf_list[i].buf_addr = amdxdna_mgmt_buff_get_dma_addr(data_hdls[i]);
+		buf_list[i].buf_size = SZ_1M;
+		buf_list[i].reserved = 0;
+	}
+
+	amdxdna_mgmt_buff_clflush(list_hdl, 0, 0);
+
+	mutex_lock(&ndev->aie2_lock);
+	ret = aie2_get_aie_coredump(ndev, list_hdl, hwctx->priv->id, num_bufs);
+	mutex_unlock(&ndev->aie2_lock);
+	mutex_unlock(&xdna->dev_lock);
+
+	if (ret) {
+		XDNA_ERR(xdna, "Failed to get coredump from firmware, ret=%d", ret);
+		goto free_data_hdls;
+	}
+
+	for (i = 0; i < num_bufs; i++) {
+		void *data = amdxdna_mgmt_buff_get_cpu_addr(data_hdls[i], 0);
+
+		if (IS_ERR(data)) {
+			ret = PTR_ERR(data);
+			goto free_data_hdls;
+		}
+
+		if (copy_to_user(buf + offset, data, SZ_1M)) {
+			ret = -EFAULT;
+			goto free_data_hdls;
+		}
+		offset += SZ_1M;
+	}
+
+free_data_hdls:
+	for (i = 0; i < num_bufs; i++) {
+		if (data_hdls[i])
+			amdxdna_mgmt_buff_free(data_hdls[i]);
+	}
+	kfree(data_hdls);
+free_list_hdl:
+	amdxdna_mgmt_buff_free(list_hdl);
+	return ret;
+}
+
 static int aie2_get_array_hwctx(struct amdxdna_client *client, struct amdxdna_drm_get_array *args)
 {
 	struct amdxdna_dev *xdna = client->xdna;
@@ -1421,6 +1613,9 @@ static int aie2_get_array(struct amdxdna_client *client, struct amdxdna_drm_get_
 		break;
 	case DRM_AMDXDNA_FW_TRACE_CONFIG:
 		ret = amdxdna_get_fw_trace_configs(xdna, args);
+		break;
+	case DRM_AMDXDNA_AIE_COREDUMP:
+		ret = aie2_get_coredump(client, args);
 		break;
 	default:
 		ret = aie2_get_array_hwctx(client, args);

--- a/src/driver/amdxdna/aie2_pci.h
+++ b/src/driver/amdxdna/aie2_pci.h
@@ -522,6 +522,8 @@ int aie2_query_aie_telemetry(struct amdxdna_dev_hdl *ndev, struct amdxdna_mgmt_d
 			     u32 type, u32 size, struct aie_version *version);
 int aie2_get_app_health(struct amdxdna_dev_hdl *ndev, struct amdxdna_mgmt_dma_hdl *dma_hdl,
 			u32 context_id, u32 size);
+int aie2_get_aie_coredump(struct amdxdna_dev_hdl *ndev, struct amdxdna_mgmt_dma_hdl *dma_hdl,
+			  u32 context_id, u32 num_bufs);
 void aie2_reset_app_health_report(struct app_health_report *r);
 int aie2_query_aie_version(struct amdxdna_dev_hdl *ndev, struct aie_version *version);
 int aie2_query_aie_metadata(struct amdxdna_dev_hdl *ndev, struct aie_metadata *metadata);

--- a/src/driver/amdxdna/amdxdna_drm.c
+++ b/src/driver/amdxdna/amdxdna_drm.c
@@ -28,6 +28,7 @@ static int amdxdna_drm_open(struct drm_device *ddev, struct drm_file *filp)
 		return -ENOMEM;
 
 	client->pid = pid_nr(filp->pid);
+	client->uid = current_euid();
 	client->xdna = xdna;
 
 #ifdef AMDXDNA_DEVEL

--- a/src/driver/amdxdna/amdxdna_drm.h
+++ b/src/driver/amdxdna/amdxdna_drm.h
@@ -161,6 +161,7 @@ struct amdxdna_stats {
 struct amdxdna_client {
 	struct list_head		node;
 	pid_t				pid;
+	kuid_t				uid;
 	/* To avoid deadlock, do NOT wait this srcu when dev_lock is hold */
 	struct srcu_struct		ctx_srcu;
 	struct xarray			ctx_xa;

--- a/src/driver/amdxdna/npu4_regs.c
+++ b/src/driver/amdxdna/npu4_regs.c
@@ -34,6 +34,7 @@ const struct msg_op_ver npu4_msg_op_tbl[] = {
 	{ 19, MSG_OP_START_FW_TRACE },
 	{ 19, MSG_OP_STOP_FW_TRACE },
 	{ 19, MSG_OP_SET_FW_TRACE_CATEGORIES },
+	{ 24, MSG_OP_GET_COREDUMP },
 	{ 0 },
 };
 


### PR DESCRIPTION
Add support for retrieving AIE coredump data from the NPU firmware.

Key changes:
- Add aie2_get_coredump() ioctl handler with DRM_AMDXDNA_AIE_COREDUMP
- Store client UID at open time for permission checks
- Add amdxdna_ctx_access_allowed() to verify caller is root or context owner
- Add shim layer support for coredump query