### PR TITLE
Fix xrt-smi archive path

### DIFF
--- a/src/shim/device.cpp
+++ b/src/shim/device.cpp
@@ -14,6 +14,7 @@
 
 #include <dlfcn.h>
 #include <libgen.h>
+#include <linux/limits.h>
 #include <sys/syscall.h>
 
 #include <algorithm>


### PR DESCRIPTION
In  #919 XRT was updated to amend the search path for xrt-smi validate archive to include $XDG_DATA_HOME or $HOME/.local/share.

This PR changes xdna-driver shim to return relative path to xrt-smi archive.  XRT handles searching for the archive through platform repo search paths by appending the relative path returned by shim.