### PR TITLE
Use unified firmware version for protocol compatibility

### DIFF
--- a/src/driver/amdxdna/aie2_message.c
+++ b/src/driver/amdxdna/aie2_message.c
@@ -22,7 +22,6 @@
 static bool
 is_supported_rt_cfg(struct amdxdna_dev_hdl *ndev, u32 type)
 {
-	int fw_minor = ndev->mgmt_prot_minor;
 	const struct rt_cfg_ver *rt_cfg_tbl;
 	int i;
 
@@ -30,16 +29,18 @@ is_supported_rt_cfg(struct amdxdna_dev_hdl *ndev, u32 type)
 	if (!rt_cfg_tbl)
 		return false;
 
-	for (i = 0; rt_cfg_tbl[i].fw_minor; i++) {
+	for (i = 0; rt_cfg_tbl[i].min_fw_version; i++) {
 		if (rt_cfg_tbl[i].type != type)
 			continue;
 
-		if (fw_minor >= rt_cfg_tbl[i].fw_minor)
+		if (ndev->mgmt_fw_version >= rt_cfg_tbl[i].min_fw_version)
 			return true;
 
-		XDNA_DBG(ndev->xdna, "Runtime cfg %d protocol %lld.%d, fw is %d.%d",
-			 type, ndev->priv->protocol_major, rt_cfg_tbl[i].fw_minor,
-			 ndev->mgmt_prot_major, ndev->mgmt_prot_minor);
+		XDNA_DBG(ndev->xdna, "Runtime cfg %d requires %d.%d, fw is %d.%d", type,
+			 AIE2_FW_MAJOR(rt_cfg_tbl[i].min_fw_version),
+			 AIE2_FW_MINOR(rt_cfg_tbl[i].min_fw_version),
+			 AIE2_FW_MAJOR(ndev->mgmt_fw_version),
+			 AIE2_FW_MINOR(ndev->mgmt_fw_version));
 		return false;
 	}
 
@@ -75,7 +76,6 @@ static int aie2_send_mgmt_msg_wait(struct amdxdna_dev_hdl *ndev,
 
 bool aie2_is_supported_msg(struct amdxdna_dev_hdl *ndev, enum aie2_msg_opcode opcode)
 {
-	int fw_minor = ndev->mgmt_prot_minor;
 	const struct msg_op_ver *op_tbl;
 	int i;
 
@@ -83,16 +83,18 @@ bool aie2_is_supported_msg(struct amdxdna_dev_hdl *ndev, enum aie2_msg_opcode op
 	if (!op_tbl)
 		return false;
 
-	for (i = 0; op_tbl[i].fw_minor; i++) {
+	for (i = 0; op_tbl[i].min_fw_version; i++) {
 		if (op_tbl[i].op != opcode)
 			continue;
 
-		if (fw_minor >= op_tbl[i].fw_minor)
+		if (ndev->mgmt_fw_version >= op_tbl[i].min_fw_version)
 			return true;
 
-		XDNA_DBG(ndev->xdna, "Opcode %d protocol %lld.%d, fw is %d.%d",
-			 opcode, ndev->priv->protocol_major, op_tbl[i].fw_minor,
-			 ndev->mgmt_prot_major, ndev->mgmt_prot_minor);
+		XDNA_DBG(ndev->xdna, "Opcode %d requires %d.%d, fw is %d.%d", opcode,
+			 AIE2_FW_MAJOR(op_tbl[i].min_fw_version),
+			 AIE2_FW_MINOR(op_tbl[i].min_fw_version),
+			 AIE2_FW_MAJOR(ndev->mgmt_fw_version),
+			 AIE2_FW_MINOR(ndev->mgmt_fw_version));
 		return false;
 	}
 

--- a/src/driver/amdxdna/aie2_msg_priv.h
+++ b/src/driver/amdxdna/aie2_msg_priv.h
@@ -730,12 +730,12 @@ struct get_app_health_resp {
 
 /* Do NOT put any firmware defined struct, enum etc. start from here */
 struct msg_op_ver {
-	u32			fw_minor;
+	u64			min_fw_version;
 	enum aie2_msg_opcode	op;
 };
 
 struct rt_cfg_ver {
-	u32			fw_minor;
+	u64			min_fw_version;
 	u32			type;
 };
 

--- a/src/driver/amdxdna/aie2_pci.h
+++ b/src/driver/amdxdna/aie2_pci.h
@@ -32,6 +32,11 @@
 #define AIE2_INTERVAL	20000	/* us */
 #define AIE2_TIMEOUT	1000000	/* us */
 
+/* Firmware version encoding: major in high 32 bits, minor in low 32 bits */
+#define AIE2_FW_VERSION(major, minor)	(((u64)(major) << 32) | (minor))
+#define AIE2_FW_MAJOR(version)		upper_32_bits(version)
+#define AIE2_FW_MINOR(version)		lower_32_bits(version)
+
 /* Firmware determines device memory base address and size */
 #define AIE2_DEVM_BASE	0x4000000
 #define AIE2_DEVM_SIZE	SZ_64M
@@ -334,8 +339,7 @@ struct amdxdna_dev_hdl {
 	struct psp_device		*psp_hdl;
 
 	struct xdna_mailbox_chann_info	mgmt_info;
-	u32				mgmt_prot_major;
-	u32				mgmt_prot_minor;
+	u64				mgmt_fw_version;
 
 	u32				total_col;
 	struct aie_version		version;
@@ -406,36 +410,35 @@ enum aie2_fw_feature {
 
 struct aie2_fw_feature_tbl {
 	enum aie2_fw_feature feature;
-	u32 max_minor;
-	u32 min_minor;
+	u64 min_fw_version;
+	u64 max_fw_version;  /* 0 = no upper limit */
 };
 
 #define AIE2_FEATURE_ON(ndev, feature)	test_bit(feature, &(ndev)->feature_mask)
 
 struct amdxdna_dev_priv {
-	const char			*fw_path;
-	u64				protocol_major;
-	u64				protocol_minor;
-	const struct rt_config		*rt_config;
-	const struct dpm_clk_freq	*dpm_clk_tbl;
-	const struct msg_op_ver		*optional_msg;
-	const struct rt_cfg_ver		*optional_cfg;
-	const struct aie2_fw_feature_tbl *fw_feature_tbl;
+	const char				*fw_path;
+	u64					min_fw_version;
+	const struct rt_config			*rt_config;
+	const struct dpm_clk_freq		*dpm_clk_tbl;
+	const struct msg_op_ver			*optional_msg;
+	const struct rt_cfg_ver			*optional_cfg;
+	const struct aie2_fw_feature_tbl	*fw_feature_tbl;
 
-	u32				col_opc;
-	u32				mbox_dev_addr;
+	u32					col_opc;
+	u32					mbox_dev_addr;
 	/* If mbox_size is 0, use BAR size. See MBOX_SIZE macro */
-	u32				mbox_size;
-	u32				hwctx_limit; /* Hardware determine */
-	u32				ctx_limit; /* Driver determine */
-	u32				temporal_only;
-	u32				sram_dev_addr;
-	struct aie2_bar_off_pair	sram_offs[SRAM_MAX_INDEX];
-	struct aie2_bar_off_pair	psp_regs_off[PSP_MAX_REGS];
-	struct aie2_bar_off_pair	smu_regs_off[SMU_MAX_REGS];
-	struct aie2_hw_ops		hw_ops;
+	u32					mbox_size;
+	u32					hwctx_limit; /* Hardware determine */
+	u32					ctx_limit; /* Driver determine */
+	u32					temporal_only;
+	u32					sram_dev_addr;
+	struct aie2_bar_off_pair		sram_offs[SRAM_MAX_INDEX];
+	struct aie2_bar_off_pair		psp_regs_off[PSP_MAX_REGS];
+	struct aie2_bar_off_pair		smu_regs_off[SMU_MAX_REGS];
+	struct aie2_hw_ops			hw_ops;
 #ifdef AMDXDNA_DEVEL
-	struct rt_config		priv_load_cfg;
+	struct rt_config			priv_load_cfg;
 #endif
 };
 

--- a/src/driver/amdxdna/npu1_regs.c
+++ b/src/driver/amdxdna/npu1_regs.c
@@ -60,19 +60,18 @@ const struct dpm_clk_freq npu1_dpm_clk_table[] = {
 };
 
 const struct msg_op_ver npu1_msg_op_tbl[] = {
-	{ 8, MSG_OP_CHAIN_EXEC_NPU },
+	{ AIE2_FW_VERSION(5, 8), MSG_OP_CHAIN_EXEC_NPU },
 	{ 0 },
 };
 
 static const struct aie2_fw_feature_tbl npu1_fw_feature_table[] = {
-	{ .feature = AIE2_NPU_COMMAND, .min_minor = 8 },
+	{ .feature = AIE2_NPU_COMMAND, .min_fw_version = AIE2_FW_VERSION(5, 8) },
 	{ 0 }
 };
 
 const struct amdxdna_dev_priv npu1_dev_priv = {
-	.fw_path        = "amdnpu/1502_00/npu.dev.sbin",
-	.protocol_major = 5,
-	.protocol_minor = 7,
+	.fw_path	= "amdnpu/1502_00/npu.dev.sbin",
+	.min_fw_version	= AIE2_FW_VERSION(5, 7),
 	.rt_config	= npu1_default_rt_cfg,
 	.dpm_clk_tbl	= npu1_dpm_clk_table,
 	.optional_msg	= npu1_msg_op_tbl,

--- a/src/driver/amdxdna/npu2_regs.c
+++ b/src/driver/amdxdna/npu2_regs.c
@@ -8,9 +8,8 @@
 /* NPU2 is the prototype of NPU4. It will be obsoleted in near future. */
 
 const struct amdxdna_dev_priv npu2_dev_priv = {
-	.fw_path        = "amdnpu/17f0_00/npu.dev.sbin",
-	.protocol_major = 0x6,
-	.protocol_minor = 0x6,
+	.fw_path	= "amdnpu/17f0_00/npu.dev.sbin",
+	.min_fw_version	= AIE2_FW_VERSION(6, 6),
 	NPU4_COMMON_DEV_PRIV,
 };
 

--- a/src/driver/amdxdna/npu4_regs.c
+++ b/src/driver/amdxdna/npu4_regs.c
@@ -17,24 +17,24 @@ const struct rt_config npu4_default_rt_cfg[] = {
 };
 
 const struct rt_cfg_ver npu4_rt_cfg_tbl[] = {
-	{ 12, NPU4_RT_TYPE_FINE_PREEMPTION },
-	{ 12, NPU4_RT_TYPE_FORCE_PREEMPTION },
-	{ 12, NPU4_RT_TYPE_FRAME_BOUNDARY_PREEMPTION },
-	{ 19, NPU4_RT_TYPE_LOG_LEVEL },
-	{ 19, NPU4_RT_TYPE_LOG_FORMAT },
-	{ 19, NPU4_RT_TYPE_LOG_DESTINATION },
+	{ AIE2_FW_VERSION(6, 12), NPU4_RT_TYPE_FINE_PREEMPTION },
+	{ AIE2_FW_VERSION(6, 12), NPU4_RT_TYPE_FORCE_PREEMPTION },
+	{ AIE2_FW_VERSION(6, 12), NPU4_RT_TYPE_FRAME_BOUNDARY_PREEMPTION },
+	{ AIE2_FW_VERSION(6, 19), NPU4_RT_TYPE_LOG_LEVEL },
+	{ AIE2_FW_VERSION(6, 19), NPU4_RT_TYPE_LOG_FORMAT },
+	{ AIE2_FW_VERSION(6, 19), NPU4_RT_TYPE_LOG_DESTINATION },
 	{ 0 },
 };
 
 const struct msg_op_ver npu4_msg_op_tbl[] = {
-	{ 15, MSG_OP_CHAIN_EXEC_NPU },
-	{ 15, MSG_OP_UPDATE_PROPERTY },
-	{ 18, MSG_OP_GET_APP_HEALTH },
-	{ 19, MSG_OP_CONFIG_FW_LOG },
-	{ 19, MSG_OP_START_FW_TRACE },
-	{ 19, MSG_OP_STOP_FW_TRACE },
-	{ 19, MSG_OP_SET_FW_TRACE_CATEGORIES },
-	{ 24, MSG_OP_GET_COREDUMP },
+	{ AIE2_FW_VERSION(6, 15), MSG_OP_CHAIN_EXEC_NPU },
+	{ AIE2_FW_VERSION(6, 15), MSG_OP_UPDATE_PROPERTY },
+	{ AIE2_FW_VERSION(6, 18), MSG_OP_GET_APP_HEALTH },
+	{ AIE2_FW_VERSION(6, 19), MSG_OP_CONFIG_FW_LOG },
+	{ AIE2_FW_VERSION(6, 19), MSG_OP_START_FW_TRACE },
+	{ AIE2_FW_VERSION(6, 19), MSG_OP_STOP_FW_TRACE },
+	{ AIE2_FW_VERSION(6, 19), MSG_OP_SET_FW_TRACE_CATEGORIES },
+	{ AIE2_FW_VERSION(6, 24), MSG_OP_GET_COREDUMP },
 	{ 0 },
 };
 
@@ -51,15 +51,14 @@ const struct dpm_clk_freq npu4_dpm_clk_table[] = {
 };
 
 const struct aie2_fw_feature_tbl npu4_fw_feature_table[] = {
-	{ .feature = AIE2_NPU_COMMAND, .min_minor = 15 },
-	{ .feature = AIE2_PREEMPT, .min_minor = 12 },
+	{ .feature = AIE2_NPU_COMMAND, .min_fw_version = AIE2_FW_VERSION(6, 15) },
+	{ .feature = AIE2_PREEMPT, .min_fw_version = AIE2_FW_VERSION(6, 12) },
 	{ 0 }
 };
 
 const struct amdxdna_dev_priv npu4_dev_priv = {
-	.fw_path        = "amdnpu/17f0_10/npu.dev.sbin",
-	.protocol_major = 6,
-	.protocol_minor = 12,
+	.fw_path	= "amdnpu/17f0_10/npu.dev.sbin",
+	.min_fw_version	= AIE2_FW_VERSION(6, 12),
 	NPU4_COMMON_DEV_PRIV,
 };
 

--- a/src/driver/amdxdna/npu5_regs.c
+++ b/src/driver/amdxdna/npu5_regs.c
@@ -6,9 +6,8 @@
 #include "npu4_family.h"
 
 const struct amdxdna_dev_priv npu5_dev_priv = {
-	.fw_path        = "amdnpu/17f0_11/npu.dev.sbin",
-	.protocol_major = 6,
-	.protocol_minor = 12,
+	.fw_path	= "amdnpu/17f0_11/npu.dev.sbin",
+	.min_fw_version	= AIE2_FW_VERSION(6, 12),
 	NPU4_COMMON_DEV_PRIV,
 };
 


### PR DESCRIPTION
Replace separate protocol_major/protocol_minor fields with a unified version number (major * 100 + minor) for simpler version comparisons. This design allows easy support for multiple firmware major versions by adding entries to the fw_ver_reqs array, and enables simple >= comparisons for feature/opcode availability checks.