### PR TITLE
Add permission checks for admin-only operations

### DIFF
--- a/src/driver/amdxdna/aie2_msg_priv.h
+++ b/src/driver/amdxdna/aie2_msg_priv.h
@@ -397,9 +397,9 @@ enum async_event_type {
 	MAX_ASYNC_EVENT_TYPE
 };
 
-#define ASYNC_BUF_SIZE 0x2000
 struct async_event_msg_req {
 	u64 buf_addr;
+#define ASYNC_BUF_SIZE		SZ_8K
 	u32 buf_size;
 } __packed;
 

--- a/src/driver/amdxdna/aie2_pci.c
+++ b/src/driver/amdxdna/aie2_pci.c
@@ -1154,6 +1154,10 @@ static int aie2_get_info(struct amdxdna_client *client, struct amdxdna_drm_get_i
 		ret = aie2_get_power_mode(client, args);
 		break;
 	case DRM_AMDXDNA_QUERY_TELEMETRY:
+		if (!amdxdna_admin_access_allowed(xdna)) {
+			ret = -EPERM;
+			break;
+		}
 		ret = aie2_query_telemetry(client, args);
 		break;
 	case DRM_AMDXDNA_GET_FORCE_PREEMPT_STATE:
@@ -1304,27 +1308,6 @@ static int aie2_get_array_async_error(struct amdxdna_dev *xdna, struct amdxdna_d
 	ret = amdxdna_drm_copy_array_to_user(args, &tmp, sizeof(tmp), ret);
 exit:
 	return ret;
-}
-
-/*
- * Returns true if caller is root (CAP_SYS_ADMIN) or, when root_only is false,
- * if the caller owns the context.
- */
-static bool amdxdna_ctx_access_allowed(struct amdxdna_ctx *ctx, bool root_only)
-{
-	struct amdxdna_dev *xdna = ctx->client->xdna;
-	bool is_admin = capable(CAP_SYS_ADMIN);
-	bool is_owner;
-
-	if (root_only) {
-		XDNA_DBG(xdna, "Access check (root only): is_admin=%d", is_admin);
-		return is_admin;
-	}
-
-	is_owner = uid_eq(current_euid(), ctx->client->uid);
-	XDNA_DBG(xdna, "Access check: is_admin=%d is_owner=%d", is_admin, is_owner);
-
-	return is_admin || is_owner;
 }
 
 static int aie2_get_coredump(struct amdxdna_client *client, struct amdxdna_drm_get_array *args)
@@ -1581,9 +1564,17 @@ static int aie2_get_array(struct amdxdna_client *client, struct amdxdna_drm_get_
 		ret = aie2_get_array_async_error(xdna, args);
 		break;
 	case DRM_AMDXDNA_FW_LOG:
+		if (!amdxdna_admin_access_allowed(xdna)) {
+			ret = -EPERM;
+			break;
+		}
 		ret = amdxdna_get_fw_log(xdna, args);
 		break;
 	case DRM_AMDXDNA_FW_TRACE:
+		if (!amdxdna_admin_access_allowed(xdna)) {
+			ret = -EPERM;
+			break;
+		}
 		ret = amdxdna_get_fw_trace(xdna, args);
 		break;
 	case DRM_AMDXDNA_FW_LOG_CONFIG:

--- a/src/driver/amdxdna/amdxdna_drm.h
+++ b/src/driver/amdxdna/amdxdna_drm.h
@@ -197,5 +197,7 @@ int amdxdna_drm_copy_array_to_user(struct amdxdna_drm_get_array *tgt,
 				   void *array, size_t element_size, size_t num_element);
 int amdxdna_drm_copy_array_from_user(struct amdxdna_drm_get_array *src,
 				     void *array, size_t element_size, size_t num_element);
+bool amdxdna_admin_access_allowed(struct amdxdna_dev *xdna);
+bool amdxdna_ctx_access_allowed(struct amdxdna_ctx *ctx, bool root_only);
 
 #endif /* _AMDXDNA_DRM_H_ */


### PR DESCRIPTION
Add permission checks for admin-only operations:
  - Event trace data query
  - Firmware log data query
  - Telemetry queries
- Use xrt_core::system_error consistently for error handling
- Use positive error codes (EPERM, EINTR, etc.) for comparisons