### PR TITLE
aie2: Implement system clock calibration with firmware

### DIFF
--- a/src/driver/amdxdna/aie2_message.c
+++ b/src/driver/amdxdna/aie2_message.c
@@ -303,6 +303,28 @@ int aie2_check_protocol_version(struct amdxdna_dev_hdl *ndev)
 	return 0;
 }
 
+int aie2_calibrate_time(struct amdxdna_dev_hdl *ndev)
+{
+	DECLARE_AIE2_MSG(calibrate_time, MSG_OP_CALIBRATE_TIME);
+	int ret;
+
+	if (!aie2_is_supported_msg(ndev, MSG_OP_CALIBRATE_TIME)) {
+		XDNA_DBG(ndev->xdna, "Calibrate time not supported, skipped");
+		return 0;
+	}
+
+	req.timestamp_ns = ktime_get_real_ns();
+
+	ret = aie2_send_mgmt_msg_wait(ndev, &msg);
+	if (ret) {
+		XDNA_ERR(ndev->xdna, "Calibrate time failed, ret %d", ret);
+		return ret;
+	}
+
+	XDNA_DBG(ndev->xdna, "System clock calibrated with firmware");
+	return 0;
+}
+
 int aie2_query_aie_telemetry(struct amdxdna_dev_hdl *ndev, struct amdxdna_mgmt_dma_hdl *dma_hdl,
 			     u32 type, u32 size, struct aie_version *version)
 {

--- a/src/driver/amdxdna/aie2_msg_priv.h
+++ b/src/driver/amdxdna/aie2_msg_priv.h
@@ -50,6 +50,7 @@ enum aie2_msg_opcode {
 	MSG_OP_ADD_HOST_BUFFER			= 0x115,
 	MSG_OP_CONFIG_FW_LOG			= 0x116,
 	MSG_OP_GET_COREDUMP			= 0x119,
+	MSG_OP_CALIBRATE_TIME			= 0x11C,
 	MSG_OP_MAX_DRV_OPCODE,
 	MSG_OP_GET_PROTOCOL_VERSION		= 0x301,
 	MSG_OP_MAX_OPCODE
@@ -753,9 +754,17 @@ struct get_coredump_req {
 } __packed;
 
 struct get_coredump_resp {
-	enum			aie2_msg_status status;
+	enum aie2_msg_status	status;
 	u32			required_buffer_size;
 	u32			reserved[7];
+} __packed;
+
+struct calibrate_time_req {
+	u64			timestamp_ns;
+} __packed;
+
+struct calibrate_time_resp {
+	enum aie2_msg_status	status;
 } __packed;
 
 #endif /* _AIE2_MSG_PRIV_H_ */

--- a/src/driver/amdxdna/aie2_pci.c
+++ b/src/driver/amdxdna/aie2_pci.c
@@ -279,6 +279,12 @@ static int aie2_mgmt_fw_init(struct amdxdna_dev_hdl *ndev)
 		return ret;
 	}
 
+	ret = aie2_calibrate_time(ndev);
+	if (ret) {
+		XDNA_ERR(ndev->xdna, "Calibrate system clock failed");
+		return ret;
+	}
+
 	return 0;
 }
 

--- a/src/driver/amdxdna/aie2_pci.h
+++ b/src/driver/amdxdna/aie2_pci.h
@@ -520,6 +520,7 @@ int aie2_frame_boundary_preemption(struct amdxdna_dev_hdl *ndev, bool enable);
 int aie2_update_prop_time_quota(struct amdxdna_dev_hdl *ndev,
 				struct amdxdna_ctx *ctx, u32 us);
 int aie2_check_protocol_version(struct amdxdna_dev_hdl *ndev);
+int aie2_calibrate_time(struct amdxdna_dev_hdl *ndev);
 int aie2_assign_mgmt_pasid(struct amdxdna_dev_hdl *ndev, u16 pasid);
 int aie2_query_aie_telemetry(struct amdxdna_dev_hdl *ndev, struct amdxdna_mgmt_dma_hdl *dma_hdl,
 			     u32 type, u32 size, struct aie_version *version);

--- a/src/driver/amdxdna/npu4_regs.c
+++ b/src/driver/amdxdna/npu4_regs.c
@@ -35,6 +35,7 @@ const struct msg_op_ver npu4_msg_op_tbl[] = {
 	{ AIE2_FW_VERSION(6, 19), MSG_OP_STOP_FW_TRACE },
 	{ AIE2_FW_VERSION(6, 19), MSG_OP_SET_FW_TRACE_CATEGORIES },
 	{ AIE2_FW_VERSION(6, 24), MSG_OP_GET_COREDUMP },
+	{ AIE2_FW_VERSION(6, 24), MSG_OP_CALIBRATE_TIME },
 	{ 0 },
 };
 


### PR DESCRIPTION
Add aie2_calibrate_time() function to synchronize the system clock with the NPU firmware.