### PR TITLE
dpt: add timer_lock and refcount for safe timer lifecycle

### DIFF
--- a/src/driver/amdxdna/amdxdna_dpt.h
+++ b/src/driver/amdxdna/amdxdna_dpt.h
@@ -7,6 +7,8 @@
 #define _AMDXDNA_DPT_H_
 
 #include <linux/kernel.h>
+#include <linux/refcount.h>
+#include <linux/mutex.h>
 #include <linux/timer.h>
 #include <linux/workqueue.h>
 
@@ -39,9 +41,11 @@ struct amdxdna_dpt {
 	struct amdxdna_dev		*xdna;
 	struct amdxdna_mgmt_dma_hdl	*dma_hdl;
 	struct wait_queue_head		wait;
-	bool				polling;
 	struct work_struct		work;
 	struct timer_list		timer;
+	/* Protects timer_refs and timer delete path. */
+	struct mutex			timer_lock;
+	refcount_t			timer_refs;
 	void			__iomem *io_base;
 	int				irq;
 	u32				msi_idx;

--- a/src/shim/device.cpp
+++ b/src/shim/device.cpp
@@ -683,6 +683,8 @@ struct event_trace
         } catch (const xrt_core::system_error& e) {
           if (e.get_code() == EINTR)
             throw xrt_core::system_error(EINTR, "Query interrupted by user");
+          else if (e.get_code() == ESHUTDOWN)
+            throw xrt_core::system_error(ESHUTDOWN, "Event trace disabled during query");
           else if (e.get_code() == EPERM)
             throw xrt_core::system_error(EPERM, "Must be root to access event trace");
           throw std::runtime_error("Failed to get event_trace");
@@ -804,6 +806,8 @@ struct firmware_log
         } catch (const xrt_core::system_error& e) {
           if (e.get_code() == EINTR)
             throw xrt_core::system_error(EINTR, "Query interrupted by user");
+          else if (e.get_code() == ESHUTDOWN)
+            throw xrt_core::system_error(ESHUTDOWN, "Firmware log disabled during query");
           else if (e.get_code() == EPERM)
             throw xrt_core::system_error(EPERM, "Must be root to access firmware log");
           throw std::runtime_error("Failed to get firmware log");


### PR DESCRIPTION
Replace amdxdna_dpt_enable_polling() with a refcounted timer mechanism. The old boolean-based approach couldn't handle multiple concurrent timer users (watch mode, dump_to_dmesg, forced polling via module params).

Add timer_get/put helpers that:
- Start the timer on first reference, increment refcount otherwise
- Stop the timer synchronously only when the last reference is released
- Use timer_lock mutex to serialize rearm and delete decisions

The timer is now set up once during init and torn down during fini, with refcounting controlling when it actively runs. This fixes potential races between watch waiters and the teardown path.

Also handle graceful shutdown by checking the enabled flag during wait and return ESHUTDOWN instead of EPERM when DPT is disabled.