### PR TITLE
vxdna: build: not warn for missing DRM_IOCTL_SET_CLIENT_NAME

### DIFF
--- a/src/vxdna/check_linux_config.cmake
+++ b/src/vxdna/check_linux_config.cmake
@@ -17,7 +17,7 @@ int main() {
 if(HAVE_DRM_SET_CLIENT_NAME)
     message(STATUS "DRM_IOCTL_SET_CLIENT_NAME is supported")
 else()
-    message(WARNING "DRM_IOCTL_SET_CLIENT_NAME is not supported - client name setting will be disabled")
+    message(STATUS "DRM_IOCTL_SET_CLIENT_NAME is not supported - client name setting will be disabled")
 endif()
 
 # Check if struct iovec is defined


### PR DESCRIPTION
DRM_IOCTL_SET_CLIENT_NAME is introduced since 6.13, change cmake warning to information message if it is missing.