### PR TITLE
ve2: Fix use-after-free race condition in scheduler FIFO during context destruction

### DIFF
--- a/src/driver/amdxdna/ve2_mgmt.h
+++ b/src/driver/amdxdna/ve2_mgmt.h
@@ -223,4 +223,14 @@ int ve2_mgmt_schedule_cmd(struct amdxdna_dev *xdna, struct amdxdna_ctx *hwctx);
  */
 void ve2_mgmt_handshake_init(struct amdxdna_dev *xdna, struct amdxdna_ctx *hwctx);
 
+/**
+ * ve2_fifo_remove_ctx - Remove all FIFO entries for a given context.
+ * @mgmtctx: Pointer to the management context.
+ * @ctx: Pointer to the context to remove.
+ *
+ * Must be called with mgmtctx->ctx_lock held.
+ * This prevents use-after-free when a context is destroyed.
+ */
+void ve2_fifo_remove_ctx(struct amdxdna_mgmtctx *mgmtctx, struct amdxdna_ctx *ctx);
+
 #endif /* _VE2_MGMT_H_ */


### PR DESCRIPTION
### Problem
When running multiple concurrent instances of applications using the amdxdna driver (stress testing with 100+ parallel processes), a kernel NULL pointer dereference crash occurs (here is a crash snippet):
`Unable to handle kernel NULL pointer dereference at virtual address 0000000000000010`
`...`
`Call trace:`
`ve2_mgmt_handshake_init+0x28/0x1b8 [amdxdna]` 
`ve2_response_ctx_switch_req+0xb8/0x160 [amdxdna]`
`ve2_scheduler_work+0x17c/0x490 [amdxdna]`

### Root Cause
A race condition existed between context destruction (ve2_hwctx_fini) and the scheduler workqueue (ve2_scheduler_work):
1. Scheduler work picks a context from the command FIFO queue
2. Concurrently, ve2_hwctx_fini() destroys the context and frees hwctx->priv
3. Scheduler work attempts to access the freed context → NULL pointer dereference

The scheduler FIFO (ctx_command_fifo) could contain stale pointers to contexts that were being destroyed, leading to use-after-free.

### Tested 
1. The simple_int8 test by having 100 instances parallelly (100+ processes) in the background at the same time. Now with this fix no longer crash is occurring and module reference count properly returns to 0 after all processes exit able to load unload amdxdna module properly. 
2. Also tested the above scenario by limiting max_col to only 4 and it works fine. Earlier it used to crash.
3. Also tested all the XRT basic hw tests on ve2 and all are passing.