### PR TITLE
Adding npu3 fw to info.json and configuring build.sh for download

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -94,7 +94,7 @@ download_npufws()
       fi
 
       echo "Download $device NPUFW version $version:"
-      if [ -d "${firmware_dir}/${pci_dev_id}_${pci_rev_id}" ]; then
+      if [ -f "${firmware_dir}/${pci_dev_id}_${pci_rev_id}/$fw_name" ]; then
         rm -r ${firmware_dir}/${pci_dev_id}_${pci_rev_id}
       fi
       mkdir -p ${firmware_dir}/${pci_dev_id}_${pci_rev_id}

--- a/tools/info.json
+++ b/tools/info.json
@@ -22,6 +22,22 @@
 			"fw_name": "npu.dev.sbin"
 		},
 		{
+			"device": "npu3",
+			"url": "https://gitlab.com/kernel-firmware/drm-firmware/-/raw/amd-ipu-staging/amdnpu/17f1_10/npu.sbin.0.0.8.41",
+			"pci_device_id": "17f1",
+			"pci_revision_id": "10",
+			"version": "0.0.8.41",
+			"fw_name": "npu.dev.sbin"
+		},
+		{
+			"device": "npu3",
+			"url": "https://gitlab.com/kernel-firmware/drm-firmware/-/raw/amd-ipu-staging/amdnpu/17f1_10/cert.sbin.20251218",
+			"pci_device_id": "17f1",
+			"pci_revision_id": "10",
+			"version": "20251218",
+			"fw_name": "cert.dev.sbin"
+		},
+		{
 			"device": "npu4",
 			"url": "https://gitlab.com/kernel-firmware/drm-firmware/-/raw/amd-ipu-staging/amdnpu/17f0_10/1.7_npu.sbin.1.1.0.59",
 			"pci_device_id": "17f0",


### PR DESCRIPTION
Needed to change the build.sh. Since npu3 needs 2 firmwares, checking if the directory exists for the device ID would remove the directory with 1 of the updated fws before script could add the second fw. Better to check if exact file exists. 