### PR TITLE
amdxdna: ve2: Add error callback synchronization to async error query

### DIFF
--- a/src/driver/amdxdna/ve2_of.h
+++ b/src/driver/amdxdna/ve2_of.h
@@ -107,6 +107,8 @@ struct amdxdna_mgmtctx {
 	u32			is_context_req; /* Hardware sync required */
 	u32			is_idle_due_to_context; /* Hardware sync required */
 	struct amdxdna_async_err_cache	async_errs_cache; /* cache for async errors */
+	struct completion	error_cb_completion; /* completion for error callback */
+	atomic_t		error_cb_in_progress; /* track if error callback is running */
 };
 
 struct amdxdna_dev_hdl {


### PR DESCRIPTION
Ensure pending error callbacks complete before reading cached errors in ve2_get_array_async_error(). This guarantees async errors are properly cached when queried via DRM_AMDXDNA_HW_LAST_ASYNC_ERR ioctl. The implementation polls briefly (50ms) then waits up to 100ms for callbacks to complete across all active mgmtctxs.