### PR TITLE
Fix crash in xdna_aie_array initialization

### DIFF
--- a/src/include/uapi/drm_local/amdxdna_accel.h
+++ b/src/include/uapi/drm_local/amdxdna_accel.h
@@ -837,6 +837,7 @@ struct amdxdna_drm_get_array {
 #define DRM_AMDXDNA_FW_LOG_CONFIG	7
 #define DRM_AMDXDNA_FW_TRACE_CONFIG	8
 #define DRM_AMDXDNA_AIE_TILE_READ	9
+#define DRM_AMDXDNA_HWCTX_AIE_PART_FD		10
 	__u32 param; /* in */
 	__u32 element_size; /* in/out */
 #define AMDXDNA_MAX_NUM_ELEMENT			1024

--- a/src/shim_ve2/xdna_aie_array.h
+++ b/src/shim_ve2/xdna_aie_array.h
@@ -28,6 +28,7 @@ public:
 	XAie_DevInst *get_dev();
    adf::driver_config get_driver_config_hwctx(const xrt_core::device* device, const xdna_hwctx* hwctx);
 private:
+  int get_aie_partition_fd(const xdna_hwctx* hwctx_obj);
   int num_cols;
   int fd;
   XAie_DevInst* dev_inst;         // AIE Device Instance pointer


### PR DESCRIPTION
### Problem and fix for https://jira.xilinx.com/browse/AIESW-21965:
While running multi process stress tests severe crash occurred. Earlier while initializing xdna_aie_array, a debug API XAie_GetPartitionFdList() was being used and ve2 userspace used to leak FDs and resources were not getting freed properly which led to crash in stress tests.

### Rootcauses:
1. FD leaks in xdna_aie_array initialization.
2. invalid num_cols while getting partition info while running multi process tests.
3. xdna_aie_array destruction used to happen after the hwctx destruction which led to improper destruction of hwctx.

### Fixes:
1. Fixed the FD leaks by adding a new param in DRM_IOCTL_AMDXDNA_GET_ARRAY to get the correct and single FD for a specific aie partition instead of getting all the FDs for all the partitions.
2. Added a check to get the correct num_cols for a correct hwctx for a specific PID to avoid getting wrong num_col in multi process tests.
3. Destroying xdna_aie_array explicity before destroying the hw context.

### Tested:
1. The provided test from https://jira.xilinx.com/browse/AIESW-21965. Tested for 1000 iterations by having 7 instances of the host running parallelly in the background. With the above fix not seeing any crash anymore. And also getting correct refcounts for zocl, amdxdna, xilinx_aie in "lsmod". And able to load-unload the modules.
2. Tested all the basic XRT hw tests in VE2.