### PR TITLE
driver: use iommu_paging_domain_alloc_flags if supported in iova mode

### DIFF
--- a/src/driver/amdxdna/amdxdna_iommu.c
+++ b/src/driver/amdxdna/amdxdna_iommu.c
@@ -3,12 +3,15 @@
  * Copyright (C) 2025, Advanced Micro Devices, Inc.
  */
 
-#include <linux/version.h>
 #include <linux/iommu.h>
-#if KERNEL_VERSION(6, 13, 0) <= LINUX_VERSION_CODE
-#include <uapi/linux/iommufd.h>
-#endif
 #include <linux/iova.h>
+#ifdef HAVE_iommu_paging_domain_alloc_flags
+/* IOMMU_HWPT_ALLOC_PASID is defined in uiommufd.h */
+#include <uapi/linux/iommufd.h>
+#else
+/* used GENMASK() to define iommu iova upper limit */
+#include <linux/bits.h>
+#endif
 
 #include "amdxdna_gem.h"
 #include "amdxdna_pci_drv.h"
@@ -24,7 +27,12 @@ static struct iova *amdxdna_iommu_alloc_iova(struct amdxdna_dev *xdna,
 	unsigned long shift, end;
 	struct iova *iova;
 
+#ifdef HAVE_iommu_paging_domain_alloc_flags
 	end = xdna->domain->geometry.aperture_end;
+#else
+	/* xdna PD_MODE_V2 device uses a 47-bit IOVA address space (0 to GENMASK(46, 0)) */
+	end = GENMASK(46, 0);
+#endif
 	shift = iova_shift(&xdna->iovad);
 	size = iova_align(&xdna->iovad, size);
 
@@ -140,7 +148,7 @@ int amdxdna_iommu_init(struct amdxdna_dev *xdna)
 		return 0;
 	}
 
-#if KERNEL_VERSION(6, 13, 0) <= LINUX_VERSION_CODE
+#ifdef HAVE_iommu_paging_domain_alloc_flags
 	xdna->domain = iommu_paging_domain_alloc_flags(xdna->ddev.dev, IOMMU_HWPT_ALLOC_PASID);
 #else
 	xdna->domain = iommu_paging_domain_alloc(xdna->ddev.dev);

--- a/src/driver/tools/configure_kernel.sh
+++ b/src/driver/tools/configure_kernel.sh
@@ -244,6 +244,19 @@ int main(void)
 }
 EOF
 
+# Test iommu_paging_domain_alloc_flags() signature in 6.13+:
+# struct iommu_domain *iommu_paging_domain_alloc_flags(struct device *dev, unsigned long flags)
+try_compile HAVE_iommu_paging_domain_alloc_flags << 'EOF'
+#include <linux/iommu.h>
+int main(void)
+{
+	struct device *a = NULL;
+	unsigned long b = 0;
+	(void)iommu_paging_domain_alloc_flags(a, b);
+	return 0;
+}
+EOF
+
 # ---- Header trailer ----------------------------------------------------
 
 cat >> "$OUT" <<EOF


### PR DESCRIPTION
iommu_paging_domain_alloc_flags is supported since Linux 6.13. In iova mode, use iommu_paging_domain_alloc_flags if supported, otherwise use iommu_paging_domain_alloc.

Tested with linux kernel 6.12.18 with `force_iova=true`, with either default amd iommu setting or `amd_iommu=force_isolation` and tested with 6.19 kernel with both amd_iommu settings.
