### PR TITLE
drivers: amdxdna: iommu: use older iommu alloc APIs if no new APIs found

### DIFF
--- a/src/driver/amdxdna/amdxdna_iommu.c
+++ b/src/driver/amdxdna/amdxdna_iommu.c
@@ -150,8 +150,10 @@ int amdxdna_iommu_init(struct amdxdna_dev *xdna)
 
 #ifdef HAVE_iommu_paging_domain_alloc_flags
 	xdna->domain = iommu_paging_domain_alloc_flags(xdna->ddev.dev, IOMMU_HWPT_ALLOC_PASID);
-#else
+#elif defined(HAVE_iommu_paging_domain_alloc)
 	xdna->domain = iommu_paging_domain_alloc(xdna->ddev.dev);
+#else
+	xdna->domain = iommu_domain_alloc(xdna->ddev.dev->bus);
 #endif
 	if (IS_ERR(xdna->domain)) {
 		XDNA_ERR(xdna, "Failed to alloc iommu domain");

--- a/src/driver/tools/configure_kernel.sh
+++ b/src/driver/tools/configure_kernel.sh
@@ -257,6 +257,18 @@ int main(void)
 }
 EOF
 
+# Test iommu_paging_domain_alloc() signature in 6.13+:
+# struct iommu_domain *iommu_paging_domain_alloc(struct device *dev)
+try_compile HAVE_iommu_paging_domain_alloc << 'EOF'
+#include <linux/iommu.h>
+int main(void)
+{
+	struct device *a = NULL;
+	(void)iommu_paging_domain_alloc(a);
+	return 0;
+}
+EOF
+
 # ---- Header trailer ----------------------------------------------------
 
 cat >> "$OUT" <<EOF


### PR DESCRIPTION
Use iommu_domain_alloc() if neither iommu_paging_domain_alloc_flags() nor iommu_paging_domain_alloc() is found.

Tested on 6.10-rc7 kernel with force_iova=true.