### PR TITLE
Implement firmware event trace callbacks and debugfs nodes

### DIFF
--- a/src/driver/amdxdna/aie4_dpt.c
+++ b/src/driver/amdxdna/aie4_dpt.c
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0
 /*
- * Copyright (C) 2025, Advanced Micro Devices, Inc.
+ * Copyright (C) 2025-2026, Advanced Micro Devices, Inc.
  */
 
 #include "aie4_pci.h"
@@ -97,6 +97,67 @@ int aie4_fw_log_fini(struct amdxdna_dev *xdna)
 	ret = aie4_stop_fw_log(xdna->dev_handle);
 	if (ret) {
 		XDNA_ERR(xdna, "Failed to reset fw log buffer: %d", ret);
+		mutex_unlock(&xdna->dev_handle->aie4_lock);
+		return ret;
+	}
+	mutex_unlock(&xdna->dev_handle->aie4_lock);
+	return 0;
+}
+
+void aie4_fw_trace_parse(struct amdxdna_dev *xdna, char *buffer, size_t size)
+{
+	if (!size)
+		return;
+
+	print_hex_dump(KERN_INFO, "[FW TRACE]: ", DUMP_PREFIX_OFFSET, 16, 4, buffer, size, false);
+}
+
+int aie4_fw_trace_init(struct amdxdna_dev *xdna, size_t size, u32 categories)
+{
+	struct amdxdna_mgmt_dma_hdl *dma_hdl = xdna->fw_trace->dma_hdl;
+	u32 msi_idx, msi_address;
+	int ret;
+
+	mutex_lock(&xdna->dev_handle->aie4_lock);
+	ret = aie4_start_fw_trace(xdna->dev_handle, dma_hdl, size, categories, &msi_idx,
+				  &msi_address);
+	if (ret) {
+		/* Silently fail for device generation that don't support FW tracing */
+		if (ret != -EOPNOTSUPP)
+			XDNA_ERR(xdna, "Failed to init fw trace buffer: %d", ret);
+		mutex_unlock(&xdna->dev_handle->aie4_lock);
+		return ret;
+	}
+	mutex_unlock(&xdna->dev_handle->aie4_lock);
+
+	xdna->fw_trace->io_base = xdna->dev_handle->mbox_base;
+	xdna->fw_trace->msi_address = msi_address & AIE4_DPT_MSI_ADDR_MASK;
+	xdna->fw_trace->msi_idx = msi_idx;
+
+	return ret;
+}
+
+int aie4_fw_trace_config(struct amdxdna_dev *xdna, u32 categories)
+{
+	int ret;
+
+	mutex_lock(&xdna->dev_handle->aie4_lock);
+	ret = aie4_set_trace_categories(xdna->dev_handle, categories);
+	if (ret)
+		XDNA_ERR(xdna, "Failed to init fw trace categories: %d", ret);
+	mutex_unlock(&xdna->dev_handle->aie4_lock);
+
+	return ret;
+}
+
+int aie4_fw_trace_fini(struct amdxdna_dev *xdna)
+{
+	int ret;
+
+	mutex_lock(&xdna->dev_handle->aie4_lock);
+	ret = aie4_stop_fw_trace(xdna->dev_handle);
+	if (ret) {
+		XDNA_ERR(xdna, "Failed to stop fw trace: %d", ret);
 		mutex_unlock(&xdna->dev_handle->aie4_lock);
 		return ret;
 	}

--- a/src/driver/amdxdna/aie4_pci.h
+++ b/src/driver/amdxdna/aie4_pci.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: GPL-2.0 */
 /*
- * Copyright (C) 2023-2025, Advanced Micro Devices, Inc.
+ * Copyright (C) 2023-2026, Advanced Micro Devices, Inc.
  */
 
 #ifndef _AIE4_PCI_H_
@@ -167,6 +167,10 @@ int aie4_start_fw_log(struct amdxdna_dev_hdl *ndev, struct amdxdna_mgmt_dma_hdl 
 		      size_t size, u32 *msi_idx, u32 *msi_address);
 int aie4_set_log_level(struct amdxdna_dev_hdl *ndev, u8 level);
 int aie4_stop_fw_log(struct amdxdna_dev_hdl *ndev);
+int aie4_start_fw_trace(struct amdxdna_dev_hdl *ndev, struct amdxdna_mgmt_dma_hdl *dma_hdl,
+			size_t size, u32 categories, u32 *msi_idx, u32 *msi_address);
+int aie4_set_trace_categories(struct amdxdna_dev_hdl *ndev, u32 categories);
+int aie4_stop_fw_trace(struct amdxdna_dev_hdl *ndev);
 void aie4_reset_prepare(struct amdxdna_dev *xdna);
 int aie4_reset_done(struct amdxdna_dev *xdna);
 
@@ -209,6 +213,10 @@ int aie4_fw_log_init(struct amdxdna_dev *xdna, size_t size, u8 level);
 int aie4_fw_log_config(struct amdxdna_dev *xdna, u8 level);
 int aie4_fw_log_fini(struct amdxdna_dev *xdna);
 void aie4_fw_log_parse(struct amdxdna_dev *xdna, char *buffer, size_t size);
+int aie4_fw_trace_init(struct amdxdna_dev *xdna, size_t size, u32 categories);
+int aie4_fw_trace_fini(struct amdxdna_dev *xdna);
+int aie4_fw_trace_config(struct amdxdna_dev *xdna, u32 categories);
+void aie4_fw_trace_parse(struct amdxdna_dev *xdna, char *buffer, size_t size);
 
 /* aie4_sriov.c */
 int aie4_sriov_configure(struct amdxdna_dev *xdna, int num_vfs);


### PR DESCRIPTION
Implement firmware event trace callbacks and debugfs nodes for aie4.

- Add aie4_fw_trace_parse/init/config/fini functions in aie4_dpt.c
- Add aie4_start_fw_trace/set_trace_categories/stop_fw_trace messaging functions in aie4_message.c
- Add fw_trace function declarations in aie4_pci.h
- Add IOCTLs callback for DRM_AMDXDNA_FW_TRACE, DRM_AMDXDNA_FW_LOG_CONFIG, DRM_AMDXDNA_FW_TRACE_CONFIG, and DRM_AMDXDNA_SET_FW_TRACE_STATE
- Add fw_trace_init/config/fini/parse callbacks to aie4_ops
- Add dump_fw_trace and dump_fw_trace_buffer debugfs entries