### PR TITLE
Support loading of amd npu firmware on xen virtualized platforms

### DIFF
--- a/src/driver/amdxdna/Kbuild
+++ b/src/driver/amdxdna/Kbuild
@@ -65,7 +65,8 @@ amdxdna-$(OFT_CONFIG_AMDXDNA_PCI) += \
 	npu4_regs.o \
 	npu5_regs.o \
 	npu6_regs.o \
-	amdxdna_pci_drv.o
+	amdxdna_pci_drv.o \
+	amdxdna_xen.o \
 
 amdxdna-$(OFT_CONFIG_AMDXDNA_OF) += \
 	ve2_of.o \

--- a/src/driver/amdxdna/aie2_pci.c
+++ b/src/driver/amdxdna/aie2_pci.c
@@ -633,6 +633,7 @@ static void aie2_fini(struct amdxdna_dev *xdna)
 
 	aie2_rq_fini(&ndev->ctx_rq);
 	aie2_hw_stop(xdna);
+	aie2_psp_destroy(&pdev->dev, ndev->psp_hdl);
 #ifdef AMDXDNA_DEVEL
 	if (iommu_mode != AMDXDNA_IOMMU_PASID)
 		goto skip_pasid;

--- a/src/driver/amdxdna/aie2_pci.h
+++ b/src/driver/amdxdna/aie2_pci.h
@@ -397,6 +397,7 @@ static inline bool aie2_pm_is_turbo(struct amdxdna_dev_hdl *ndev)
 
 /* aie2_psp.c */
 struct psp_device *aie2m_psp_create(struct device *dev, struct psp_config *conf);
+void aie2_psp_destroy(struct device *dev, void *psp_hdl);
 int aie2_psp_start(struct psp_device *psp);
 void aie2_psp_stop(struct psp_device *psp);
 int aie2_psp_waitmode_poll(struct psp_device *psp);

--- a/src/driver/amdxdna/amdxdna_xen.c
+++ b/src/driver/amdxdna/amdxdna_xen.c
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Copyright (C) 2026, Advanced Micro Devices, Inc.
+ */
+
+#include "amdxdna_xen.h"
+
+#ifdef HAVE_xen_phy_dma_ops
+#include <xen/phy-dma-ops.h>
+#endif
+
+void *amdxdna_xen_alloc_buf_phys(struct device *dev, u32 size, dma_addr_t *dma_addr)
+{
+	if (!is_xen_initial_pvh_domain()) {
+		dev_err(dev, "failed to allocate Xen buffer, not in a Xen initial PvH domain");
+		return NULL;
+	}
+
+#ifdef HAVE_xen_phy_dma_ops
+	if (!size || !dma_addr) {
+		dev_err(dev, "failed to allocate Xen buffer, invalid arguments");
+		return NULL;
+	}
+
+	return xen_phy_dma_ops.alloc(dev, size, dma_addr, GFP_KERNEL, 0);
+#else
+	dev_err(dev, "failed to allocate Xen buffer, xen phy dma ops not supported");
+	return NULL;
+#endif
+}
+
+void amdxdna_xen_free_buf_phys(struct device *dev, void *vaddr, dma_addr_t dma_addr, u32 size)
+{
+	if (!is_xen_initial_pvh_domain()) {
+		dev_err(dev, "failed to free Xen buffer, not in a Xen initial PvH domain");
+		return;
+	}
+
+#ifdef HAVE_xen_phy_dma_ops
+	if (!vaddr || !size) {
+		dev_err(dev, "failed to free Xen buffer, invalid arguments");
+		return;
+	}
+
+	xen_phy_dma_ops.free(dev, size, vaddr, dma_addr, 0);
+#endif
+}
+

--- a/src/driver/amdxdna/amdxdna_xen.h
+++ b/src/driver/amdxdna/amdxdna_xen.h
@@ -1,0 +1,39 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+/*
+ * Copyright (C) 2026, Advanced Micro Devices, Inc.
+ */
+
+#ifndef _AMDXDNA_XEN_H_
+#define _AMDXDNA_XEN_H_
+
+#include <linux/device.h>
+#include <linux/gfp.h>
+#include <linux/types.h>
+#include <xen/xen.h>
+#include <xen/xen-ops.h>
+
+static inline bool is_xen_initial_pvh_domain(void)
+{
+	return xen_initial_domain() && xen_pvh_domain();
+}
+
+ /**
+  * @brief Allocate a physical buffer for the Xen domain
+  * @param dev: The device to allocate the buffer for
+  * @param size: The requested size of the buffer to allocate
+  * @param dma_addr: The DMA address of the buffer
+  * @return: A virtual address pointer to the allocated buffer on success, or NULL on failure.
+  */
+void *amdxdna_xen_alloc_buf_phys(struct device *dev, u32 size, dma_addr_t *dma_addr);
+
+ /**
+  * @brief Free a physical buffer for the Xen domain
+  * @param dev: The device to free the buffer for
+  * @param vaddr: The virtual address of the buffer
+  * @param dma_addr: The DMA address of the buffer
+  * @param size: The size of the buffer
+  */
+void amdxdna_xen_free_buf_phys(struct device *dev, void *vaddr, dma_addr_t dma_addr, u32 size);
+
+ #endif /* _AMDXDNA_XEN_H_ */
+

--- a/src/driver/tools/configure_kernel.sh
+++ b/src/driver/tools/configure_kernel.sh
@@ -269,6 +269,17 @@ int main(void)
 }
 EOF
 
+# Test xen_phy_dma_ops signature:
+# const struct dma_map_ops xen_phy_dma_ops;
+try_compile HAVE_xen_phy_dma_ops << 'EOF'
+#include <xen/phy-dma-ops.h>
+int main(void)
+{
+	const struct dma_map_ops *a = &xen_phy_dma_ops;
+	return 0;
+}
+EOF
+
 # ---- Header trailer ----------------------------------------------------
 
 cat >> "$OUT" <<EOF


### PR DESCRIPTION
Update the amdxdna driver to allocate contiguous memory using xen dma ops. This allocated memory is used for loading npu firmware. The allocated DMA memory from the XEN DMA ops is physical memory which is required by PSP.