### PR TITLE
fix missing release_firmware

### DIFF
--- a/src/driver/amdxdna/aie4_pci.c
+++ b/src/driver/amdxdna/aie4_pci.c
@@ -691,6 +691,7 @@ static int aie4_alloc_work_buffer(struct amdxdna_dev_hdl *ndev)
 static void aie4_free_work_buffer(struct amdxdna_dev_hdl *ndev)
 {
 	struct amdxdna_dev *xdna = ndev->xdna;
+	struct pci_dev *pdev = to_pci_dev(xdna->ddev.dev);
 
 	if (is_npu3_vf_dev(pdev) || skip_work_buffer) {
 		XDNA_DBG(xdna, "skip free work buffer");
@@ -1260,7 +1261,6 @@ static void aie4_iommu_fini(struct amdxdna_dev_hdl *ndev)
 static void aie4_pcidev_fini(struct amdxdna_dev_hdl *ndev)
 {
 	struct amdxdna_dev *xdna = ndev->xdna;
-	struct pci_dev *pdev = to_pci_dev(xdna->ddev.dev);
 
 	mutex_lock(&ndev->aie4_lock);
 	aie4_hw_stop(xdna);


### PR DESCRIPTION
tested on silicon, without the change FW version locked up, only reboot can fix it.

with the fix, FW can be updated with latest updated version by insmod and rmmod.

```
[  304.052159] aie4_check_firmware_version: amdxdna 0000:c5:00.1: FW version: 0.0.12.75
[  304.052293] aie4_query_aie_version: amdxdna 0000:c5:00.1: Query AIE version - major: 1 minor: 1 completed
[  304.052739] aie4_check_firmware_version: amdxdna 0000:c5:00.1: FW version: 0.0.12.75
[  327.345470] aie4_check_firmware_version: amdxdna 0000:c5:00.1: FW version: 0.0.8.41
[  327.345618] aie4_query_aie_version: amdxdna 0000:c5:00.1: Query AIE version - major: 1 minor: 1 completed
[  327.346042] aie4_check_firmware_version: amdxdna 0000:c5:00.1: FW version: 0.0.8.41
[  346.037518] aie4_check_firmware_version: amdxdna 0000:c5:00.1: FW version: 0.0.8.41
[  346.037669] aie4_query_aie_version: amdxdna 0000:c5:00.1: Query AIE version - major: 1 minor: 1 completed
[  346.038086] aie4_check_firmware_version: amdxdna 0000:c5:00.1: FW version: 0.0.8.41
[  348.925809] aie4_check_firmware_version: amdxdna 0000:c5:00.1: FW version: 0.0.12.75
[  348.925965] aie4_query_aie_version: amdxdna 0000:c5:00.1: Query AIE version - major: 1 minor: 1 completed
[  348.926407] aie4_check_firmware_version: amdxdna 0000:c5:00.1: FW version: 0.0.12.75
```