### PR TITLE
Implement clock calibration for AIE4

### DIFF
--- a/src/driver/amdxdna/aie4_message.c
+++ b/src/driver/amdxdna/aie4_message.c
@@ -325,6 +325,23 @@ int aie4_set_pm_msg(struct amdxdna_dev_hdl *ndev, u32 target)
 	return 0;
 }
 
+int aie4_calibrate_clock(struct amdxdna_dev_hdl *ndev)
+{
+	DECLARE_AIE4_MSG(aie4_msg_calibrate_clock_trace, AIE4_MSG_OP_CALIBRATE_CLOCK);
+	int ret;
+
+	req.time_base_ns = ktime_get_real_ns();
+
+	ret = aie4_send_msg_wait(ndev, &msg);
+	if (ret) {
+		XDNA_ERR(ndev->xdna, "Calibrate clock failed, ret %d", ret);
+		return ret;
+	}
+
+	XDNA_DBG(ndev->xdna, "System clock calibrated with firmware");
+	return 0;
+}
+
 int aie4_register_asyn_event_msg(struct amdxdna_dev_hdl *ndev,
 				 struct amdxdna_mgmt_dma_hdl *dma_hdl, void *handle,
 				 int (*cb)(void*, void __iomem *, size_t))

--- a/src/driver/amdxdna/aie4_pci.c
+++ b/src/driver/amdxdna/aie4_pci.c
@@ -290,8 +290,18 @@ static int aie4_mgmt_fw_init(struct amdxdna_dev_hdl *ndev)
 	struct pci_dev *pdev = to_pci_dev(ndev->xdna->ddev.dev);
 	struct amdxdna_mgmt_dma_hdl *dma_hdl;
 	dma_addr_t dma_addr;
+	int ret;
 
-	if (is_npu3_vf_dev(pdev) || skip_work_buffer)
+	if (is_npu3_vf_dev(pdev))
+		return 0;
+
+	ret = aie4_calibrate_clock(ndev);
+	if (ret) {
+		XDNA_ERR(ndev->xdna, "Calibrate system clock failed");
+		return ret;
+	}
+
+	if (skip_work_buffer)
 		return 0;
 
 	dma_hdl = ndev->mpnpu_work_buffer;

--- a/src/driver/amdxdna/aie4_pci.h
+++ b/src/driver/amdxdna/aie4_pci.h
@@ -186,6 +186,7 @@ int aie4_query_aie_version(struct amdxdna_dev_hdl *ndev, struct aie_version *ver
 int aie4_query_aie_metadata(struct amdxdna_dev_hdl *ndev, struct aie_metadata *metadata);
 int aie4_query_aie_telemetry(struct amdxdna_dev_hdl *ndev, u32 type, dma_addr_t addr, u32 size);
 int aie4_set_pm_msg(struct amdxdna_dev_hdl *ndev, u32 target);
+int aie4_calibrate_clock(struct amdxdna_dev_hdl *ndev);
 int aie4_start_fw_log(struct amdxdna_dev_hdl *ndev, struct amdxdna_mgmt_dma_hdl *dma_hdl, u8 level,
 		      size_t size, u32 *msi_idx, u32 *msi_address);
 int aie4_set_log_level(struct amdxdna_dev_hdl *ndev, u8 level);


### PR DESCRIPTION
Add aie4_calibrate_clock() function to synchronize system clock with firmware.