### PR TITLE
providing an option to user to chose mem index for hardware context

### DIFF
--- a/src/driver/amdxdna/ve2_host_queue.h
+++ b/src/driver/amdxdna/ve2_host_queue.h
@@ -119,6 +119,7 @@ struct ve2_hsa_queue {
 	// hq_lock protects [read | write]_index and reserved_write_index
 	struct mutex			hq_lock;
 	u64				reserved_write_index;
+	struct device			*alloc_dev; /* Device used for dma allocation */
 };
 
 /* handshake */

--- a/src/driver/amdxdna/ve2_mgmt.c
+++ b/src/driver/amdxdna/ve2_mgmt.c
@@ -211,6 +211,7 @@ int ve2_xrs_request(struct amdxdna_dev *xdna, struct amdxdna_ctx *hwctx)
 		}
 	}
 	xrs_req->rqos.user_start_col = hwctx->qos.user_start_col;
+	xrs_req->rqos.mem_index = hwctx->qos.mem_index;
 	xrs_req->rid = (uintptr_t)hwctx;
 	ret = xrs_allocate_resource(xrs, xrs_req, &load_act);
 	if (ret) {

--- a/src/driver/amdxdna/ve2_res_solver.h
+++ b/src/driver/amdxdna/ve2_res_solver.h
@@ -39,6 +39,7 @@ struct aie_qos {
 	u32		priority;	/* Request priority */
 	u32		exclusive;      /* Exclusive Request or not */
 	u32		user_start_col; /* Start Col Requested by user */
+	u32		mem_index;	/* Memory region index */
 };
 
 /*

--- a/src/include/uapi/drm_local/amdxdna_accel.h
+++ b/src/include/uapi/drm_local/amdxdna_accel.h
@@ -92,7 +92,7 @@ extern "C" {
  * @frame_exec_time: Frame execution time.
  * @priority: Request priority.
  * @user_start_col: User preferred start column, or USER_START_COL_NOT_REQUESTED if not specified.
- * @reserved: Padding for 64-bit alignment (MBZ, reserved for future use).
+ * @mem_index: Memory region index for hw_context buffers (0-255).
  *
  * User program can provide QoS hints to driver.
  */
@@ -104,7 +104,7 @@ struct amdxdna_qos_info {
 	__u32 frame_exec_time;
 	__u32 priority;
 	__u32 user_start_col;
-	__u32 reserved; /* ensure 64-bit alignment */
+	__u32 mem_index;
 };
 
 /**

--- a/src/shim_ve2/xdna_hwctx.cpp
+++ b/src/shim_ve2/xdna_hwctx.cpp
@@ -104,8 +104,8 @@ xdna_hwctx(const device_xdna* dev, const xrt::xclbin& xclbin, const xrt::hw_cont
   // making use of umq_bo field for now.
   arg.umq_bo = xrt_core::config::get_privileged_context();
 
-  shim_debug("Calling DRM_IOCTL_AMDXDNA_CREATE_HWCTX: num_tiles=%u, qos_p=0x%lx, user_start_col=%u",
-             arg.num_tiles, arg.qos_p, m_qos.user_start_col);
+  shim_debug("Calling DRM_IOCTL_AMDXDNA_CREATE_HWCTX: num_tiles=%u, qos_p=0x%lx, user_start_col=%u, mem_index=%u",
+             arg.num_tiles, arg.qos_p, m_qos.user_start_col, m_qos.mem_index);
 
   try {
     m_device->get_edev()->ioctl(DRM_IOCTL_AMDXDNA_CREATE_HWCTX, &arg);
@@ -201,8 +201,8 @@ xdna_hwctx(const device_xdna* dev, uint32_t partition_size, const xrt::hw_contex
   // making use of umq_bo field for now.
   arg.umq_bo = xrt_core::config::get_privileged_context();
 
-  shim_debug("Calling DRM_IOCTL_AMDXDNA_CREATE_HWCTX: num_tiles=%u, qos_p=0x%lx, user_start_col=%u",
-             arg.num_tiles, arg.qos_p, m_qos.user_start_col);
+  shim_debug("Calling DRM_IOCTL_AMDXDNA_CREATE_HWCTX: num_tiles=%u, qos_p=0x%lx, user_start_col=%u, mem_index=%u",
+             arg.num_tiles, arg.qos_p, m_qos.user_start_col, m_qos.mem_index);
 
   try {
     m_device->get_edev()->ioctl(DRM_IOCTL_AMDXDNA_CREATE_HWCTX, &arg);
@@ -381,10 +381,16 @@ init_qos_info(const qos_type& qos)
       m_qos.priority = value;
     else if (key == "start_col")
       m_qos.user_start_col = value;
+    else if (key == "mem_index")
+      m_qos.mem_index = value;
   }
 
   if (m_qos.user_start_col != USER_START_COL_NOT_REQUESTED) {
     shim_debug("QoS user_start_col requested: %u", m_qos.user_start_col);
+  }
+
+  if (m_qos.mem_index != 0) {
+    shim_debug("QoS mem_index requested: %u", m_qos.mem_index);
   }
 
   return 0;


### PR DESCRIPTION
In Embedded platforms, start column of Hardware context can be controlled by the application to get the optimial performance. We need to create all the buffers related to hardware context in specific bank where that start column is being connected to. Otherwise, column firmware may not have the connection to the DDR.

This PR adds support for configuring memory bank allocation per hardware context. It introduces a mechanism to specify memory indices via hardware context configuration parameters and adds a runtime configuration option to skip kernel argument connectivity validation.