### PR TITLE
Add context switch hysteresis configuration support

### DIFF
--- a/src/driver/amdxdna/aie4_message.c
+++ b/src/driver/amdxdna/aie4_message.c
@@ -397,6 +397,29 @@ int aie4_start_fw_log(struct amdxdna_dev_hdl *ndev, struct amdxdna_mgmt_dma_hdl 
 	return 0;
 }
 
+int aie4_set_ctx_hysteresis(struct amdxdna_dev_hdl *ndev, u32 timeout_us)
+{
+	DECLARE_AIE4_MSG(aie4_msg_set_runtime_cfg, AIE4_MSG_OP_SET_RUNTIME_CONFIG);
+	struct aie4_msg_runtime_config_ctx_switch_hysteresis *hyst;
+	int ret;
+
+	req.type = AIE4_RUNTIME_CONFIG_CTX_SWITCH_HYSTERESIS;
+	hyst = (struct aie4_msg_runtime_config_ctx_switch_hysteresis *)req.data;
+	hyst->timeout_us = timeout_us;
+
+	msg.send_size = sizeof(req.type) + sizeof(*hyst);
+
+	ret = aie4_send_msg_wait(ndev, &msg);
+	if (ret) {
+		XDNA_ERR(ndev->xdna, "Failed to set runtime config, ret %d", ret);
+		return ret;
+	}
+
+	XDNA_DBG(ndev->xdna, "Context hysteresis set to %dus", timeout_us);
+
+	return 0;
+}
+
 int aie4_set_log_level(struct amdxdna_dev_hdl *ndev, u8 level)
 {
 	DECLARE_AIE4_MSG(aie4_msg_set_runtime_cfg, AIE4_MSG_OP_SET_RUNTIME_CONFIG);

--- a/src/driver/amdxdna/aie4_pci.c
+++ b/src/driver/amdxdna/aie4_pci.c
@@ -310,7 +310,13 @@ static int aie4_mgmt_fw_init(struct amdxdna_dev_hdl *ndev)
 	if (!dma_addr)
 		XDNA_ERR(ndev->xdna, "Invalid DMA address: 0x%llx", dma_addr);
 
-	return aie4_attach_work_buffer(ndev, 0, dma_addr, dma_hdl->size);
+	ret = aie4_attach_work_buffer(ndev, 0, dma_addr, dma_hdl->size);
+	if (ret) {
+		XDNA_ERR(ndev->xdna, "Failed to attach DRAM work buffer");
+		return ret;
+	}
+
+	return aie4_set_ctx_hysteresis(ndev, AIE4_CTX_HYSTERESIS_US);
 }
 
 static int aie4_mgmt_fw_query(struct amdxdna_dev_hdl *ndev)

--- a/src/driver/amdxdna/aie4_pci.h
+++ b/src/driver/amdxdna/aie4_pci.h
@@ -23,6 +23,7 @@
 #else
 #define AIE4_TIMEOUT		1000000	/* us */
 #endif
+#define AIE4_CTX_HYSTERESIS_US	1000	/* us */
 
 #define MAX_NUM_CERTS		6
 
@@ -199,6 +200,7 @@ int aie4_attach_work_buffer(struct amdxdna_dev_hdl *ndev, u32 pasid, dma_addr_t 
 int aie4_detach_work_buffer(struct amdxdna_dev_hdl *ndev);
 void aie4_reset_prepare(struct amdxdna_dev *xdna);
 int aie4_reset_done(struct amdxdna_dev *xdna);
+int aie4_set_ctx_hysteresis(struct amdxdna_dev_hdl *ndev, u32 timeout_us);
 
 /* aie4_hwctx.c */
 int aie4_ctx_init(struct amdxdna_ctx *ctx);

--- a/tools/info.json
+++ b/tools/info.json
@@ -15,10 +15,10 @@
 		},
 		{
 			"device": "npu3",
-			"url": "https://gitlab.com/kernel-firmware/drm-firmware/-/raw/amd-ipu-staging/amdnpu/17f1_10/npu.sbin.0.0.12.75",
+			"url": "https://gitlab.com/kernel-firmware/drm-firmware/-/raw/amd-ipu-staging/amdnpu/17f1_10/npu.sbin.0.0.15.112",
 			"pci_device_id": "17f1",
 			"pci_revision_id": "10",
-			"version": "0.0.12.75",
+			"version": "0.0.15.112",
 			"fw_name": "npu.dev.sbin"
 		},
 		{
@@ -32,10 +32,10 @@
 		},
 		{
 			"device": "npu3",
-			"url": "https://gitlab.com/kernel-firmware/drm-firmware/-/raw/amd-ipu-staging/amdnpu/17f2_10/npu.sbin.0.0.12.75",
+			"url": "https://gitlab.com/kernel-firmware/drm-firmware/-/raw/amd-ipu-staging/amdnpu/17f2_10/npu.sbin.0.0.15.112",
 			"pci_device_id": "17f2",
 			"pci_revision_id": "10",
-			"version": "0.0.12.75",
+			"version": "0.0.15.112",
 			"fw_name": "npu.dev.sbin"
 		},
 		{


### PR DESCRIPTION
Add aie4_set_ctx_hysteresis() function to configure the context switch hysteresis timeout via the runtime configuration message. This is called during firmware initialization with a default timeout of 1000us.