### PR TITLE
[ve2] Auto-select CMA region based on DT topology

### DIFF
--- a/src/driver/amdxdna/amdxdna_ctx.c
+++ b/src/driver/amdxdna/amdxdna_ctx.c
@@ -138,6 +138,12 @@ int amdxdna_drm_create_hwctx_ioctl(struct drm_device *dev, void *data, struct dr
 		goto free_name;
 	}
 
+	/* Write back the corrected QoS (mem_index may have been auto-selected) */
+	if (copy_to_user(u64_to_user_ptr(args->qos_p), &ctx->qos, sizeof(ctx->qos))) {
+		XDNA_WARN(xdna, "Failed to write back QoS info to userspace");
+		/* Non-fatal: context is created successfully, just log warning */
+	}
+
 	atomic64_set(&ctx->job_free_cnt, 0);
 	args->handle = ctx->id;
 	args->syncobj_handle = ctx->syncobj_hdl;

--- a/src/driver/amdxdna/ve2_hwctx.c
+++ b/src/driver/amdxdna/ve2_hwctx.c
@@ -1239,6 +1239,9 @@ int ve2_hwctx_init(struct amdxdna_ctx *hwctx)
 	hwctx->priv = priv;
 	init_waitqueue_head(&priv->waitq);
 
+	/* Auto-select mem_index based on start_col from memory topology */
+	ve2_auto_select_mem_index(xdna, hwctx);
+
 	/* one host_queue entry per hwctx */
 	ret = ve2_create_host_queue(xdna, &priv->hwctx_hsa_queue);
 	if (ret) {

--- a/src/driver/amdxdna/ve2_of.c
+++ b/src/driver/amdxdna/ve2_of.c
@@ -173,6 +173,161 @@ cleanup:
 	return ret;
 }
 
+/**
+ * ve2_parse_mem_topology - Parse AIE memory topology from device tree
+ * @xdna: Pointer to the device structure
+ * @pdev: Platform device
+ *
+ * Parses the aie_memory_topology node from device tree and stores the
+ * column to memory region mapping in xdna_hdl->mem_topology.
+ *
+ * Returns 0 on success, negative error code on failure.
+ * If the node doesn't exist, returns -ENOENT (not fatal, backward compat).
+ */
+int ve2_parse_mem_topology(struct amdxdna_dev *xdna, struct platform_device *pdev)
+{
+	struct amdxdna_dev_hdl *xdna_hdl = xdna->dev_handle;
+	struct device_node *topo_np, *region_np;
+	struct device_node *mem_node;
+	u32 columns[2];
+	u32 reg;
+	int i, ret;
+
+	/* First try as child of telluride_drm */
+	topo_np = of_get_child_by_name(pdev->dev.of_node, "aie_memory_topology");
+
+	/* If not found, try as sibling (in parent node) */
+	if (!topo_np && pdev->dev.of_node->parent)
+		topo_np = of_get_child_by_name(pdev->dev.of_node->parent, "aie_memory_topology");
+
+	if (!topo_np) {
+		XDNA_DBG(xdna, "No aie_memory_topology node found, using backward compat mode");
+		xdna_hdl->mem_topology.num_regions = 0;
+		return -ENOENT;
+	}
+
+	xdna_hdl->mem_topology.num_regions = 0;
+
+	for_each_child_of_node(topo_np, region_np) {
+		if (xdna_hdl->mem_topology.num_regions >= MAX_MEM_REGIONS) {
+			XDNA_WARN(xdna, "Too many memory regions, max %d", MAX_MEM_REGIONS);
+			break;
+		}
+
+		ret = of_property_read_u32(region_np, "reg", &reg);
+		if (ret) {
+			XDNA_WARN(xdna, "Failed to read reg property: %d", ret);
+			continue;
+		}
+
+		ret = of_property_read_u32_array(region_np, "columns", columns, 2);
+		if (ret) {
+			XDNA_WARN(xdna, "Failed to read columns property: %d", ret);
+			continue;
+		}
+
+		mem_node = of_parse_phandle(region_np, "memory-region", 0);
+		if (!mem_node) {
+			XDNA_WARN(xdna, "Failed to parse memory-region phandle");
+			continue;
+		}
+
+		/* Match phandle to telluride_drm's memory-region array index */
+		for (i = 0; i < MAX_MEM_REGIONS; i++) {
+			struct device_node *drm_mem_node;
+
+			drm_mem_node = of_parse_phandle(pdev->dev.of_node, "memory-region", i);
+			if (!drm_mem_node)
+				break;
+
+			if (drm_mem_node == mem_node) {
+				/* Found match - i is the CMA region index */
+				if (xdna->cma_region_devs[i]) {
+					xdna_hdl->mem_topology.regions[reg].start_col = columns[0];
+					xdna_hdl->mem_topology.regions[reg].end_col = columns[1];
+					xdna_hdl->mem_topology.regions[reg].mem_index = i;
+					xdna_hdl->mem_topology.num_regions++;
+
+					XDNA_DBG(xdna, "Mem region %d: cols %d-%d -> mem_idx %d",
+						 reg, columns[0], columns[1], i);
+				}
+				of_node_put(drm_mem_node);
+				of_node_put(mem_node);
+				break;
+			}
+			of_node_put(drm_mem_node);
+		}
+
+		if (i == MAX_MEM_REGIONS) {
+			XDNA_WARN(xdna, "Failed to match memory-region phandle to CMA device");
+			of_node_put(mem_node);
+		}
+	}
+
+	of_node_put(topo_np);
+	return 0;
+}
+
+/**
+ * ve2_auto_select_mem_index - Auto-select memory index based on start_col
+ * @xdna: Pointer to the device structure
+ * @hwctx: Hardware context
+ *
+ * Automatically selects the correct mem_index for the hardware context based
+ * on the user-provided start_col and the parsed memory topology.
+ * Overrides hwctx->qos.mem_index if topology is available.
+ * Falls back to user's mem_index if topology is not available (backward compat).
+ */
+void ve2_auto_select_mem_index(struct amdxdna_dev *xdna, struct amdxdna_ctx *hwctx)
+{
+	struct amdxdna_dev_hdl *xdna_hdl = xdna->dev_handle;
+	struct ve2_mem_topology *topo = &xdna_hdl->mem_topology;
+	u32 start_col = hwctx->qos.user_start_col;
+	u32 user_mem_index = hwctx->qos.mem_index;
+	u32 selected_mem_index = user_mem_index;
+	bool found = false;
+	int i;
+
+	/* Backward compat: no topology, use user's mem_index */
+	if (topo->num_regions == 0) {
+		XDNA_DBG(xdna, "No memory topology, using user mem_index=%u", user_mem_index);
+		return;
+	}
+
+	/* If user didn't provide start_col, can't auto-select */
+	if (start_col == USER_START_COL_NOT_REQUESTED) {
+		XDNA_DBG(xdna, "No start_col provided, using user mem_index=%u", user_mem_index);
+		return;
+	}
+
+	/* Find which region contains start_col */
+	for (i = 0; i < topo->num_regions; i++) {
+		if (start_col >= topo->regions[i].start_col &&
+		    start_col <= topo->regions[i].end_col) {
+			selected_mem_index = topo->regions[i].mem_index;
+			found = true;
+			break;
+		}
+	}
+
+	if (!found) {
+		XDNA_WARN(xdna, "start_col %u not in topology, using user mem_index=%u",
+			  start_col, user_mem_index);
+		return;
+	}
+
+	/* Override mem_index */
+	if (selected_mem_index != user_mem_index) {
+		XDNA_INFO(xdna, "Auto-selected mem_index=%u for start_col=%u (user mem_index=%u)",
+			  selected_mem_index, start_col, user_mem_index);
+	} else {
+		XDNA_DBG(xdna, "Validated mem_index=%u for start_col=%u",
+			 selected_mem_index, start_col);
+	}
+
+	hwctx->qos.mem_index = selected_mem_index;
+}
+
 static int ve2_init(struct amdxdna_dev *xdna)
 {
 	struct platform_device *pdev = to_platform_device(xdna->ddev.dev);
@@ -265,6 +420,13 @@ static int ve2_init(struct amdxdna_dev *xdna)
 	if (ret < 0) {
 		/* CMA region initialization is optional - system will fall back to default CMA */
 		XDNA_DBG(xdna, "Failed to initialize the cma memories\n");
+	}
+
+	/* Parse memory topology from device tree */
+	ret = ve2_parse_mem_topology(xdna, pdev);
+	if (ret < 0 && ret != -ENOENT) {
+		XDNA_WARN(xdna, "Failed to parse memory topology: %d", ret);
+		/* Not fatal - continue with backward compat */
 	}
 
 	XDNA_DBG(xdna, "VE2 device initialized: cols=%u, rows=%u, hwctx_limit=%u",

--- a/src/driver/amdxdna/ve2_of.h
+++ b/src/driver/amdxdna/ve2_of.h
@@ -121,6 +121,17 @@ struct amdxdna_mgmtctx {
 	atomic_t		error_cb_in_progress; /* track if error callback is running */
 };
 
+struct ve2_mem_region {
+	u32	start_col;
+	u32	end_col;
+	u32	mem_index;
+};
+
+struct ve2_mem_topology {
+	u32			num_regions;
+	struct ve2_mem_region	regions[MAX_MEM_REGIONS];
+};
+
 struct amdxdna_dev_hdl {
 	struct amdxdna_dev		*xdna;
 	const struct amdxdna_dev_priv	*priv;
@@ -131,10 +142,13 @@ struct amdxdna_dev_hdl {
 	struct aie_device_info		aie_dev_info;
 	struct ve2_firmware_status	**fw_slots;
 	struct amdxdna_mgmtctx          *ve2_mgmtctx;
+	struct ve2_mem_topology		mem_topology;
 };
 
 /* ve2_of.c */
 extern const struct amdxdna_dev_ops ve2_ops;
+int ve2_parse_mem_topology(struct amdxdna_dev *xdna, struct platform_device *pdev);
+void ve2_auto_select_mem_index(struct amdxdna_dev *xdna, struct amdxdna_ctx *hwctx);
 int ve2_hwctx_init(struct amdxdna_ctx *hwctx);
 void ve2_hwctx_fini(struct amdxdna_ctx *hwctx);
 int ve2_hwctx_config(struct amdxdna_ctx *hwctx, u32 type, u64 mdata_hdl, void *buf, u32 size);


### PR DESCRIPTION
Implement automatic CMA memory region selection to eliminate manual mem_index specification. Users now only need to provide start_col and based on that while creating hw context, it can have a dedicated cma region associated with the hw context if DT has the topology. So for that particular hw context all the internal external buffers can be allocated to that correct dedicated cma region

### Tested:
1. Tested the provided special usecase in which the 36 aie cols are divided into 3 parts. 0-23 connected to only cma region0, 24-31 connected to only cma region1 and 32-35 connected to only cma region2. Tested by having multiple combinations.
2. Tested existing XRT hw unit tests for ve2 with the existing platform. All the tests are passing.

