### PR TITLE
fix nested down_read() during job submission

### DIFF
--- a/src/driver/amdxdna/aie4_hwctx.c
+++ b/src/driver/amdxdna/aie4_hwctx.c
@@ -845,7 +845,7 @@ static int submit_one_cmd(struct amdxdna_ctx *ctx,
 		ring_doorbell(ctx);
 	else
 		queue_work(priv->cert_work_q, &priv->cert_work);
-	XDNA_DBG(xdna, "Submitted one cmd, seq %lld", *seq);
+	XDNA_DBG(xdna, "Submitted one cmd, %s seq %lld", ctx->name, *seq);
 	return 0;
 }
 

--- a/src/driver/amdxdna/aie4_message.c
+++ b/src/driver/amdxdna/aie4_message.c
@@ -55,11 +55,6 @@ static int xdna_send_msg_wait(struct amdxdna_dev *xdna,
 		return ret;
 	}
 
-#ifdef AMDXDNA_DEVEL
-	/* for devel version, we run on slower simulator, wait forever */
-	wait_for_completion(&hdl->comp);
-#else
-	/* should we consider timeout as serious hardware issue? */
 	ret = wait_for_completion_timeout(&hdl->comp,
 					  msecs_to_jiffies(RX_TIMEOUT));
 	if (!ret) {
@@ -67,7 +62,6 @@ static int xdna_send_msg_wait(struct amdxdna_dev *xdna,
 		return -ETIME;
 	}
 
-#endif
 	return hdl->error;
 }
 

--- a/src/driver/amdxdna/amdxdna_ctx.c
+++ b/src/driver/amdxdna/amdxdna_ctx.c
@@ -436,7 +436,6 @@ retry:
 		if (!abo->mem.map_invalid)
 			continue;
 
-		up_read(&xdna->notifier_lock);
 		amdxdna_unlock_objects(job, ctx);
 		if (!timeout)
 			timeout = jiffies + msecs_to_jiffies(HMM_RANGE_DEFAULT_TIMEOUT);

--- a/src/driver/amdxdna/amdxdna_gem.h
+++ b/src/driver/amdxdna/amdxdna_gem.h
@@ -30,6 +30,11 @@ struct amdxdna_gem_obj {
 	u64				flags;
 	struct mutex			lock; /* Protects: pinned, assigned_ctx, mem.kv_addr */
 	struct amdxdna_mem		mem;
+	/*
+	 * Cache the first mmap uva as PASID addr, which can be accessed by driver
+	 * without taking notifier_lock.
+	 */
+	u64				uva;
 
 	/* Below members are initialized when needed */
 	struct drm_mm			mm; /* For AMDXDNA_BO_DEV_HEAP */


### PR DESCRIPTION
When driver submit a job, it will down_read(notifier_lock) in amdxdna_lock_objects(), then down_read(notifier_lock) in  amdxdna_gem_uva(). If another thread trying down_write(notifier_lock) in between, the 2nd down_read() can't be completed. This causes a deadlock. We have to remove the down_read() from amdxdna_gem_uva() to avoid this situation by caching the uva.