### PR TITLE
aie2: Use run_list_id from app health to identify timed out subcmd

### DIFF
--- a/src/driver/amdxdna/aie2_msg_priv.h
+++ b/src/driver/amdxdna/aie2_msg_priv.h
@@ -687,7 +687,7 @@ struct fatal_error_info {
 	u32 exception_pc;       /* Program Counter at the time of the exception */
 	u32 app_module;         /* Error Module name */
 	u32 task_index;         /* Index of the task in which the error occurred */
-	u32 reserved[128];      /* for future use */
+	u32 reserved[127];      /* for future use */
 };
 
 struct app_health_report {
@@ -718,6 +718,8 @@ struct app_health_report {
 	u32				ctx_pc;
 #define AIE2_APP_HEALTH_RESET_FATAL_INFO	0
 	struct fatal_error_info		fatal_info;
+	/* Index of the most recently executed run list entry. Default value is UINT32_MAX */
+	u32				run_list_id;
 };
 
 struct get_app_health_req {

--- a/src/driver/amdxdna/amdxdna_ctx.h
+++ b/src/driver/amdxdna/amdxdna_ctx.h
@@ -244,6 +244,7 @@ struct amdxdna_ctx {
 	struct semaphore		io_slot_sem;
 
 	struct amdxdna_ctx_health_data	health_data;
+	u32				timeout_run_list_id;
 	bool				health_reported;
 
 	struct list_head		entry;

--- a/test/shim_test/io_test.cpp
+++ b/test/shim_test/io_test.cpp
@@ -248,7 +248,7 @@ get_fine_preemption_counter_delta(device *dev, hw_ctx& ctx, std::vector<std::pai
   auto cur = get_fine_preemption_counters(dev);
   uint64_t fine_preemption_count;
   int index = -1;
-  
+
   // Find the user task ID for the ctx id
   for (int i = 0; i < cur.size(); i++) {
     auto id = cur[i].first;
@@ -629,8 +629,7 @@ TEST_io_runlist_bad_cmd(device::id_type id, std::shared_ptr<device>& sdev, arg_t
 
   // Create and send the chained command, keep the bad one in the middle
   // Command chain: good, bad (error or timeout), good
-  // In case of timeout, the index returned from fw is always 0.
-  const uint32_t bad_index = is_timeout ? 0 : 1;
+  const uint32_t bad_index = 1;
   const uint32_t bad_state = is_timeout ? ERT_CMD_STATE_TIMEOUT : ERT_CMD_STATE_ERROR;
   io_test_bo_set_base *bad = is_timeout ? &timeout_bo_set : &error_bo_set;
   std::vector<bo*> tmp_cmd_bos;
@@ -645,7 +644,7 @@ TEST_io_runlist_bad_cmd(device::id_type id, std::shared_ptr<device>& sdev, arg_t
   auto hwq = hwctx.get()->get_hw_queue();
   auto cmd_hdl = cbo->get();
   auto cmd_pkt = reinterpret_cast<ert_start_kernel_cmd *>(cbo->map());
-  
+
   hwq->submit_command(cmd_hdl);
   hwq->wait_command(cmd_hdl, 0);
 

--- a/tools/info.json
+++ b/tools/info.json
@@ -49,18 +49,18 @@
 		},
 		{
 			"device": "npu4",
-			"url": "https://gitlab.com/kernel-firmware/drm-firmware/-/raw/amd-ipu-staging/amdnpu/17f0_10/npu.sbin.255.0.10.67",
+			"url": "https://gitlab.com/kernel-firmware/drm-firmware/-/raw/amd-ipu-staging/amdnpu/17f0_10/npu.sbin.255.0.11.69",
 			"pci_device_id": "17f0",
 			"pci_revision_id": "10",
-			"version": "255.0.10.67",
+			"version": "255.0.11.69",
 			"fw_name": "npu.dev.sbin"
 		},
 		{
 			"device": "npu5",
-			"url": "https://gitlab.com/kernel-firmware/drm-firmware/-/raw/amd-ipu-staging/amdnpu/17f0_11/npu.sbin.255.0.10.69",
+			"url": "https://gitlab.com/kernel-firmware/drm-firmware/-/raw/amd-ipu-staging/amdnpu/17f0_11/npu.sbin.255.0.11.71",
 			"pci_device_id": "17f0",
 			"pci_revision_id": "11",
-			"version": "255.0.10.69",
+			"version": "255.0.11.71",
 			"fw_name": "npu.dev.sbin"
 		}
 	],


### PR DESCRIPTION
When a runlist times out, the driver was always copying app health data to the 0th cmd BO in the list. Instead, use the run_list_id field from the app health report to identify the actual timed out subcmd and copy the health data to that specific BO only. Fall back to index 0 if the run_list_id is invalid.