### PR TITLE
ve2: change indirect pkt array to [uc][slot] and fix driver with this format

### DIFF
--- a/src/driver/amdxdna/ve2_host_queue.h
+++ b/src/driver/amdxdna/ve2_host_queue.h
@@ -99,7 +99,7 @@ struct hsa_queue {
 	struct host_queue_header	hq_header;
 	struct host_queue_packet	hq_entry[HOST_QUEUE_ENTRY];
 	struct host_queue_indirect_hdr	hq_indirect_hdr[HOST_QUEUE_ENTRY];
-	struct host_queue_indirect_pkt	hq_indirect_pkt[HOST_QUEUE_ENTRY][HOST_INDIRECT_PKT_NUM];
+	struct host_queue_indirect_pkt	hq_indirect_pkt[HOST_INDIRECT_PKT_NUM][HOST_QUEUE_ENTRY];
 };
 
 struct ve2_hq_complete {


### PR DESCRIPTION
-The hsa_queue.h layout for hq_indirect_pkt is changed from [slot][uc] to [uc][slot]. -This preserves the overall BO layout (header, packets, completion) but improves per UC locality and cache locality in CERT/firmware access.

Driver updates:
* ve2_create_host_queue(): init hq_indirect_pkt as [uc][slot]
* submit_command_indirect(): use [uc][slot] for CPU/DMA, write exec payloads
* packet_dump(): dump indirect packets with new order