### PR TITLE
amdxdna: add progressive TDR recovery escalation

### DIFF
--- a/src/driver/amdxdna/aie2_pci.h
+++ b/src/driver/amdxdna/aie2_pci.h
@@ -382,6 +382,9 @@ int aie2_pm_set_mode(struct amdxdna_dev_hdl *ndev, int target);
 #define aie2_pm_del_dpm_level(d, l) aie2_pm_set_dft_dpm_level(d, l, false)
 void aie2_pm_set_dft_dpm_level(struct amdxdna_dev_hdl *ndev, u32 level, bool add);
 
+/* aie2_pci.c */
+int aie2_flr(struct amdxdna_dev *xdna);
+
 /* aie2_tdr.c */
 void aie2_tdr_start(struct amdxdna_dev *xdna);
 void aie2_tdr_stop(struct amdxdna_dev *xdna);

--- a/src/driver/amdxdna/aie2_tdr.c
+++ b/src/driver/amdxdna/aie2_tdr.c
@@ -35,17 +35,102 @@ static bool aie2_tdr_detect(struct aie2_tdr *tdr)
 	return aie2_rq_is_all_context_stuck(rq);
 }
 
+/*
+ * Progressive recovery escalation.
+ *
+ * Each consecutive TDR failure escalates to a harder reset:
+ *   counter == 1: Soft recovery (context stop/restart)
+ *   counter == 2: Firmware reset (suspend/resume firmware)
+ *   counter == 3: PCIe FLR (full hardware reset)
+ *   counter >= 4: Device declared unrecoverable
+ *
+ * Success at any level resets the counter to 0. The counter is also
+ * reset when the device resumes making progress on its own.
+ *
+ * Uses manual mutex_lock/unlock instead of guard(mutex) because the
+ * FLR path needs to release dev_lock around the PCI reset.
+ */
 static void aie2_tdr_recover(struct aie2_tdr *tdr, bool dump_only)
 {
 	struct amdxdna_dev *xdna = tdr_to_xdna(tdr);
-	struct aie2_ctx_rq *rq = &xdna->dev_handle->ctx_rq;
+	struct amdxdna_dev_hdl *ndev = xdna->dev_handle;
+	struct aie2_ctx_rq *rq = &ndev->ctx_rq;
+	int ret;
 
-	guard(mutex)(&xdna->dev_lock);
+	mutex_lock(&xdna->dev_lock);
 	aie2_rq_dump_all(rq);
-	if (dump_only)
+	if (dump_only) {
+		mutex_unlock(&xdna->dev_lock);
 		return;
+	}
+
 	aie2_rq_stop_all(rq);
+
+	switch (tdr->counter) {
+	case 1:
+		/* Level 0: Soft recovery -- just restart contexts */
+		break;
+	case 2:
+		/* Level 1: Firmware reset via suspend/resume */
+		XDNA_WARN(xdna, "Soft recovery failed, escalating to firmware reset");
+		mutex_lock(&ndev->aie2_lock);
+		ret = aie2_suspend_fw(ndev);
+		if (!ret)
+			ret = aie2_resume_fw(ndev);
+		mutex_unlock(&ndev->aie2_lock);
+		if (ret) {
+			XDNA_ERR(xdna, "Firmware reset failed, ret %d", ret);
+			goto restart;
+		}
+		XDNA_INFO(xdna, "Firmware reset successful");
+		tdr->counter = 0;
+		break;
+	case 3:
+		/* Level 2: PCIe Function Level Reset */
+		XDNA_WARN(xdna, "Firmware reset failed, escalating to FLR");
+		/*
+		 * Release dev_lock before FLR. aie2_flr() manages its own
+		 * locking internally. The runqueue is already stopped and
+		 * dev_status will be set to INIT by the teardown, so no
+		 * new work can start during this window.
+		 */
+		mutex_unlock(&xdna->dev_lock);
+		ret = aie2_flr(xdna);
+		mutex_lock(&xdna->dev_lock);
+		if (ret) {
+			/*
+			 * FLR tears down firmware before the PCI reset.
+			 * If the reset itself fails, the device is left
+			 * without firmware -- restarting contexts would
+			 * crash. Treat as unrecoverable.
+			 */
+			XDNA_ERR(xdna, "FLR failed (ret %d), device is unrecoverable", ret);
+			goto unrecoverable;
+		}
+		XDNA_INFO(xdna, "FLR successful");
+		tdr->counter = 0;
+		break;
+	default:
+unrecoverable:
+		/* All recovery exhausted -- device is unrecoverable */
+		XDNA_ERR(xdna, "All recovery methods exhausted, device is unrecoverable");
+		XDNA_ERR(xdna, "Device requires reboot to restore NPU functionality");
+		/*
+		 * Stop the timer to prevent further TDR firings.
+		 * timer_delete_sync() waits for any concurrent timer
+		 * callback to finish, preventing a re-arm race where
+		 * the callback's mod_timer() runs after our delete.
+		 * Safe from work context (not timer context).
+		 */
+		timer_delete_sync(&tdr->timer);
+		tdr->started = 0;
+		mutex_unlock(&xdna->dev_lock);
+		return;
+	}
+
+restart:
 	aie2_rq_restart_all(rq);
+	mutex_unlock(&xdna->dev_lock);
 }
 
 static void aie2_tdr_work(struct work_struct *work)
@@ -54,8 +139,12 @@ static void aie2_tdr_work(struct work_struct *work)
 
 	if (aie2_tdr_detect(tdr)) {
 		XDNA_WARN(tdr_to_xdna(tdr),
-			  "Device isn't making progress... Count %d", ++tdr->counter);
+			  "Device isn't making progress... Count %d",
+			  ++tdr->counter);
 		aie2_tdr_recover(tdr, tdr_dump_ctx);
+	} else if (tdr->counter) {
+		/* Device recovered, reset escalation level */
+		tdr->counter = 0;
 	}
 }
 


### PR DESCRIPTION
## Summary

- Add progressive recovery escalation to TDR: soft recovery -> firmware reset -> PCIe FLR -> device declared unrecoverable
- Factor firmware teardown/rebuild into shared helpers (`aie2_fw_teardown`/`aie2_fw_rebuild`) used by both the PCI error handler and TDR paths
- When the AIE array is stuck, soft recovery (context stop/restart) has no effect -- the hardware itself is jammed. TDR loops indefinitely (see #1083). This patch gives it teeth.

Depends on #1101 (FLR support for aie2).

### Escalation model

| Counter | Action | On success |
|---------|--------|------------|
| 1 | Soft recovery (stop/restart contexts) | Reset to 0 |
| 2 | Firmware reset (suspend/resume) | Reset to 0 |
| 3 | PCIe FLR (full hardware reset) | Reset to 0 |
| 4+ | Device declared unrecoverable, TDR stopped | Reboot required |

The counter also resets to 0 when the device resumes making progress on its own.

### Locking

Uses manual `mutex_lock`/`mutex_unlock` instead of `guard(mutex)` because the FLR path needs to release `dev_lock` around the PCI reset. The lock hierarchy (`dev_lock -> aie2_lock`) is preserved throughout.

## Test plan

- Built and loaded on Phoenix (NPU1, device 0x1502) with kernel 6.19.0
- TDR fires at count 1, soft recovery succeeds, counter resets -- verified via dmesg
- checkpatch: 0 errors, 0 warnings
- Escalation to firmware reset and FLR not yet triggered in testing (soft recovery has been sufficient), but the code paths exist as a safety net for truly stuck hardware