### PR TITLE
Skip destroy VFs firmware message when no VFs were created

### DIFF
--- a/src/driver/amdxdna/aie4_sriov.c
+++ b/src/driver/amdxdna/aie4_sriov.c
@@ -18,6 +18,9 @@ static int aie4_sriov_stop(struct amdxdna_dev_hdl *ndev)
 	struct pci_dev *pdev = to_pci_dev(xdna->ddev.dev);
 	int ret;
 
+	if (ndev->num_vfs == 0)
+		return 0;
+
 	ret = pci_sriov_configure_simple(pdev, 0);
 	if (ret) {
 		XDNA_ERR(xdna, "configure vfs to 0 failed: %d", ret);


### PR DESCRIPTION
Add early return in aie4_sriov_stop() when ndev->num_vfs is already 0 to avoid sending an unnecessary DESTROY_VFS message to firmware.