### PR TITLE
aie4: Set default context timeout to 2seconds

### DIFF
--- a/src/driver/amdxdna/aie2_tdr.h
+++ b/src/driver/amdxdna/aie2_tdr.h
@@ -19,4 +19,6 @@ struct aie2_tdr {
 	u32			progress;
 };
 
+extern uint timeout_in_sec;
+
 #endif /* _AIE2_TDR_H_ */

--- a/src/driver/amdxdna/aie4_message.c
+++ b/src/driver/amdxdna/aie4_message.c
@@ -423,6 +423,29 @@ int aie4_set_ctx_hysteresis(struct amdxdna_dev_hdl *ndev, u32 timeout_us)
 	return 0;
 }
 
+int aie4_set_ctx_timeout(struct amdxdna_dev_hdl *ndev, u32 timeout_ms)
+{
+	DECLARE_AIE4_MSG(aie4_msg_set_runtime_cfg, AIE4_MSG_OP_SET_RUNTIME_CONFIG);
+	struct aie4_msg_runtime_config_context_timeout *ctx_timeout;
+	int ret;
+
+	req.type = AIE4_RUNTIME_CONFIG_CONTEXT_TIMEOUT;
+	ctx_timeout = (struct aie4_msg_runtime_config_context_timeout *)req.data;
+	ctx_timeout->timeout_ms = timeout_ms;
+
+	msg.send_size = sizeof(req.type) + sizeof(*ctx_timeout);
+
+	ret = aie4_send_msg_wait(ndev, &msg);
+	if (ret) {
+		XDNA_ERR(ndev->xdna, "Failed to set runtime config, ret %d", ret);
+		return ret;
+	}
+
+	XDNA_DBG(ndev->xdna, "Context timeout set to %dms", timeout_ms);
+
+	return 0;
+}
+
 int aie4_set_log_level(struct amdxdna_dev_hdl *ndev, u8 level)
 {
 	DECLARE_AIE4_MSG(aie4_msg_set_runtime_cfg, AIE4_MSG_OP_SET_RUNTIME_CONFIG);

--- a/src/driver/amdxdna/aie4_pci.c
+++ b/src/driver/amdxdna/aie4_pci.c
@@ -15,6 +15,7 @@
 
 #include "aie4_pci.h"
 #include "aie4_message.h"
+#include "aie2_tdr.h"
 #include "aie4_solver.h"
 #include "aie4_devel.h"
 #include "amdxdna_dpt.h"
@@ -317,7 +318,11 @@ static int aie4_mgmt_fw_init(struct amdxdna_dev_hdl *ndev)
 		return ret;
 	}
 
-	return aie4_set_ctx_hysteresis(ndev, AIE4_CTX_HYSTERESIS_US);
+	ret = aie4_set_ctx_hysteresis(ndev, AIE4_CTX_HYSTERESIS_US);
+	if (ret)
+		return ret;
+
+	return aie4_set_ctx_timeout(ndev, timeout_in_sec * 1000);
 }
 
 static int aie4_mgmt_fw_query(struct amdxdna_dev_hdl *ndev)

--- a/src/driver/amdxdna/aie4_pci.h
+++ b/src/driver/amdxdna/aie4_pci.h
@@ -216,6 +216,7 @@ int aie4_get_aie_coredump(struct amdxdna_dev_hdl *ndev, struct amdxdna_mgmt_dma_
 void aie4_reset_prepare(struct amdxdna_dev *xdna);
 int aie4_reset_done(struct amdxdna_dev *xdna);
 int aie4_set_ctx_hysteresis(struct amdxdna_dev_hdl *ndev, u32 timeout_us);
+int aie4_set_ctx_timeout(struct amdxdna_dev_hdl *ndev, u32 timeout_ms);
 
 /* aie4_hwctx.c */
 int aie4_ctx_init(struct amdxdna_ctx *ctx);


### PR DESCRIPTION
Add aie4_set_ctx_timeout() to configure the FW context timeout using the timeout_in_sec module parameter (default 2s).