### PR TITLE
Make AIE PSP code common for aie2 and aie4

### DIFF
--- a/src/driver/amdxdna/Kbuild
+++ b/src/driver/amdxdna/Kbuild
@@ -35,6 +35,7 @@ amdxdna-y := \
 	amdxdna_cma_buf.o \
 
 amdxdna-$(OFT_CONFIG_AMDXDNA_PCI) += \
+	aie_psp.o \
 	aie_smu.o \
 	aie2_smu.o \
 	aie2_psp.o \

--- a/src/driver/amdxdna/aie2_pci.c
+++ b/src/driver/amdxdna/aie2_pci.c
@@ -148,7 +148,7 @@ static int aie2_mgmt_chann_init(struct amdxdna_dev_hdl *ndev)
 	 * is alive.
 	 */
 	ret = readx_poll_timeout(readl, SRAM_GET_ADDR(ndev, FW_ALIVE_OFF),
-				 addr, addr, AIE2_INTERVAL, AIE2_TIMEOUT);
+				 addr, addr, AIE_INTERVAL, AIE_TIMEOUT);
 	if (ret || !addr)
 		return -ETIME;
 
@@ -584,9 +584,13 @@ skip_pasid:
 #endif
 	psp_conf.fw_size = fw->size;
 	psp_conf.fw_buf = fw->data;
+	/* Reset cert FW related parameters */
+	psp_conf.certfw_size = 0;
+	psp_conf.certfw_buf = NULL;
+
 	for (i = 0; i < PSP_MAX_REGS; i++)
 		psp_conf.psp_regs[i] = tbl[PSP_REG_BAR(ndev, i)] + PSP_REG_OFF(ndev, i);
-	ndev->psp_hdl = aie2m_psp_create(&pdev->dev, &psp_conf);
+	ndev->psp_hdl = aiem_psp_create(&xdna->ddev, &pdev->dev, &psp_conf);
 	if (!ndev->psp_hdl) {
 		XDNA_ERR(xdna, "failed to create psp");
 		ret = -ENOMEM;

--- a/src/driver/amdxdna/aie2_pci.h
+++ b/src/driver/amdxdna/aie2_pci.h
@@ -29,9 +29,7 @@
 #include "amdxdna_devel.h"
 #endif
 #include "amdxdna_aie.h"
-
-#define AIE2_INTERVAL	20000	/* us */
-#define AIE2_TIMEOUT	1000000	/* us */
+#include "aie_common.h"
 
 /* Firmware version encoding: major in high 32 bits, minor in low 32 bits */
 #define AIE2_FW_VERSION(major, minor)	(((u64)(major) << 32) | (minor))
@@ -294,14 +292,6 @@ struct amdxdna_dev_hdl {
 	struct amdxdna_async_err_cache	async_errs_cache; // For async error event cache
 };
 
-#define DEFINE_BAR_OFFSET(reg_name, bar, reg_addr) \
-	[reg_name] = {bar##_BAR_INDEX, (reg_addr) - bar##_BAR_BASE}
-
-struct aie2_bar_off_pair {
-	int	bar_idx;
-	u32	offset;
-};
-
 struct aie2_hw_ops {
 	int (*set_dpm)(struct amdxdna_dev_hdl *ndev, u32 dpm_level);
 };
@@ -393,11 +383,10 @@ static inline bool aie2_pm_is_turbo(struct amdxdna_dev_hdl *ndev)
 }
 
 /* aie2_psp.c */
-struct psp_device *aie2m_psp_create(struct device *dev, struct psp_config *conf);
-void aie2_psp_destroy(struct device *dev, void *psp_hdl);
 int aie2_psp_start(struct psp_device *psp);
 void aie2_psp_stop(struct psp_device *psp);
 int aie2_psp_waitmode_poll(struct psp_device *psp);
+void aie2_psp_destroy(struct device *dev, void *psp_hdl);
 
 /* aie2_debugfs.c */
 void aie2_debugfs_init(struct amdxdna_dev *xdna);

--- a/src/driver/amdxdna/aie2_psp.c
+++ b/src/driver/amdxdna/aie2_psp.c
@@ -1,48 +1,13 @@
 // SPDX-License-Identifier: GPL-2.0
 /*
- * Copyright (C) 2022-2024, Advanced Micro Devices, Inc.
+ * Copyright (C) 2022-2026, Advanced Micro Devices, Inc.
  */
 
 #include <linux/bitfield.h>
 #include <linux/slab.h>
 #include <linux/iopoll.h>
 #include "aie2_pci.h"
-
 #include "amdxdna_xen.h"
-
-#define PSP_STATUS_READY	BIT(31)
-
-/* PSP commands */
-#define PSP_VALIDATE		1
-#define PSP_START		2
-#define PSP_RELEASE_TMR		3
-
-/* PSP special arguments */
-#define PSP_START_COPY_FW	1
-
-/* PSP response error code */
-#define PSP_ERROR_CANCEL	0xFFFF0002
-#define PSP_ERROR_BAD_STATE	0xFFFF0007
-
-#define PSP_FW_ALIGN		0x10000
-#define PSP_POLL_INTERVAL	20000	/* us */
-#define PSP_POLL_TIMEOUT	1000000	/* us */
-
-#define PSP_REG(p, reg) \
-	((p)->psp_regs[reg])
-
-struct psp_device {
-	struct device	  *dev;
-	struct psp_config conf;
-	u32		  fw_buf_sz;
-	u64		  fw_paddr;
-	void		  *fw_buffer;
-	dma_addr_t	  fw_dma_handle;
-	void __iomem	  *psp_regs[PSP_MAX_REGS];
-#ifdef HAVE_xen_phy_dma_ops
-	struct device	  xen_dma_dev;
-#endif
-};
 
 static inline char *psp_decode_resp(u32 resp)
 {
@@ -140,40 +105,6 @@ int aie2_psp_start(struct psp_device *psp)
 	}
 
 	return 0;
-}
-
-struct psp_device *aie2m_psp_create(struct device *dev, struct psp_config *conf)
-{
-	struct psp_device *psp;
-	u64 offset;
-
-	psp = devm_kzalloc(dev, sizeof(*psp), GFP_KERNEL);
-	if (!psp)
-		return NULL;
-
-	psp->dev = dev;
-	memcpy(psp->psp_regs, conf->psp_regs, sizeof(psp->psp_regs));
-
-	psp->fw_buf_sz = ALIGN(conf->fw_size, PSP_FW_ALIGN);
-	if (is_xen_initial_pvh_domain()) {
-		psp->fw_buffer = amdxdna_xen_alloc_buf_phys(psp->dev, psp->fw_buf_sz + PSP_FW_ALIGN,
-							    &psp->fw_dma_handle);
-		if (!psp->fw_buffer)
-			return NULL;
-		psp->fw_paddr = psp->fw_dma_handle;
-	} else {
-		psp->fw_buffer = devm_kmalloc(psp->dev, psp->fw_buf_sz + PSP_FW_ALIGN, GFP_KERNEL);
-		if (!psp->fw_buffer)
-			return NULL;
-
-		psp->fw_paddr = virt_to_phys(psp->fw_buffer);
-	}
-
-	offset = ALIGN(psp->fw_paddr, PSP_FW_ALIGN) - psp->fw_paddr;
-	psp->fw_paddr += offset;
-	memcpy(psp->fw_buffer + offset, conf->fw_buf, conf->fw_size);
-
-	return psp;
 }
 
 void aie2_psp_destroy(struct device *dev, void *psp_hdl)

--- a/src/driver/amdxdna/aie4_pci.c
+++ b/src/driver/amdxdna/aie4_pci.c
@@ -121,10 +121,10 @@ static int aie4_fw_is_alive(struct amdxdna_dev *xdna)
 
 	ret = readx_poll_timeout(readl, src + offsetof(struct mailbox_info, valid),
 				 fw_is_ready, (fw_is_ready == 0x1),
-				 AIE4_INTERVAL, AIE4_TIMEOUT);
+				 AIE_INTERVAL, AIE_TIMEOUT);
 	if (ret) {
 		XDNA_ERR(xdna, "firmware is not ready (%d) after %d ms",
-			 fw_is_ready, DIV_ROUND_CLOSEST(AIE4_TIMEOUT, 1000000));
+			 fw_is_ready, DIV_ROUND_CLOSEST(AIE_TIMEOUT, 1000000));
 	}
 
 	XDNA_DBG(xdna, "firmware is ready (%d)", fw_is_ready);
@@ -621,7 +621,8 @@ static int aie4_request_firmware(struct amdxdna_dev_hdl *ndev,
 		       pdev->device, pdev->revision, ndev->priv->certfw_path);
 	if (ret >= sizeof(fw_name)) {
 		XDNA_ERR(xdna, "fw_name %s is truncated", fw_name);
-		return -EINVAL;
+		ret = -EINVAL;
+		goto release_npufw;
 	}
 
 	XDNA_DBG(xdna, "Request fw %s", fw_name);
@@ -661,12 +662,12 @@ static int aie4_release_firmware(struct amdxdna_dev_hdl *ndev,
 
 static int aie4_prepare_firmware(struct amdxdna_dev_hdl *ndev,
 				 const struct firmware *npufw,
-				 const struct firmware *certfw)
+				 const struct firmware *certfw,
+				 void __iomem *tbl[PCI_NUM_RESOURCES])
 {
 	struct amdxdna_dev *xdna = ndev->xdna;
-	struct pci_dev *pdev = to_pci_dev(xdna->ddev.dev);
+	struct psp_config psp_conf;
 	struct smu_config smu_conf;
-	struct aie4_psp_config psp_conf;
 	int i;
 
 	if (!aie4_fw_load_support(ndev))
@@ -677,9 +678,8 @@ static int aie4_prepare_firmware(struct amdxdna_dev_hdl *ndev,
 	psp_conf.certfw_size = certfw->size;
 	psp_conf.certfw_buf = certfw->data;
 	for (i = 0; i < PSP_MAX_REGS; i++)
-		psp_conf.psp_regs[i] = ndev->psp_base + PSP_REG_OFF(ndev, i);
-
-	ndev->psp_hdl = aie4_psp_create(&pdev->dev, &psp_conf);
+		psp_conf.psp_regs[i] = tbl[PSP_REG_BAR(ndev, i)] + PSP_REG_OFF(ndev, i);
+	ndev->psp_hdl = aiem_psp_create(&xdna->ddev, xdna->ddev.dev, &psp_conf);
 	if (!ndev->psp_hdl) {
 		XDNA_ERR(xdna, "failed to create psp");
 		return -ENOMEM;
@@ -767,7 +767,8 @@ static int aie4_pcidev_init(struct amdxdna_dev_hdl *ndev)
 	set_bit(xdna->dev_info->mbox_bar, &bars);
 	set_bit(xdna->dev_info->sram_bar, &bars);
 	if (!is_npu3_vf_dev(pdev)) {
-		set_bit(xdna->dev_info->psp_bar, &bars);
+		for (i = 0; i < PSP_MAX_REGS; i++)
+			set_bit(PSP_REG_BAR(ndev, i), &bars);
 		for (i = 0; i < SMU_MAX_REGS; i++)
 			set_bit(SMU_REG_BAR(ndev, i), &bars);
 	}
@@ -787,17 +788,28 @@ static int aie4_pcidev_init(struct amdxdna_dev_hdl *ndev)
 
 	ndev->mbox_base = tbl[xdna->dev_info->mbox_bar];
 	ndev->rbuf_base = tbl[xdna->dev_info->sram_bar];
-	ndev->psp_base = tbl[xdna->dev_info->psp_bar];
 	ndev->smu_base = tbl[xdna->dev_info->smu_bar];
 	ndev->doorbell_base = tbl[xdna->dev_info->doorbell_bar];
 
+	/* Request firmware */
 	ret = aie4_request_firmware(ndev, &npufw, &certfw);
-	if (ret)
+	if (ret) {
+		XDNA_ERR(xdna, "failed to request firmware, ret %d", ret);
 		return ret;
-	ret = aie4_prepare_firmware(ndev, npufw, certfw);
-	aie4_release_firmware(ndev, npufw, certfw);
-	if (ret)
+	}
+
+	/* Prepare firmware */
+	ret = aie4_prepare_firmware(ndev, npufw, certfw, tbl);
+	if (ret) {
+		XDNA_ERR(xdna, "failed to prepare firmware, ret %d", ret);
 		return ret;
+	}
+
+	ret = aie4_release_firmware(ndev, npufw, certfw);
+	if (ret) {
+		XDNA_ERR(xdna, "failed to release firmware, ret %d", ret);
+		return ret;
+	}
 
 	pci_set_master(pdev);
 

--- a/src/driver/amdxdna/aie4_pci.h
+++ b/src/driver/amdxdna/aie4_pci.h
@@ -15,6 +15,7 @@
 #include "amdxdna_mailbox.h"
 #include "amdxdna_error.h"
 #include "amdxdna_aie.h"
+#include "aie_common.h"
 #include "amdxdna_mgmt.h"
 #include "aie4_msg_priv.h"
 
@@ -55,13 +56,6 @@ aie4_health_get_runlist_read_idx(struct aie4_msg_app_health_report *h)
 
 	return h->runlist_read_idx;
 }
-
-#define AIE4_INTERVAL		20000	/* us */
-#ifdef AMDXDNA_DEVEL
-#define AIE4_TIMEOUT		(1000000 * 1000) /* us */
-#else
-#define AIE4_TIMEOUT		1000000	/* us */
-#endif
 
 #define MAX_NUM_CERTS		6
 
@@ -286,10 +280,8 @@ int aie4_pm_set_mode(struct amdxdna_dev_hdl *ndev, int target);
 int aie4_get_tops(struct amdxdna_dev_hdl *ndev, u64 *max, u64 *curr);
 
 /* aie4_psp.c */
-struct psp_device *aie4_psp_create(struct device *dev, struct aie4_psp_config *conf);
 int aie4_psp_start(struct psp_device *psp);
 void aie4_psp_stop(struct psp_device *psp);
-int aie4_psp_waitmode_poll(struct psp_device *psp);
 
 /* aie4_pci.c */
 int aie4_create_context(struct amdxdna_dev_hdl *ndev, struct amdxdna_ctx *ctx);

--- a/src/driver/amdxdna/aie4_psp.c
+++ b/src/driver/amdxdna/aie4_psp.c
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0
 /*
- * Copyright (C) 2025, Advanced Micro Devices, Inc.
+ * Copyright (C) 2025-2026, Advanced Micro Devices, Inc.
  */
 
 #include <linux/bitfield.h>
@@ -8,43 +8,7 @@
 #include <linux/iopoll.h>
 #include "aie4_pci.h"
 
-#define PSP_STATUS_READY	BIT(31)
-
-/* PSP commands */
-#define PSP_VALIDATE		0x01
-#define PSP_START		0x02
-#define PSP_RELEASE_TMR		0x03
-#define PSP_VALIDATE_CERT	0x04
-
-/* PSP special arguments */
-#define PSP_START_COPY_FW	0x1
-
-/* PSP response error code */
-#define PSP_ERROR_CANCEL	0xFFFF0002
-#define PSP_ERROR_BAD_STATE	0xFFFF0007
-
-#define PSP_FW_ALIGN		0x10000
-#define PSP_CFW_ALIGN		0x8000
-#define PSP_POLL_INTERVAL	20000	/* us */
-#define PSP_POLL_TIMEOUT	1000000	/* us */
-#define PSP_NOTIFY_INTR		0xD007BE11
-
-#define PSP_REG(p, reg) \
-	((p)->psp_regs[reg])
-
 #define PSP_SET_CMD_ARG2(cmd, arg2)	(((cmd) << 24) | (arg2))
-
-struct psp_device {
-	struct device	  *dev;
-	struct aie4_psp_config conf;
-	u32		  fw_buf_sz;
-	u64		  fw_paddr;
-	void		  *fw_buffer;
-	u32		  certfw_buf_sz;
-	u64		  certfw_paddr;
-	void		  *certfw_buffer;
-	void __iomem	  *psp_regs[PSP_MAX_REGS];
-};
 
 static inline char *psp_decode_resp(u32 resp)
 {
@@ -54,8 +18,10 @@ static inline char *psp_decode_resp(u32 resp)
 	case PSP_ERROR_BAD_STATE:
 		return "Error bad state";
 	default:
-		return "Error unknown";
-	};
+		break;
+	}
+
+	return "Error unknown";
 }
 
 static int psp_exec(struct psp_device *psp, u32 *reg_vals)
@@ -69,7 +35,7 @@ static int psp_exec(struct psp_device *psp, u32 *reg_vals)
 				 FIELD_GET(PSP_STATUS_READY, ready),
 				 PSP_POLL_INTERVAL, PSP_POLL_TIMEOUT);
 	if (ret) {
-		dev_err(psp->dev, "PSP is not ready, ret 0x%x", ret);
+		drm_err(psp->ddev, "PSP is not ready, ret 0x%x", ret);
 		return ret;
 	}
 
@@ -86,30 +52,15 @@ static int psp_exec(struct psp_device *psp, u32 *reg_vals)
 				 FIELD_GET(PSP_STATUS_READY, ready),
 				 PSP_POLL_INTERVAL, PSP_POLL_TIMEOUT);
 	if (ret) {
-		dev_err(psp->dev, "PSP is not ready, ret 0x%x", ret);
+		drm_err(psp->ddev, "PSP is not ready, ret 0x%x", ret);
 		return ret;
 	}
 
 	resp_code = readl(PSP_REG(psp, PSP_RESP_REG));
 	if (resp_code) {
-		dev_err(psp->dev, "fw return error 0x%x (%s)", resp_code,
+		drm_err(psp->ddev, "fw return error 0x%x (%s)", resp_code,
 			psp_decode_resp(resp_code));
 		return -EIO;
-	}
-
-	return 0;
-}
-
-int aie4_psp_waitmode_poll(struct psp_device *psp)
-{
-	int mode_reg = -1, ret;
-
-	ret = readx_poll_timeout(readl, PSP_REG(psp, PSP_PWAITMODE_REG), mode_reg,
-				 (mode_reg & 0x1) == 1,
-				 PSP_POLL_INTERVAL, PSP_POLL_TIMEOUT);
-	if (ret) {
-		dev_err(psp->dev, "fw waitmode reg error, ret 0x%x", ret);
-		return ret;
 	}
 
 	return 0;
@@ -125,9 +76,9 @@ void aie4_psp_stop(struct psp_device *psp)
 
 	ret = psp_exec(psp, reg_vals);
 	if (ret)
-		dev_err(psp->dev, "release tmr failed, ret %d", ret);
+		drm_err(psp->ddev, "release tmr failed, ret %d", ret);
 	else
-		dev_dbg(psp->dev, "release tmr successful");
+		drm_dbg(psp->ddev, "release tmr successful");
 }
 
 int aie4_psp_start(struct psp_device *psp)
@@ -143,7 +94,7 @@ int aie4_psp_start(struct psp_device *psp)
 
 	ret = psp_exec(psp, reg_vals);
 	if (ret) {
-		dev_err(psp->dev, "failed to validate fw, ret %d", ret);
+		drm_err(psp->ddev, "failed to validate fw, ret %d", ret);
 		return ret;
 	}
 
@@ -155,7 +106,7 @@ int aie4_psp_start(struct psp_device *psp)
 
 	ret = psp_exec(psp, reg_vals);
 	if (ret) {
-		dev_err(psp->dev, "failed to validate cert fw, ret %d", ret);
+		drm_err(psp->ddev, "failed to validate cert fw, ret %d", ret);
 		return ret;
 	}
 
@@ -166,51 +117,10 @@ int aie4_psp_start(struct psp_device *psp)
 
 	ret = psp_exec(psp, reg_vals);
 	if (ret) {
-		dev_err(psp->dev, "failed to start cert fw, ret %d", ret);
+		drm_err(psp->ddev, "failed to start cert fw, ret %d", ret);
 		return ret;
 	}
 
-	dev_dbg(psp->dev, "successfully download mpnpu and cert fw");
+	drm_dbg(psp->ddev, "successfully download mpnpu and cert fw");
 	return 0;
-}
-
-struct psp_device *aie4_psp_create(struct device *dev, struct aie4_psp_config *conf)
-{
-	struct psp_device *psp;
-	u64 offset;
-
-	psp = devm_kzalloc(dev, sizeof(*psp), GFP_KERNEL);
-	if (!psp)
-		return NULL;
-
-	psp->dev = dev;
-	memcpy(psp->psp_regs, conf->psp_regs, sizeof(psp->psp_regs));
-
-	/* NPU firmware*/
-	psp->fw_buf_sz = ALIGN(conf->fw_size, PSP_FW_ALIGN);
-	psp->fw_buffer = devm_kmalloc(psp->dev, psp->fw_buf_sz + PSP_FW_ALIGN, GFP_KERNEL);
-	if (!psp->fw_buffer) {
-		dev_err(psp->dev, "no memory for fw buffer");
-		return NULL;
-	}
-
-	psp->fw_paddr = virt_to_phys(psp->fw_buffer);
-	offset = ALIGN(psp->fw_paddr, PSP_FW_ALIGN) - psp->fw_paddr;
-	psp->fw_paddr += offset;
-	memcpy(psp->fw_buffer + offset, conf->fw_buf, conf->fw_size);
-
-	/* CERT firmware*/
-	psp->certfw_buf_sz = ALIGN(conf->certfw_size, PSP_CFW_ALIGN);
-	psp->certfw_buffer = devm_kmalloc(psp->dev, psp->certfw_buf_sz + PSP_CFW_ALIGN, GFP_KERNEL);
-	if (!psp->certfw_buffer) {
-		dev_err(psp->dev, "no memory for cert fw buffer");
-		return NULL;
-	}
-
-	psp->certfw_paddr = virt_to_phys(psp->certfw_buffer);
-	offset = ALIGN(psp->certfw_paddr, PSP_CFW_ALIGN) - psp->certfw_paddr;
-	psp->certfw_paddr += offset;
-	memcpy(psp->certfw_buffer + offset, conf->certfw_buf, conf->certfw_size);
-
-	return psp;
 }

--- a/src/driver/amdxdna/aie_common.h
+++ b/src/driver/amdxdna/aie_common.h
@@ -1,15 +1,40 @@
 /* SPDX-License-Identifier: GPL-2.0 */
 /*
- * Copyright (C) 2025-2026, Advanced Micro Devices, Inc.
+ * Copyright (C) 2026, Advanced Micro Devices, Inc.
  */
 
 #ifndef _AIE_COMMON_H_
 #define _AIE_COMMON_H_
 
+#include "amdxdna_aie.h"
+
 #define AIE_INTERVAL	20000	/* us */
 #define AIE_TIMEOUT	1000000	/* us */
 
-#define SMU_RESULT_OK	1
+#define PSP_STATUS_READY	BIT(31)
+
+/* PSP commands */
+#define PSP_VALIDATE		1
+#define PSP_START		2
+#define PSP_RELEASE_TMR		3
+#define PSP_VALIDATE_CERT	4
+
+/* PSP special arguments */
+#define PSP_START_COPY_FW	1
+
+/* PSP response error code */
+#define PSP_ERROR_CANCEL	0xFFFF0002
+#define PSP_ERROR_BAD_STATE	0xFFFF0007
+
+#define PSP_FW_ALIGN		0x10000
+#define PSP_CFW_ALIGN		0x8000
+#define PSP_POLL_INTERVAL	20000	/* us */
+#define PSP_POLL_TIMEOUT	1000000	/* us */
+#define PSP_NOTIFY_INTR		0xD007BE11
+
+#define PSP_REG_BAR(ndev, idx) ((ndev)->priv->psp_regs_off[(idx)].bar_idx)
+#define PSP_REG_OFF(ndev, idx) ((ndev)->priv->psp_regs_off[(idx)].offset)
+#define PSP_REG(p, reg) ((p)->psp_regs[reg])
 
 /* SMU commands */
 #define AIE_SMU_POWER_ON		0x3
@@ -21,8 +46,22 @@
 #define AIE_SMU_SET_SOFT_DPMLEVEL	0x7
 #define AIE_SMU_SET_HARD_DPMLEVEL	0x8
 
+#define SMU_RESULT_OK	1
 #define SMU_REG_BAR(ndev, idx) ((ndev)->priv->smu_regs_off[(idx)].bar_idx)
 #define SMU_REG_OFF(ndev, idx) ((ndev)->priv->smu_regs_off[(idx)].offset)
+
+enum psp_reg_idx {
+	PSP_CMD_REG = 0,
+	PSP_ARG0_REG,
+	PSP_ARG1_REG,
+	PSP_ARG2_REG,
+	PSP_NUM_IN_REGS, /* number of input registers */
+	PSP_INTR_REG = PSP_NUM_IN_REGS,
+	PSP_STATUS_REG,
+	PSP_RESP_REG,
+	PSP_PWAITMODE_REG,
+	PSP_MAX_REGS /* Keep this at the end */
+};
 
 enum aie_smu_reg_idx {
 	SMU_CMD_REG = 0,
@@ -40,12 +79,45 @@ enum aie_smu_rev {
 	SMU_REVISION_MAX
 };
 
+struct aie_bar_off_pair {
+	int	bar_idx;
+	u32	offset;
+};
+
+struct psp_config {
+	const void	*fw_buf;
+	u32		fw_size;
+	const void	*certfw_buf;
+	u32		certfw_size;
+	void __iomem	*psp_regs[PSP_MAX_REGS];
+};
+
+struct psp_device {
+	struct drm_device *ddev;
+	struct device	  *dev;
+	struct psp_config conf;
+	u32		  fw_buf_sz;
+	u64		  fw_paddr;
+	void		  *fw_buffer;
+	dma_addr_t	  fw_dma_handle;
+	u32		  certfw_buf_sz;
+	u64		  certfw_paddr;
+	void		  *certfw_buffer;
+	void __iomem	  *psp_regs[PSP_MAX_REGS];
+#ifdef HAVE_xen_phy_dma_ops
+	struct device	  xen_dma_dev;
+#endif
+};
+
 struct smu_config {
 	void __iomem	*smu_regs[SMU_MAX_REGS];
 };
 
 struct drm_device;
 struct smu_device;
+
+struct psp_device *aiem_psp_create(struct drm_device *ddev, struct device *dev,
+				   struct psp_config *conf);
 struct smu_device *aiem_smu_create(struct drm_device *ddev, struct smu_config *conf);
 int aie_smu_exec(struct smu_device *smu, u32 reg_cmd, u32 reg_arg, u32 *out);
 

--- a/src/driver/amdxdna/aie_psp.c
+++ b/src/driver/amdxdna/aie_psp.c
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Copyright (C) 2026, Advanced Micro Devices, Inc.
+ */
+
+#include <linux/device.h>
+#include <linux/iopoll.h>
+#include <linux/slab.h>
+
+#include "aie_common.h"
+#include "amdxdna_xen.h"
+
+struct psp_device *aiem_psp_create(struct drm_device *ddev, struct device *dev,
+				   struct psp_config *conf)
+{
+	struct psp_device *psp;
+	u64 offset;
+
+	psp = devm_kzalloc(dev, sizeof(*psp), GFP_KERNEL);
+	if (!psp)
+		return NULL;
+
+	psp->ddev = ddev;
+	psp->dev = dev;
+	memcpy(psp->psp_regs, conf->psp_regs, sizeof(psp->psp_regs));
+
+	if (!conf->certfw_size && !conf->certfw_buf) {
+		/* aie2: NPU firmware only */
+		psp->fw_buf_sz = ALIGN(conf->fw_size, PSP_FW_ALIGN);
+		if (is_xen_initial_pvh_domain()) {
+			psp->fw_buffer =
+				amdxdna_xen_alloc_buf_phys(psp->dev,
+							   psp->fw_buf_sz + PSP_FW_ALIGN,
+							   &psp->fw_dma_handle);
+			if (!psp->fw_buffer)
+				return NULL;
+			psp->fw_paddr = psp->fw_dma_handle;
+		} else {
+			psp->fw_buffer =
+				devm_kmalloc(psp->dev,
+					     psp->fw_buf_sz + PSP_FW_ALIGN,
+					     GFP_KERNEL);
+			if (!psp->fw_buffer)
+				return NULL;
+
+			psp->fw_paddr = virt_to_phys(psp->fw_buffer);
+		}
+
+		offset = ALIGN(psp->fw_paddr, PSP_FW_ALIGN) - psp->fw_paddr;
+		psp->fw_paddr += offset;
+		memcpy(psp->fw_buffer + offset, conf->fw_buf, conf->fw_size);
+	} else {
+		/* aie4: NPU firmware + CERT firmware (Xen not supported) */
+		psp->fw_buf_sz = ALIGN(conf->fw_size, PSP_FW_ALIGN);
+		psp->fw_buffer = devm_kmalloc(psp->dev,
+					      psp->fw_buf_sz + PSP_FW_ALIGN,
+					      GFP_KERNEL);
+		if (!psp->fw_buffer)
+			return NULL;
+
+		psp->fw_paddr = virt_to_phys(psp->fw_buffer);
+		offset = ALIGN(psp->fw_paddr, PSP_FW_ALIGN) - psp->fw_paddr;
+		psp->fw_paddr += offset;
+		memcpy(psp->fw_buffer + offset, conf->fw_buf, conf->fw_size);
+
+		psp->certfw_buf_sz = ALIGN(conf->certfw_size, PSP_CFW_ALIGN);
+		psp->certfw_buffer = devm_kmalloc(psp->dev,
+						  psp->certfw_buf_sz + PSP_CFW_ALIGN,
+						  GFP_KERNEL);
+		if (!psp->certfw_buffer) {
+			dev_err(psp->dev, "no memory for cert fw buffer");
+			return NULL;
+		}
+		psp->certfw_paddr = virt_to_phys(psp->certfw_buffer);
+		offset = ALIGN(psp->certfw_paddr, PSP_CFW_ALIGN) - psp->certfw_paddr;
+		psp->certfw_paddr += offset;
+		memcpy(psp->certfw_buffer + offset, conf->certfw_buf, conf->certfw_size);
+	}
+
+	return psp;
+}

--- a/src/driver/amdxdna/amdxdna_aie.h
+++ b/src/driver/amdxdna/amdxdna_aie.h
@@ -8,39 +8,9 @@
 
 #include "aie_common.h"
 
-#define PSP_REG_BAR(ndev, idx) ((ndev)->priv->psp_regs_off[(idx)].bar_idx)
-#define PSP_REG_OFF(ndev, idx) ((ndev)->priv->psp_regs_off[(idx)].offset)
-#define SRAM_REG_OFF(ndev, idx) ((ndev)->priv->sram_offs[(idx)].offset)
-
 #define DEFINE_BAR_OFFSET(reg_name, bar, reg_addr) \
 	[reg_name] = {bar##_BAR_INDEX, (reg_addr) - bar##_BAR_BASE}
-
-enum psp_reg_idx {
-	PSP_CMD_REG = 0,
-	PSP_ARG0_REG,
-	PSP_ARG1_REG,
-	PSP_ARG2_REG,
-	PSP_NUM_IN_REGS, /* number of input registers */
-	PSP_INTR_REG = PSP_NUM_IN_REGS,
-	PSP_STATUS_REG,
-	PSP_RESP_REG,
-	PSP_PWAITMODE_REG,
-	PSP_MAX_REGS /* Keep this at the end */
-};
-
-struct psp_config {
-	const void	*fw_buf;
-	u32		fw_size;
-	void __iomem	*psp_regs[PSP_MAX_REGS];
-};
-
-struct aie4_psp_config {
-	const void      *fw_buf;
-	u32             fw_size;
-	const void      *certfw_buf;
-	u32             certfw_size;
-	void __iomem    *psp_regs[PSP_MAX_REGS];
-};
+#define SRAM_REG_OFF(ndev, idx) ((ndev)->priv->sram_offs[(idx)].offset)
 
 enum dpm_level {
 	DPM_LEVEL_0 = 0,
@@ -90,11 +60,6 @@ struct dpm_clk_freq {
 enum aie_power_state {
 	SMU_POWER_OFF,
 	SMU_POWER_ON,
-};
-
-struct aie_bar_off_pair {
-	int	bar_idx;
-	u32	offset;
 };
 
 struct amdxdna_dev_hdl;


### PR DESCRIPTION
**Problem solved by the commit**
Add common psp code for both aie2 and aie4

**Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered**
N/A

**How problem was solved, alternative solutions (if any) and why they were rejected**
1> Removed duplicates and merged common code.

**Risks (if any) associated the changes in the commit**
Should be backward compatible

**What has been tested and how, request additional testing if necessary**
1> Driver installation successful.
2> Ran xrt_test 0 1 2 3 6 7 9 successfully on Medusa board.

**Documentation impact (if any)**
N/A