### PR TITLE
Make aie smu code common for aie2 and aie4

### DIFF
--- a/src/driver/amdxdna/Kbuild
+++ b/src/driver/amdxdna/Kbuild
@@ -35,6 +35,7 @@ amdxdna-y := \
 	amdxdna_cma_buf.o \
 
 amdxdna-$(OFT_CONFIG_AMDXDNA_PCI) += \
+	aie_smu.o \
 	aie2_smu.o \
 	aie2_psp.o \
 	aie2_ctx.o \

--- a/src/driver/amdxdna/aie2_pci.c
+++ b/src/driver/amdxdna/aie2_pci.c
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0
 /*
- * Copyright (C) 2023-2025, Advanced Micro Devices, Inc.
+ * Copyright (C) 2023-2026, Advanced Micro Devices, Inc.
  */
 
 #include <linux/errno.h>
@@ -494,6 +494,7 @@ static int aie2_init(struct amdxdna_dev *xdna)
 	struct pci_dev *pdev = to_pci_dev(xdna->ddev.dev);
 	void __iomem *tbl[PCI_NUM_RESOURCES] = {0};
 	struct amdxdna_dev_hdl *ndev;
+	struct smu_config smu_conf;
 	struct psp_config psp_conf;
 	const struct firmware *fw;
 	unsigned long bars = 0;
@@ -524,9 +525,10 @@ static int aie2_init(struct amdxdna_dev *xdna)
 
 	for (i = 0; i < PSP_MAX_REGS; i++)
 		set_bit(PSP_REG_BAR(ndev, i), &bars);
+	for (i = 0; i < SMU_MAX_REGS; i++)
+		set_bit(SMU_REG_BAR(ndev, i), &bars);
 
 	set_bit(xdna->dev_info->sram_bar, &bars);
-	set_bit(xdna->dev_info->smu_bar, &bars);
 	set_bit(xdna->dev_info->mbox_bar, &bars);
 
 	for (i = 0; i < PCI_NUM_RESOURCES; i++) {
@@ -541,7 +543,6 @@ static int aie2_init(struct amdxdna_dev *xdna)
 	}
 
 	ndev->sram_base = tbl[xdna->dev_info->sram_bar];
-	ndev->smu_base = tbl[xdna->dev_info->smu_bar];
 	ndev->mbox_base = tbl[xdna->dev_info->mbox_bar];
 
 	ret = dma_set_mask_and_coherent(&pdev->dev, DMA_BIT_MASK(64));
@@ -588,6 +589,14 @@ skip_pasid:
 	ndev->psp_hdl = aie2m_psp_create(&pdev->dev, &psp_conf);
 	if (!ndev->psp_hdl) {
 		XDNA_ERR(xdna, "failed to create psp");
+		ret = -ENOMEM;
+		goto disable_sva;
+	}
+	for (i = 0; i < SMU_MAX_REGS; i++)
+		smu_conf.smu_regs[i] = tbl[SMU_REG_BAR(ndev, i)] + SMU_REG_OFF(ndev, i);
+	ndev->smu_hdl = aiem_smu_create(&xdna->ddev, &smu_conf);
+	if (!ndev->smu_hdl) {
+		XDNA_ERR(xdna, "failed to create smu");
 		ret = -ENOMEM;
 		goto disable_sva;
 	}
@@ -2137,3 +2146,4 @@ const struct amdxdna_dev_ops aie2_ops = {
 	.hmm_invalidate		= aie2_hmm_invalidate,
 	.cmd_get_out_fence	= aie2_cmd_get_out_fence,
 };
+

--- a/src/driver/amdxdna/aie2_pci.h
+++ b/src/driver/amdxdna/aie2_pci.h
@@ -240,6 +240,7 @@ struct amdxdna_dev_hdl {
 	void			__iomem *smu_base;
 	void			__iomem *mbox_base;
 	struct psp_device		*psp_hdl;
+	struct smu_device		*smu_hdl;
 
 	struct xdna_mailbox_chann_info	mgmt_info;
 	u64				mgmt_fw_version;
@@ -570,3 +571,4 @@ int aie2_fw_trace_config(struct amdxdna_dev *xdna, u32 categories);
 void aie2_fw_trace_parse(struct amdxdna_dev *xdna, char *buffer, size_t size);
 
 #endif /* _AIE2_PCI_H_ */
+

--- a/src/driver/amdxdna/aie2_smu.c
+++ b/src/driver/amdxdna/aie2_smu.c
@@ -1,21 +1,9 @@
 // SPDX-License-Identifier: GPL-2.0
 /*
- * Copyright (C) 2022-2025, Advanced Micro Devices, Inc.
+ * Copyright (C) 2022-2026, Advanced Micro Devices, Inc.
  */
 
 #include "aie2_pci.h"
-
-#define SMU_RESULT_OK		1
-
-/* SMU commands */
-#define AIE2_SMU_POWER_ON		0x3
-#define AIE2_SMU_POWER_OFF		0x4
-/* For SMU v0 */
-#define AIE2_SMU_SET_MPNPUCLK_FREQ	0x5
-#define AIE2_SMU_SET_HCLK_FREQ		0x6
-/* For SMU v1 */
-#define AIE2_SMU_SET_SOFT_DPMLEVEL	0x7
-#define AIE2_SMU_SET_HARD_DPMLEVEL	0x8
 
 #define NPU4_DPM_TOPS(ndev, dpm_level) \
 ({ \
@@ -24,55 +12,21 @@
 	 (_ndev)->priv->dpm_clk_tbl[dpm_level].hclk / 1000000); \
 })
 
-static int aie2_smu_exec(struct amdxdna_dev_hdl *ndev, u32 reg_cmd,
-			 u32 reg_arg, u32 *out)
-{
-	u32 resp;
-	int ret;
-
-	WARN_ON(!mutex_is_locked(&ndev->aie2_lock));
-
-	writel(0, SMU_REG(ndev, SMU_RESP_REG));
-	writel(reg_arg, SMU_REG(ndev, SMU_ARG_REG));
-	writel(reg_cmd, SMU_REG(ndev, SMU_CMD_REG));
-
-	/* Clear and set SMU_INTR_REG to kick off */
-	writel(0, SMU_REG(ndev, SMU_INTR_REG));
-	writel(1, SMU_REG(ndev, SMU_INTR_REG));
-
-	ret = readx_poll_timeout(readl, SMU_REG(ndev, SMU_RESP_REG), resp,
-				 resp, AIE2_INTERVAL, AIE2_TIMEOUT);
-	if (ret) {
-		XDNA_ERR(ndev->xdna, "SMU cmd %d timed out", reg_cmd);
-		return ret;
-	}
-
-	if (out)
-		*out = readl(SMU_REG(ndev, SMU_OUT_REG));
-
-	if (resp != SMU_RESULT_OK) {
-		XDNA_ERR(ndev->xdna, "SMU cmd %d failed, 0x%x", reg_cmd, resp);
-		return -EINVAL;
-	}
-
-	return 0;
-}
-
 int npu1_set_dpm(struct amdxdna_dev_hdl *ndev, u32 dpm_level)
 {
 	u32 freq;
 	int ret;
 
-	ret = aie2_smu_exec(ndev, AIE2_SMU_SET_MPNPUCLK_FREQ,
-			    ndev->priv->dpm_clk_tbl[dpm_level].npuclk, &freq);
+	ret = aie_smu_exec(ndev->smu_hdl, AIE_SMU_SET_MPNPUCLK_FREQ,
+			   ndev->priv->dpm_clk_tbl[dpm_level].npuclk, &freq);
 	if (ret) {
 		XDNA_ERR(ndev->xdna, "Set npu clock to %d failed, ret %d\n",
 			 ndev->priv->dpm_clk_tbl[dpm_level].npuclk, ret);
 	}
 	ndev->npuclk_freq = freq;
 
-	ret = aie2_smu_exec(ndev, AIE2_SMU_SET_HCLK_FREQ,
-			    ndev->priv->dpm_clk_tbl[dpm_level].hclk, &freq);
+	ret = aie_smu_exec(ndev->smu_hdl, AIE_SMU_SET_HCLK_FREQ,
+			   ndev->priv->dpm_clk_tbl[dpm_level].hclk, &freq);
 	if (ret) {
 		XDNA_ERR(ndev->xdna, "Set h clock to %d failed, ret %d\n",
 			 ndev->priv->dpm_clk_tbl[dpm_level].hclk, ret);
@@ -92,14 +46,14 @@ int npu4_set_dpm(struct amdxdna_dev_hdl *ndev, u32 dpm_level)
 {
 	int ret;
 
-	ret = aie2_smu_exec(ndev, AIE2_SMU_SET_HARD_DPMLEVEL, dpm_level, NULL);
+	ret = aie_smu_exec(ndev->smu_hdl, AIE_SMU_SET_HARD_DPMLEVEL, dpm_level, NULL);
 	if (ret) {
 		XDNA_ERR(ndev->xdna, "Set hard dpm level %d failed, ret %d ",
 			 dpm_level, ret);
 		return ret;
 	}
 
-	ret = aie2_smu_exec(ndev, AIE2_SMU_SET_SOFT_DPMLEVEL, dpm_level, NULL);
+	ret = aie_smu_exec(ndev->smu_hdl, AIE_SMU_SET_SOFT_DPMLEVEL, dpm_level, NULL);
 	if (ret) {
 		XDNA_ERR(ndev->xdna, "Set soft dpm level %d failed, ret %d",
 			 dpm_level, ret);
@@ -132,7 +86,7 @@ int aie2_smu_set_power_on(struct amdxdna_dev_hdl *ndev)
 {
 	int ret;
 
-	ret = aie2_smu_exec(ndev, AIE2_SMU_POWER_ON, 0, NULL);
+	ret = aie_smu_exec(ndev->smu_hdl, AIE_SMU_POWER_ON, 0, NULL);
 	if (ret)
 		return ret;
 	ndev->power_state = SMU_POWER_ON;
@@ -144,7 +98,7 @@ int aie2_smu_set_power_off(struct amdxdna_dev_hdl *ndev)
 {
 	int ret;
 
-	ret = aie2_smu_exec(ndev, AIE2_SMU_POWER_OFF, 0, NULL);
+	ret = aie_smu_exec(ndev->smu_hdl, AIE_SMU_POWER_OFF, 0, NULL);
 	if (ret)
 		return ret;
 	ndev->power_state = SMU_POWER_OFF;
@@ -192,3 +146,4 @@ void aie2_smu_stop(struct amdxdna_dev_hdl *ndev)
 	if (ret)
 		XDNA_WARN(ndev->xdna, "Power off failed, ret %d", ret);
 }
+

--- a/src/driver/amdxdna/aie4_error.c
+++ b/src/driver/amdxdna/aie4_error.c
@@ -510,7 +510,7 @@ static void aie4_error_worker(struct work_struct *err_work)
 
 	max_err = (ASYNC_BUF_SIZE - sizeof(*info)) / sizeof(struct aie_error);
 	if (unlikely(info->err_cnt > max_err)) {
-		XDNA_WARN_ONCE(xdna, "Error count too large %d", info->err_cnt);
+		WARN_ONCE(1, "Error count too large %d\n", info->err_cnt);
 		return;
 	}
 	err_col = aie4_error_backtrack(e->ndev, info->payload, info->err_cnt);

--- a/src/driver/amdxdna/aie4_message.c
+++ b/src/driver/amdxdna/aie4_message.c
@@ -126,29 +126,6 @@ int aie4_force_preemption(struct amdxdna_dev_hdl *ndev)
 	return 0;
 }
 
-int aie4_hws_debug_mode(struct amdxdna_dev_hdl *ndev, u32 ctx_id)
-{
-	DECLARE_AIE4_MSG(aie4_msg_set_runtime_cfg, AIE4_MSG_OP_SET_RUNTIME_CONFIG);
-	struct aie4_msg_runtime_config_hws_debug_mode *hws_debug;
-	u32 type = AIE4_RUNTIME_CONFIG_HWS_DEBUG_MODE;
-	int ret;
-
-	req.type = type;
-	hws_debug = (struct aie4_msg_runtime_config_hws_debug_mode *)req.data;
-	hws_debug->enable = AIE4_RUNTIME_HWS_DEBUG_MODE_ENABLE;
-	hws_debug->ctx_id = ctx_id;
-
-	msg.send_size = sizeof(req.type) + sizeof(*hws_debug);
-
-	ret = aie4_send_msg_wait(ndev, &msg);
-	if (ret) {
-		XDNA_ERR(ndev->xdna, "Failed to set HWS debug mode, ret %d", ret);
-		return ret;
-	}
-
-	return 0;
-}
-
 int aie4_check_firmware_version(struct amdxdna_dev_hdl *ndev)
 {
 	DECLARE_AIE4_MSG(aie4_msg_identify, AIE4_MSG_OP_IDENTIFY);

--- a/src/driver/amdxdna/aie4_pci.c
+++ b/src/driver/amdxdna/aie4_pci.c
@@ -31,31 +31,27 @@
 #define AIE4_MAX_COL 128
 uint aie4_max_col = AIE4_MAX_COL;
 module_param(aie4_max_col, uint, 0600);
-MODULE_PARM_DESC(aie4_max_col, " Maximum column could be used");
+MODULE_PARM_DESC(aie4_max_col, "Maximum column could be used");
 
 int enable_aie4_polling;
 module_param(enable_aie4_polling, int, 0644);
-MODULE_PARM_DESC(enable_aie4_polling, " Enable aie4 polling mode");
+MODULE_PARM_DESC(enable_aie4_polling, "Enable aie4 polling mode");
 
 static int skip_fw_load;
 module_param(skip_fw_load, int, 0644);
-MODULE_PARM_DESC(skip_fw_load, " Skip fw load via psp");
+MODULE_PARM_DESC(skip_fw_load, "Skip fw load via psp");
 
 static int fw_reload;
 module_param(fw_reload, int, 0644);
-MODULE_PARM_DESC(fw_reload, " Enforce fw reload during flr");
+MODULE_PARM_DESC(fw_reload, "enforce fw reload during flr");
 
 static int skip_work_buffer;
 module_param(skip_work_buffer, int, 0644);
-MODULE_PARM_DESC(skip_work_buffer, " Skip MPNPU work buffer attach");
+MODULE_PARM_DESC(skip_work_buffer, "Skip MPNPU work buffer attach");
 
 static uint aie4_ctx_hysteresis_us = 1000;
 module_param(aie4_ctx_hysteresis_us, uint, 0644);
 MODULE_PARM_DESC(aie4_ctx_hysteresis_us, " Context switch hysteresis in microseconds (0 = disabled)");
-
-static int hws_debug_mode;
-module_param(hws_debug_mode, int, 0644);
-MODULE_PARM_DESC(hws_debug_mode, " Enable HWS debug mode (0 = disabled, 1 = enabled)");
 
 /*
  * This struct is the register layout.
@@ -665,6 +661,7 @@ static int aie4_prepare_firmware(struct amdxdna_dev_hdl *ndev,
 {
 	struct amdxdna_dev *xdna = ndev->xdna;
 	struct pci_dev *pdev = to_pci_dev(xdna->ddev.dev);
+	struct smu_config smu_conf;
 	struct aie4_psp_config psp_conf;
 	int i;
 
@@ -681,6 +678,14 @@ static int aie4_prepare_firmware(struct amdxdna_dev_hdl *ndev,
 	ndev->psp_hdl = aie4_psp_create(&pdev->dev, &psp_conf);
 	if (!ndev->psp_hdl) {
 		XDNA_ERR(xdna, "failed to create psp");
+		return -ENOMEM;
+	}
+
+	for (i = 0; i < SMU_MAX_REGS; i++)
+		smu_conf.smu_regs[i] = ndev->smu_base + SMU_REG_OFF(ndev, i);
+	ndev->smu_hdl = aiem_smu_create(&xdna->ddev, &smu_conf);
+	if (!ndev->smu_hdl) {
+		XDNA_ERR(xdna, "failed to create smu");
 		return -ENOMEM;
 	}
 
@@ -759,7 +764,8 @@ static int aie4_pcidev_init(struct amdxdna_dev_hdl *ndev)
 	set_bit(xdna->dev_info->sram_bar, &bars);
 	if (!is_npu3_vf_dev(pdev)) {
 		set_bit(xdna->dev_info->psp_bar, &bars);
-		set_bit(xdna->dev_info->smu_bar, &bars);
+		for (i = 0; i < SMU_MAX_REGS; i++)
+			set_bit(SMU_REG_BAR(ndev, i), &bars);
 	}
 
 	if (!is_npu3_pf_dev(pdev))
@@ -995,14 +1001,7 @@ int aie4_create_context(struct amdxdna_dev_hdl *ndev, struct amdxdna_ctx *ctx)
 
 	if (ndev->force_preempt_enabled) {
 		ret = aie4_force_preemption(ndev);
-		if (ret)
-			XDNA_WARN_ONCE(xdna, "Failed to config force preemption");
-	}
-
-	if (hws_debug_mode) {
-		ret = aie4_hws_debug_mode(ndev, resp.hw_context_id);
-		if (ret)
-			XDNA_WARN_ONCE(xdna, "Failed to config HWS debug mode");
+		WARN_ONCE(ret, "Failed to config force preemption");
 	}
 
 	nctx->cert_comp = aie4_lookup_cert_comp(ndev, resp.job_complete_msix_idx);
@@ -2727,3 +2726,4 @@ const struct amdxdna_dev_ops aie4_ops = {
 	.debugfs		= aie4_debugfs_init,
 	.sriov_configure        = aie4_sriov_configure,
 };
+

--- a/src/driver/amdxdna/aie4_pci.h
+++ b/src/driver/amdxdna/aie4_pci.h
@@ -137,6 +137,7 @@ struct amdxdna_dev_hdl {
 	const struct amdxdna_dev_priv	*priv;
 	void				*xrs_hdl;
 	struct psp_device		*psp_hdl;
+	struct smu_device		*smu_hdl;
 
 	u32				partition_id;
 
@@ -212,7 +213,6 @@ int aie4_error_get_last_async(struct amdxdna_dev *xdna,
 int aie4_suspend_fw(struct amdxdna_dev_hdl *ndev);
 int aie4_resume_fw(struct amdxdna_dev_hdl *ndev);
 int aie4_force_preemption(struct amdxdna_dev_hdl *ndev);
-int aie4_hws_debug_mode(struct amdxdna_dev_hdl *ndev, u32 ctx_id);
 int aie4_check_firmware_version(struct amdxdna_dev_hdl *ndev);
 int aie4_register_asyn_event_msg(struct amdxdna_dev_hdl *ndev,
 				 struct amdxdna_mgmt_dma_hdl *dma_hdl, void *handle,
@@ -303,3 +303,4 @@ void aie4_put_cert_comp_locked(struct cert_comp *comp);
 void aie4_ctx_cleanup_pending_jobs(struct amdxdna_ctx *ctx);
 
 #endif /* _AIE4_PCI_H_ */
+

--- a/src/driver/amdxdna/aie4_smu.c
+++ b/src/driver/amdxdna/aie4_smu.c
@@ -1,68 +1,22 @@
 // SPDX-License-Identifier: GPL-2.0
 /*
- * Copyright (C) 2025, Advanced Micro Devices, Inc.
+ * Copyright (C) 2025-2026, Advanced Micro Devices, Inc.
  */
 
 #include "aie4_pci.h"
-
-#define SMU_RESULT_OK		1
-
-/* SMU commands */
-#define AIE4_SMU_POWER_ON		0x3
-#define AIE4_SMU_POWER_OFF		0x4
-/* For SMU v0 */
-#define AIE4_SMU_SET_MPNPUCLK_FREQ	0x5
-#define AIE4_SMU_SET_HCLK_FREQ		0x6
-/* For SMU v1 */
-#define AIE4_SMU_SET_SOFT_DPMLEVEL	0x7
-#define AIE4_SMU_SET_HARD_DPMLEVEL	0x8
-
-static int aie4_smu_exec(struct amdxdna_dev_hdl *ndev, u32 reg_cmd,
-			 u32 reg_arg, u32 *out)
-{
-	u32 resp;
-	int ret;
-
-	writel(0, SMU_REG(ndev, SMU_RESP_REG));
-	writel(reg_arg, SMU_REG(ndev, SMU_ARG_REG));
-	writel(reg_cmd, SMU_REG(ndev, SMU_CMD_REG));
-
-	/* Clear and set SMU_INTR_REG to kick off */
-	writel(0, SMU_REG(ndev, SMU_INTR_REG));
-	writel(1, SMU_REG(ndev, SMU_INTR_REG));
-
-	XDNA_DBG(ndev->xdna, "smu exec timeout %d ns", AIE4_TIMEOUT);
-
-	ret = readx_poll_timeout(readl, SMU_REG(ndev, SMU_RESP_REG), resp,
-				 resp, AIE4_INTERVAL, AIE4_TIMEOUT);
-	if (ret) {
-		XDNA_ERR(ndev->xdna, "SMU cmd %d timed out", reg_cmd);
-		return ret;
-	}
-
-	if (out)
-		*out = readl(SMU_REG(ndev, SMU_OUT_REG));
-
-	if (resp != SMU_RESULT_OK) {
-		XDNA_ERR(ndev->xdna, "SMU cmd %d failed, 0x%x", reg_cmd, resp);
-		return -EINVAL;
-	}
-
-	return 0;
-}
 
 int aie4_set_dpm(struct amdxdna_dev_hdl *ndev, u32 dpm_level)
 {
 	int ret;
 
-	ret = aie4_smu_exec(ndev, AIE4_SMU_SET_HARD_DPMLEVEL, dpm_level, NULL);
+	ret = aie_smu_exec(ndev->smu_hdl, AIE_SMU_SET_HARD_DPMLEVEL, dpm_level, NULL);
 	if (ret) {
 		XDNA_ERR(ndev->xdna, "Set hard dpm level %d failed, ret %d ",
 			 dpm_level, ret);
 		return ret;
 	}
 
-	ret = aie4_smu_exec(ndev, AIE4_SMU_SET_SOFT_DPMLEVEL, dpm_level, NULL);
+	ret = aie_smu_exec(ndev->smu_hdl, AIE_SMU_SET_SOFT_DPMLEVEL, dpm_level, NULL);
 	if (ret) {
 		XDNA_ERR(ndev->xdna, "Set soft dpm level %d failed, ret %d",
 			 dpm_level, ret);
@@ -83,7 +37,7 @@ int aie4_smu_set_power_on(struct amdxdna_dev_hdl *ndev)
 {
 	int ret;
 
-	ret = aie4_smu_exec(ndev, AIE4_SMU_POWER_ON, 0, NULL);
+	ret = aie_smu_exec(ndev->smu_hdl, AIE_SMU_POWER_ON, 0, NULL);
 	if (ret)
 		return ret;
 	ndev->power_state = SMU_POWER_ON;
@@ -95,7 +49,7 @@ int aie4_smu_set_power_off(struct amdxdna_dev_hdl *ndev)
 {
 	int ret;
 
-	ret = aie4_smu_exec(ndev, AIE4_SMU_POWER_OFF, 0, NULL);
+	ret = aie_smu_exec(ndev->smu_hdl, AIE_SMU_POWER_OFF, 0, NULL);
 	if (ret)
 		return ret;
 	ndev->power_state = SMU_POWER_OFF;
@@ -134,3 +88,4 @@ void aie4_smu_stop(struct amdxdna_dev_hdl *ndev)
 	if (ret)
 		XDNA_WARN(ndev->xdna, "Power off failed, ret %d", ret);
 }
+

--- a/src/driver/amdxdna/aie_common.h
+++ b/src/driver/amdxdna/aie_common.h
@@ -1,0 +1,53 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+/*
+ * Copyright (C) 2025-2026, Advanced Micro Devices, Inc.
+ */
+
+#ifndef _AIE_COMMON_H_
+#define _AIE_COMMON_H_
+
+#define AIE_INTERVAL	20000	/* us */
+#define AIE_TIMEOUT	1000000	/* us */
+
+#define SMU_RESULT_OK	1
+
+/* SMU commands */
+#define AIE_SMU_POWER_ON		0x3
+#define AIE_SMU_POWER_OFF		0x4
+/* For SMU v0 */
+#define AIE_SMU_SET_MPNPUCLK_FREQ	0x5
+#define AIE_SMU_SET_HCLK_FREQ		0x6
+/* For SMU v1 */
+#define AIE_SMU_SET_SOFT_DPMLEVEL	0x7
+#define AIE_SMU_SET_HARD_DPMLEVEL	0x8
+
+#define SMU_REG_BAR(ndev, idx) ((ndev)->priv->smu_regs_off[(idx)].bar_idx)
+#define SMU_REG_OFF(ndev, idx) ((ndev)->priv->smu_regs_off[(idx)].offset)
+
+enum aie_smu_reg_idx {
+	SMU_CMD_REG = 0,
+	SMU_ARG_REG,
+	SMU_INTR_REG,
+	SMU_RESP_REG,
+	SMU_OUT_REG,
+	SMU_MAX_REGS /* Keep this at the end */
+};
+
+enum aie_smu_rev {
+	SMU_REVISION_NONE = 0,
+	SMU_REVISION_NPU1,
+	SMU_REVISION_NPU4,
+	SMU_REVISION_MAX
+};
+
+struct smu_config {
+	void __iomem	*smu_regs[SMU_MAX_REGS];
+};
+
+struct drm_device;
+struct smu_device;
+struct smu_device *aiem_smu_create(struct drm_device *ddev, struct smu_config *conf);
+int aie_smu_exec(struct smu_device *smu, u32 reg_cmd, u32 reg_arg, u32 *out);
+
+#endif /* _AIE_COMMON_H_ */
+

--- a/src/driver/amdxdna/aie_smu.c
+++ b/src/driver/amdxdna/aie_smu.c
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Copyright (C) 2026, Advanced Micro Devices, Inc.
+ */
+
+#include <drm/drm_device.h>
+#include <drm/drm_managed.h>
+#include <drm/drm_print.h>
+#include <linux/iopoll.h>
+
+#include "drm_local/amdxdna_accel.h"
+#include "aie_common.h"
+#include "amdxdna_pci_drv.h"
+
+#define SMU_REG(s, reg) ((s)->smu_regs[reg])
+
+struct smu_device {
+	struct drm_device	*ddev;
+	struct smu_config	conf;
+	void __iomem		*smu_regs[SMU_MAX_REGS];
+};
+
+int aie_smu_exec(struct smu_device *smu, u32 reg_cmd, u32 reg_arg, u32 *out)
+{
+	u32 resp;
+	int ret;
+
+	writel(0, SMU_REG(smu, SMU_RESP_REG));
+	writel(reg_arg, SMU_REG(smu, SMU_ARG_REG));
+	writel(reg_cmd, SMU_REG(smu, SMU_CMD_REG));
+
+	/* Clear and set SMU_INTR_REG to kick off */
+	writel(0, SMU_REG(smu, SMU_INTR_REG));
+	writel(1, SMU_REG(smu, SMU_INTR_REG));
+
+	ret = readx_poll_timeout(readl, SMU_REG(smu, SMU_RESP_REG), resp,
+				 resp, AIE_INTERVAL, AIE_TIMEOUT);
+	if (ret) {
+		drm_err(smu->ddev, "smu cmd %d timed out", reg_cmd);
+		return ret;
+	}
+
+	if (out)
+		*out = readl(SMU_REG(smu, SMU_OUT_REG));
+
+	if (resp != SMU_RESULT_OK) {
+		drm_err(smu->ddev, "smu cmd %d failed, 0x%x", reg_cmd, resp);
+		return -EINVAL;
+	}
+
+	return 0;
+}
+
+struct smu_device *aiem_smu_create(struct drm_device *ddev, struct smu_config *conf)
+{
+	struct smu_device *smu;
+
+	smu = drmm_kzalloc(ddev, sizeof(*smu), GFP_KERNEL);
+	if (!smu)
+		return NULL;
+
+	smu->ddev = ddev;
+	memcpy(smu->smu_regs, conf->smu_regs, sizeof(smu->smu_regs));
+
+	return smu;
+}
+

--- a/src/driver/amdxdna/amdxdna_aie.h
+++ b/src/driver/amdxdna/amdxdna_aie.h
@@ -1,39 +1,19 @@
 /* SPDX-License-Identifier: GPL-2.0 */
 /*
- * Copyright (C) 2025, Advanced Micro Devices, Inc.
+ * Copyright (C) 2025-2026, Advanced Micro Devices, Inc.
  */
 
 #ifndef _AMDXDNA_AIE_H_
 #define _AMDXDNA_AIE_H_
 
+#include "aie_common.h"
+
 #define PSP_REG_BAR(ndev, idx) ((ndev)->priv->psp_regs_off[(idx)].bar_idx)
 #define PSP_REG_OFF(ndev, idx) ((ndev)->priv->psp_regs_off[(idx)].offset)
 #define SRAM_REG_OFF(ndev, idx) ((ndev)->priv->sram_offs[(idx)].offset)
 
-#define SMU_REG(ndev, idx) \
-({ \
-	typeof(ndev) _ndev = ndev; \
-	((_ndev)->smu_base + (_ndev)->priv->smu_regs_off[(idx)].offset); \
-})
-
 #define DEFINE_BAR_OFFSET(reg_name, bar, reg_addr) \
 	[reg_name] = {bar##_BAR_INDEX, (reg_addr) - bar##_BAR_BASE}
-
-enum aie_smu_reg_idx {
-	SMU_CMD_REG = 0,
-	SMU_ARG_REG,
-	SMU_INTR_REG,
-	SMU_RESP_REG,
-	SMU_OUT_REG,
-	SMU_MAX_REGS /* Keep this at the end */
-};
-
-enum aie_smu_rev {
-	SMU_REVISION_NONE = 0,
-	SMU_REVISION_NPU1,
-	SMU_REVISION_NPU4,
-	SMU_REVISION_MAX
-};
 
 enum psp_reg_idx {
 	PSP_CMD_REG = 0,
@@ -124,3 +104,4 @@ struct aie_hw_ops {
 };
 
 #endif /* _AMDXDNA_AIE_H_ */
+

--- a/src/driver/amdxdna/amdxdna_drm.h
+++ b/src/driver/amdxdna/amdxdna_drm.h
@@ -30,8 +30,6 @@
 #define XDNA_DBG(xdna, fmt, args...)	dev_dbg((xdna)->ddev.dev, fmt, ##args)
 
 #define XDNA_INFO_ONCE(xdna, fmt, args...)	dev_info_once((xdna)->ddev.dev, fmt, ##args)
-#define XDNA_WARN_ONCE(xdna, fmt, args...) \
-	dev_warn_once((xdna)->ddev.dev, "%s: " fmt, __func__, ##args)
 
 #define to_xdna_dev(drm_dev) \
 	((struct amdxdna_dev *)container_of(drm_dev, struct amdxdna_dev, ddev))

--- a/test/shim_test/shim_test.cpp
+++ b/test/shim_test/shim_test.cpp
@@ -18,14 +18,12 @@
 #include "core/common/system.h"
 #include "core/common/device.h"
 
-#include <array>
 #include <filesystem>
 #include <fstream>
 #include <vector>
 #include <iostream>
 #include <sstream>
 #include <string>
-#include <dirent.h>
 
 #include <libgen.h>
 #include <sys/utsname.h>
@@ -248,59 +246,16 @@ dev_filter_is_npu4_and_amdxdna_drv(device::id_type id, device* dev)
   return true;
 }
 
-std::string
-get_sysfs_path(device* dev)
-{
-  query::sub_device_path::args query_arg = {std::string(""), 0};
-  std::string sysfs = device_query<query::sub_device_path>(dev, query_arg);
-  return sysfs + "/accel";
-}
-
-// Returns an open fd for the accel device node corresponding to dev. Caller must close(fd).
-// Throws std::runtime_error on failure (opendir, missing accel entry, or open).
-int
-open_accel_fd(device* dev)
-{
-  // FIXME: reimplement this when query key is defined in xrt
-  std::string accel_path = get_sysfs_path(dev);
-
-  struct dir_guard {
-    DIR* d;
-    explicit dir_guard(DIR* p) : d(p) {}
-    ~dir_guard() { if (d) closedir(d); }
-    DIR* get() const { return d; }
-    explicit operator bool() const { return d != nullptr; }
-  };
-  dir_guard dp(opendir(accel_path.c_str()));
-  if (!dp) {
-    throw std::runtime_error("opendir failed: " + accel_path);
-  }
-
-  std::string accel_node;
-  while (auto entry = readdir(dp.get())) {
-    std::string dirname{entry->d_name};
-    if (dirname.find("accel") == 0) {
-      accel_node = "/dev/accel/" + dirname;
-      break;
-    }
-  }
-
-  if (accel_node.empty()) {
-    throw std::runtime_error("Failed to find accel node under " + accel_path + " for device");
-  }
-
-  int fd = open(accel_node.c_str(), O_RDONLY);
-  if (fd < 0) {
-    throw std::runtime_error("open failed: " + accel_node);
-  }
-  return fd;
-}
-
 std::tuple<uint64_t, uint64_t, uint64_t>
 get_bo_usage(device* dev, int pid)
 {
   // FIXME: reimplement this when query key is defined in xrt
-  int fd = open_accel_fd(dev);
+  const char *xdna = "/dev/accel/accel0";
+  int fd = open(xdna, O_RDONLY);
+  if (fd < 0) {
+    std::perror("open");
+    return {0, 0, 0};
+  }
 
   amdxdna_drm_bo_usage usage = { .pid = pid };
   amdxdna_drm_get_array arg = {
@@ -312,7 +267,8 @@ get_bo_usage(device* dev, int pid)
   int ret = ioctl(fd, DRM_IOCTL_AMDXDNA_GET_ARRAY, &arg);
   close(fd);
   if (ret == -1) {
-    throw std::runtime_error("ioctl(DRM_IOCTL_AMDXDNA_GET_ARRAY) failed");
+    std::perror("ioctl(DRM_IOCTL_AMDXDNA_GET_ARRAY)");
+    return {0, 0, 0};
   }
 
   return {usage.total_usage, usage.internal_usage, usage.heap_usage};
@@ -433,17 +389,13 @@ TEST_create_destroy_virtual_context(device::id_type id, std::shared_ptr<device>&
   int is_negative = static_cast<unsigned int>(arg[0]);
   int num_virt_ctx;
 
-  // XDNA driver by default supports 6 virtual context on npu1, 128 on npu3, and 32 virtual context on npu4
+  // XDNA driver by default supports 6 virtual context on npu1 and 32 virtual context on npu4
   if (device_id == npu1_device_id)
     num_virt_ctx = 6;
-  else if (device_id == npu3_device_id || device_id == npu3_device_id1)
-    num_virt_ctx = 128;
   else
     num_virt_ctx = 32;
 
-  if (is_negative && (device_id == npu3_device_id || device_id == npu3_device_id1))
-    num_virt_ctx = 10000;
-  else if (is_negative)
+  if (is_negative)
     num_virt_ctx += 1;
 
   std::cout << "Creating " << num_virt_ctx << " contexts" << std::endl;
@@ -460,17 +412,7 @@ TEST_multi_context_io_test(device::id_type id, std::shared_ptr<device>& sdev, ar
 {
   auto dev = sdev.get();
   auto device_id = device_query<query::pcie_device>(dev);
-  int num_virt_ctx;
-
-  const std::array<int, 3> ctx = [&]() {
-    if (device_id == npu1_device_id)
-      return std::array<int, 3>{2, 4, 6};
-    if (device_id == npu3_device_id || device_id == npu3_device_id1)
-      return std::array<int, 3>{4, 8, 32};
-    return std::array<int, 3>{4, 8, 16};
-  }();
-
-  num_virt_ctx = ctx[arg[0]];
+  int num_virt_ctx = static_cast<unsigned int>(arg[0]);
 
   multi_thread threads(num_virt_ctx, TEST_io_latency);
   threads.run_test(id, sdev, {IO_TEST_NORMAL_RUN, IO_TEST_IOCTL_WAIT, 3000});
@@ -859,7 +801,7 @@ std::vector<test_case> test_list {
     TEST_POSITIVE, dev_filter_xdna, TEST_create_free_debug_bo, { 0x100000 }
   },
   test_case{ "multi-command io test real kernel good run", {},
-    TEST_POSITIVE, dev_filter_xdna, TEST_io, { IO_TEST_NORMAL_RUN, 3 }
+    TEST_POSITIVE, dev_filter_is_aie2, TEST_io, { IO_TEST_NORMAL_RUN, 3 }
   },
   test_case{ "measure no-op kernel throughput command", {},
     TEST_POSITIVE, dev_filter_is_aie, TEST_io_throughput, { IO_TEST_NOOP_RUN, IO_TEST_IOCTL_WAIT, 32000 }
@@ -910,22 +852,34 @@ std::vector<test_case> test_list {
     TEST_POSITIVE, dev_filter_is_aie2, TEST_elf_io, { IO_TEST_NORMAL_RUN, 3 }
   },
   test_case{ "virtual context test", {~0U, ~0U},
-    TEST_POSITIVE, dev_filter_is_aie, TEST_create_destroy_virtual_context, { 0 }
+    TEST_POSITIVE, dev_filter_is_aie2, TEST_create_destroy_virtual_context, { 0 }
   },
   test_case{ "virtual context bad test", {},
-    TEST_NEGATIVE, dev_filter_is_aie, TEST_create_destroy_virtual_context, { 1 }
+    TEST_NEGATIVE, dev_filter_is_aie2, TEST_create_destroy_virtual_context, { 1 }
   },
-  test_case{ "Multi context IO test 1", {},
-    TEST_POSITIVE, dev_filter_is_aie, TEST_multi_context_io_test, { 0 }
+  test_case{ "Multi context IO test 1 (npu1)", {},
+    TEST_POSITIVE, dev_filter_is_npu1, TEST_multi_context_io_test, { 2 }
   },
-  test_case{ "Multi context IO test 2", {},
-    TEST_POSITIVE, dev_filter_is_aie, TEST_multi_context_io_test, { 1 }
+  test_case{ "Multi context IO test 2 (npu1)", {},
+    TEST_POSITIVE, dev_filter_is_npu1, TEST_multi_context_io_test, { 4 }
   },
-  test_case{ "Multi context IO test 3", {},
-    TEST_POSITIVE, dev_filter_is_aie, TEST_multi_context_io_test, { 2 }
+  test_case{ "Multi context IO test 3 (npu1)", {},
+    TEST_POSITIVE, dev_filter_is_npu1, TEST_multi_context_io_test, { 6 }
+  },
+  test_case{ "Multi context IO test 1 (npu4)", {},
+    TEST_POSITIVE, dev_filter_is_npu4, TEST_multi_context_io_test, { 2 }
+  },
+  test_case{ "Multi context IO test 2 (npu4)", {},
+    TEST_POSITIVE, dev_filter_is_npu4, TEST_multi_context_io_test, { 4 }
+  },
+  test_case{ "Multi context IO test 3 (npu4)", {},
+    TEST_POSITIVE, dev_filter_is_npu4, TEST_multi_context_io_test, { 16 }
+  },
+  test_case{ "Multi context IO test 4 (npu4)", {},
+    TEST_POSITIVE, skip_dev_filter, TEST_multi_context_io_test, { 20 }
   },
   test_case{ "Create and destroy devices", {},
-    TEST_POSITIVE, dev_filter_xdna, TEST_create_destroy_device, {}
+    TEST_POSITIVE, dev_filter_is_aie2, TEST_create_destroy_device, {}
   },
   test_case{ "multi-command preempt ELF io test real kernel good run", {},
     TEST_POSITIVE, dev_filter_is_npu4_and_amdxdna_drv, TEST_preempt_elf_io, { IO_TEST_FORCE_PREEMPTION, 8 }
@@ -1092,28 +1046,37 @@ run_all_test(std::vector<int>& tests)
 }
 
 int
-get_driver_version(unsigned int *major, unsigned int *minor, device::id_type device_index = 0)
+get_driver_version(unsigned int *major, unsigned int *minor)
 {
-  auto sdev = get_userpf_device(device_index);
-  int fd = open_accel_fd(sdev.get());
-
+  const char *xdna = "/dev/accel/accel0";
   drm_version version = {};
   char name[128];
   char date[128];
   char desc[256];
 
+  int fd = open(xdna, O_RDONLY);
+  if (fd < 0) {
+    std::perror("open");
+    return -1;
+  }
+
   version.name_len = sizeof(name);
-  version.name = name;
-  version.date_len = sizeof(date);
-  version.date = date;
-  version.desc_len = sizeof(desc);
-  version.desc = desc;
+    version.name = name;
+
+    version.date_len = sizeof(date);
+    version.date = date;
+
+    version.desc_len = sizeof(desc);
+    version.desc = desc;
 
   int result = ioctl(fd, DRM_IOCTL_VERSION, &version);
-  close(fd);
   if (result) {
-    throw std::runtime_error("ioctl(DRM_IOCTL_VERSION) failed");
+    perror("Failed to get DRM version");
+    close(fd);
+    return -EFAULT;
   }
+
+  close(fd);
 
   *major = version.version_major;
   *minor = version.version_minor;


### PR DESCRIPTION
Problem solved by the commit
Add common smu code for both aie2 and aie4

Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
N/A

How problem was solved, alternative solutions (if any) and why they were rejected
1> Removed duplicates and merged common code.
2> Added extra smu_conf, smu handle, smu_create() in order to make code common for aie2 and aie4.

Risks (if any) associated the changes in the commit
Should be backward compatible

What has been tested and how, request additional testing if necessary
1> Driver installation successful.
2>Ran xrt_test 0 1 2 3 6 7 9 successfully on Medusa board.

Documentation impact (if any)
N/A

