### PR TITLE
amdxdna_mailbox: log error string when mailbox_acquire_msgid() fails

### DIFF
--- a/src/driver/amdxdna/amdxdna_mailbox.c
+++ b/src/driver/amdxdna/amdxdna_mailbox.c
@@ -686,7 +686,7 @@ int xdna_mailbox_send_msg(struct mailbox_channel *mb_chann,
 
 	ret = mailbox_acquire_msgid(mb_chann, mb_msg);
 	if (unlikely(ret < 0)) {
-		MB_ERR(mb_chann, "mailbox_acquire_msgid failed");
+		MB_ERR(mb_chann, "mailbox_acquire_msgid failed, err: %d", ret);
 		goto msg_id_failed;
 	}
 	header->id = ret;


### PR DESCRIPTION
In xdna_mailbox_send_msg(), report the error code if mailbox_acquire_msgid() fails. This enhances log messages for mailbox ID allocation failures, making it easier to diagnose and debug issues when the driver is unable to acquire a message ID.