### PR TITLE
quick fix build in xdna-driver repo for kernel < 6.15

### DIFF
--- a/CMake/native.cmake
+++ b/CMake/native.cmake
@@ -29,7 +29,7 @@ endif()
 include(${CMAKE_CURRENT_SOURCE_DIR}/CMake/pkg.cmake)
 
 add_subdirectory(src)
-#add_subdirectory(drivers)
+add_subdirectory(drivers)
 
 if(NOT SKIP_KMOD)
   add_subdirectory(test)

--- a/drivers/accel/amdxdna/aie2_ctx.c
+++ b/drivers/accel/amdxdna/aie2_ctx.c
@@ -558,6 +558,7 @@ int aie2_hwctx_init(struct amdxdna_hwctx *hwctx)
 {
 	struct amdxdna_client *client = hwctx->client;
 	struct amdxdna_dev *xdna = client->xdna;
+#ifdef HAVE_6_15_drm_sched_init
 	const struct drm_sched_init_args args = {
 		.ops = &sched_ops,
 		.num_rqs = DRM_SCHED_PRIORITY_COUNT,
@@ -566,6 +567,7 @@ int aie2_hwctx_init(struct amdxdna_hwctx *hwctx)
 		.name = "amdxdna_js",
 		.dev = xdna->ddev.dev,
 	};
+#endif
 	struct drm_gpu_scheduler *sched;
 	struct amdxdna_hwctx_priv *priv;
 	struct amdxdna_gem_obj *heap;
@@ -625,8 +627,13 @@ int aie2_hwctx_init(struct amdxdna_hwctx *hwctx)
 	fs_reclaim_acquire(GFP_KERNEL);
 	might_lock(&priv->io_lock);
 	fs_reclaim_release(GFP_KERNEL);
-
+#ifdef HAVE_6_15_drm_sched_init
 	ret = drm_sched_init(sched, &args);
+#else
+	ret = drm_sched_init(sched, &sched_ops, NULL, DRM_SCHED_PRIORITY_COUNT,
+			     HWCTX_MAX_CMDS, 0, HWCTX_MAX_TIMEOUT,
+			     NULL, NULL, "amdxdna_js", xdna->ddev.dev);
+#endif
 	if (ret) {
 		XDNA_ERR(xdna, "Failed to init DRM scheduler. ret %d", ret);
 		goto free_cmd_bufs;

--- a/drivers/accel/amdxdna/amdxdna_gem.c
+++ b/drivers/accel/amdxdna/amdxdna_gem.c
@@ -21,7 +21,11 @@
 #include "amdxdna_pci_drv.h"
 #include "amdxdna_ubuf.h"
 
+#ifdef HAVE_6_13_MODULE_IMPORT_NS
 MODULE_IMPORT_NS("DMA_BUF");
+#else
+MODULE_IMPORT_NS(DMA_BUF);
+#endif
 
 static int
 amdxdna_gem_heap_alloc(struct amdxdna_gem_obj *abo)
@@ -389,6 +393,9 @@ put_obj:
 }
 
 static const struct dma_buf_ops amdxdna_dmabuf_ops = {
+#ifdef HAVE_cache_sgt_mapping
+	.cache_sgt_mapping = true,
+#endif
 	.attach = drm_gem_map_attach,
 	.detach = drm_gem_map_detach,
 	.map_dma_buf = drm_gem_map_dma_buf,

--- a/drivers/accel/amdxdna/amdxdna_ubuf.c
+++ b/drivers/accel/amdxdna/amdxdna_ubuf.c
@@ -128,6 +128,9 @@ static void amdxdna_ubuf_vunmap(struct dma_buf *dbuf, struct iosys_map *map)
 }
 
 static const struct dma_buf_ops amdxdna_ubuf_dmabuf_ops = {
+#ifdef HAVE_cache_sgt_mapping
+	.cache_sgt_mapping = true,
+#endif
 	.map_dma_buf = amdxdna_ubuf_map,
 	.unmap_dma_buf = amdxdna_ubuf_unmap,
 	.release = amdxdna_ubuf_release,


### PR DESCRIPTION
This is to fix xdna-driver repo build under 6.15- kernel.