### PR TITLE
[XRT-SMI] Add --iter option

### DIFF
--- a/src/shim/smi_xdna.cpp
+++ b/src/shim/smi_xdna.cpp
@@ -55,7 +55,7 @@ config_gen_xdna::create_validate_subcommand()
   validate_suboptions.emplace("path", std::make_shared<option>("path", "p", "Path to the directory containing validate xclbins", "hidden", "", "string"));
   validate_suboptions.emplace("param", std::make_shared<option>("param", "", "Extended parameter for a given test. Format: <test-name>:<key>:<value>", "param", "", "string"));
   validate_suboptions.emplace("pmode", std::make_shared<option>("pmode", "", "Specify which power mode to run the benchmarks in. Note: Some tests might be unavailable for some modes", "hidden", "", "string")); 
-  validate_suboptions.emplace("elf", std::make_shared<option>("elf", "", "Run the test in ELF mode", "hidden", "", "none"));
+  validate_suboptions.emplace("iter", std::make_shared<option>("iter", "", "Number of iterations to run the test", "hidden", "", "string"));
 
   return {"validate", "Validates the given device by executing the platform's validate executable", "common", std::move(validate_suboptions)};
 }

--- a/tools/info.json
+++ b/tools/info.json
@@ -1,7 +1,7 @@
 {
 	"copyright": "Copyright (C) 2023-2026 Advanced Micro Devices, Inc. All rights reserved.",
 	"xrt" : {
-		"version": "202610.2.23.160",
+		"version": "202610.2.23.165",
 		"os_rel": ["22.04", "24.04"]
 	},
 	"firmwares": [
@@ -70,17 +70,17 @@
 	"vtd_archives": [
 		{
 			"device": "strx",
-			"url": "https://github.com/Xilinx/VTD/raw/c79b5d21568a4ffa5b0612a8279b352fc4e1109a/archive/strx/xrt_smi_strx.a",
+			"url": "https://github.com/Xilinx/VTD/raw/5f5ad4f7b929428d28fe6808895a09125af011ac/archive/strx/xrt_smi_strx.a",
 			"filename": "xrt_smi_strx.a"
 		},
 		{
 			"device": "phx",
-			"url": "https://github.com/Xilinx/VTD/raw/c79b5d21568a4ffa5b0612a8279b352fc4e1109a/archive/phx/xrt_smi_phx.a",
+			"url": "https://github.com/Xilinx/VTD/raw/5f5ad4f7b929428d28fe6808895a09125af011ac/archive/phx/xrt_smi_phx.a",
 			"filename": "xrt_smi_phx.a"
 		},
 		{
 			"device": "npu3",
-			"url": "https://github.com/Xilinx/VTD/raw/c79b5d21568a4ffa5b0612a8279b352fc4e1109a/archive/npu3/xrt_smi_npu3.a",
+			"url": "https://github.com/Xilinx/VTD/raw/5f5ad4f7b929428d28fe6808895a09125af011ac/archive/npu3/xrt_smi_npu3.a",
 			"filename": "xrt_smi_npu3.a"
 		}
 	]


### PR DESCRIPTION
https://jira.xilinx.com/browse/AIESW-3036
This PR is in conjunction with https://github.com/Xilinx/XRT/pull/9616 to provide --iter option in xrt-smi validate to run tests for multiple iterations.
This PR also removes the redundant option --elf which is not used anymore.