### PR TITLE
accel/amdxdna: implement unlimited dev bo support

### DIFF
--- a/drivers/accel/amdxdna/aie2_ctx.c
+++ b/drivers/accel/amdxdna/aie2_ctx.c
@@ -101,9 +101,76 @@ static void aie2_hwctx_stop(struct amdxdna_dev *xdna, struct amdxdna_hwctx *hwct
 #endif
 }
 
+static void aie2_hwctx_release_heap(struct amdxdna_hwctx *hwctx)
+{
+	struct amdxdna_gem_obj *last = hwctx->priv->last_pinned_chunk;
+	struct amdxdna_client *client = hwctx->client;
+	struct amdxdna_gem_obj *chunk;
+
+	if (!last)
+		return;
+
+	list_for_each_entry(chunk, &client->dev_heap_chunks, heap_chunk_node) {
+		amdxdna_gem_unpin(chunk);
+		drm_gem_object_put(to_gobj(chunk));
+		if (chunk == last)
+			break;
+	}
+	hwctx->priv->last_pinned_chunk = NULL;
+}
+
+static int aie2_hwctx_map_heap(struct amdxdna_hwctx *hwctx)
+{
+	struct amdxdna_client *client = hwctx->client;
+	struct amdxdna_dev *xdna = client->xdna;
+	bool need_pin = !hwctx->priv->last_pinned_chunk;
+	struct amdxdna_gem_obj *chunk;
+	u64 offset = 0;
+	u64 addr;
+	int ret;
+
+	drm_WARN_ON(&xdna->ddev, !mutex_is_locked(&xdna->dev_lock));
+
+	list_for_each_entry(chunk, &client->dev_heap_chunks, heap_chunk_node) {
+		if (need_pin) {
+			ret = amdxdna_gem_pin(chunk);
+			if (ret)
+				goto release;
+			drm_gem_object_get(to_gobj(chunk));
+			hwctx->priv->last_pinned_chunk = chunk;
+		}
+
+		addr = amdxdna_obj_dma_addr(chunk);
+		if (!offset)
+			ret = aie2_map_host_buf(xdna->dev_handle,
+						hwctx->fw_ctx_id,
+						addr, chunk->mem.size);
+		else
+			ret = aie2_add_host_buf(xdna->dev_handle,
+						hwctx->fw_ctx_id,
+						addr, chunk->mem.size);
+		if (ret) {
+			XDNA_ERR(xdna,
+				 "Notify FW hwctx %d chunk offset 0x%llx failed, ret %d",
+				 hwctx->fw_ctx_id, offset, ret);
+			goto release;
+		}
+
+		if (!need_pin && chunk == hwctx->priv->last_pinned_chunk)
+			need_pin = true;
+
+		offset += chunk->mem.size;
+	}
+
+	return 0;
+
+release:
+	aie2_hwctx_release_heap(hwctx);
+	return ret;
+}
+
 static int aie2_hwctx_restart(struct amdxdna_dev *xdna, struct amdxdna_hwctx *hwctx)
 {
-	struct amdxdna_gem_obj *heap = hwctx->priv->heap;
 	int ret;
 
 	ret = aie2_create_context(xdna->dev_handle, hwctx);
@@ -112,9 +179,7 @@ static int aie2_hwctx_restart(struct amdxdna_dev *xdna, struct amdxdna_hwctx *hw
 		goto out;
 	}
 
-	ret = aie2_map_host_buf(xdna->dev_handle, hwctx->fw_ctx_id,
-				amdxdna_obj_dma_addr(heap),
-				heap->mem.size);
+	ret = aie2_hwctx_map_heap(hwctx);
 	if (ret) {
 		XDNA_ERR(xdna, "Map host buf failed, ret %d", ret);
 		goto out;
@@ -690,7 +755,6 @@ int aie2_hwctx_init(struct amdxdna_hwctx *hwctx)
 #endif
 	struct drm_gpu_scheduler *sched;
 	struct amdxdna_hwctx_priv *priv;
-	struct amdxdna_gem_obj *heap;
 	int i, ret;
 
 	priv = kzalloc_obj(*hwctx->priv);
@@ -698,24 +762,7 @@ int aie2_hwctx_init(struct amdxdna_hwctx *hwctx)
 		return -ENOMEM;
 	hwctx->priv = priv;
 
-	mutex_lock(&client->mm_lock);
-	heap = client->dev_heap;
-	if (!heap) {
-		XDNA_ERR(xdna, "The client dev heap object not exist");
-		mutex_unlock(&client->mm_lock);
-		ret = -ENOENT;
-		goto free_priv;
-	}
-	drm_gem_object_get(to_gobj(heap));
-	mutex_unlock(&client->mm_lock);
-	priv->heap = heap;
 	sema_init(&priv->job_sem, HWCTX_MAX_CMDS);
-
-	ret = amdxdna_gem_pin(heap);
-	if (ret) {
-		XDNA_ERR(xdna, "Dev heap pin failed, ret %d", ret);
-		goto put_heap;
-	}
 
 	for (i = 0; i < ARRAY_SIZE(priv->cmd_buf); i++) {
 		struct amdxdna_gem_obj *abo;
@@ -728,6 +775,7 @@ int aie2_hwctx_init(struct amdxdna_hwctx *hwctx)
 
 		abo = amdxdna_drm_create_dev_bo(&xdna->ddev, &args, client->filp);
 		if (IS_ERR(abo)) {
+			XDNA_ERR(xdna, "Create dev bo failed, ret %ld", PTR_ERR(abo));
 			ret = PTR_ERR(abo);
 			goto free_cmd_bufs;
 		}
@@ -789,9 +837,7 @@ int aie2_hwctx_init(struct amdxdna_hwctx *hwctx)
 		goto release_resource;
 	}
 
-	ret = aie2_map_host_buf(xdna->dev_handle, hwctx->fw_ctx_id,
-				amdxdna_obj_dma_addr(heap),
-				heap->mem.size);
+	ret = aie2_hwctx_map_heap(hwctx);
 	if (ret) {
 		XDNA_ERR(xdna, "Map host buffer failed, ret %d", ret);
 		goto release_dpm;
@@ -814,6 +860,7 @@ release_dpm:
 	aie2_pm_release_dpm_level(xdna->dev_handle, hwctx->priv->req_dpm_level);
 release_resource:
 	aie2_release_resource(hwctx);
+	aie2_hwctx_release_heap(hwctx);
 suspend_put:
 	amdxdna_pm_suspend_put(xdna);
 free_col_list:
@@ -828,10 +875,7 @@ free_cmd_bufs:
 			continue;
 		drm_gem_object_put(to_gobj(priv->cmd_buf[i]));
 	}
-	amdxdna_gem_unpin(heap);
-put_heap:
-	drm_gem_object_put(to_gobj(heap));
-free_priv:
+
 	kfree(priv);
 	return ret;
 }
@@ -850,6 +894,8 @@ void aie2_hwctx_fini(struct amdxdna_hwctx *hwctx)
 	drm_sched_stop(&hwctx->priv->sched, NULL);
 	aie2_pm_release_dpm_level(xdna->dev_handle, hwctx->priv->req_dpm_level);
 	aie2_release_resource(hwctx);
+
+	aie2_hwctx_release_heap(hwctx);
 #ifdef HAVE_6_13_drm_sched_start_errno
 	drm_sched_start(&hwctx->priv->sched, 0);
 #elif defined(HAVE_6_10_drm_sched_start_full_recovery)
@@ -872,8 +918,6 @@ void aie2_hwctx_fini(struct amdxdna_hwctx *hwctx)
 
 	for (idx = 0; idx < ARRAY_SIZE(hwctx->priv->cmd_buf); idx++)
 		drm_gem_object_put(to_gobj(hwctx->priv->cmd_buf[idx]));
-	amdxdna_gem_unpin(hwctx->priv->heap);
-	drm_gem_object_put(to_gobj(hwctx->priv->heap));
 
 	mutex_destroy(&hwctx->priv->io_lock);
 	kfree(hwctx->col_list);
@@ -1223,6 +1267,45 @@ up_sem:
 	up(&hwctx->priv->job_sem);
 	job->job_done = true;
 	return ret;
+}
+
+int aie2_hwctx_heap_expand(struct amdxdna_hwctx *hwctx)
+{
+	struct amdxdna_client *client = hwctx->client;
+	struct amdxdna_dev *xdna = client->xdna;
+	struct amdxdna_gem_obj *new_chunk;
+	u64 addr;
+	int ret;
+
+	new_chunk = list_last_entry(&client->dev_heap_chunks,
+				    struct amdxdna_gem_obj,
+				    heap_chunk_node);
+
+	if (hwctx->priv->last_pinned_chunk !=
+	    list_prev_entry(new_chunk, heap_chunk_node))
+		return -EIO;
+
+	ret = amdxdna_gem_pin(new_chunk);
+	if (ret) {
+		XDNA_ERR(xdna, "Pin chunk for hwctx %s failed, ret %d",
+			 hwctx->name, ret);
+		return ret;
+	}
+	drm_gem_object_get(to_gobj(new_chunk));
+
+	addr = amdxdna_obj_dma_addr(new_chunk);
+	ret = aie2_add_host_buf(xdna->dev_handle, hwctx->fw_ctx_id,
+				addr, new_chunk->mem.size);
+	if (ret) {
+		XDNA_ERR(xdna, "Add host buf for hwctx %s failed, ret %d",
+			 hwctx->name, ret);
+		amdxdna_gem_unpin(new_chunk);
+		drm_gem_object_put(to_gobj(new_chunk));
+		return ret;
+	}
+
+	hwctx->priv->last_pinned_chunk = new_chunk;
+	return 0;
 }
 
 void aie2_hmm_invalidate(struct amdxdna_gem_obj *abo,

--- a/drivers/accel/amdxdna/aie2_message.c
+++ b/drivers/accel/amdxdna/aie2_message.c
@@ -336,23 +336,54 @@ int aie2_destroy_context(struct amdxdna_dev_hdl *ndev, struct amdxdna_hwctx *hwc
 	return ret;
 }
 
-int aie2_map_host_buf(struct amdxdna_dev_hdl *ndev, u32 context_id, u64 addr, u64 size)
+static int aie2_send_host_buf_msgs(struct amdxdna_dev_hdl *ndev, u32 context_id,
+				   u64 addr, u64 size, u32 initial_opcode)
 {
 	DECLARE_AIE_MSG(map_host_buffer, MSG_OP_MAP_HOST_BUFFER);
 	struct amdxdna_dev *xdna = ndev->aie.xdna;
+	size_t chunk_size;
 	int ret;
 
-	req.context_id = context_id;
-	req.buf_addr = addr;
-	req.buf_size = size;
-	ret = aie_send_mgmt_msg_wait(&ndev->aie, &msg);
-	if (ret)
-		return ret;
+	chunk_size = xdna->dev_info->dev_mem_size;
+	if (!size || !IS_ALIGNED(size, chunk_size)) {
+		XDNA_ERR(xdna, "Invalid size 0x%llx for chunk 0x%lx",
+			 size, chunk_size);
+		return -EINVAL;
+	}
 
-	XDNA_DBG(xdna, "fw ctx %d map host buf addr 0x%llx size 0x%llx",
-		 context_id, addr, size);
+	msg.opcode = initial_opcode;
+	do {
+		req.context_id = context_id;
+		req.buf_addr = addr;
+		req.buf_size = chunk_size;
+		ret = aie_send_mgmt_msg_wait(&ndev->aie, &msg);
+		if (ret) {
+			XDNA_ERR(xdna, "fw ctx %d addr 0x%llx size 0x%lx",
+				 context_id, addr, chunk_size);
+			return ret;
+		}
+
+		XDNA_DBG(xdna, "fw ctx %d host buf op 0x%x addr 0x%llx size 0x%lx",
+			 context_id, msg.opcode, addr, chunk_size);
+
+		addr += chunk_size;
+		size -= chunk_size;
+		msg.opcode = MSG_OP_ADD_HOST_BUFFER;
+	} while (size);
 
 	return 0;
+}
+
+int aie2_map_host_buf(struct amdxdna_dev_hdl *ndev, u32 context_id, u64 addr, u64 size)
+{
+	return aie2_send_host_buf_msgs(ndev, context_id, addr, size,
+				       MSG_OP_MAP_HOST_BUFFER);
+}
+
+int aie2_add_host_buf(struct amdxdna_dev_hdl *ndev, u32 context_id, u64 addr, u64 size)
+{
+	return aie2_send_host_buf_msgs(ndev, context_id, addr, size,
+				       MSG_OP_ADD_HOST_BUFFER);
 }
 
 static int amdxdna_hwctx_col_map(struct amdxdna_hwctx *hwctx, void *arg)
@@ -1028,7 +1059,6 @@ int aie2_cmdlist_multi_execbuf(struct amdxdna_hwctx *hwctx,
 	if (msg.opcode == MSG_OP_MAX_OPCODE)
 		return -EOPNOTSUPP;
 
-	/* The offset is the accumulated total size of the cmd buffer */
 	EXEC_MSG_OPS(xdna)->init_chain_req(&req, amdxdna_gem_dev_addr(cmdbuf_abo),
 					   offset, ccnt);
 	drm_clflush_virt_range(cmd_buf, offset);
@@ -1088,7 +1118,7 @@ int aie2_cmdlist_single_execbuf(struct amdxdna_hwctx *hwctx,
 			     &req, msg.send_size, false);
 	ret = xdna_mailbox_send_msg(chann, &msg, TX_TIMEOUT);
 	if (ret) {
-		XDNA_ERR(hwctx->client->xdna, "Send message failed");
+		XDNA_ERR(xdna, "Send message failed");
 		return ret;
 	}
 

--- a/drivers/accel/amdxdna/aie2_msg_priv.h
+++ b/drivers/accel/amdxdna/aie2_msg_priv.h
@@ -33,6 +33,7 @@ enum aie2_msg_opcode {
 	MSG_OP_REGISTER_ASYNC_EVENT_MSG    = 0x10C,
 	MSG_OP_UPDATE_PROPERTY             = 0x113,
 	MSG_OP_GET_APP_HEALTH              = 0x114,
+	MSG_OP_ADD_HOST_BUFFER             = 0x115,
 	MSG_OP_GET_DEV_REVISION            = 0x117,
 	MSG_OP_MAX_DRV_OPCODE,
 	MSG_OP_GET_PROTOCOL_VERSION        = 0x301,

--- a/drivers/accel/amdxdna/aie2_pci.c
+++ b/drivers/accel/amdxdna/aie2_pci.c
@@ -1321,4 +1321,5 @@ const struct amdxdna_dev_ops aie2_ops = {
 	.hmm_invalidate = aie2_hmm_invalidate,
 	.get_array = aie2_get_array,
 	.get_dev_revision = aie2_get_dev_rev,
+	.hwctx_heap_expand = aie2_hwctx_heap_expand,
 };

--- a/drivers/accel/amdxdna/aie2_pci.h
+++ b/drivers/accel/amdxdna/aie2_pci.h
@@ -20,8 +20,9 @@
 struct amdxdna_qos_info;
 
 /* Firmware determines device memory base address and size */
-#define AIE2_DEVM_BASE	0x4000000
-#define AIE2_DEVM_SIZE	SZ_64M
+#define AIE2_DEVM_BASE		0x4000000
+#define AIE2_DEVM_SIZE		SZ_64M
+#define AIE2_DEVM_MAX_SIZE	SZ_512M
 
 #define NDEV2PDEV(ndev) (to_pci_dev((ndev)->aie.xdna->ddev.dev))
 
@@ -131,7 +132,6 @@ struct dpm_clk_freq {
 #define HWCTX_MAX_CMDS		4
 #define get_job_idx(seq) ((seq) & (HWCTX_MAX_CMDS - 1))
 struct amdxdna_hwctx_priv {
-	struct amdxdna_gem_obj		*heap;
 	void				*mbox_chann;
 
 	struct drm_gpu_scheduler	sched;
@@ -152,6 +152,8 @@ struct amdxdna_hwctx_priv {
 
 	struct amdxdna_gem_obj		*cmd_buf[HWCTX_MAX_CMDS];
 	struct drm_syncobj		*syncobj;
+
+	struct amdxdna_gem_obj		*last_pinned_chunk;
 };
 
 enum aie2_dev_status {
@@ -241,6 +243,7 @@ enum aie2_fw_feature {
 	AIE2_PREEMPT,
 	AIE2_TEMPORAL_ONLY,
 	AIE2_APP_HEALTH,
+	AIE2_ADD_HOST_BUFFER,
 	AIE2_UPDATE_PROPERTY,
 	AIE2_GET_DEV_REVISION,
 	AIE2_FEATURE_MAX
@@ -317,6 +320,7 @@ int aie2_get_dev_revision(struct amdxdna_dev_hdl *ndev, enum aie2_dev_revision *
 int aie2_create_context(struct amdxdna_dev_hdl *ndev, struct amdxdna_hwctx *hwctx);
 int aie2_destroy_context(struct amdxdna_dev_hdl *ndev, struct amdxdna_hwctx *hwctx);
 int aie2_map_host_buf(struct amdxdna_dev_hdl *ndev, u32 context_id, u64 addr, u64 size);
+int aie2_add_host_buf(struct amdxdna_dev_hdl *ndev, u32 context_id, u64 addr, u64 size);
 int aie2_query_status(struct amdxdna_dev_hdl *ndev, char __user *buf, u32 size, u32 *cols_filled);
 int aie2_query_telemetry(struct amdxdna_dev_hdl *ndev,
 			 char __user *buf, u32 size,
@@ -351,6 +355,7 @@ int aie2_hwctx_sync_debug_bo(struct amdxdna_hwctx *hwctx, u32 debug_bo_hdl);
 void aie2_hwctx_suspend(struct amdxdna_client *client);
 int aie2_hwctx_resume(struct amdxdna_client *client);
 int aie2_cmd_submit(struct amdxdna_hwctx *hwctx, struct amdxdna_sched_job *job, u64 *seq);
+int aie2_hwctx_heap_expand(struct amdxdna_hwctx *hwctx);
 void aie2_hmm_invalidate(struct amdxdna_gem_obj *abo, unsigned long cur_seq);
 
 /* TDR APIs */

--- a/drivers/accel/amdxdna/amdxdna_gem.c
+++ b/drivers/accel/amdxdna/amdxdna_gem.c
@@ -1239,11 +1239,18 @@ static int amdxdna_gem_dev_bo_clflush(struct amdxdna_gem_obj *abo,
 	struct amdxdna_client *client = abo->client;
 	struct amdxdna_dev *xdna = client->xdna;
 	u64 dev_base = xdna->dev_info->dev_mem_base;
-	u64 flush_start = abo->mm_node.start - dev_base + offset;
-	u64 flush_end = flush_start + len;
+	u64 flush_start, flush_end;
 	struct amdxdna_gem_obj *chunk;
 	u64 chunk_start = 0;
 	int ret = 0;
+
+	if (!len)
+		return 0;
+	if (offset > abo->mm_node.size || len > abo->mm_node.size - offset)
+		return -EINVAL;
+
+	flush_start = abo->mm_node.start - dev_base + offset;
+	flush_end = flush_start + len;
 
 	mutex_lock(&client->mm_lock);
 	list_for_each_entry(chunk, &client->dev_heap_chunks, heap_chunk_node) {

--- a/drivers/accel/amdxdna/amdxdna_gem.c
+++ b/drivers/accel/amdxdna/amdxdna_gem.c
@@ -641,8 +641,7 @@ static void amdxdna_gem_obj_free(struct drm_gem_object *gobj)
 	/*
 	 * DEV_HEAP chunks are always removed from client->dev_heap_chunks
 	 * by amdxdna_client_cleanup() before this free callback runs.
-	 * DRM core calls drm_gem_release() before postclose, so abo->client
-	 * is already NULL here. No list removal needed.
+	 * No list removal needed.
 	 */
 	if (abo->type == AMDXDNA_BO_DEV_HEAP &&
 	    drm_mm_initialized(&abo->mm))
@@ -694,8 +693,16 @@ static void amdxdna_gem_obj_close(struct drm_gem_object *gobj, struct drm_file *
 
 	if (abo->open_ref == 0) {
 		amdxdna_gem_del_bo_usage(abo);
-		/* Detach from the client when last closed by it. */
-		abo->client = NULL;
+		/*
+		 * DEV_HEAP BOs are kept on client->dev_heap_chunks and
+		 * accessed by the driver (e.g. TDR restart) after .close
+		 * but before .postclose tears down hwctxs. Keep abo->client
+		 * valid to avoid a NULL-pointer dereference in that window.
+		 * DEV_HEAP BOs cannot outlive the client, so no dangling
+		 * pointer risk.
+		 */
+		if (abo->type != AMDXDNA_BO_DEV_HEAP)
+			abo->client = NULL;
 	}
 }
 

--- a/drivers/accel/amdxdna/amdxdna_gem.c
+++ b/drivers/accel/amdxdna/amdxdna_gem.c
@@ -20,6 +20,7 @@
 #include "amdxdna_ctx.h"
 #include "amdxdna_gem.h"
 #include "amdxdna_pci_drv.h"
+#include "amdxdna_pm.h"
 #include "amdxdna_ubuf.h"
 
 #ifdef HAVE_6_13_MODULE_IMPORT_NS
@@ -52,19 +53,35 @@ amdxdna_gem_heap_alloc(struct amdxdna_gem_obj *abo)
 		goto unlock_out;
 	}
 
-	if (mem->size == 0 || mem->size > heap->mem.size) {
-		XDNA_ERR(xdna, "Invalid dev bo size 0x%lx, limit 0x%lx",
-			 mem->size, heap->mem.size);
+	if (!mem->size || mem->size > xdna->dev_info->dev_heap_max_size) {
+		XDNA_ERR(xdna, "Invalid dev bo size 0x%lx, max heap 0x%lx",
+			 mem->size, xdna->dev_info->dev_heap_max_size);
 		ret = -EINVAL;
 		goto unlock_out;
 	}
-
 	align = 1 << max(PAGE_SHIFT, xdna->dev_info->dev_mem_buf_shift);
-	ret = drm_mm_insert_node_generic(&heap->mm, &abo->mm_node,
-					 mem->size, align,
-					 0, DRM_MM_INSERT_BEST);
+	ret = drm_mm_insert_node_in_range(&heap->mm, &abo->mm_node,
+					  mem->size, align, 0,
+					  xdna->dev_info->dev_mem_base,
+					  xdna->dev_info->dev_mem_base +
+					  client->total_heap_size,
+					  DRM_MM_INSERT_BEST);
 	if (ret) {
-		XDNA_ERR(xdna, "Failed to alloc dev bo memory, ret %d", ret);
+		if (client->total_heap_size < xdna->dev_info->dev_heap_max_size) {
+			/*
+			 * Heap can still grow. Return -EAGAIN so userspace
+			 * shim expands the heap and retries the allocation.
+			 * Use XDNA_INFO intentionally — heap expansion is
+			 * infrequent and worth logging for diagnostics.
+			 */
+			XDNA_INFO(xdna, "No space in committed heap 0x%lx for bo 0x%lx",
+				  client->total_heap_size, mem->size);
+			ret = -EAGAIN;
+		} else {
+			XDNA_ERR(xdna, "Failed to alloc dev bo 0x%lx, heap at max 0x%lx",
+				 mem->size, client->total_heap_size);
+			ret = -ENOSPC;
+		}
 		goto unlock_out;
 	}
 
@@ -113,6 +130,7 @@ amdxdna_gem_create_obj(struct drm_device *dev, size_t size)
 	abo->open_ref = 0;
 	abo->internal = false;
 	INIT_LIST_HEAD(&abo->mem.umap_list);
+	INIT_LIST_HEAD(&abo->heap_chunk_node);
 
 	return abo;
 }
@@ -166,6 +184,32 @@ static void amdxdna_gem_vunmap(struct amdxdna_gem_obj *abo)
 }
 
 /*
+ * Compute the expected UVA for a DEV_HEAP chunk.  The shim reserves a
+ * contiguous VA range for the entire heap, so once the first chunk is
+ * mmapped every subsequent chunk's UVA is deterministic:
+ *   base_uva + sum-of-preceding-chunk-sizes.
+ * Returns AMDXDNA_INVALID_ADDR if the base UVA is not yet known.
+ */
+static u64 amdxdna_dev_heap_uva(struct amdxdna_gem_obj *abo)
+{
+	struct amdxdna_gem_obj *heap = abo->client->dev_heap;
+	struct amdxdna_gem_obj *chunk;
+	u64 offset = 0;
+
+	if (heap->mem.uva == AMDXDNA_INVALID_ADDR)
+		return AMDXDNA_INVALID_ADDR;
+
+	list_for_each_entry(chunk, &abo->client->dev_heap_chunks,
+			    heap_chunk_node) {
+		if (chunk == abo)
+			return heap->mem.uva + offset;
+		offset += chunk->mem.size;
+	}
+
+	return AMDXDNA_INVALID_ADDR;
+}
+
+/*
  * Obtain the user virtual address for accessing the BO.
  * It can be used for device to access the BO when PASID is enabled.
  */
@@ -179,6 +223,10 @@ u64 amdxdna_gem_uva(struct amdxdna_gem_obj *abo)
 			return amdxdna_gem_uva(heap) + off;
 		return AMDXDNA_INVALID_ADDR;
 	}
+
+	if (abo->type == AMDXDNA_BO_DEV_HEAP &&
+	    abo->mem.uva == AMDXDNA_INVALID_ADDR && abo->client)
+		return amdxdna_dev_heap_uva(abo);
 
 	return abo->mem.uva;
 }
@@ -335,6 +383,22 @@ static int amdxdna_hmm_register(struct amdxdna_gem_obj *abo,
 	if (is_import_bo(abo) && vma->vm_file && vma->vm_file->f_mapping)
 		mapping_set_unevictable(vma->vm_file->f_mapping);
 
+	if (abo->type == AMDXDNA_BO_DEV_HEAP && abo->client) {
+		u64 expected;
+
+		mutex_lock(&abo->client->mm_lock);
+		expected = amdxdna_dev_heap_uva(abo);
+		mutex_unlock(&abo->client->mm_lock);
+
+		if (expected != AMDXDNA_INVALID_ADDR &&
+		    expected != addr) {
+			XDNA_ERR(xdna, "Dev heap mmap addr 0x%lx != expected 0x%llx",
+				 addr, expected);
+			ret = -EINVAL;
+			goto unreg_notifier;
+		}
+	}
+
 	down_write(&xdna->notifier_lock);
 	if (list_empty(&abo->mem.umap_list))
 		abo->mem.uva = addr;
@@ -343,6 +407,8 @@ static int amdxdna_hmm_register(struct amdxdna_gem_obj *abo,
 
 	return 0;
 
+unreg_notifier:
+	mmu_interval_notifier_remove(&mapp->notifier);
 free_pfns:
 	kvfree(mapp->range.hmm_pfns);
 free_map:
@@ -572,7 +638,14 @@ static void amdxdna_gem_obj_free(struct drm_gem_object *gobj)
 	if (abo->pinned)
 		amdxdna_gem_unpin(abo);
 
-	if (abo->type == AMDXDNA_BO_DEV_HEAP)
+	/*
+	 * DEV_HEAP chunks are always removed from client->dev_heap_chunks
+	 * by amdxdna_client_cleanup() before this free callback runs.
+	 * DRM core calls drm_gem_release() before postclose, so abo->client
+	 * is already NULL here. No list removal needed.
+	 */
+	if (abo->type == AMDXDNA_BO_DEV_HEAP &&
+	    drm_mm_initialized(&abo->mm))
 		drm_mm_takedown(&abo->mm);
 
 	if (amdxdna_iova_on(xdna))
@@ -659,16 +732,48 @@ static void amdxdna_gem_obj_vunmap(struct drm_gem_object *obj, struct iosys_map 
 		drm_gem_shmem_object_vunmap(obj, map);
 }
 
+/*
+ * Map a DEV BO for CPU access using the containing chunk's kva.
+ * The chunk is lazily vmapped on first access via amdxdna_gem_vmap().
+ * The BO must fit entirely within a single chunk.
+ */
 static int amdxdna_gem_dev_obj_vmap(struct drm_gem_object *obj, struct iosys_map *map)
 {
 	struct amdxdna_gem_obj *abo = to_xdna_obj(obj);
-	void *base = amdxdna_gem_vmap(abo->client->dev_heap);
-	u64 offset = amdxdna_dev_bo_offset(abo);
+	struct amdxdna_client *client = abo->client;
+	u64 dev_base = client->xdna->dev_info->dev_mem_base;
+	u64 bo_start = abo->mm_node.start - dev_base;
+	u64 bo_end = bo_start + abo->mm_node.size;
+	struct amdxdna_gem_obj *chunk;
+	u64 chunk_start = 0;
 
-	if (!base)
-		return -ENOMEM;
-	iosys_map_set_vaddr(map, base + offset);
-	return 0;
+	mutex_lock(&client->mm_lock);
+	list_for_each_entry(chunk, &client->dev_heap_chunks, heap_chunk_node) {
+		u64 chunk_end = chunk_start + chunk->mem.size;
+
+		if (bo_start >= chunk_start && bo_end <= chunk_end) {
+			u64 offset = bo_start - chunk_start;
+			void *kva = chunk->mem.kva;
+
+			if (!kva) {
+				kva = amdxdna_gem_vmap(chunk);
+				if (!kva) {
+					mutex_unlock(&client->mm_lock);
+					return -ENOMEM;
+				}
+			}
+			mutex_unlock(&client->mm_lock);
+			iosys_map_set_vaddr(map, kva + offset);
+			return 0;
+		}
+		chunk_start = chunk_end;
+	}
+	mutex_unlock(&client->mm_lock);
+
+	drm_WARN(&client->xdna->ddev, 1,
+		 "DEV BO [0x%llx, 0x%llx) not contained in a single heap chunk",
+		 bo_start, bo_end);
+	return -EINVAL;
 }
 
 static const struct drm_gem_object_funcs amdxdna_gem_dev_obj_funcs = {
@@ -863,40 +968,84 @@ amdxdna_drm_create_dev_heap_bo(struct drm_device *dev,
 	struct amdxdna_client *client = filp->driver_priv;
 	struct amdxdna_dev *xdna = to_xdna_dev(dev);
 	struct amdxdna_gem_obj *abo;
+	struct amdxdna_hwctx *hwctx;
+	unsigned long hwctx_id;
 	int ret;
 
 	WARN_ON(!is_power_of_2(xdna->dev_info->dev_mem_size));
 	XDNA_DBG(xdna, "Requested dev heap size 0x%llx", args->size);
 	if (!args->size || !IS_ALIGNED(args->size, xdna->dev_info->dev_mem_size)) {
-		XDNA_ERR(xdna, "The dev heap size 0x%llx is not multiple of 0x%lx",
+		XDNA_ERR(xdna, "Invalid dev heap chunk size 0x%llx, alignment 0x%lx",
 			 args->size, xdna->dev_info->dev_mem_size);
 		return ERR_PTR(-EINVAL);
 	}
 
-	/* HEAP BO is a special case of SHARE BO. */
 	abo = amdxdna_drm_create_share_bo(dev, args, filp);
 	if (IS_ERR(abo))
 		return ERR_CAST(abo);
 
-	/* Set up heap for this client. */
+	/* Create handle early so abo->client is set before expansion. */
+	ret = drm_gem_handle_create(filp, to_gobj(abo), &args->handle);
+	if (ret) {
+		XDNA_ERR(xdna, "Create handle failed");
+		drm_gem_object_put(to_gobj(abo));
+		return ERR_PTR(ret);
+	}
+
+	/*
+	 * Hold dev_lock across add + notify so that hwctx_init (map_heap)
+	 * and heap_expand never both run for the same chunk.
+	 */
+	guard(mutex)(&xdna->dev_lock);
+
+	ret = amdxdna_pm_resume_get_locked(xdna);
+	if (ret) {
+		XDNA_ERR(xdna, "PM resume failed, cannot notify FW, ret %d",
+			 ret);
+		goto del_handle;
+	}
+
 	mutex_lock(&client->mm_lock);
 
-	if (client->dev_heap) {
-		XDNA_DBG(client->xdna, "dev heap is already created");
-		ret = -EBUSY;
-		goto mm_unlock;
+	if (client->total_heap_size + abo->mem.size >
+	    xdna->dev_info->dev_heap_max_size) {
+		XDNA_ERR(xdna, "Heap size 0x%lx + 0x%lx exceeds max 0x%lx",
+			 client->total_heap_size, abo->mem.size,
+			 xdna->dev_info->dev_heap_max_size);
+		mutex_unlock(&client->mm_lock);
+		ret = -ENOSPC;
+		goto suspend_put;
 	}
-	client->dev_heap = abo;
-	drm_gem_object_get(to_gobj(abo));
 
-	drm_mm_init(&abo->mm, xdna->dev_info->dev_mem_base, abo->mem.size);
+	if (!client->dev_heap) {
+		client->dev_heap = abo;
+		drm_mm_init(&abo->mm, xdna->dev_info->dev_mem_base,
+			    xdna->dev_info->dev_heap_max_size);
+	}
+	list_add_tail(&abo->heap_chunk_node, &client->dev_heap_chunks);
+	client->total_heap_size += abo->mem.size;
 
 	mutex_unlock(&client->mm_lock);
+
+	if (xdna->dev_info->ops->hwctx_heap_expand) {
+		amdxdna_for_each_hwctx(client, hwctx_id, hwctx) {
+			ret = xdna->dev_info->ops->hwctx_heap_expand(hwctx);
+			if (ret)
+				XDNA_ERR(xdna, "hwctx %s heap expand failed, ret %d",
+					 hwctx->name, ret);
+		}
+	}
+	amdxdna_pm_suspend_put(xdna);
+
+	XDNA_DBG(xdna, "Dev heap chunk hdl %d created, size 0x%lx",
+		 args->handle, abo->mem.size);
 
 	return abo;
 
-mm_unlock:
-	mutex_unlock(&client->mm_lock);
+suspend_put:
+	amdxdna_pm_suspend_put(xdna);
+del_handle:
+	drm_gem_handle_delete(filp, args->handle);
 	drm_gem_object_put(to_gobj(abo));
 	return ERR_PTR(ret);
 }
@@ -932,7 +1081,8 @@ amdxdna_drm_create_dev_bo(struct drm_device *dev,
 
 	ret = amdxdna_gem_heap_alloc(abo);
 	if (ret) {
-		XDNA_ERR(xdna, "Failed to alloc dev bo memory, ret %d", ret);
+		if (ret != -EAGAIN)
+			XDNA_ERR(xdna, "Failed to alloc dev bo memory, ret %d", ret);
 		amdxdna_gem_destroy_obj(abo);
 		return ERR_PTR(ret);
 	}
@@ -970,6 +1120,9 @@ int amdxdna_drm_create_bo_ioctl(struct drm_device *dev, void *data, struct drm_f
 	if (IS_ERR(abo))
 		return PTR_ERR(abo);
 
+	if (args->type == AMDXDNA_BO_DEV_HEAP)
+		return 0; /* Handle already created, creation ref is chunk list ref */
+
 	/* Ready to publish object to userspace and count for BO usage. */
 	ret = drm_gem_handle_create(filp, to_gobj(abo), &args->handle);
 	if (ret) {
@@ -992,7 +1145,7 @@ int amdxdna_gem_pin_nolock(struct amdxdna_gem_obj *abo)
 	int ret;
 
 	if (abo->type == AMDXDNA_BO_DEV)
-		abo = abo->client->dev_heap;
+		return 0; /* Heap chunks are pinned at expansion time */
 
 	if (is_import_bo(abo))
 		return 0;
@@ -1017,7 +1170,7 @@ int amdxdna_gem_pin(struct amdxdna_gem_obj *abo)
 void amdxdna_gem_unpin(struct amdxdna_gem_obj *abo)
 {
 	if (abo->type == AMDXDNA_BO_DEV)
-		abo = abo->client->dev_heap;
+		return; /* Heap chunks are unpinned at client cleanup */
 
 	if (is_import_bo(abo))
 		return;
@@ -1080,6 +1233,46 @@ int amdxdna_drm_get_bo_info_ioctl(struct drm_device *dev, void *data, struct drm
 	return ret;
 }
 
+static int amdxdna_gem_dev_bo_clflush(struct amdxdna_gem_obj *abo,
+				      u64 offset, size_t len)
+{
+	struct amdxdna_client *client = abo->client;
+	struct amdxdna_dev *xdna = client->xdna;
+	u64 dev_base = xdna->dev_info->dev_mem_base;
+	u64 flush_start = abo->mm_node.start - dev_base + offset;
+	u64 flush_end = flush_start + len;
+	struct amdxdna_gem_obj *chunk;
+	u64 chunk_start = 0;
+	int ret = 0;
+
+	mutex_lock(&client->mm_lock);
+	list_for_each_entry(chunk, &client->dev_heap_chunks, heap_chunk_node) {
+		u64 chunk_end = chunk_start + chunk->mem.size;
+
+		if (chunk_start >= flush_end)
+			break;
+
+		if (chunk_end > flush_start) {
+			u64 ov_start = max(flush_start, chunk_start);
+			u64 ov_end = min(flush_end, chunk_end);
+
+			if (!chunk->mem.kva)
+				amdxdna_gem_vmap(chunk);
+			if (!chunk->mem.kva) {
+				XDNA_WARN(xdna, "Can not vmap chunk for flush");
+				ret = -ENOMEM;
+				break;
+			}
+			drm_clflush_virt_range(chunk->mem.kva + ov_start - chunk_start,
+					       ov_end - ov_start);
+		}
+		chunk_start = chunk_end;
+	}
+	mutex_unlock(&client->mm_lock);
+
+	return ret;
+}
+
 /*
  * The sync bo ioctl is to make sure the CPU cache is in sync with memory.
  * This is required because NPU is not cache coherent device. CPU cache
@@ -1109,7 +1302,9 @@ int amdxdna_drm_sync_bo_ioctl(struct drm_device *dev,
 		goto put_obj;
 	}
 
-	if (is_import_bo(abo))
+	if (abo->type == AMDXDNA_BO_DEV)
+		ret = amdxdna_gem_dev_bo_clflush(abo, args->offset, args->size);
+	else if (is_import_bo(abo))
 		drm_clflush_sg(abo->base.sgt);
 	else if (amdxdna_gem_vmap(abo))
 		drm_clflush_virt_range(amdxdna_gem_vmap(abo) + args->offset, args->size);

--- a/drivers/accel/amdxdna/amdxdna_gem.h
+++ b/drivers/accel/amdxdna/amdxdna_gem.h
@@ -46,7 +46,8 @@ struct amdxdna_gem_obj {
 	int				open_ref;
 
 	/* Below members are initialized when needed */
-	struct drm_mm			mm; /* For AMDXDNA_BO_DEV_HEAP */
+	struct drm_mm			mm; /* For first AMDXDNA_BO_DEV_HEAP */
+	struct list_head		heap_chunk_node; /* Link in client chunk list */
 	struct drm_mm_node		mm_node; /* For AMDXDNA_BO_DEV */
 	u32				assigned_hwctx;
 	struct dma_buf			*dma_buf;
@@ -93,7 +94,8 @@ struct drm_gem_object *
 amdxdna_gem_prime_import(struct drm_device *dev, struct dma_buf *dma_buf);
 struct amdxdna_gem_obj *
 amdxdna_drm_create_dev_bo(struct drm_device *dev,
-			  struct amdxdna_drm_create_bo *args, struct drm_file *filp);
+			  struct amdxdna_drm_create_bo *args,
+			  struct drm_file *filp);
 
 int amdxdna_gem_pin_nolock(struct amdxdna_gem_obj *abo);
 int amdxdna_gem_pin(struct amdxdna_gem_obj *abo);

--- a/drivers/accel/amdxdna/amdxdna_pci_drv.c
+++ b/drivers/accel/amdxdna/amdxdna_pci_drv.c
@@ -125,6 +125,7 @@ static int amdxdna_drm_open(struct drm_device *ddev, struct drm_file *filp)
 	init_srcu_struct(&client->hwctx_srcu);
 	xa_init_flags(&client->hwctx_xa, XA_FLAGS_ALLOC);
 	mutex_init(&client->mm_lock);
+	INIT_LIST_HEAD(&client->dev_heap_chunks);
 
 	mutex_lock(&xdna->dev_lock);
 	list_add_tail(&client->node, &xdna->client_list);
@@ -144,8 +145,14 @@ static void amdxdna_client_cleanup(struct amdxdna_client *client)
 	xa_destroy(&client->hwctx_xa);
 	cleanup_srcu_struct(&client->hwctx_srcu);
 
-	if (client->dev_heap)
-		drm_gem_object_put(to_gobj(client->dev_heap));
+	while (!list_empty(&client->dev_heap_chunks)) {
+		struct amdxdna_gem_obj *chunk;
+
+		chunk = list_last_entry(&client->dev_heap_chunks,
+					struct amdxdna_gem_obj, heap_chunk_node);
+		list_del_init(&chunk->heap_chunk_node);
+		drm_gem_object_put(to_gobj(chunk)); /* drop creation ref */
+	}
 
 	mutex_destroy(&client->mm_lock);
 	mmdrop(client->mm);

--- a/drivers/accel/amdxdna/amdxdna_pci_drv.h
+++ b/drivers/accel/amdxdna/amdxdna_pci_drv.h
@@ -67,6 +67,7 @@ struct amdxdna_dev_ops {
 	int (*set_aie_state)(struct amdxdna_client *client, struct amdxdna_drm_set_state *args);
 	int (*get_array)(struct amdxdna_client *client, struct amdxdna_drm_get_array *args);
 	int (*get_dev_revision)(struct amdxdna_dev *xdna, u32 *rev);
+	int (*hwctx_heap_expand)(struct amdxdna_hwctx *hwctx);
 };
 
 struct amdxdna_fw_feature_tbl {
@@ -93,6 +94,7 @@ struct amdxdna_dev_info {
 	size_t				dev_mem_size;
 	const char			*default_vbnv;
 	const struct amdxdna_rev_vbnv	*rev_vbnv_tbl;
+	size_t				dev_heap_max_size;
 	const struct amdxdna_dev_priv	*dev_priv;
 	const struct amdxdna_fw_feature_tbl *fw_feature_tbl;
 	const struct amdxdna_dev_ops	*ops;
@@ -148,6 +150,8 @@ struct amdxdna_client {
 
 	struct mutex			mm_lock; /* protect memory related */
 	struct amdxdna_gem_obj		*dev_heap;
+	struct list_head		dev_heap_chunks;
+	size_t				total_heap_size;
 
 	struct iommu_sva		*sva;
 	int				pasid;

--- a/drivers/accel/amdxdna/npu1_regs.c
+++ b/drivers/accel/amdxdna/npu1_regs.c
@@ -139,6 +139,7 @@ const struct amdxdna_dev_info dev_npu1_info = {
 	.dev_mem_base      = AIE2_DEVM_BASE,
 	.dev_mem_size      = AIE2_DEVM_SIZE,
 	.default_vbnv      = "RyzenAI-npu1",
+	.dev_heap_max_size = AIE2_DEVM_SIZE,
 	.device_type       = AMDXDNA_DEV_TYPE_KMQ,
 	.dev_priv          = &npu1_dev_priv,
 	.fw_feature_tbl    = npu1_fw_feature_table,

--- a/drivers/accel/amdxdna/npu4_regs.c
+++ b/drivers/accel/amdxdna/npu4_regs.c
@@ -98,6 +98,7 @@ const struct amdxdna_fw_feature_tbl npu4_fw_feature_table[] = {
 	{ .features = BIT_U64(AIE2_NPU_COMMAND), .major = 6, .min_minor = 15 },
 	{ .features = BIT_U64(AIE2_UPDATE_PROPERTY), .major = 6, .min_minor = 15 },
 	{ .features = BIT_U64(AIE2_APP_HEALTH), .major = 6, .min_minor = 18 },
+	{ .features = BIT_U64(AIE2_ADD_HOST_BUFFER), .major = 6, .min_minor = 18 },
 	{ .features = BIT_U64(AIE2_GET_DEV_REVISION), .major = 6, .min_minor = 24 },
 	{ .features = AIE2_ALL_FEATURES, .major = 7 },
 	{ 0 }
@@ -204,6 +205,7 @@ const struct amdxdna_dev_info dev_npu4_info = {
 	.dev_mem_base      = AIE2_DEVM_BASE,
 	.dev_mem_size      = AIE2_DEVM_SIZE,
 	.default_vbnv      = "RyzenAI-npu4",
+	.dev_heap_max_size = AIE2_DEVM_MAX_SIZE,
 	.device_type       = AMDXDNA_DEV_TYPE_KMQ,
 	.rev_vbnv_tbl      = npu4_rev_vbnv_tbl,
 	.dev_priv          = &npu4_dev_priv,

--- a/drivers/accel/amdxdna/npu5_regs.c
+++ b/drivers/accel/amdxdna/npu5_regs.c
@@ -107,6 +107,7 @@ const struct amdxdna_dev_info dev_npu5_info = {
 	.dev_mem_base      = AIE2_DEVM_BASE,
 	.dev_mem_size      = AIE2_DEVM_SIZE,
 	.default_vbnv      = "RyzenAI-npu5",
+	.dev_heap_max_size = AIE2_DEVM_MAX_SIZE,
 	.device_type       = AMDXDNA_DEV_TYPE_KMQ,
 	.rev_vbnv_tbl      = npu4_rev_vbnv_tbl,
 	.dev_priv          = &npu5_dev_priv,

--- a/drivers/accel/amdxdna/npu6_regs.c
+++ b/drivers/accel/amdxdna/npu6_regs.c
@@ -108,6 +108,7 @@ const struct amdxdna_dev_info dev_npu6_info = {
 	.dev_mem_base      = AIE2_DEVM_BASE,
 	.dev_mem_size      = AIE2_DEVM_SIZE,
 	.default_vbnv      = "RyzenAI-npu6",
+	.dev_heap_max_size = AIE2_DEVM_MAX_SIZE,
 	.device_type       = AMDXDNA_DEV_TYPE_KMQ,
 	.rev_vbnv_tbl      = npu4_rev_vbnv_tbl,
 	.dev_priv          = &npu6_dev_priv,


### PR DESCRIPTION
implement unlimited dev bo support.
AIE2 executes instructions on a buffer which is internal to XRT. Due to TLB requirement from NPU firmware, each chunk of the memory has 64MB limitation. If we want to have more than 64MB npu heap buffer, we need to have multiple chunks.

Today the staging driver in `drivers/accel/amdxdna` only supports single chunk. this patch set enable multiple chunks support.
In the beginning, when the shim opens drm client, it will allocate first 64MB chunk of heap memory. At runtime, if heap buffer allocation fails, userspace shim layer will request to expand the heap, every expansion will add one 64MB chunk until it meets the requirement or hit the max heap size, and then try to allocate the buffer from heap again.
also see PR: https://github.com/amd/xdna-driver/pull/1234

Test with baremetal Linux with/without `force_iova=` module parameter, and with QEMU KVM guest.

example output from QEMU KVM:
```
installed_testcases/xrt_unlimited_bo/xrt_unlimited_bo
-------------------------------------------------------
    [#37] : runlist
-------------------------------------------------------
        Going to start the runlist #5
                Sync bos to device
                Sync bos to device
                Sync ofm from device
                Validating ofm  passed
                Sync ofm from device
                Validating ofm  passed
-------------------------------------------------------
    [#38] : runlist
-------------------------------------------------------
        Going to start the runlist #6
                Sync bos to device
                Sync bos to device
                Sync bos to device
                Sync ofm from device
                Validating ofm  passed
                Sync ofm from device
                Validating ofm  passed
                Sync ofm from device
                Validating ofm  passed
INFO: TEST PASSED
                                       .--.
                _______             .-"  .'
        .---u"""       """"---._  ."    %
      .'                        "--.    %
 __.--'  o                          "".. "
(____.                                  ":
 `----.__                                 ".
         `----------__                     ".
               ".   . ""--.                 ".
                 ". ". bIt ""-.              ".
                   "-.)        ""-.           ".
                                   "".         ".
                                      "".       ".
                                         "".      ".
                                            "".    ".
                      ^~^~^~^~^~^~^~^~^~^~^~^~^"".  "^~^~^~^~^
                                            ^~^~^~^  ~^~
                                                 ^~^~^~


=== PASSED: configs/runlist_bo_on_another_bank.ini ===

===============================
Results: 15 passed, 0 failed out of 15 total
===================s
```