### PR TITLE
Fix drm_sched_start compat macro name mismatch

### DIFF
--- a/drivers/accel/tools/configure_kernel.sh
+++ b/drivers/accel/tools/configure_kernel.sh
@@ -370,7 +370,7 @@ EOF
 
 # Test drm_sched_start() with bool full_recovery parameter (pre-6.12):
 # void drm_sched_start(struct drm_gpu_scheduler *sched, bool full_recovery);
-try_compile HAVE_drm_6_10_sched_start_full_recovery << 'EOF'
+try_compile HAVE_6_10_drm_sched_start_full_recovery << 'EOF'
 #include <drm/gpu_scheduler.h>
 typedef void (*expected_t)(struct drm_gpu_scheduler *, _Bool);
 _Static_assert(__builtin_types_compatible_p(typeof(&drm_sched_start), expected_t),


### PR DESCRIPTION
The try_compile macro name HAVE_drm_6_10_sched_start_full_recovery does not match the HAVE_6_10_drm_sched_start_full_recovery used in aie2_ctx.c and aie2_tdr.c, causing the preprocessor to fall through to the no-argument drm_sched_start() call on kernels 6.10-6.12.