### PR TITLE
accel/amdxdna: fix checkpatch multiple blank lines warnings

### DIFF
--- a/drivers/accel/amdxdna/aie2_solver.h
+++ b/drivers/accel/amdxdna/aie2_solver.h
@@ -10,7 +10,6 @@
 
 #define DEFAULT_SYS_EFF_FACTOR	2
 
-
 /*
  * Structure used to describe a partition. A partition is column based
  * allocation unit described by its start column and number of columns.

--- a/drivers/accel/amdxdna/amdxdna_ctx.c
+++ b/drivers/accel/amdxdna/amdxdna_ctx.c
@@ -514,7 +514,6 @@ int amdxdna_cmd_submit(struct amdxdna_client *client,
 		goto unlock_srcu;
 	}
 
-
 	job->hwctx = hwctx;
 	job->mm = current->mm;
 


### PR DESCRIPTION
Remove extra blank lines flagged by checkpatch --strict:
- aie2_solver.h: double blank line after DEFAULT_SYS_EFF_FACTOR define
- amdxdna_ctx.c: double blank line in amdxdna_cmd_submit()