### PR TITLE
accel/amdxdna: Expose NPU device busy time via DRM fdinfo

### DIFF
--- a/drivers/accel/amdxdna/aie.c
+++ b/drivers/accel/amdxdna/aie.c
@@ -119,3 +119,42 @@ void amdxdna_vbnv_init(struct amdxdna_dev *xdna)
 	if (!xdna->vbnv)
 		xdna->vbnv = info->default_vbnv;
 }
+
+void amdxdna_io_stats_job_start(struct amdxdna_client *client)
+{
+	int depth;
+
+	guard(spinlock)(&client->io_stats.lock);
+
+	depth = client->io_stats.job_depth++;
+	if (!depth)
+		client->io_stats.start_time = ktime_get_ns();
+}
+
+void amdxdna_io_stats_job_done(struct amdxdna_client *client)
+{
+	u64 busy_ns;
+	int depth;
+
+	guard(spinlock)(&client->io_stats.lock);
+
+	depth = --client->io_stats.job_depth;
+	if (!depth) {
+		busy_ns = ktime_get_ns() - client->io_stats.start_time;
+		client->io_stats.start_time = 0;
+		client->io_stats.busy_time += busy_ns;
+	}
+}
+
+u64 amdxdna_io_stats_busy_time_ns(struct amdxdna_client *client)
+{
+	u64 busy_ns;
+
+	guard(spinlock)(&client->io_stats.lock);
+
+	busy_ns = client->io_stats.busy_time;
+	if (client->io_stats.job_depth)
+		busy_ns += ktime_get_ns() - client->io_stats.start_time;
+
+	return busy_ns;
+}

--- a/drivers/accel/amdxdna/aie.h
+++ b/drivers/accel/amdxdna/aie.h
@@ -108,4 +108,8 @@ void aie_smu_fini(struct smu_device *smu);
 int aie_smu_set_clocks(struct smu_device *smu, u32 *npuclk, u32 *hclk);
 int aie_smu_set_dpm(struct smu_device *smu, u32 dpm_level);
 
+void amdxdna_io_stats_job_start(struct amdxdna_client *client);
+void amdxdna_io_stats_job_done(struct amdxdna_client *client);
+u64 amdxdna_io_stats_busy_time_ns(struct amdxdna_client *client);
+
 #endif /* _AIE_H_ */

--- a/drivers/accel/amdxdna/aie2_ctx.c
+++ b/drivers/accel/amdxdna/aie2_ctx.c
@@ -345,6 +345,7 @@ aie2_sched_resp_handler(void *handle, void __iomem *data, size_t size)
 	int ret = 0;
 	u32 status;
 
+	amdxdna_io_stats_job_done(job->hwctx->client);
 	cmd_abo = job->cmd_bo;
 
 	if (unlikely(job->job_timeout)) {
@@ -403,6 +404,7 @@ aie2_sched_cmdlist_resp_handler(void *handle, void __iomem *data, size_t size)
 	u32 cmd_status;
 	int ret = 0;
 
+	amdxdna_io_stats_job_done(job->hwctx->client);
 	cmd_abo = job->cmd_bo;
 
 	if (unlikely(job->job_timeout)) {
@@ -498,6 +500,7 @@ out:
 		fence = ERR_PTR(ret);
 	} else {
 		aie2_tdr_signal(hwctx->client->xdna);
+		amdxdna_io_stats_job_start(job->hwctx->client);
 	}
 	trace_xdna_job(sched_job, hwctx->name, "sent to device",
 		       job->seq, job->drv_cmd ? job->drv_cmd->opcode : DEFAULT_IO);

--- a/drivers/accel/amdxdna/amdxdna_pci_drv.c
+++ b/drivers/accel/amdxdna/amdxdna_pci_drv.c
@@ -14,6 +14,7 @@
 #include <linux/iommu.h>
 #include <linux/pci.h>
 
+#include "aie.h"
 #include "amdxdna_cbuf.h"
 #include "amdxdna_ctx.h"
 #include "amdxdna_gem.h"
@@ -134,6 +135,8 @@ static int amdxdna_drm_open(struct drm_device *ddev, struct drm_file *filp)
 	filp->driver_priv = client;
 	client->filp = filp;
 
+	spin_lock_init(&client->io_stats.lock);
+
 	XDNA_DBG(xdna, "pid %d opened", client->pid);
 	return 0;
 }
@@ -252,6 +255,9 @@ static void amdxdna_show_fdinfo(struct drm_printer *p, struct drm_file *filp)
 	struct amdxdna_client *client = filp->driver_priv;
 	size_t heap_usage, external_usage, internal_usage;
 	char *drv_name = filp->minor->dev->driver->name;
+
+	drm_printf(p, "drm-engine-%s:\t%llu ns\n",
+		   drv_name, amdxdna_io_stats_busy_time_ns(client));
 
 	mutex_lock(&client->mm_lock);
 

--- a/drivers/accel/amdxdna/amdxdna_pci_drv.h
+++ b/drivers/accel/amdxdna/amdxdna_pci_drv.h
@@ -135,6 +135,13 @@ struct amdxdna_device_id {
 	const struct amdxdna_dev_info *dev_info;
 };
 
+struct amdxdna_io_stats {
+	spinlock_t			lock; /* protect io stats */
+	int				job_depth;
+	u64				start_time;
+	u64				busy_time;
+};
+
 /*
  * struct amdxdna_client - amdxdna client
  * A per fd data structure for managing context and other user process stuffs.
@@ -160,6 +167,8 @@ struct amdxdna_client {
 	size_t				heap_usage;
 	size_t				total_bo_usage;
 	size_t				total_int_bo_usage;
+
+	struct amdxdna_io_stats		io_stats;
 };
 
 #define amdxdna_for_each_hwctx(client, hwctx_id, entry)		\

--- a/test/shim_test/io_test.cpp
+++ b/test/shim_test/io_test.cpp
@@ -10,12 +10,16 @@
 
 #include "core/common/device.h"
 #include <fstream>
+#include <sstream>
 #include <string>
 #include <regex>
 #include <chrono>
+#include <cstdint>
 #include <thread>
+#include <dirent.h>
 #include <unistd.h>
 #include <sys/ioctl.h>
+#include <sys/types.h>
 
 // FIXME
 #include "../../src/include/uapi/drm_local/amdxdna_accel.h"
@@ -123,7 +127,7 @@ void io_test_cmd_wait(hwqueue_handle *hwq, std::shared_ptr<bo> bo)
     }
 }
 
-static void
+void
 reset_cmd_headers_before_submit(
   std::vector<std::unique_ptr<io_test_bo_set_base>>& bo_set,
   size_t list_idx, int cmds_per_list, ert_start_kernel_cmd* cmd_pkt)
@@ -278,6 +282,46 @@ get_fine_preemption_counter_delta(device *dev, hw_ctx& ctx, std::vector<std::pai
   return fine_preemption_count - pre.at(index).second;
 }
 
+uint64_t
+get_npu_busy_time_ns()
+{
+  std::ostringstream dir_path;
+  dir_path << "/proc/" << getpid() << "/fdinfo";
+
+  DIR *dir = ::opendir(dir_path.str().c_str());
+  if (!dir)
+    throw std::runtime_error("Failed to open fdinfo directory!");
+
+  struct dirent *de;
+  static const std::regex re(R"(drm-engine-[^:]+:\s*([0-9]+)\s+ns)");
+
+  while ((de = ::readdir(dir)) != nullptr) {
+    if (de->d_name[0] == '.')
+      continue;
+
+    std::ostringstream fdinfo_path;
+    fdinfo_path << dir_path.str() << "/" << de->d_name;
+
+    std::ifstream ifs(fdinfo_path.str());
+    if (!ifs)
+      continue;
+
+    std::string line;
+    std::smatch match;
+    while (std::getline(ifs, line)) {
+      if (std::regex_search(line, match, re)) {
+        ::closedir(dir);
+        return std::stoull(match[1].str());
+      }
+    }
+  }
+
+  ::closedir(dir);
+  // TODO: Throw when aie4 also support the same io stat
+  //throw std::runtime_error("Failed to find drm-engine entry!");
+  return 0;
+}
+
 void
 io_test(device::id_type id, device* dev, int total_hwq_submit, int num_cmdlist,
   int cmds_per_list, const char *tag, const flow_type* flow = nullptr)
@@ -333,12 +377,14 @@ io_test(device::id_type id, device* dev, int total_hwq_submit, int num_cmdlist,
   }
 
   // Submit commands and wait for results
+  auto start_busy = get_npu_busy_time_ns();
   auto start = clk::now();
   if (io_test_parameters.perf == IO_TEST_THRUPUT_PERF)
     io_test_cmd_submit_and_wait_thruput(hwq, total_hwq_submit, cmdlist_bos, bo_set, cmds_per_list);
   else
     io_test_cmd_submit_and_wait_latency(hwq, total_hwq_submit, cmdlist_bos, bo_set, cmds_per_list);
   auto end = clk::now();
+  auto end_busy = get_npu_busy_time_ns();
 
   // Verify preemption counters
   if (preemption_enabled) {
@@ -366,12 +412,15 @@ io_test(device::id_type id, device* dev, int total_hwq_submit, int num_cmdlist,
   // Report the performance numbers
   if (io_test_parameters.perf != IO_TEST_NO_PERF) {
     auto duration_us = std::chrono::duration_cast<us_t>(end - start).count();
+    auto busy_us = (end_busy - start_busy) / 1000;
     auto cps = (total_hwq_submit * cmds_per_list * 1000000.0) / duration_us;
     auto latency_us = 1000000.0 / cps;
     std::cout << total_hwq_submit * cmds_per_list << " commands finished in "
               << duration_us << " us, " << cmds_per_list << " commands per list, "
               << cps << " Command/sec,"
-              << " Average latency " << latency_us << " us" << std::endl;
+              << " Average latency " << latency_us << " us,"
+              << " Device was " << busy_us * 100.0 / duration_us << "% busy"
+              << std::endl;
   }
 }
 


### PR DESCRIPTION
- No-op latency I/O device busy time is ~82%
- No-op latency runlist with 24 sub-cmds I/O device busy time is ~93%
- No-op throughput I/O device busy time is ~99.9%