### PR TITLE
Refactor 27516b2 add per-context DPM level reference counting

### DIFF
--- a/drivers/accel/amdxdna/aie2_ctx.c
+++ b/drivers/accel/amdxdna/aie2_ctx.c
@@ -647,22 +647,24 @@ static int aie2_alloc_resource(struct amdxdna_hwctx *hwctx)
 {
 	struct amdxdna_dev *xdna = hwctx->client->xdna;
 	struct alloc_requests *xrs_req;
+	u32 temporal_only_col = 0;
 	int ret;
-
-	if (AIE_FEATURE_ON(&xdna->dev_handle->aie, AIE2_TEMPORAL_ONLY)) {
-		hwctx->num_unused_col = xdna->dev_handle->total_col - hwctx->num_col;
-		hwctx->num_col = xdna->dev_handle->total_col;
-		return aie2_create_context(xdna->dev_handle, hwctx);
-	}
 
 	xrs_req = kzalloc_obj(*xrs_req);
 	if (!xrs_req)
 		return -ENOMEM;
 
-	xrs_req->cdo.start_cols = hwctx->col_list;
-	xrs_req->cdo.cols_len = hwctx->col_list_len;
-	xrs_req->cdo.ncols = hwctx->num_col;
-	xrs_req->cdo.qos_cap.opc = hwctx->max_opc;
+	if (AIE_FEATURE_ON(&xdna->dev_handle->aie, AIE2_TEMPORAL_ONLY)) {
+		xrs_req->cdo.start_cols = &temporal_only_col;
+		xrs_req->cdo.cols_len = 1;
+		xrs_req->cdo.ncols = xdna->dev_handle->total_col;
+	} else {
+		xrs_req->cdo.start_cols = hwctx->col_list;
+		xrs_req->cdo.cols_len = hwctx->col_list_len;
+		xrs_req->cdo.ncols = hwctx->num_col;
+	}
+	/* Use platform opc */
+	xrs_req->cdo.qos_cap.opc = xdna->dev_handle->priv->col_opc * hwctx->num_col;
 
 	xrs_req->rqos.gops = hwctx->qos.gops;
 	xrs_req->rqos.fps = hwctx->qos.fps;
@@ -686,15 +688,9 @@ static void aie2_release_resource(struct amdxdna_hwctx *hwctx)
 	struct amdxdna_dev *xdna = hwctx->client->xdna;
 	int ret;
 
-	if (AIE_FEATURE_ON(&xdna->dev_handle->aie, AIE2_TEMPORAL_ONLY)) {
-		ret = aie2_destroy_context(xdna->dev_handle, hwctx);
-		if (ret && ret != -ENODEV)
-			XDNA_ERR(xdna, "Destroy temporal only context failed, ret %d", ret);
-	} else {
-		ret = xrs_release_resource(xdna->xrs_hdl, (uintptr_t)hwctx);
-		if (ret)
-			XDNA_ERR(xdna, "Release AIE resource failed, ret %d", ret);
-	}
+	ret = xrs_release_resource(xdna->xrs_hdl, (uintptr_t)hwctx);
+	if (ret)
+		XDNA_ERR(xdna, "Release AIE resource failed, ret %d", ret);
 }
 
 static int aie2_ctx_syncobj_create(struct amdxdna_hwctx *hwctx)
@@ -815,7 +811,6 @@ int aie2_hwctx_init(struct amdxdna_hwctx *hwctx)
 		XDNA_ERR(xdna, "Create col list failed, ret %d", ret);
 		goto free_entity;
 	}
-	hwctx->max_opc = xdna->dev_handle->priv->col_opc * hwctx->num_col;
 
 	ret = amdxdna_pm_resume_get_locked(xdna);
 	if (ret)
@@ -827,26 +822,16 @@ int aie2_hwctx_init(struct amdxdna_hwctx *hwctx)
 		goto suspend_put;
 	}
 
-	hwctx->priv->req_dpm_level = aie2_pm_calc_dpm_level(xdna->dev_handle,
-							    hwctx->max_opc,
-							    &hwctx->qos);
-	ret = aie2_pm_request_dpm_level(xdna->dev_handle, hwctx->priv->req_dpm_level);
-	if (ret) {
-		XDNA_ERR(xdna, "Request DPM level %d failed, ret %d",
-			 hwctx->priv->req_dpm_level, ret);
-		goto release_resource;
-	}
-
 	ret = aie2_hwctx_map_heap(hwctx);
 	if (ret) {
 		XDNA_ERR(xdna, "Map host buffer failed, ret %d", ret);
-		goto release_dpm;
+		goto release_resource;
 	}
 
 	ret = aie2_ctx_syncobj_create(hwctx);
 	if (ret) {
 		XDNA_ERR(xdna, "Create syncobj failed, ret %d", ret);
-		goto release_dpm;
+		goto release_resource;
 	}
 	amdxdna_pm_suspend_put(xdna);
 
@@ -856,8 +841,6 @@ int aie2_hwctx_init(struct amdxdna_hwctx *hwctx)
 
 	return 0;
 
-release_dpm:
-	aie2_pm_release_dpm_level(xdna->dev_handle, hwctx->priv->req_dpm_level);
 release_resource:
 	aie2_release_resource(hwctx);
 	aie2_hwctx_release_heap(hwctx);
@@ -892,7 +875,6 @@ void aie2_hwctx_fini(struct amdxdna_hwctx *hwctx)
 
 	/* Request fw to destroy hwctx and cancel the rest pending requests */
 	drm_sched_stop(&hwctx->priv->sched, NULL);
-	aie2_pm_release_dpm_level(xdna->dev_handle, hwctx->priv->req_dpm_level);
 	aie2_release_resource(hwctx);
 
 	aie2_hwctx_release_heap(hwctx);

--- a/drivers/accel/amdxdna/aie2_pci.c
+++ b/drivers/accel/amdxdna/aie2_pci.c
@@ -247,6 +247,7 @@ static int aie2_xrs_load(void *cb_arg, struct xrs_action_load *action)
 	xdna = hwctx->client->xdna;
 
 	hwctx->start_col = action->part.start_col;
+	hwctx->num_unused_col = action->part.ncols - hwctx->num_col;
 	hwctx->num_col = action->part.ncols;
 	ret = aie2_create_context(xdna->dev_handle, hwctx);
 	if (ret)
@@ -402,7 +403,7 @@ static int aie2_hw_start(struct amdxdna_dev *xdna)
 		goto stop_fw;
 	}
 
-	ret = aie2_pm_init(ndev);
+	ret = aie2_pm_start(ndev);
 	if (ret) {
 		XDNA_ERR(xdna, "failed to init pm, ret %d", ret);
 		goto stop_fw;
@@ -460,12 +461,6 @@ static int aie2_hw_resume(struct amdxdna_dev *xdna)
 	ret = aie2_hw_start(xdna);
 	if (ret) {
 		XDNA_ERR(xdna, "Start hardware failed, %d", ret);
-		return ret;
-	}
-
-	ret = aie2_pm_resume(xdna->dev_handle);
-	if (ret) {
-		XDNA_ERR(xdna, "Restore PM state failed, %d", ret);
 		return ret;
 	}
 
@@ -594,18 +589,6 @@ static int aie2_init(struct amdxdna_dev *xdna)
 	}
 	xdna->dev_handle = ndev;
 
-	while (ndev->priv->dpm_clk_tbl[ndev->max_dpm_level].hclk)
-		ndev->max_dpm_level++;
-
-	if (ndev->max_dpm_level > DPM_MAX_LEVELS) {
-		XDNA_ERR(xdna, "DPM levels %d exceeds max %d",
-			 ndev->max_dpm_level, DPM_MAX_LEVELS);
-		ret = -EINVAL;
-		goto release_fw;
-	}
-
-	ndev->max_dpm_level--;
-
 	ret = aie2_hw_start(xdna);
 	if (ret) {
 		XDNA_ERR(xdna, "start npu failed, ret %d", ret);
@@ -615,7 +598,7 @@ static int aie2_init(struct amdxdna_dev *xdna)
 	xrs_cfg.clk_list.num_levels = ndev->max_dpm_level + 1;
 	for (i = 0; i < xrs_cfg.clk_list.num_levels; i++)
 		xrs_cfg.clk_list.cu_clk_list[i] = ndev->priv->dpm_clk_tbl[i].hclk;
-	xrs_cfg.sys_eff_factor = DEFAULT_SYS_EFF_FACTOR;
+	xrs_cfg.sys_eff_factor = 2;
 	xrs_cfg.ddev = &xdna->ddev;
 	xrs_cfg.actions = &aie2_xrs_actions;
 	xrs_cfg.total_col = ndev->total_col;

--- a/drivers/accel/amdxdna/aie2_pci.h
+++ b/drivers/accel/amdxdna/aie2_pci.h
@@ -17,8 +17,6 @@
 #include "aie2_msg_priv.h"
 #include "amdxdna_mailbox.h"
 
-struct amdxdna_qos_info;
-
 /* Firmware determines device memory base address and size */
 #define AIE2_DEVM_BASE		0x4000000
 #define AIE2_DEVM_SIZE		SZ_64M
@@ -147,9 +145,6 @@ struct amdxdna_hwctx_priv {
 	/* Completed job counter */
 	u64				completed;
 
-	/* DPM level computed for this context */
-	u32				req_dpm_level;
-
 	struct amdxdna_gem_obj		*cmd_buf[HWCTX_MAX_CMDS];
 	struct drm_syncobj		*syncobj;
 
@@ -204,8 +199,6 @@ struct amdxdna_dev_hdl {
 	u32				dpm_level;
 	u32				dft_dpm_level;
 	u32				max_dpm_level;
-#define DPM_MAX_LEVELS			8
-	u32				dpm_refcnt[DPM_MAX_LEVELS];
 	u32				clk_gating;
 	u32				npuclk_freq;
 	u32				hclk_freq;
@@ -286,14 +279,9 @@ extern const struct amdxdna_rev_vbnv npu4_rev_vbnv_tbl[];
 extern const struct aie2_hw_ops npu4_hw_ops;
 
 /* aie2_pm.c */
-int aie2_pm_init(struct amdxdna_dev_hdl *ndev);
-int aie2_pm_resume(struct amdxdna_dev_hdl *ndev);
+int aie2_pm_start(struct amdxdna_dev_hdl *ndev);
 int aie2_pm_set_mode(struct amdxdna_dev_hdl *ndev, enum amdxdna_power_mode_type target);
 int aie2_pm_set_dpm(struct amdxdna_dev_hdl *ndev, u32 dpm_level);
-int aie2_pm_update_dpm_ref(struct amdxdna_dev_hdl *ndev, u32 level, bool add);
-#define aie2_pm_request_dpm_level(ndev, level)	aie2_pm_update_dpm_ref(ndev, level, true)
-#define aie2_pm_release_dpm_level(ndev, level)	aie2_pm_update_dpm_ref(ndev, level, false)
-u32 aie2_pm_calc_dpm_level(struct amdxdna_dev_hdl *ndev, u32 opc, struct amdxdna_qos_info *qos);
 
 /* aie2_error.c */
 int aie2_error_async_events_alloc(struct amdxdna_dev_hdl *ndev);

--- a/drivers/accel/amdxdna/aie2_pm.c
+++ b/drivers/accel/amdxdna/aie2_pm.c
@@ -9,7 +9,6 @@
 #include <drm/gpu_scheduler.h>
 
 #include "aie2_pci.h"
-#include "aie2_solver.h"
 #include "amdxdna_pci_drv.h"
 #include "amdxdna_pm.h"
 
@@ -44,68 +43,26 @@ int aie2_pm_set_dpm(struct amdxdna_dev_hdl *ndev, u32 dpm_level)
 	return ret;
 }
 
-int aie2_pm_update_dpm_ref(struct amdxdna_dev_hdl *ndev, u32 level, bool add)
-{
-	struct amdxdna_dev *xdna = ndev->aie.xdna;
-	int i, ret;
-
-	drm_WARN_ON(&xdna->ddev, !mutex_is_locked(&xdna->dev_lock));
-
-	if (level > ndev->max_dpm_level)
-		return -EINVAL;
-
-	if (add) {
-		ndev->dpm_refcnt[level]++;
-	} else {
-		if (!ndev->dpm_refcnt[level])
-			return -EINVAL;
-		ndev->dpm_refcnt[level]--;
-	}
-
-	/* Find highest DPM level in use */
-	ndev->dft_dpm_level = 0;
-	for (i = ndev->max_dpm_level; i >= 0; i--) {
-		if (ndev->dpm_refcnt[i]) {
-			ndev->dft_dpm_level = i;
-			break;
-		}
-	}
-
-	if (ndev->pw_mode != POWER_MODE_DEFAULT || ndev->dft_dpm_level == ndev->dpm_level)
-		return 0;
-
-	ret = ndev->priv->hw_ops->set_dpm(ndev, ndev->dft_dpm_level);
-	if (ret) {
-		if (add)
-			ndev->dpm_refcnt[level]--;
-		return ret;
-	}
-
-	ndev->dpm_level = ndev->dft_dpm_level;
-
-	return 0;
-}
-
-u32 aie2_pm_calc_dpm_level(struct amdxdna_dev_hdl *ndev, u32 opc, struct amdxdna_qos_info *qos)
-{
-	struct aie_qos rqos = { .gops = qos->gops, .fps = qos->fps, .latency = qos->latency };
-	u32 req_gops, level;
-
-	req_gops = xrs_get_gops(&rqos);
-	if (!req_gops)
-		return ndev->max_dpm_level;
-
-	for (level = 0; level <= ndev->max_dpm_level; level++) {
-		if (req_gops <= opc * ndev->priv->dpm_clk_tbl[level].hclk / 1000)
-			return level;
-	}
-
-	return ndev->max_dpm_level;
-}
-
-int aie2_pm_init(struct amdxdna_dev_hdl *ndev)
+int aie2_pm_start(struct amdxdna_dev_hdl *ndev)
 {
 	int ret;
+
+	if (ndev->dev_status != AIE2_DEV_UNINIT) {
+		/* Resume device */
+		ret = ndev->priv->hw_ops->set_dpm(ndev, ndev->dpm_level);
+		if (ret)
+			return ret;
+
+		ret = aie2_pm_set_clk_gating(ndev, ndev->clk_gating);
+		if (ret)
+			return ret;
+
+		return 0;
+	}
+
+	while (ndev->priv->dpm_clk_tbl[ndev->max_dpm_level].hclk)
+		ndev->max_dpm_level++;
+	ndev->max_dpm_level--;
 
 	ret = ndev->priv->hw_ops->set_dpm(ndev, ndev->max_dpm_level);
 	if (ret)
@@ -118,21 +75,6 @@ int aie2_pm_init(struct amdxdna_dev_hdl *ndev)
 
 	ndev->pw_mode = POWER_MODE_DEFAULT;
 	ndev->dft_dpm_level = 0;
-
-	return 0;
-}
-
-int aie2_pm_resume(struct amdxdna_dev_hdl *ndev)
-{
-	int ret;
-
-	ret = ndev->priv->hw_ops->set_dpm(ndev, ndev->dpm_level);
-	if (ret)
-		return ret;
-
-	ret = aie2_pm_set_clk_gating(ndev, ndev->clk_gating);
-	if (ret)
-		return ret;
 
 	return 0;
 }

--- a/drivers/accel/amdxdna/aie2_solver.c
+++ b/drivers/accel/amdxdna/aie2_solver.c
@@ -109,14 +109,6 @@ static bool is_valid_qos_dpm_params(struct aie_qos *rqos)
 	return false;
 }
 
-u32 xrs_get_gops(struct aie_qos *rqos)
-{
-	if (!is_valid_qos_dpm_params(rqos))
-		return 0;
-
-	return calculate_gops(rqos) * DEFAULT_SYS_EFF_FACTOR;
-}
-
 static int set_dpm_level(struct solver_state *xrs, struct alloc_requests *req, u32 *dpm_level)
 {
 	struct solver_rgroup *rgp = &xrs->rgp;
@@ -356,6 +348,7 @@ int xrs_release_resource(void *hdl, u64 rid)
 {
 	struct solver_state *xrs = hdl;
 	struct solver_node *node;
+	u32 level = 0;
 
 	node = rg_search_node(&xrs->rgp, rid);
 	if (!node) {
@@ -365,6 +358,13 @@ int xrs_release_resource(void *hdl, u64 rid)
 
 	xrs->cfg.actions->unload(node->cb_arg);
 	remove_solver_node(&xrs->rgp, node);
+
+	/* set the dpm level which fits all the sessions */
+	list_for_each_entry(node, &xrs->rgp.node_list, list) {
+		if (node->dpm_level > level)
+			level = node->dpm_level;
+	}
+	xrs->cfg.actions->set_dft_dpm_level(xrs->cfg.ddev, level);
 
 	return 0;
 }

--- a/drivers/accel/amdxdna/aie2_solver.h
+++ b/drivers/accel/amdxdna/aie2_solver.h
@@ -6,9 +6,7 @@
 #ifndef _AIE2_SOLVER_H
 #define _AIE2_SOLVER_H
 
-#define XRS_MAX_COL		128
-
-#define DEFAULT_SYS_EFF_FACTOR	2
+#define XRS_MAX_COL 128
 
 /*
  * Structure used to describe a partition. A partition is column based
@@ -127,9 +125,6 @@ struct init_config {
  * Note: We should only create one handle per AIE array to be managed.
  */
 void *xrsm_init(struct init_config *cfg);
-
-/* QoS helper functions shared with power management */
-u32 xrs_get_gops(struct aie_qos *rqos);
 
 /*
  * xrs_allocate_resource() - Request to allocate resources for a given context


### PR DESCRIPTION
The default dpm logic is supported in solver. Remove the duplicate implementation and use solver.