### PR TITLE
amdxdna: add debugfs tdr_control for manual NPU dump/recover

### DIFF
--- a/src/driver/amdxdna/aie2_debugfs.c
+++ b/src/driver/amdxdna/aie2_debugfs.c
@@ -550,7 +550,7 @@ static int aie2_tdr_control_show(struct seq_file *m, void *unused)
 	seq_printf(m, "status         %s (%u)\n", aie2_tdr_status_name(status), status);
 	seq_printf(m, "progress       %u\n", progress);
 	seq_printf(m, "timeout_sec    %u\n", timeout_in_sec);
-	seq_printf(m, "dump_only      %u\n", tdr_dump_ctx);
+	seq_printf(m, "dump_only      %d\n", tdr_dump_ctx);
 	seq_puts(m, "actions        dump recover\n");
 
 	return 0;

--- a/src/driver/amdxdna/aie2_debugfs.c
+++ b/src/driver/amdxdna/aie2_debugfs.c
@@ -541,11 +541,14 @@ static int aie2_tdr_control_show(struct seq_file *m, void *unused)
 	struct amdxdna_dev_hdl *ndev = m->private;
 	struct aie2_tdr *tdr = &ndev->tdr;
 	u32 status = READ_ONCE(tdr->status);
+	int started = READ_ONCE(tdr->started);
+	int counter = READ_ONCE(tdr->counter);
+	u32 progress = READ_ONCE(tdr->progress);
 
-	seq_printf(m, "started        %d\n", tdr->started);
-	seq_printf(m, "counter        %d\n", tdr->counter);
+	seq_printf(m, "started        %d\n", started);
+	seq_printf(m, "counter        %d\n", counter);
 	seq_printf(m, "status         %s (%u)\n", aie2_tdr_status_name(status), status);
-	seq_printf(m, "progress       %u\n", tdr->progress);
+	seq_printf(m, "progress       %u\n", progress);
 	seq_printf(m, "timeout_sec    %u\n", timeout_in_sec);
 	seq_printf(m, "dump_only      %u\n", tdr_dump_ctx);
 	seq_puts(m, "actions        dump recover\n");

--- a/src/driver/amdxdna/aie2_debugfs.c
+++ b/src/driver/amdxdna/aie2_debugfs.c
@@ -524,6 +524,69 @@ static int aie2_ctx_rq_show(struct seq_file *m, void *unused)
 
 AIE2_DBGFS_FOPS(ctx_rq, aie2_ctx_rq_show, NULL);
 
+static const char *aie2_tdr_status_name(u32 status)
+{
+	switch (status) {
+	case AIE2_TDR_WAIT:
+		return "wait";
+	case AIE2_TDR_SIGNALED:
+		return "signaled";
+	default:
+		return "unknown";
+	}
+}
+
+static int aie2_tdr_control_show(struct seq_file *m, void *unused)
+{
+	struct amdxdna_dev_hdl *ndev = m->private;
+	struct aie2_tdr *tdr = &ndev->tdr;
+	u32 status = READ_ONCE(tdr->status);
+
+	seq_printf(m, "started        %d\n", tdr->started);
+	seq_printf(m, "counter        %d\n", tdr->counter);
+	seq_printf(m, "status         %s (%u)\n", aie2_tdr_status_name(status), status);
+	seq_printf(m, "progress       %u\n", tdr->progress);
+	seq_printf(m, "timeout_sec    %u\n", timeout_in_sec);
+	seq_printf(m, "dump_only      %u\n", tdr_dump_ctx);
+	seq_puts(m, "actions        dump recover\n");
+
+	return 0;
+}
+
+static ssize_t aie2_tdr_control_write(struct file *file, const char __user *ptr,
+				      size_t len, loff_t *off)
+{
+	struct amdxdna_dev_hdl *ndev = file_to_ndev_rw(file);
+	struct amdxdna_dev *xdna = ndev->xdna;
+	char input[SIZE + 1];
+
+	if (len > SIZE) {
+		XDNA_ERR(xdna, "Length %zu of the buffer exceeds size %d", len, SIZE);
+		return -EINVAL;
+	}
+
+	if (copy_from_user(input, ptr, len))
+		return -EFAULT;
+	input[len] = '\0';
+
+	if (sysfs_streq(input, "dump")) {
+		XDNA_WARN(xdna, "Manual TDR context dump requested via debugfs");
+		aie2_tdr_force_recover(xdna, true);
+		return len;
+	}
+
+	if (sysfs_streq(input, "recover")) {
+		XDNA_WARN(xdna, "Manual TDR recovery requested via debugfs");
+		aie2_tdr_force_recover(xdna, false);
+		return len;
+	}
+
+	XDNA_ERR(xdna, "Invalid TDR action: %s", input);
+	return -EINVAL;
+}
+
+AIE2_DBGFS_FOPS(tdr_control, aie2_tdr_control_show, aie2_tdr_control_write);
+
 static int aie2_get_app_health_show(struct seq_file *m, void *unused)
 {
 	struct amdxdna_dev_hdl *ndev = m->private;
@@ -721,6 +784,7 @@ const struct {
 	AIE2_DBGFS_FILE(telemetry_profiling, 0400),
 	AIE2_DBGFS_FILE(telemetry_debug, 0400),
 	AIE2_DBGFS_FILE(ctx_rq, 0400),
+	AIE2_DBGFS_FILE(tdr_control, 0600),
 	AIE2_DBGFS_FILE(get_app_health, 0400),
 	AIE2_DBGFS_FILE(dump_fw_log, 0600),
 	AIE2_DBGFS_FILE(dump_fw_log_buffer, 0400),

--- a/src/driver/amdxdna/aie2_tdr.c
+++ b/src/driver/amdxdna/aie2_tdr.c
@@ -53,7 +53,7 @@ static void aie2_tdr_work(struct work_struct *work)
 
 	if (aie2_tdr_detect(tdr)) {
 		XDNA_WARN(tdr_to_xdna(tdr),
-			  "Device isn't making progress... Count %d timeout %u dump_only %u",
+			  "Device isn't making progress... Count %d timeout %u dump_only %d",
 			  ++tdr->counter, timeout_in_sec, tdr_dump_ctx);
 		aie2_tdr_force_recover(tdr_to_xdna(tdr), tdr_dump_ctx);
 	}

--- a/src/driver/amdxdna/aie2_tdr.c
+++ b/src/driver/amdxdna/aie2_tdr.c
@@ -35,9 +35,8 @@ static bool aie2_tdr_detect(struct aie2_tdr *tdr)
 	return aie2_rq_is_all_context_stuck(rq);
 }
 
-static void aie2_tdr_recover(struct aie2_tdr *tdr, bool dump_only)
+void aie2_tdr_force_recover(struct amdxdna_dev *xdna, bool dump_only)
 {
-	struct amdxdna_dev *xdna = tdr_to_xdna(tdr);
 	struct aie2_ctx_rq *rq = &xdna->dev_handle->ctx_rq;
 
 	guard(mutex)(&xdna->dev_lock);
@@ -54,8 +53,9 @@ static void aie2_tdr_work(struct work_struct *work)
 
 	if (aie2_tdr_detect(tdr)) {
 		XDNA_WARN(tdr_to_xdna(tdr),
-			  "Device isn't making progress... Count %d", ++tdr->counter);
-		aie2_tdr_recover(tdr, tdr_dump_ctx);
+			  "Device isn't making progress... Count %d timeout %u dump_only %u",
+			  ++tdr->counter, timeout_in_sec, tdr_dump_ctx);
+		aie2_tdr_force_recover(tdr_to_xdna(tdr), tdr_dump_ctx);
 	}
 }
 

--- a/src/driver/amdxdna/aie2_tdr.h
+++ b/src/driver/amdxdna/aie2_tdr.h
@@ -10,6 +10,8 @@
 #include <linux/timer.h>
 #include <linux/workqueue.h>
 
+struct amdxdna_dev;
+
 struct aie2_tdr {
 	struct timer_list	timer;
 	struct work_struct	work;
@@ -20,5 +22,8 @@ struct aie2_tdr {
 };
 
 extern uint timeout_in_sec;
+extern bool tdr_dump_ctx;
+
+void aie2_tdr_force_recover(struct amdxdna_dev *xdna, bool dump_only);
 
 #endif /* _AIE2_TDR_H_ */


### PR DESCRIPTION
Expose the TDR (timeout detection & recovery) path via a new debugfs file `tdr_control`:

- Read shows TDR state: started, counter, status, progress, timeout_in_sec, dump_only flag.
- Write accepts "dump" (force aie2_dump_ctx without resetting) or "recover" (full TDR recovery).

Splits the recovery work out of aie2_tdr_recover() into a non-static aie2_tdr_force_recover(struct amdxdna_dev *, bool) so debugfs and the watchdog timer share one code path.  Logs the active timeout and dump_only flags when the watchdog fires.

This is needed for AIE2P bring-up debugging where we want to trigger a context dump without rebooting — e.g. to inspect firmware state after a reproducible silicon wedge.