### PR TITLE
accel: amdxdna: add VE2 auxiliary driver probe and device init

### DIFF
--- a/drivers/accel/amdxdna/Kbuild
+++ b/drivers/accel/amdxdna/Kbuild
@@ -60,4 +60,5 @@ amdxdna-$(CONFIG_PCI_IOV) += \
 
 amdxdna-$(OFT_CONFIG_AMDXDNA_AUX) += \
 	amdxdna_aux_drv.o \
-	ve2_aux.o
+	ve2_aux.o \
+	ve2_hw.o

--- a/drivers/accel/amdxdna/amdxdna_aux_drv.c
+++ b/drivers/accel/amdxdna/amdxdna_aux_drv.c
@@ -1,6 +1,10 @@
 // SPDX-License-Identifier: GPL-2.0
 /*
- * Copyright (C) 2022-2026, Advanced Micro Devices, Inc.
+ * Copyright (C) 2026, Advanced Micro Devices, Inc.
+ *
+ * Auxiliary-bus attachment for AMD XDNA devices. A matching auxiliary
+ * client name selects struct amdxdna_dev_info via the matched entry's
+ * .driver_data; see amdxdna_aux_id_table below.
  */
 
 #include <drm/drm_drv.h>
@@ -13,27 +17,24 @@
 #include "amdxdna_aux_drv.h"
 #include "ve2_aux.h"
 
-const struct amdxdna_dev_priv ve2_dev_priv = {
-	.fw_path	= "amdnpu/release_cert_ve2.elf",
-	.hwctx_limit	= 255,
-	.ctx_limit	= 255,
-};
-
-const struct amdxdna_dev_info dev_ve2_info = {
-	.device_type	= AMDXDNA_DEV_TYPE_KMQ,
-	.dev_priv	= &ve2_dev_priv,
-	.ops		= &ve2_ops,
-};
-
-static const struct auxiliary_device_id amdxdna_ve2_aux_id_table[] = {
-	{ .name = "xilinx_aie.amdxdna" },
+/*
+ * amdxdna_aux_id_table: each struct auxiliary_device_id row binds an
+ * auxiliary-bus device name to const struct amdxdna_dev_info (via
+ * .driver_data). Add an entry (and matching dev_info/ops) when supporting
+ * new auxiliary-attached hardware.
+ */
+static const struct auxiliary_device_id amdxdna_aux_id_table[] = {
+	{
+		.name = "xilinx_aie.amdxdna",
+		.driver_data = (kernel_ulong_t)&dev_ve2_info,
+	},
 	{}
 };
 
-MODULE_DEVICE_TABLE(auxiliary, amdxdna_ve2_aux_id_table);
+MODULE_DEVICE_TABLE(auxiliary, amdxdna_aux_id_table);
 
-static int amdxdna_ve2_aux_probe(struct auxiliary_device *auxdev,
-				 const struct auxiliary_device_id *id)
+static int amdxdna_aux_probe(struct auxiliary_device *auxdev,
+			     const struct auxiliary_device_id *id)
 {
 	struct device *dev = &auxdev->dev;
 	struct amdxdna_dev *xdna;
@@ -43,15 +44,13 @@ static int amdxdna_ve2_aux_probe(struct auxiliary_device *auxdev,
 	if (IS_ERR(xdna))
 		return PTR_ERR(xdna);
 
-	xdna->dev_info = &dev_ve2_info;
-	if (!xdna->dev_info)
-		return -ENODEV;
+	xdna->dev_info = (const struct amdxdna_dev_info *)id->driver_data;
+	if (!xdna->dev_info || !xdna->dev_info->ops) {
+		XDNA_WARN(xdna, "No matching aux device found");
+		return -EINVAL;
+	}
 
 	auxiliary_set_drvdata(auxdev, xdna);
-
-	ret = amdxdna_dev_init(xdna);
-	if (ret)
-		return ret;
 
 	if (!dev->dma_mask) {
 		dev->coherent_dma_mask = DMA_BIT_MASK(64);
@@ -62,33 +61,35 @@ static int amdxdna_ve2_aux_probe(struct auxiliary_device *auxdev,
 		ret = dma_set_mask_and_coherent(dev, DMA_BIT_MASK(32));
 		if (ret) {
 			XDNA_ERR(xdna, "DMA mask set failed (64 and 32 bit), ret %d", ret);
-			goto failed_dev_cleanup;
+			return ret;
 		}
-		XDNA_WARN(xdna, "DMA configuration downgraded to 32bit Mask\n");
+		XDNA_WARN(xdna, "DMA configuration downgraded to 32bit mask");
+	}
+
+	ret = amdxdna_dev_init(xdna);
+	if (ret) {
+		XDNA_ERR(xdna, "amdxdna dev init failed with ret %d", ret);
+		return ret;
 	}
 
 	return 0;
-
-failed_dev_cleanup:
-	amdxdna_dev_cleanup(xdna);
-	return ret;
 }
 
-static void amdxdna_ve2_aux_remove(struct auxiliary_device *auxdev)
+static void amdxdna_aux_remove(struct auxiliary_device *auxdev)
 {
 	struct amdxdna_dev *xdna = auxiliary_get_drvdata(auxdev);
 
 	amdxdna_dev_cleanup(xdna);
 }
 
-static struct auxiliary_driver amdxdna_ve2_aux_driver = {
-	.name		= "amdxdna",
-	.probe		= amdxdna_ve2_aux_probe,
-	.remove		= amdxdna_ve2_aux_remove,
-	.id_table	= amdxdna_ve2_aux_id_table,
+static struct auxiliary_driver amdxdna_aux_driver = {
+	.name		= KBUILD_MODNAME,
+	.probe		= amdxdna_aux_probe,
+	.remove		= amdxdna_aux_remove,
+	.id_table	= amdxdna_aux_id_table,
 };
 
-module_auxiliary_driver(amdxdna_ve2_aux_driver);
+module_auxiliary_driver(amdxdna_aux_driver);
 
 MODULE_LICENSE(AMDXDNA_MODULE_LICENSE);
 MODULE_AUTHOR(AMDXDNA_MODULE_AUTHOR);

--- a/drivers/accel/amdxdna/amdxdna_aux_drv.h
+++ b/drivers/accel/amdxdna/amdxdna_aux_drv.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: GPL-2.0 */
 /*
- * Copyright (C) 2022-2026, Advanced Micro Devices, Inc.
+ * Copyright (C) 2026, Advanced Micro Devices, Inc.
  */
 
 #ifndef _AMDXDNA_AUX_DRV_H_
@@ -14,19 +14,7 @@
  * Record device static information, like reg, mbox, PSP, SMU bar index
  */
 struct amdxdna_dev_info {
-	int				reg_bar;
-	int				mbox_bar;
-	int				sram_bar;
-	int				psp_bar;
-	int				smu_bar;
-	int				doorbell_bar;
 	int				device_type;
-	int				first_col;
-	u32				dev_mem_buf_shift;
-	u64				dev_mem_base;
-	size_t				dev_mem_size;
-	const char			*default_vbnv;
-	const struct amdxdna_rev_vbnv	*rev_vbnv_tbl;
 	const struct amdxdna_dev_priv	*dev_priv;
 	const struct amdxdna_dev_ops	*ops;
 };

--- a/drivers/accel/amdxdna/amdxdna_aux_drv.h
+++ b/drivers/accel/amdxdna/amdxdna_aux_drv.h
@@ -9,17 +9,4 @@
 #include "amdxdna_drv.h"
 #include "drm/amdxdna_accel.h"
 
-/*
- * struct amdxdna_dev_info - Device hardware information
- * Record device static information, like reg, mbox, PSP, SMU bar index
- */
-struct amdxdna_dev_info {
-	int				device_type;
-	const struct amdxdna_dev_priv	*dev_priv;
-	const struct amdxdna_dev_ops	*ops;
-};
-
-/* Add device info below */
-extern const struct amdxdna_dev_info dev_ve2_info;
-
 #endif /* _AMDXDNA_AUX_DRV_H_ */

--- a/drivers/accel/amdxdna/amdxdna_ctx.h
+++ b/drivers/accel/amdxdna/amdxdna_ctx.h
@@ -9,6 +9,7 @@
 #include <linux/bitfield.h>
 
 #include "amdxdna_gem.h"
+#include <drm/gpu_scheduler.h>
 
 /*
  * Define the maximum number of pending commands in a hardware context.

--- a/drivers/accel/amdxdna/amdxdna_drv.h
+++ b/drivers/accel/amdxdna/amdxdna_drv.h
@@ -41,7 +41,6 @@ extern const struct drm_driver amdxdna_drm_drv;
 
 struct amdxdna_client;
 struct amdxdna_dev;
-struct amdxdna_dev_info;
 struct amdxdna_drm_get_info;
 struct amdxdna_drm_set_state;
 struct amdxdna_drm_get_array;
@@ -88,6 +87,41 @@ struct amdxdna_dev_ops {
 	int (*get_array)(struct amdxdna_client *client, struct amdxdna_drm_get_array *args);
 	int (*get_dev_revision)(struct amdxdna_dev *xdna, u32 *rev);
 	int (*hwctx_heap_expand)(struct amdxdna_hwctx *hwctx);
+};
+
+struct amdxdna_rev_vbnv;
+struct amdxdna_dev_priv;
+
+struct amdxdna_fw_feature_tbl {
+	u64 features;
+	u32 major;
+	u32 max_minor;
+	u32 min_minor;
+};
+
+/*
+ * struct amdxdna_dev_info - Device hardware information
+ * Record device static information, like reg, mbox, PSP, SMU bar index.
+ * PCI devices populate all fields; auxiliary-bus devices use a subset and
+ * leave BAR/memory fields at zero when unused.
+ */
+struct amdxdna_dev_info {
+	int				reg_bar;
+	int				mbox_bar;
+	int				sram_bar;
+	int				psp_bar;
+	int				smu_bar;
+	int				device_type;
+	int				first_col;
+	u32				dev_mem_buf_shift;
+	u64				dev_mem_base;
+	size_t				dev_mem_size;
+	const char			*default_vbnv;
+	const struct amdxdna_rev_vbnv	*rev_vbnv_tbl;
+	size_t				dev_heap_max_size;
+	const struct amdxdna_dev_priv	*dev_priv;
+	const struct amdxdna_fw_feature_tbl *fw_feature_tbl;
+	const struct amdxdna_dev_ops	*ops;
 };
 
 struct amdxdna_fw_ver {

--- a/drivers/accel/amdxdna/amdxdna_pci_drv.h
+++ b/drivers/accel/amdxdna/amdxdna_pci_drv.h
@@ -8,36 +8,6 @@
 
 #include "amdxdna_drv.h"
 
-struct amdxdna_fw_feature_tbl {
-	u64 features;
-	u32 major;
-	u32 max_minor;
-	u32 min_minor;
-};
-
-/*
- * struct amdxdna_dev_info - Device hardware information
- * Record device static information, like reg, mbox, PSP, SMU bar index
- */
-struct amdxdna_dev_info {
-	int				reg_bar;
-	int				mbox_bar;
-	int				sram_bar;
-	int				psp_bar;
-	int				smu_bar;
-	int				device_type;
-	int				first_col;
-	u32				dev_mem_buf_shift;
-	u64				dev_mem_base;
-	size_t				dev_mem_size;
-	const char			*default_vbnv;
-	const struct amdxdna_rev_vbnv	*rev_vbnv_tbl;
-	size_t				dev_heap_max_size;
-	const struct amdxdna_dev_priv	*dev_priv;
-	const struct amdxdna_fw_feature_tbl *fw_feature_tbl;
-	const struct amdxdna_dev_ops	*ops;
-};
-
 /* Add device info below */
 extern const struct amdxdna_dev_info dev_npu1_info;
 extern const struct amdxdna_dev_info dev_npu3_pf_info;

--- a/drivers/accel/amdxdna/ve2_aux.c
+++ b/drivers/accel/amdxdna/ve2_aux.c
@@ -3,9 +3,7 @@
  * Copyright (C) 2026, Advanced Micro Devices, Inc.
  */
 
-#include "drm/amdxdna_accel.h"
 #include <linux/firmware.h>
-#include <linux/slab.h>
 #include <linux/string.h>
 
 #include "amdxdna_aux_drv.h"

--- a/drivers/accel/amdxdna/ve2_aux.c
+++ b/drivers/accel/amdxdna/ve2_aux.c
@@ -12,7 +12,6 @@
 #include "amdxdna_aux_drv.h"
 #include "amdxdna_ctx.h"
 #include "ve2_aux.h"
-#include "ve2_ctx.h"
 #include "ve2_hw.h"
 
 const struct amdxdna_dev_priv ve2_aux_priv = {
@@ -83,6 +82,20 @@ static int ve2_get_aie_info(struct amdxdna_client *client, struct amdxdna_drm_ge
 }
 
 static int ve2_set_aie_state(struct amdxdna_client *client, struct amdxdna_drm_set_state *args)
+{
+	return -EOPNOTSUPP;
+}
+
+static int ve2_hwctx_init(struct amdxdna_hwctx *hwctx)
+{
+	return -EOPNOTSUPP;
+}
+
+static void ve2_hwctx_fini(struct amdxdna_hwctx *hwctx)
+{
+}
+
+static int ve2_hwctx_config(struct amdxdna_hwctx *hwctx, u32 type, u64 value, void *buf, u32 size)
 {
 	return -EOPNOTSUPP;
 }

--- a/drivers/accel/amdxdna/ve2_aux.c
+++ b/drivers/accel/amdxdna/ve2_aux.c
@@ -1,34 +1,217 @@
 // SPDX-License-Identifier: GPL-2.0
 /*
- * Copyright (C) 2025-2026, Advanced Micro Devices, Inc.
+ * Copyright (C) 2026, Advanced Micro Devices, Inc.
  */
 
-#include <linux/errno.h>
+#include "drm/amdxdna_accel.h"
+#include <linux/firmware.h>
+#include <linux/slab.h>
+#include <linux/string.h>
 
-#include "amdxdna_drv.h"
+#include "amdxdna_aux_drv.h"
+#include "amdxdna_ctx.h"
 #include "ve2_aux.h"
 
-struct amdxdna_hwctx;
-struct amdxdna_sched_job;
-struct amdxdna_gem_obj;
+/*
+ * Declares firmware for modinfo/packaging.
+ * Loaded at runtime via request_firmware() in ve2_load_fw().
+ */
+MODULE_FIRMWARE("amdnpu/release_cert_ve2.elf");
+
+const struct amdxdna_dev_priv ve2_aux_priv = {
+	.fw_path	= "amdnpu/release_cert_ve2.elf",
+};
+
+const struct amdxdna_dev_info dev_ve2_info = {
+	.device_type	= AMDXDNA_DEV_TYPE_KMQ,
+	.dev_priv	= &ve2_aux_priv,
+	.ops		= &ve2_ops,
+};
+
+static int ve2_partition_read_wrap(struct device *aie_dev, u32 col, u32 row,
+				   u32 offset, size_t size, void *buf)
+{
+	struct aie_location loc = { .col = col, .row = row };
+
+	return aie_partition_read(aie_dev, loc, offset, size, buf);
+}
+
+static int ve2_store_firmware_version(struct ve2_firmware_version *c_version,
+				      struct device *xaie_dev)
+{
+	struct ve2_firmware_version *version;
+	int ret;
+
+	version = kzalloc(sizeof(*version), GFP_KERNEL);
+	if (!version)
+		return -ENOMEM;
+
+	ret = ve2_partition_read_wrap(xaie_dev, 0, 0,
+				      VE2_PROG_DATA_MEMORY_OFF + VE2_CERT_VERSION_OFF,
+				      VE2_CERT_VERSION_SIZE, version);
+	if (ret < 0) {
+		kfree(version);
+		return ret;
+	}
+
+	c_version->major = version->major;
+	c_version->minor = version->minor;
+	strscpy(c_version->git_hash, version->git_hash, VE2_FW_HASH_STRING_LENGTH);
+	strscpy(c_version->date, version->date, VE2_FW_DATE_STRING_LENGTH);
+	c_version->hotfix = version->hotfix;
+	c_version->build = version->build;
+	kfree(version);
+
+	return 0;
+}
+
+static int ve2_partition_initialize_wrap(struct device *dev, struct aie_partition_init_args *args)
+{
+	return aie_partition_initialize(dev, args);
+}
+
+static int ve2_load_fw(struct amdxdna_dev_hdl *xdna_hdl)
+{
+	struct amdxdna_dev *xdna = xdna_hdl->xdna;
+	struct aie_partition_init_args args;
+	struct aie_partition_req request;
+	const struct firmware *fw;
+	struct device *xaie_dev;
+	char *buf;
+	int ret;
+
+	XDNA_DBG(xdna, "Loading firmware: %s", xdna_hdl->ve2_priv->fw_path);
+
+	ret = request_firmware(&fw, xdna_hdl->ve2_priv->fw_path, xdna->ddev.dev);
+	if (ret) {
+		XDNA_ERR(xdna, "request fw %s failed %d", xdna_hdl->ve2_priv->fw_path, ret);
+		return -ENODEV;
+	}
+
+	buf = kmalloc(fw->size, GFP_KERNEL);
+	if (!buf) {
+		release_firmware(fw);
+		return -ENOMEM;
+	}
+	memcpy(buf, fw->data, fw->size);
+	release_firmware(fw);
+
+	xaie_dev = aie_partition_request(&request);
+	if (IS_ERR(xaie_dev)) {
+		ret = PTR_ERR(xaie_dev);
+		XDNA_ERR(xdna, "aie partition request failed: %d", ret);
+		goto out;
+	}
+	XDNA_DBG(xdna, "aie partition request succeeded: 0x%x", request.partition_id);
+
+	args.locs = NULL;
+	args.num_tiles = 0;
+	args.handshake_cols = 0;
+	args.handshake = NULL;
+	args.init_opts = (AIE_PART_INIT_OPT_DEFAULT | AIE_PART_INIT_OPT_DIS_TLAST_ERROR) &
+			 ~AIE_PART_INIT_OPT_UC_ENB_MEM_PRIV;
+	ret = ve2_partition_initialize_wrap(xaie_dev, &args);
+	if (ret) {
+		XDNA_ERR(xdna, "aie partition init failed: %d", ret);
+		goto release;
+	}
+
+	ret = aie_load_cert_broadcast(xaie_dev, buf);
+	if (ret) {
+		XDNA_ERR(xdna, "aie load cert broadcast failed %d", ret);
+		goto teardown;
+	}
+	XDNA_INFO(xdna, "aie load cert broadcast complete");
+
+	ret = ve2_store_firmware_version(&xdna_hdl->fw_version, xaie_dev);
+	if (ret < 0) {
+		XDNA_ERR(xdna, "cert status read failed with err %d", ret);
+		goto teardown;
+	}
+	XDNA_INFO(xdna, "CERT major: %d", xdna_hdl->fw_version.major);
+	XDNA_INFO(xdna, "CERT minor: %d", xdna_hdl->fw_version.minor);
+
+teardown:
+	aie_partition_teardown(xaie_dev);
+release:
+	aie_partition_release(xaie_dev);
+out:
+	kfree(buf);
+	return ret;
+}
 
 static int ve2_init(struct amdxdna_dev *xdna)
 {
-	return -EOPNOTSUPP;
+	struct ve2_firmware_status *fw_slots;
+	struct device *dev = xdna->ddev.dev;
+	struct amdxdna_dev_hdl *xdna_hdl;
+	int ret;
+	u32 col;
+
+	XDNA_DBG(xdna, "Initializing VE2 device");
+
+	xdna_hdl = devm_kzalloc(dev, sizeof(*xdna_hdl), GFP_KERNEL);
+	if (!xdna_hdl)
+		return -ENOMEM;
+
+	xdna_hdl->xdna = xdna;
+	xdna_hdl->ve2_priv = &ve2_aux_priv;
+	xdna->dev_handle = xdna_hdl;
+
+	ret = aie_get_device_info(&xdna_hdl->aie_dev_info);
+	if (ret) {
+		if (ret == -ENODEV) {
+			XDNA_INFO(xdna, "AIE device not ready yet, deferring probe");
+			return -EPROBE_DEFER;
+		}
+		XDNA_ERR(xdna, "Failed to get AIE device info, ret %d", ret);
+		return ret;
+	}
+	XDNA_INFO(xdna, "AIE device: %d columns, %d rows",
+		  xdna_hdl->aie_dev_info.cols, xdna_hdl->aie_dev_info.rows);
+
+	ret = ve2_load_fw(xdna_hdl);
+	if (ret) {
+		XDNA_ERR(xdna, "aie load %s failed with err %d", xdna_hdl->ve2_priv->fw_path, ret);
+		return ret;
+	}
+	XDNA_DBG(xdna, "aie fw load %s completed", xdna_hdl->ve2_priv->fw_path);
+
+	xdna_hdl->fw_slots = devm_kcalloc(dev, xdna_hdl->aie_dev_info.cols,
+					  sizeof(*xdna_hdl->fw_slots), GFP_KERNEL);
+	if (!xdna_hdl->fw_slots) {
+		XDNA_ERR(xdna, "No memory for fw_slots array");
+		return -ENOMEM;
+	}
+
+	for (col = 0; col < xdna_hdl->aie_dev_info.cols; col++) {
+		fw_slots = devm_kzalloc(dev, sizeof(*fw_slots), GFP_KERNEL);
+		if (!fw_slots) {
+			XDNA_ERR(xdna, "No memory for fw status");
+			return -ENOMEM;
+		}
+		xdna_hdl->fw_slots[col] = fw_slots;
+	}
+
+	return 0;
 }
 
 static void ve2_fini(struct amdxdna_dev *xdna)
 {
+	struct amdxdna_dev_hdl *hdl = ve2_dev_hdl(xdna);
+
+	if (!hdl)
+		return;
+
+	XDNA_DBG(xdna, "VE2 device cleanup");
 }
 
-static int ve2_get_aie_info(struct amdxdna_client *client,
-			    struct amdxdna_drm_get_info *args)
+static int ve2_get_aie_info(struct amdxdna_client *client, struct amdxdna_drm_get_info *args)
 {
 	return -EOPNOTSUPP;
 }
 
-static int ve2_set_aie_state(struct amdxdna_client *client,
-			     struct amdxdna_drm_set_state *args)
+static int ve2_set_aie_state(struct amdxdna_client *client, struct amdxdna_drm_set_state *args)
 {
 	return -EOPNOTSUPP;
 }
@@ -70,8 +253,7 @@ static int ve2_cmd_wait(struct amdxdna_hwctx *hwctx, u64 seq, u32 timeout_ms)
 	return -EOPNOTSUPP;
 }
 
-static int ve2_get_array(struct amdxdna_client *client,
-			 struct amdxdna_drm_get_array *args)
+static int ve2_get_array(struct amdxdna_client *client, struct amdxdna_drm_get_array *args)
 {
 	return -EOPNOTSUPP;
 }

--- a/drivers/accel/amdxdna/ve2_aux.c
+++ b/drivers/accel/amdxdna/ve2_aux.c
@@ -1,20 +1,19 @@
 // SPDX-License-Identifier: GPL-2.0
 /*
  * Copyright (C) 2026, Advanced Micro Devices, Inc.
+ *
+ * VE2 auxiliary entry: `amdxdna_dev_info` / `ve2_ops`.  Firmware and AIE
+ * partition bring-up live in ve2_hw.c.
  */
 
-#include <linux/firmware.h>
+#include <linux/errno.h>
 #include <linux/string.h>
 
 #include "amdxdna_aux_drv.h"
 #include "amdxdna_ctx.h"
 #include "ve2_aux.h"
-
-/*
- * Declares firmware for modinfo/packaging.
- * Loaded at runtime via request_firmware() in ve2_load_fw().
- */
-MODULE_FIRMWARE("amdnpu/release_cert_ve2.elf");
+#include "ve2_ctx.h"
+#include "ve2_hw.h"
 
 const struct amdxdna_dev_priv ve2_aux_priv = {
 	.fw_path	= "amdnpu/release_cert_ve2.elf",
@@ -26,125 +25,11 @@ const struct amdxdna_dev_info dev_ve2_info = {
 	.ops		= &ve2_ops,
 };
 
-static int ve2_partition_read_wrap(struct device *aie_dev, u32 col, u32 row,
-				   u32 offset, size_t size, void *buf)
-{
-	struct aie_location loc = { .col = col, .row = row };
-
-	return aie_partition_read(aie_dev, loc, offset, size, buf);
-}
-
-static int ve2_store_firmware_version(struct ve2_firmware_version *c_version,
-				      struct device *xaie_dev)
-{
-	struct ve2_firmware_version *version;
-	int ret;
-
-	version = kzalloc(sizeof(*version), GFP_KERNEL);
-	if (!version)
-		return -ENOMEM;
-
-	ret = ve2_partition_read_wrap(xaie_dev, 0, 0,
-				      VE2_PROG_DATA_MEMORY_OFF + VE2_CERT_VERSION_OFF,
-				      VE2_CERT_VERSION_SIZE, version);
-	if (ret < 0) {
-		kfree(version);
-		return ret;
-	}
-
-	c_version->major = version->major;
-	c_version->minor = version->minor;
-	strscpy(c_version->git_hash, version->git_hash, VE2_FW_HASH_STRING_LENGTH);
-	strscpy(c_version->date, version->date, VE2_FW_DATE_STRING_LENGTH);
-	c_version->hotfix = version->hotfix;
-	c_version->build = version->build;
-	kfree(version);
-
-	return 0;
-}
-
-static int ve2_partition_initialize_wrap(struct device *dev, struct aie_partition_init_args *args)
-{
-	return aie_partition_initialize(dev, args);
-}
-
-static int ve2_load_fw(struct amdxdna_dev_hdl *xdna_hdl)
-{
-	struct amdxdna_dev *xdna = xdna_hdl->xdna;
-	struct aie_partition_init_args args;
-	struct aie_partition_req request;
-	const struct firmware *fw;
-	struct device *xaie_dev;
-	char *buf;
-	int ret;
-
-	XDNA_DBG(xdna, "Loading firmware: %s", xdna_hdl->ve2_priv->fw_path);
-
-	ret = request_firmware(&fw, xdna_hdl->ve2_priv->fw_path, xdna->ddev.dev);
-	if (ret) {
-		XDNA_ERR(xdna, "request fw %s failed %d", xdna_hdl->ve2_priv->fw_path, ret);
-		return -ENODEV;
-	}
-
-	buf = kmalloc(fw->size, GFP_KERNEL);
-	if (!buf) {
-		release_firmware(fw);
-		return -ENOMEM;
-	}
-	memcpy(buf, fw->data, fw->size);
-	release_firmware(fw);
-
-	xaie_dev = aie_partition_request(&request);
-	if (IS_ERR(xaie_dev)) {
-		ret = PTR_ERR(xaie_dev);
-		XDNA_ERR(xdna, "aie partition request failed: %d", ret);
-		goto out;
-	}
-	XDNA_DBG(xdna, "aie partition request succeeded: 0x%x", request.partition_id);
-
-	args.locs = NULL;
-	args.num_tiles = 0;
-	args.handshake_cols = 0;
-	args.handshake = NULL;
-	args.init_opts = (AIE_PART_INIT_OPT_DEFAULT | AIE_PART_INIT_OPT_DIS_TLAST_ERROR) &
-			 ~AIE_PART_INIT_OPT_UC_ENB_MEM_PRIV;
-	ret = ve2_partition_initialize_wrap(xaie_dev, &args);
-	if (ret) {
-		XDNA_ERR(xdna, "aie partition init failed: %d", ret);
-		goto release;
-	}
-
-	ret = aie_load_cert_broadcast(xaie_dev, buf);
-	if (ret) {
-		XDNA_ERR(xdna, "aie load cert broadcast failed %d", ret);
-		goto teardown;
-	}
-	XDNA_INFO(xdna, "aie load cert broadcast complete");
-
-	ret = ve2_store_firmware_version(&xdna_hdl->fw_version, xaie_dev);
-	if (ret < 0) {
-		XDNA_ERR(xdna, "cert status read failed with err %d", ret);
-		goto teardown;
-	}
-	XDNA_INFO(xdna, "CERT major: %d", xdna_hdl->fw_version.major);
-	XDNA_INFO(xdna, "CERT minor: %d", xdna_hdl->fw_version.minor);
-
-teardown:
-	aie_partition_teardown(xaie_dev);
-release:
-	aie_partition_release(xaie_dev);
-out:
-	kfree(buf);
-	return ret;
-}
-
 static int ve2_init(struct amdxdna_dev *xdna)
 {
-	struct ve2_firmware_status *fw_slots;
 	struct device *dev = xdna->ddev.dev;
 	struct amdxdna_dev_hdl *xdna_hdl;
 	int ret;
-	u32 col;
 
 	XDNA_DBG(xdna, "Initializing VE2 device");
 
@@ -168,28 +53,16 @@ static int ve2_init(struct amdxdna_dev *xdna)
 	XDNA_INFO(xdna, "AIE device: %d columns, %d rows",
 		  xdna_hdl->aie_dev_info.cols, xdna_hdl->aie_dev_info.rows);
 
-	ret = ve2_load_fw(xdna_hdl);
+	ret = ve2_hw_load_cert_firmware(xdna_hdl);
 	if (ret) {
 		XDNA_ERR(xdna, "aie load %s failed with err %d", xdna_hdl->ve2_priv->fw_path, ret);
 		return ret;
 	}
 	XDNA_DBG(xdna, "aie fw load %s completed", xdna_hdl->ve2_priv->fw_path);
 
-	xdna_hdl->fw_slots = devm_kcalloc(dev, xdna_hdl->aie_dev_info.cols,
-					  sizeof(*xdna_hdl->fw_slots), GFP_KERNEL);
-	if (!xdna_hdl->fw_slots) {
-		XDNA_ERR(xdna, "No memory for fw_slots array");
-		return -ENOMEM;
-	}
-
-	for (col = 0; col < xdna_hdl->aie_dev_info.cols; col++) {
-		fw_slots = devm_kzalloc(dev, sizeof(*fw_slots), GFP_KERNEL);
-		if (!fw_slots) {
-			XDNA_ERR(xdna, "No memory for fw status");
-			return -ENOMEM;
-		}
-		xdna_hdl->fw_slots[col] = fw_slots;
-	}
+	ret = ve2_hw_init_fw_status_slots(xdna, xdna_hdl);
+	if (ret)
+		return ret;
 
 	return 0;
 }
@@ -214,20 +87,6 @@ static int ve2_set_aie_state(struct amdxdna_client *client, struct amdxdna_drm_s
 	return -EOPNOTSUPP;
 }
 
-static int ve2_hwctx_init(struct amdxdna_hwctx *hwctx)
-{
-	return -EOPNOTSUPP;
-}
-
-static void ve2_hwctx_fini(struct amdxdna_hwctx *hwctx)
-{
-}
-
-static int ve2_hwctx_config(struct amdxdna_hwctx *hwctx, u32 type, u64 value, void *buf, u32 size)
-{
-	return -EOPNOTSUPP;
-}
-
 static int ve2_hwctx_sync_debug_bo(struct amdxdna_hwctx *hwctx, u32 debug_bo_hdl)
 {
 	return -EOPNOTSUPP;
@@ -239,16 +98,12 @@ static void ve2_hmm_invalidate(struct amdxdna_gem_obj *abo, unsigned long cur_se
 
 static int ve2_cmd_submit(struct amdxdna_hwctx *hwctx, struct amdxdna_sched_job *job, u64 *seq)
 {
-	return -EOPNOTSUPP;
+	return ve2_hw_get_ops()->cmd_submit(hwctx, job, seq);
 }
 
 static int ve2_cmd_wait(struct amdxdna_hwctx *hwctx, u64 seq, u32 timeout_ms)
 {
-	/*
-	 * VE2 cmd_wait will be implemented in a later patch when the DRM
-	 * scheduler and hardware context submit path are functional.
-	 */
-	return -EOPNOTSUPP;
+	return ve2_hw_get_ops()->cmd_wait(hwctx, seq, timeout_ms);
 }
 
 static int ve2_get_array(struct amdxdna_client *client, struct amdxdna_drm_get_array *args)

--- a/drivers/accel/amdxdna/ve2_aux.h
+++ b/drivers/accel/amdxdna/ve2_aux.h
@@ -7,16 +7,12 @@
 #define _VE2_AUX_H_
 
 #include <linux/device.h>
-#include <linux/mutex.h>
 #include <linux/types.h>
-#include <linux/workqueue.h>
-
 #include <linux/xlnx-ai-engine.h>
 
 #include "amdxdna_drv.h"
 
 struct amdxdna_dev_priv;
-#define VE2_MAX_MEM_REGIONS		8
 
 #define VE2_PROG_DATA_MEMORY_OFF	0x80000
 #define VE2_CERT_VERSION_OFF		0x50

--- a/drivers/accel/amdxdna/ve2_aux.h
+++ b/drivers/accel/amdxdna/ve2_aux.h
@@ -6,17 +6,62 @@
 #ifndef _VE2_AUX_H_
 #define _VE2_AUX_H_
 
+#include <linux/device.h>
+#include <linux/mutex.h>
+#include <linux/types.h>
+#include <linux/workqueue.h>
+
+#include <linux/xlnx-ai-engine.h>
+
 #include "amdxdna_drv.h"
 
-/*
- * VE2 Device private data
- */
-struct amdxdna_dev_priv {
-	const char	*fw_path;
-	u32		hwctx_limit;
-	u32		ctx_limit;
+struct amdxdna_dev_priv;
+#define VE2_MAX_MEM_REGIONS		8
+
+#define VE2_PROG_DATA_MEMORY_OFF	0x80000
+#define VE2_CERT_VERSION_OFF		0x50
+#define VE2_CERT_VERSION_SIZE		0x40
+
+#define VE2_FW_HASH_STRING_LENGTH	41
+#define VE2_FW_DATE_STRING_LENGTH	11
+
+struct ve2_firmware_version {
+	u8 major;
+	u8 minor;
+	char git_hash[VE2_FW_HASH_STRING_LENGTH];
+	char date[VE2_FW_DATE_STRING_LENGTH];
+	u8 hotfix;
+	u8 build;
 };
 
+struct ve2_firmware_status {
+	u32 state;
+	u32 abs_page_index;
+	u32 ppc;
+	u32 idle_status;
+	u32 misc_status;
+};
+
+struct amdxdna_dev_priv {
+	const char *fw_path;
+};
+
+struct amdxdna_dev;
+
+struct amdxdna_dev_hdl {
+	struct amdxdna_dev			*xdna;
+	const struct amdxdna_dev_priv		*ve2_priv;
+	struct ve2_firmware_version		fw_version;
+	struct aie_device_info			aie_dev_info;
+	struct ve2_firmware_status		**fw_slots;
+};
+
+extern const struct amdxdna_dev_info dev_ve2_info;
 extern const struct amdxdna_dev_ops ve2_ops;
+
+static inline struct amdxdna_dev_hdl *ve2_dev_hdl(struct amdxdna_dev *xdna)
+{
+	return xdna->dev_handle;
+}
 
 #endif /* _VE2_AUX_H_ */

--- a/drivers/accel/amdxdna/ve2_aux.h
+++ b/drivers/accel/amdxdna/ve2_aux.h
@@ -1,6 +1,7 @@
 /* SPDX-License-Identifier: GPL-2.0 */
 /*
  * Copyright (C) 2025-2026, Advanced Micro Devices, Inc.
+ *
  */
 
 #ifndef _VE2_AUX_H_
@@ -11,32 +12,7 @@
 #include <linux/xlnx-ai-engine.h>
 
 #include "amdxdna_drv.h"
-
-struct amdxdna_dev_priv;
-
-#define VE2_PROG_DATA_MEMORY_OFF	0x80000
-#define VE2_CERT_VERSION_OFF		0x50
-#define VE2_CERT_VERSION_SIZE		0x40
-
-#define VE2_FW_HASH_STRING_LENGTH	41
-#define VE2_FW_DATE_STRING_LENGTH	11
-
-struct ve2_firmware_version {
-	u8 major;
-	u8 minor;
-	char git_hash[VE2_FW_HASH_STRING_LENGTH];
-	char date[VE2_FW_DATE_STRING_LENGTH];
-	u8 hotfix;
-	u8 build;
-};
-
-struct ve2_firmware_status {
-	u32 state;
-	u32 abs_page_index;
-	u32 ppc;
-	u32 idle_status;
-	u32 misc_status;
-};
+#include "ve2_hw.h"
 
 struct amdxdna_dev_priv {
 	const char *fw_path;

--- a/drivers/accel/amdxdna/ve2_hw.c
+++ b/drivers/accel/amdxdna/ve2_hw.c
@@ -1,0 +1,208 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Copyright (C) 2026, Advanced Micro Devices, Inc.
+ *
+ * VE2 Layer 2: device firmware (cert path, AIE partition, version read), HAL
+ * slots, and `ve2_hw_ops` (ctx + command path).  Downstream ve2_fw.c and
+ * ve2_mgmt.c port into this file.
+ */
+
+#include <linux/errno.h>
+#include <linux/firmware.h>
+#include <linux/module.h>
+#include <linux/slab.h>
+#include <linux/string.h>
+#include <linux/xlnx-ai-engine.h>
+
+#include "amdxdna_drv.h"
+#include "amdxdna_ctx.h"
+#include "ve2_aux.h"
+#include "ve2_hw.h"
+
+/* Declared for modinfo / packaging; path must match `ve2_aux_priv.fw_path`. */
+MODULE_FIRMWARE("amdnpu/release_cert_ve2.elf");
+
+static int ve2_partition_read_fw(struct device *aie_dev, u32 col, u32 row,
+				 u32 offset, size_t size, void *buf)
+{
+	struct aie_location loc = { .col = col, .row = row };
+
+	return aie_partition_read(aie_dev, loc, offset, size, buf);
+}
+
+static int ve2_store_firmware_version(struct ve2_firmware_version *c_version,
+				      struct device *xaie_dev)
+{
+	struct ve2_firmware_version *version;
+	int ret;
+
+	version = kzalloc(sizeof(*version), GFP_KERNEL);
+	if (!version)
+		return -ENOMEM;
+
+	ret = ve2_partition_read_fw(xaie_dev, 0, 0,
+				    VE2_PROG_DATA_MEMORY_OFF + VE2_CERT_VERSION_OFF,
+				    VE2_CERT_VERSION_SIZE, version);
+	if (ret < 0) {
+		kfree(version);
+		return ret;
+	}
+
+	c_version->major = version->major;
+	c_version->minor = version->minor;
+	strscpy(c_version->git_hash, version->git_hash, VE2_FW_HASH_STRING_LENGTH);
+	strscpy(c_version->date, version->date, VE2_FW_DATE_STRING_LENGTH);
+	c_version->hotfix = version->hotfix;
+	c_version->build = version->build;
+	kfree(version);
+
+	return 0;
+}
+
+static int ve2_partition_init_fw(struct device *dev, struct aie_partition_init_args *args)
+{
+	return aie_partition_initialize(dev, args);
+}
+
+int ve2_hw_load_cert_firmware(struct amdxdna_dev_hdl *xdna_hdl)
+{
+	struct amdxdna_dev *xdna = xdna_hdl->xdna;
+	struct aie_partition_init_args args;
+	struct aie_partition_req request;
+	const struct firmware *fw;
+	struct device *xaie_dev;
+	char *buf;
+	int ret;
+
+	if (!xdna_hdl->ve2_priv || !xdna_hdl->ve2_priv->fw_path)
+		return -EINVAL;
+
+	XDNA_DBG(xdna, "Loading firmware: %s", xdna_hdl->ve2_priv->fw_path);
+
+	ret = request_firmware(&fw, xdna_hdl->ve2_priv->fw_path, xdna->ddev.dev);
+	if (ret) {
+		XDNA_ERR(xdna, "request fw %s failed %d", xdna_hdl->ve2_priv->fw_path, ret);
+		return -ENODEV;
+	}
+
+	buf = kmalloc(fw->size, GFP_KERNEL);
+	if (!buf) {
+		release_firmware(fw);
+		return -ENOMEM;
+	}
+	memcpy(buf, fw->data, fw->size);
+	release_firmware(fw);
+
+	xaie_dev = aie_partition_request(&request);
+	if (IS_ERR(xaie_dev)) {
+		ret = PTR_ERR(xaie_dev);
+		XDNA_ERR(xdna, "aie partition request failed: %d", ret);
+		goto out;
+	}
+	XDNA_DBG(xdna, "aie partition request succeeded: 0x%x", request.partition_id);
+
+	args.locs = NULL;
+	args.num_tiles = 0;
+	args.handshake_cols = 0;
+	args.handshake = NULL;
+	args.init_opts = (AIE_PART_INIT_OPT_DEFAULT | AIE_PART_INIT_OPT_DIS_TLAST_ERROR) &
+			 ~AIE_PART_INIT_OPT_UC_ENB_MEM_PRIV;
+	ret = ve2_partition_init_fw(xaie_dev, &args);
+	if (ret) {
+		XDNA_ERR(xdna, "aie partition init failed: %d", ret);
+		goto release;
+	}
+
+	ret = aie_load_cert_broadcast(xaie_dev, buf);
+	if (ret) {
+		XDNA_ERR(xdna, "aie load cert broadcast failed %d", ret);
+		goto teardown;
+	}
+	XDNA_INFO(xdna, "aie load cert broadcast complete");
+
+	ret = ve2_store_firmware_version(&xdna_hdl->fw_version, xaie_dev);
+	if (ret < 0) {
+		XDNA_ERR(xdna, "cert status read failed with err %d", ret);
+		goto teardown;
+	}
+	XDNA_INFO(xdna, "CERT major: %d", xdna_hdl->fw_version.major);
+	XDNA_INFO(xdna, "CERT minor: %d", xdna_hdl->fw_version.minor);
+
+teardown:
+	aie_partition_teardown(xaie_dev);
+release:
+	aie_partition_release(xaie_dev);
+out:
+	kfree(buf);
+	return ret;
+}
+
+int ve2_hw_init_fw_status_slots(struct amdxdna_dev *xdna, struct amdxdna_dev_hdl *hdl)
+{
+	struct device *dev = xdna->ddev.dev;
+	struct ve2_firmware_status *sl;
+	u32 col;
+
+	if (!hdl->aie_dev_info.cols)
+		return 0;
+
+	hdl->fw_slots = devm_kcalloc(dev, hdl->aie_dev_info.cols, sizeof(*hdl->fw_slots),
+				    GFP_KERNEL);
+	if (!hdl->fw_slots) {
+		XDNA_ERR(xdna, "No memory for fw_slots array");
+		return -ENOMEM;
+	}
+
+	for (col = 0; col < hdl->aie_dev_info.cols; col++) {
+		sl = devm_kzalloc(dev, sizeof(*sl), GFP_KERNEL);
+		if (!sl) {
+			XDNA_ERR(xdna, "No memory for fw status");
+			return -ENOMEM;
+		}
+		hdl->fw_slots[col] = sl;
+	}
+
+	return 0;
+}
+
+static int ve2_l2_ctx_init(struct amdxdna_hwctx *hwctx, u32 start_col, u32 num_cols)
+{
+	(void)hwctx;
+	(void)start_col;
+	(void)num_cols;
+	return 0;
+}
+
+static void ve2_l2_ctx_fini(struct amdxdna_hwctx *hwctx)
+{
+	(void)hwctx;
+}
+
+static int ve2_l2_cmd_submit(struct amdxdna_hwctx *hwctx, struct amdxdna_sched_job *job,
+			     u64 *seq)
+{
+	(void)hwctx;
+	(void)job;
+	(void)seq;
+	return -EOPNOTSUPP;
+}
+
+static int ve2_l2_cmd_wait(struct amdxdna_hwctx *hwctx, u64 seq, u32 timeout_ms)
+{
+	(void)hwctx;
+	(void)seq;
+	(void)timeout_ms;
+	return -EOPNOTSUPP;
+}
+
+static const struct ve2_hw_ops ve2_hw_ops_table = {
+	.ctx_init	= ve2_l2_ctx_init,
+	.ctx_fini	= ve2_l2_ctx_fini,
+	.cmd_submit	= ve2_l2_cmd_submit,
+	.cmd_wait	= ve2_l2_cmd_wait,
+};
+
+const struct ve2_hw_ops *ve2_hw_get_ops(void)
+{
+	return &ve2_hw_ops_table;
+}

--- a/drivers/accel/amdxdna/ve2_hw.c
+++ b/drivers/accel/amdxdna/ve2_hw.c
@@ -15,7 +15,6 @@
 #include <linux/xlnx-ai-engine.h>
 
 #include "amdxdna_drv.h"
-#include "amdxdna_ctx.h"
 #include "ve2_aux.h"
 #include "ve2_hw.h"
 
@@ -147,7 +146,7 @@ int ve2_hw_init_fw_status_slots(struct amdxdna_dev *xdna, struct amdxdna_dev_hdl
 		return 0;
 
 	hdl->fw_slots = devm_kcalloc(dev, hdl->aie_dev_info.cols, sizeof(*hdl->fw_slots),
-				    GFP_KERNEL);
+				     GFP_KERNEL);
 	if (!hdl->fw_slots) {
 		XDNA_ERR(xdna, "No memory for fw_slots array");
 		return -ENOMEM;

--- a/drivers/accel/amdxdna/ve2_hw.h
+++ b/drivers/accel/amdxdna/ve2_hw.h
@@ -1,0 +1,67 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+/*
+ * Copyright (C) 2026, Advanced Micro Devices, Inc.
+ *
+ * VE2 Layer 2: AIE HAL, firmware, and `ve2_hw_ops`.  `ve2_aux.h` includes this
+ * for shared `struct amdxdna_dev_hdl` members (fw version / slots).
+ */
+
+#ifndef _VE2_HW_H_
+#define _VE2_HW_H_
+
+#include <linux/types.h>
+
+struct amdxdna_hwctx;
+struct amdxdna_dev;
+struct amdxdna_dev_hdl;
+struct amdxdna_sched_job;
+
+/* Certificate image layout (AIE program data memory) */
+#define VE2_PROG_DATA_MEMORY_OFF	0x80000
+#define VE2_CERT_VERSION_OFF		0x50
+#define VE2_CERT_VERSION_SIZE		0x40
+#define VE2_FW_HASH_STRING_LENGTH	41
+#define VE2_FW_DATE_STRING_LENGTH	11
+
+struct ve2_firmware_version {
+	u8 major;
+	u8 minor;
+	char git_hash[VE2_FW_HASH_STRING_LENGTH];
+	char date[VE2_FW_DATE_STRING_LENGTH];
+	u8 hotfix;
+	u8 build;
+};
+
+struct ve2_firmware_status {
+	u32 state;
+	u32 abs_page_index;
+	u32 ppc;
+	u32 idle_status;
+	u32 misc_status;
+};
+
+/*
+ * struct ve2_hw_ops — single boundary from Layer 1 to Layer 2
+ *
+ * Layer 1: ve2_aux.c, ve2_ctx.c, ve2_debug.c, ve2_res_solver.c — use
+ * ve2_hw_get_ops() only, not xlnx-aie / partition APIs directly.
+ *
+ * Layer 2: ve2_hw.c — implement ops and device firmware (former ve2_mgmt/ve2_fw).
+ */
+struct ve2_hw_ops {
+	int (*ctx_init)(struct amdxdna_hwctx *hwctx, u32 start_col, u32 num_cols);
+	void (*ctx_fini)(struct amdxdna_hwctx *hwctx);
+	int (*cmd_submit)(struct amdxdna_hwctx *hwctx, struct amdxdna_sched_job *job,
+			  u64 *seq);
+	int (*cmd_wait)(struct amdxdna_hwctx *hwctx, u64 seq, u32 timeout_ms);
+};
+
+const struct ve2_hw_ops *ve2_hw_get_ops(void);
+
+/* Device probe: request cert image, AIE partition init, broadcast, version read. */
+int ve2_hw_load_cert_firmware(struct amdxdna_dev_hdl *xdna_hdl);
+
+/* Per-column `struct ve2_firmware_status` pointers in @hdl (devm). */
+int ve2_hw_init_fw_status_slots(struct amdxdna_dev *xdna, struct amdxdna_dev_hdl *hdl);
+
+#endif /* _VE2_HW_H_ */


### PR DESCRIPTION
1) Add amdxdna_aux_drv.c as the auxiliary_bus glue: DMA mask and amdxdna_dev_init ordering aligned with PCI.
2) Implement ve2_init/fini in ve2_aux.c from the out-of-tree VE2 path: device handle, AIE topology via aie_get_device_info(), firmware load and cert broadcast, per-column fw_slots. 
3) Define VE2-specific struct amdxdna_dev_hdl in ve2_aux.h
4) Restructure the auxiliary VE2 path so device firmware and the hardware abstraction sit in ve2_hw.c/ve2_hw.h (Layer 2), while ve2_aux.c/h stay focused on amdxdna_dev_info, ve2_ops, and probe wiring (Layer 1).
->ve2_hw.h defines UAPI-related firmware types (e.g. ve2_firmware_version,
    ve2_firmware_status, cert memory offsets), the public HAL entry points
    ve2_hw_load_cert_firmware() and ve2_hw_init_fw_status_slots(), and
    struct ve2_hw_ops with ve2_hw_get_ops() for context and command paths.
    Layer 1 must use those interfaces instead of calling the AIE/partition
    APIs for firmware.
->ve2_hw.c implements cert image load (request_firmware, temporary buffer,
    aie partition request/initialize, aie_load_cert_broadcast, version read
    from program data), per-column firmware status slot allocation, and
    MODULE_FIRMWARE for the cert blob. Default ve2_hw_ops keep ctx_init/
    ctx_fini and cmd_submit/cmd_wait as minimal stubs until the downstream
    port continues.
->ve2_aux.h pulls in ve2_hw.h for the dev handle’s fw_version and fw_slots
    members; the migration map comment in the header documents the intended
    split: ve2_of → ve2_aux, ve2_mgmt+ve2_fw → ve2_hw, hwctx/debug/resolver
    in Layer 1 with calls only through ve2_hw_get_ops() and the new device
    firmware helpers.
5) This matches the VE2 upstream proposal: clear L1 (framework) vs L2 (AIE HAL) boundary and a single place to grow partition and handshake logic.