### PR TITLE
Fix building with clang 22.x

### DIFF
--- a/src/shim/shim_debug.h
+++ b/src/shim/shim_debug.h
@@ -12,19 +12,29 @@
 
 namespace {
 
+template <typename T>
+decltype(auto) convert(T&& arg)
+{
+  if constexpr (std::is_same_v<std::decay_t<T>, std::string>) {
+      return arg.c_str();
+  } else {
+      return std::forward<T>(arg);
+  }
+}
+
 template <typename ...Args>
 [[ noreturn ]] void
 shim_err(int err, const char* fmt, Args&&... args)
 {
   std::string format = std::string(fmt);
   format += " (err=%d)";
-  int sz = std::snprintf(nullptr, 0, format.c_str(), args ..., err) + 1;
+  int sz = std::snprintf(nullptr, 0, format.c_str(), convert(std::forward<Args>(args)) ..., err) + 1;
   if(sz <= 0)
     throw xrt_core::system_error(sz, "could not format error string");
 
   auto size = static_cast<size_t>(sz);
   std::unique_ptr<char[]> buf(new char[size]);
-  std::snprintf(buf.get(), size, format.c_str(), args ..., err);
+  std::snprintf(buf.get(), size, format.c_str(), convert(std::forward<Args>(args)) ..., err);
   throw xrt_core::system_error(err, std::string(buf.get()));
 }
 

--- a/src/shim/virtio/platform_virtio.cpp
+++ b/src/shim/virtio/platform_virtio.cpp
@@ -651,7 +651,7 @@ submit_cmd(submit_cmd_arg& arg) const
   req_sz += nargs * sizeof(uint32_t); // For args handle
   // Get a 64 bit aligned buffer for req
   auto req_sz_in_u64 = req_sz / sizeof(uint64_t) + 1;
-  uint64_t req_buf[req_sz_in_u64] = {};
+  uint64_t req_buf[req_sz_in_u64];
   auto req = reinterpret_cast<amdxdna_ccmd_exec_cmd_req*>(req_buf);
   amdxdna_ccmd_exec_cmd_rsp rsp = {};
 


### PR DESCRIPTION
Without this patch, clang fails on shim_debug.h when a std::string (as opposed to a POD like char*) is passed through varargs. This probably causes a runtime crash with gcc, and definitely causes a compile time error with clang.

It also fails on virtio/platform_virtio.cpp because of the attempt to initialize a variable length array to nothing (which gcc seems to treat as a no-op).