### PR TITLE
accel/amdxdna: add AIE coredump support

### DIFF
--- a/drivers/accel/amdxdna/aie.c
+++ b/drivers/accel/amdxdna/aie.c
@@ -4,11 +4,18 @@
  */
 
 #include "drm/amdxdna_accel.h"
+#include <drm/drm_cache.h>
 #include <drm/drm_drv.h>
 #include <drm/drm_print.h>
+#include <drm/gpu_scheduler.h>
 #include <linux/errno.h>
+#include <linux/sched.h>
+#include <linux/sizes.h>
+#include <linux/slab.h>
+#include <linux/uaccess.h>
 
 #include "aie.h"
+#include "amdxdna_ctx.h"
 #include "amdxdna_gem.h"
 #include "amdxdna_mailbox_helper.h"
 #include "amdxdna_mailbox.h"
@@ -222,36 +229,243 @@ void amdxdna_hmm_invalidate(struct amdxdna_gem_obj *abo,
 		XDNA_DBG(xdna, "Wait for bo interrupted by signal");
 }
 
-void *amdxdna_alloc_msg_buffer(struct amdxdna_dev *xdna, u32 *size,
-			       dma_addr_t *dma_addr)
+bool amdxdna_hwctx_access_allowed(struct amdxdna_hwctx *hwctx, bool root_only)
 {
-	void *vaddr;
-	int order;
+	if (amdxdna_is_admin())
+		return true;
 
-	*size = max_t(u32, *size, SZ_8K);
-	order = get_order(*size);
-	if (order > MAX_PAGE_ORDER)
-		return ERR_PTR(-EINVAL);
-	*size = PAGE_SIZE << order;
+	if (root_only)
+		return false;
 
-	if (amdxdna_iova_on(xdna))
-		return amdxdna_iommu_alloc(xdna, *size, dma_addr);
-
-	vaddr = dma_alloc_noncoherent(xdna->ddev.dev, *size, dma_addr,
-				      DMA_FROM_DEVICE, GFP_KERNEL);
-	if (!vaddr)
-		return ERR_PTR(-ENOMEM);
-
-	return vaddr;
+	return task_tgid_nr(current) == hwctx->client->pid;
 }
 
-void amdxdna_free_msg_buffer(struct amdxdna_dev *xdna, size_t size,
-			     void *cpu_addr, dma_addr_t dma_addr)
+struct amdxdna_msg_buf_hdl *amdxdna_alloc_msg_buff(struct amdxdna_dev *xdna, u32 size)
 {
+	struct amdxdna_msg_buf_hdl *hdl;
+	int order;
+
+	hdl = kzalloc_obj(*hdl);
+	if (!hdl)
+		return ERR_PTR(-ENOMEM);
+
+	hdl->xdna = xdna;
+	hdl->size = max_t(u32, size, SZ_8K);
+	order = get_order(hdl->size);
+	if (order > MAX_PAGE_ORDER) {
+		kfree(hdl);
+		return ERR_PTR(-EINVAL);
+	}
+	hdl->size = PAGE_SIZE << order;
+
 	if (amdxdna_iova_on(xdna)) {
-		amdxdna_iommu_free(xdna, size, cpu_addr, dma_addr);
-		return;
+		hdl->vaddr = amdxdna_iommu_alloc(xdna, hdl->size, &hdl->dma_addr);
+	} else {
+		hdl->vaddr = dma_alloc_noncoherent(xdna->ddev.dev, hdl->size,
+						   &hdl->dma_addr,
+						   DMA_FROM_DEVICE, GFP_KERNEL);
+		if (!hdl->vaddr)
+			hdl->vaddr = ERR_PTR(-ENOMEM);
 	}
 
-	dma_free_noncoherent(xdna->ddev.dev, size, cpu_addr, dma_addr, DMA_FROM_DEVICE);
+	if (IS_ERR(hdl->vaddr)) {
+		int ret = PTR_ERR(hdl->vaddr);
+
+		kfree(hdl);
+		return ERR_PTR(ret);
+	}
+
+	return hdl;
+}
+
+void amdxdna_free_msg_buff(struct amdxdna_msg_buf_hdl *hdl)
+{
+	if (!hdl)
+		return;
+
+	if (amdxdna_iova_on(hdl->xdna)) {
+		amdxdna_iommu_free(hdl->xdna, hdl->size, hdl->vaddr,
+				   hdl->dma_addr);
+	} else {
+		dma_free_noncoherent(hdl->xdna->ddev.dev, hdl->size,
+				     hdl->vaddr, hdl->dma_addr,
+				     DMA_FROM_DEVICE);
+	}
+
+	kfree(hdl);
+}
+
+void amdxdna_clflush_msg_buff(struct amdxdna_msg_buf_hdl *hdl, u32 offset, u32 size)
+{
+	if (!hdl || offset > hdl->size)
+		return;
+	if (!size)
+		size = hdl->size - offset;
+	else if (size > hdl->size - offset)
+		return;
+
+	drm_clflush_virt_range(to_cpu_addr(hdl, offset), size);
+}
+
+int amdxdna_get_coredump(struct aie_device *aie,
+			 struct amdxdna_client *client,
+			 struct amdxdna_drm_get_array *args)
+{
+	struct amdxdna_msg_buf_hdl **data_hdls = NULL;
+	struct amdxdna_drm_aie_coredump config = {};
+	struct amdxdna_coredump_buf_entry *buf_list;
+	struct amdxdna_msg_buf_hdl *list_hdl = NULL;
+	struct amdxdna_client *ctx_client = NULL;
+	struct amdxdna_dev *xdna = client->xdna;
+	struct amdxdna_hwctx *hwctx = NULL;
+	struct amdxdna_client *tmp_client;
+	u32 data_buf_size = SZ_1M;
+	int ret = 0, idx = 0, i;
+	unsigned long hwctx_id;
+	size_t offset = 0;
+	size_t total_size;
+	size_t buf_size;
+	u8 __user *buf;
+	u32 num_bufs;
+	u32 orig_col;
+
+	if (!xdna->dev_info->ops->get_coredump)
+		return -EOPNOTSUPP;
+
+	drm_WARN_ON(&xdna->ddev, !mutex_is_locked(&xdna->dev_lock));
+
+	if (args->num_element != 1) {
+		XDNA_ERR(xdna, "Invalid num_element %u, expected 1",
+			 args->num_element);
+		return -EINVAL;
+	}
+
+	buf_size = (size_t)args->num_element * args->element_size;
+	buf = u64_to_user_ptr(args->buffer);
+	if (!access_ok(buf, buf_size)) {
+		XDNA_ERR(xdna, "Failed to access buffer, element num %d size 0x%x",
+			 args->num_element, args->element_size);
+		return -EFAULT;
+	}
+
+	if (buf_size < sizeof(config)) {
+		XDNA_ERR(xdna, "Insufficient buffer size: 0x%zx", buf_size);
+		args->element_size = sizeof(config);
+		return -ENOSPC;
+	}
+
+	if (copy_from_user(&config, buf, sizeof(config))) {
+		XDNA_ERR(xdna, "Failed to copy coredump config from user");
+		return -EFAULT;
+	}
+
+	if (XDNA_MBZ_DBG(xdna, &config.pad, sizeof(config.pad)))
+		return -EINVAL;
+
+	XDNA_DBG(xdna, "AIE Coredump request for context_id=%u pid=%llu",
+		 config.context_id, config.pid);
+
+	amdxdna_for_each_client(xdna, tmp_client) {
+		struct amdxdna_hwctx *hw_ctx;
+
+		idx = srcu_read_lock(&tmp_client->hwctx_srcu);
+		amdxdna_for_each_hwctx(tmp_client, hwctx_id, hw_ctx) {
+			if (config.context_id == hwctx_id &&
+			    config.pid == hw_ctx->client->pid) {
+				hwctx = hw_ctx;
+				ctx_client = tmp_client;
+				break;
+			}
+		}
+		if (hwctx)
+			break;
+		srcu_read_unlock(&tmp_client->hwctx_srcu, idx);
+	}
+
+	if (!hwctx) {
+		XDNA_ERR(xdna, "Context %u for pid %llu not found",
+			 config.context_id, config.pid);
+		return -EINVAL;
+	}
+
+	if (!amdxdna_hwctx_access_allowed(hwctx, false)) {
+		XDNA_ERR(xdna, "Permission denied for context %u",
+			 config.context_id);
+		ret = -EPERM;
+		goto unlock_srcu;
+	}
+
+	orig_col = hwctx->num_col - hwctx->num_unused_col;
+	num_bufs = aie->metadata.rows * orig_col;
+	total_size = (size_t)num_bufs * data_buf_size;
+
+	if (buf_size < total_size) {
+		XDNA_DBG(xdna, "Insufficient buffer size %zu, need %zu",
+			 buf_size, total_size);
+		args->element_size = total_size;
+		ret = -ENOSPC;
+		goto unlock_srcu;
+	}
+
+	list_hdl = amdxdna_alloc_msg_buff(xdna,
+					  max_t(u32, num_bufs * sizeof(*buf_list), SZ_8K));
+	if (IS_ERR(list_hdl)) {
+		XDNA_ERR(xdna, "Failed to allocate buffer list");
+		ret = PTR_ERR(list_hdl);
+		goto unlock_srcu;
+	}
+
+	buf_list = to_cpu_addr(list_hdl, 0);
+	memset(buf_list, 0, to_buf_size(list_hdl));
+
+	data_hdls = kzalloc_objs(*data_hdls, num_bufs);
+	if (!data_hdls) {
+		ret = -ENOMEM;
+		goto free_list_hdl;
+	}
+
+	for (i = 0; i < num_bufs; i++) {
+		data_hdls[i] = amdxdna_alloc_msg_buff(xdna, data_buf_size);
+		if (IS_ERR(data_hdls[i])) {
+			XDNA_ERR(xdna, "Failed to allocate data buffer %d", i);
+			ret = PTR_ERR(data_hdls[i]);
+			data_hdls[i] = NULL;
+			goto free_data_hdls;
+		}
+
+		memset(to_cpu_addr(data_hdls[i], 0), 0, data_buf_size);
+		amdxdna_clflush_msg_buff(data_hdls[i], 0, 0);
+
+		buf_list[i].buf_addr = to_dma_addr(data_hdls[i], 0);
+		buf_list[i].buf_size = data_buf_size;
+	}
+
+	amdxdna_clflush_msg_buff(list_hdl, 0, 0);
+
+	ret = xdna->dev_info->ops->get_coredump(xdna, list_hdl,
+					       hwctx, num_bufs);
+	if (ret) {
+		XDNA_ERR(xdna, "Failed to get coredump from firmware, ret=%d",
+			 ret);
+		goto free_data_hdls;
+	}
+
+	for (i = 0; i < num_bufs; i++) {
+		if (copy_to_user(buf + offset, to_cpu_addr(data_hdls[i], 0),
+				 data_buf_size)) {
+			ret = -EFAULT;
+			goto free_data_hdls;
+		}
+		offset += data_buf_size;
+	}
+
+free_data_hdls:
+	for (i = 0; i < num_bufs; i++)
+		amdxdna_free_msg_buff(data_hdls[i]);
+	kfree(data_hdls);
+free_list_hdl:
+	amdxdna_free_msg_buff(list_hdl);
+unlock_srcu:
+	srcu_read_unlock(&ctx_client->hwctx_srcu, idx);
+	return ret;
 }

--- a/drivers/accel/amdxdna/aie.h
+++ b/drivers/accel/amdxdna/aie.h
@@ -122,10 +122,35 @@ void amdxdna_vbnv_init(struct amdxdna_dev *xdna);
 int amdxdna_get_metadata(struct aie_device *aie, struct amdxdna_client *client,
 			 struct amdxdna_drm_get_info *args);
 void amdxdna_hmm_invalidate(struct amdxdna_gem_obj *abo, unsigned long cur_seq);
-void *amdxdna_alloc_msg_buffer(struct amdxdna_dev *xdna, u32 *size,
-			       dma_addr_t *dma_addr);
-void amdxdna_free_msg_buffer(struct amdxdna_dev *xdna, size_t size,
-			     void *cpu_addr, dma_addr_t dma_addr);
+bool amdxdna_hwctx_access_allowed(struct amdxdna_hwctx *hwctx, bool root_only);
+
+struct amdxdna_msg_buf_hdl {
+	struct amdxdna_dev	*xdna;
+	void			*vaddr;
+	dma_addr_t		dma_addr;
+	u32			size;
+};
+
+#define to_cpu_addr(hdl, offset)  ((void *)((u8 *)(hdl)->vaddr + (offset)))
+#define to_dma_addr(hdl, offset)  ((hdl)->dma_addr + (offset))
+#define to_buf_size(hdl)          ((hdl)->size)
+
+struct amdxdna_msg_buf_hdl *amdxdna_alloc_msg_buff(struct amdxdna_dev *xdna, u32 size);
+void amdxdna_free_msg_buff(struct amdxdna_msg_buf_hdl *hdl);
+void amdxdna_clflush_msg_buff(struct amdxdna_msg_buf_hdl *hdl, u32 offset, u32 size);
+
+/*
+ * struct amdxdna_coredump_buf_entry - __packed to match firmware buffer_list
+ */
+struct amdxdna_coredump_buf_entry {
+	u64				buf_addr;
+	u32				buf_size;
+	u32				reserved;
+} __packed;
+
+int amdxdna_get_coredump(struct aie_device *aie,
+			 struct amdxdna_client *client,
+			 struct amdxdna_drm_get_array *args);
 
 /* aie_psp.c */
 struct psp_device *aiem_psp_create(struct drm_device *ddev, struct psp_config *conf);

--- a/drivers/accel/amdxdna/aie2_error.c
+++ b/drivers/accel/amdxdna/aie2_error.c
@@ -30,9 +30,7 @@ struct async_event {
 
 struct async_events {
 	struct workqueue_struct		*wq;
-	u8				*buf;
-	dma_addr_t			addr;
-	u32				size;
+	struct amdxdna_msg_buf_hdl	*hdl;
 	u32				event_cnt;
 	struct async_event		event[] __counted_by(event_cnt);
 };
@@ -339,7 +337,7 @@ void aie2_error_async_events_free(struct amdxdna_dev_hdl *ndev)
 	destroy_workqueue(events->wq);
 	mutex_lock(&xdna->dev_lock);
 
-	amdxdna_free_msg_buffer(xdna, events->size, events->buf, events->addr);
+	amdxdna_free_msg_buff(events->hdl);
 	kfree(events);
 }
 
@@ -347,7 +345,6 @@ int aie2_error_async_events_alloc(struct amdxdna_dev_hdl *ndev)
 {
 	struct amdxdna_dev *xdna = ndev->aie.xdna;
 	u32 total_col = ndev->total_col;
-	u32 total_size = ASYNC_BUF_SIZE * total_col;
 	struct async_events *events;
 	int i, ret;
 
@@ -355,12 +352,11 @@ int aie2_error_async_events_alloc(struct amdxdna_dev_hdl *ndev)
 	if (!events)
 		return -ENOMEM;
 
-	events->buf = amdxdna_alloc_msg_buffer(xdna, &total_size, &events->addr);
-	if (IS_ERR(events->buf)) {
-		ret = PTR_ERR(events->buf);
+	events->hdl = amdxdna_alloc_msg_buff(xdna, ASYNC_BUF_SIZE * total_col);
+	if (IS_ERR(events->hdl)) {
+		ret = PTR_ERR(events->hdl);
 		goto free_events;
 	}
-	events->size = total_size;
 	events->event_cnt = total_col;
 
 	events->wq = alloc_ordered_workqueue("async_wq", 0);
@@ -375,8 +371,8 @@ int aie2_error_async_events_alloc(struct amdxdna_dev_hdl *ndev)
 
 		e->ndev = ndev;
 		e->wq = events->wq;
-		e->buf = &events->buf[offset];
-		e->addr = events->addr + offset;
+		e->buf = to_cpu_addr(events->hdl, offset);
+		e->addr = to_dma_addr(events->hdl, offset);
 		e->size = ASYNC_BUF_SIZE;
 		e->resp.status = MAX_AIE2_STATUS_CODE;
 		INIT_WORK(&e->work, aie2_error_worker);
@@ -389,13 +385,13 @@ int aie2_error_async_events_alloc(struct amdxdna_dev_hdl *ndev)
 	ndev->async_events = events;
 
 	XDNA_DBG(xdna, "Async event count %d, buf total size 0x%x",
-		 events->event_cnt, events->size);
+		 events->event_cnt, to_buf_size(events->hdl));
 	return 0;
 
 free_wq:
 	destroy_workqueue(events->wq);
 free_buf:
-	amdxdna_free_msg_buffer(xdna, events->size, events->buf, events->addr);
+	amdxdna_free_msg_buff(events->hdl);
 free_events:
 	kfree(events);
 	return ret;

--- a/drivers/accel/amdxdna/aie2_message.c
+++ b/drivers/accel/amdxdna/aie2_message.c
@@ -363,28 +363,26 @@ int aie2_query_status(struct amdxdna_dev_hdl *ndev, char __user *buf,
 {
 	DECLARE_AIE_MSG(aie_column_info, MSG_OP_QUERY_COL_STATUS);
 	struct amdxdna_dev *xdna = ndev->aie.xdna;
-	u32 buf_sz, aie_bitmap = 0;
+	struct amdxdna_msg_buf_hdl *buf_hdl;
 	struct amdxdna_client *client;
-	dma_addr_t dma_addr;
-	u8 *buff_addr;
+	u32 aie_bitmap = 0;
 	int ret;
 
-	buf_sz = ndev->aie.metadata.cols * ndev->aie.metadata.size;
-	buff_addr = amdxdna_alloc_msg_buffer(xdna, &buf_sz, &dma_addr);
-	if (IS_ERR(buff_addr))
-		return PTR_ERR(buff_addr);
+	buf_hdl = amdxdna_alloc_msg_buff(xdna, ndev->aie.metadata.cols * ndev->aie.metadata.size);
+	if (IS_ERR(buf_hdl))
+		return PTR_ERR(buf_hdl);
 
 	/* Go through each hardware context and mark the AIE columns that are active */
 	list_for_each_entry(client, &xdna->client_list, node)
 		amdxdna_hwctx_walk(client, &aie_bitmap, amdxdna_hwctx_col_map);
 
 	*cols_filled = 0;
-	req.dump_buff_addr = dma_addr;
-	req.dump_buff_size = buf_sz;
+	req.dump_buff_addr = to_dma_addr(buf_hdl, 0);
+	req.dump_buff_size = to_buf_size(buf_hdl);
 	req.num_cols = hweight32(aie_bitmap);
 	req.aie_bitmap = aie_bitmap;
 
-	drm_clflush_virt_range(buff_addr, size); /* device can access */
+	amdxdna_clflush_msg_buff(buf_hdl, 0, 0);
 	ret = aie_send_mgmt_msg_wait(&ndev->aie, &msg);
 	if (ret) {
 		XDNA_ERR(xdna, "Error during NPU query, status %d", ret);
@@ -393,14 +391,15 @@ int aie2_query_status(struct amdxdna_dev_hdl *ndev, char __user *buf,
 
 	XDNA_DBG(xdna, "Query NPU status completed");
 
-	if (buf_sz < resp.size) {
+	if (to_buf_size(buf_hdl) < resp.size) {
 		ret = -EINVAL;
-		XDNA_ERR(xdna, "Bad buffer size. Available: %u. Needs: %u", buf_sz, resp.size);
+		XDNA_ERR(xdna, "Bad buffer size. Available: %u. Needs: %u",
+			 to_buf_size(buf_hdl), resp.size);
 		goto fail;
 	}
 
 	size = min(size, resp.size);
-	if (copy_to_user(buf, buff_addr, size)) {
+	if (copy_to_user(buf, to_cpu_addr(buf_hdl, 0), size)) {
 		ret = -EFAULT;
 		XDNA_ERR(xdna, "Failed to copy NPU status to user space");
 		goto fail;
@@ -409,7 +408,7 @@ int aie2_query_status(struct amdxdna_dev_hdl *ndev, char __user *buf,
 	*cols_filled = aie_bitmap;
 
 fail:
-	amdxdna_free_msg_buffer(xdna, buf_sz, buff_addr, dma_addr);
+	amdxdna_free_msg_buff(buf_hdl);
 	return ret;
 }
 
@@ -419,38 +418,36 @@ int aie2_query_telemetry(struct amdxdna_dev_hdl *ndev,
 {
 	DECLARE_AIE_MSG(get_telemetry, MSG_OP_GET_TELEMETRY);
 	struct amdxdna_dev *xdna = ndev->aie.xdna;
-	dma_addr_t dma_addr;
-	u32 buf_sz;
-	u8 *addr;
+	struct amdxdna_msg_buf_hdl *buf_hdl;
 	int ret;
 
 	if (header->type >= MAX_TELEMETRY_TYPE)
 		return -EINVAL;
 
-	buf_sz = min(size, SZ_4M);
-	addr = amdxdna_alloc_msg_buffer(xdna, &buf_sz, &dma_addr);
-	if (IS_ERR(addr))
-		return PTR_ERR(addr);
+	buf_hdl = amdxdna_alloc_msg_buff(xdna, min(size, SZ_4M));
+	if (IS_ERR(buf_hdl))
+		return PTR_ERR(buf_hdl);
 
-	req.buf_addr = dma_addr;
-	req.buf_size = buf_sz;
+	req.buf_addr = to_dma_addr(buf_hdl, 0);
+	req.buf_size = to_buf_size(buf_hdl);
 	req.type = header->type;
 
-	drm_clflush_virt_range(addr, size); /* device can access */
+	amdxdna_clflush_msg_buff(buf_hdl, 0, 0);
 	ret = aie_send_mgmt_msg_wait(&ndev->aie, &msg);
 	if (ret) {
 		XDNA_ERR(xdna, "Query telemetry failed, status %d", ret);
 		goto free_buf;
 	}
 
-	if (buf_sz < resp.size) {
+	if (to_buf_size(buf_hdl) < resp.size) {
 		ret = -EINVAL;
-		XDNA_ERR(xdna, "Bad buffer size. Available: %u. Needs: %u", buf_sz, resp.size);
+		XDNA_ERR(xdna, "Bad buffer size. Available: %u. Needs: %u",
+			 to_buf_size(buf_hdl), resp.size);
 		goto free_buf;
 	}
 
 	size = min(size, resp.size);
-	if (copy_to_user(buf, addr, size)) {
+	if (copy_to_user(buf, to_cpu_addr(buf_hdl, 0), size)) {
 		ret = -EFAULT;
 		XDNA_ERR(xdna, "Failed to copy telemetry to user space");
 		goto free_buf;
@@ -460,7 +457,7 @@ int aie2_query_telemetry(struct amdxdna_dev_hdl *ndev,
 	header->minor = resp.minor;
 
 free_buf:
-	amdxdna_free_msg_buffer(xdna, buf_sz, addr, dma_addr);
+	amdxdna_free_msg_buff(buf_hdl);
 	return ret;
 }
 
@@ -1158,9 +1155,7 @@ int aie2_query_app_health(struct amdxdna_dev_hdl *ndev, u32 context_id,
 {
 	DECLARE_AIE_MSG(get_app_health, MSG_OP_GET_APP_HEALTH);
 	struct amdxdna_dev *xdna = ndev->aie.xdna;
-	struct app_health_report *buf;
-	dma_addr_t dma_addr;
-	u32 buf_size;
+	struct amdxdna_msg_buf_hdl *buf_hdl;
 	int ret;
 
 	if (!AIE_FEATURE_ON(&ndev->aie, AIE2_APP_HEALTH)) {
@@ -1168,18 +1163,17 @@ int aie2_query_app_health(struct amdxdna_dev_hdl *ndev, u32 context_id,
 		return -EOPNOTSUPP;
 	}
 
-	buf_size = sizeof(*report);
-	buf = amdxdna_alloc_msg_buffer(xdna, &buf_size, &dma_addr);
-	if (IS_ERR(buf)) {
+	buf_hdl = amdxdna_alloc_msg_buff(xdna, sizeof(*report));
+	if (IS_ERR(buf_hdl)) {
 		XDNA_ERR(xdna, "Failed to allocate buffer for app health");
-		return PTR_ERR(buf);
+		return PTR_ERR(buf_hdl);
 	}
 
-	req.buf_addr = dma_addr;
+	req.buf_addr = to_dma_addr(buf_hdl, 0);
 	req.context_id = context_id;
-	req.buf_size = buf_size;
+	req.buf_size = to_buf_size(buf_hdl);
 
-	drm_clflush_virt_range(buf, sizeof(*report));
+	amdxdna_clflush_msg_buff(buf_hdl, 0, 0);
 	ret = aie_send_mgmt_msg_wait(&ndev->aie, &msg);
 	if (ret) {
 		XDNA_ERR(xdna, "Get app health failed, ret %d status 0x%x", ret, resp.status);
@@ -1187,10 +1181,10 @@ int aie2_query_app_health(struct amdxdna_dev_hdl *ndev, u32 context_id,
 	}
 
 	/* Copy the report to caller's buffer */
-	memcpy(report, buf, sizeof(*report));
+	memcpy(report, to_cpu_addr(buf_hdl, 0), sizeof(*report));
 
 free_buf:
-	amdxdna_free_msg_buffer(xdna, buf_size, buf, dma_addr);
+	amdxdna_free_msg_buff(buf_hdl);
 	return ret;
 }
 
@@ -1261,4 +1255,34 @@ int aie2_get_dev_revision(struct amdxdna_dev_hdl *ndev, enum aie2_dev_revision *
 
 	XDNA_DBG(xdna, "Device revision: %d (raw fuse: 0x%x)", *rev, resp.raw_fuse_data);
 	return 0;
+}
+
+int aie2_get_aie_coredump(struct amdxdna_dev *xdna,
+			  struct amdxdna_msg_buf_hdl *list_hdl,
+			  struct amdxdna_hwctx *hwctx, u32 num_bufs)
+{
+	struct amdxdna_dev_hdl *ndev = xdna->dev_handle;
+	DECLARE_AIE_MSG(get_coredump, MSG_OP_GET_COREDUMP);
+	int ret;
+
+	if (!AIE_FEATURE_ON(&ndev->aie, AIE2_GET_COREDUMP)) {
+		XDNA_DBG(xdna, "Get coredump unsupported for the device or firmware version");
+		return -EOPNOTSUPP;
+	}
+
+	req.context_id = hwctx->fw_ctx_id;
+	req.num_bufs = num_bufs;
+	req.list_addr = to_dma_addr(list_hdl, 0);
+	req.list_size = to_buf_size(list_hdl);
+
+	ret = aie_send_mgmt_msg_wait(&ndev->aie, &msg);
+	if (ret) {
+		if (resp.status == AIE2_STATUS_MGMT_ERT_DRAM_BUFFER_SIZE_INVALID)
+			XDNA_ERR(xdna, "Invalid buffer size(required 0x%x) for get coredump",
+				 resp.required_buffer_size);
+		else
+			XDNA_ERR(xdna, "Get coredump got status 0x%x", resp.status);
+	}
+
+	return ret;
 }

--- a/drivers/accel/amdxdna/aie2_msg_priv.h
+++ b/drivers/accel/amdxdna/aie2_msg_priv.h
@@ -35,6 +35,7 @@ enum aie2_msg_opcode {
 	MSG_OP_GET_APP_HEALTH              = 0x114,
 	MSG_OP_ADD_HOST_BUFFER             = 0x115,
 	MSG_OP_GET_DEV_REVISION            = 0x117,
+	MSG_OP_GET_COREDUMP                = 0x119,
 	MSG_OP_MAX_DRV_OPCODE,
 	MSG_OP_GET_PROTOCOL_VERSION        = 0x301,
 	MSG_OP_MAX_OPCODE
@@ -64,6 +65,7 @@ enum aie2_msg_status {
 	AIE2_STATUS_MGMT_ERT_ENTER_SUSPEND_FAILURE,
 	AIE2_STATUS_MGMT_ERT_BUSY,
 	AIE2_STATUS_MGMT_ERT_APPLICATION_ACTIVE,
+	AIE2_STATUS_MGMT_ERT_DRAM_BUFFER_SIZE_INVALID,
 	MAX_MGMT_ERT_STATUS_CODE,
 	/* APP ERT Error codes */
 	AIE2_STATUS_APP_ERT_FIRST_ERROR			= 0x3000001,
@@ -541,6 +543,19 @@ struct get_dev_revision_resp {
 	enum aie2_msg_status	status;
 	enum aie2_dev_revision	rev;
 	__u32			raw_fuse_data;
+} __packed;
+
+struct get_coredump_req {
+	__u32		context_id;
+	__u32		num_bufs;
+	__u64		list_addr;
+	__u32		list_size;
+} __packed;
+
+struct get_coredump_resp {
+	enum aie2_msg_status	status;
+	__u32			required_buffer_size;
+	__u32			reserved[7];
 } __packed;
 
 #endif /* _AIE2_MSG_PRIV_H_ */

--- a/drivers/accel/amdxdna/aie2_pci.c
+++ b/drivers/accel/amdxdna/aie2_pci.c
@@ -20,6 +20,7 @@
 #include <linux/xarray.h>
 #include <asm/hypervisor.h>
 
+#include "aie.h"
 #include "aie2_msg_priv.h"
 #include "aie2_pci.h"
 #include "aie2_solver.h"
@@ -869,6 +870,9 @@ static int aie2_get_hwctx_status(struct amdxdna_client *client,
 	struct amdxdna_client *tmp_client;
 	int ret;
 
+	if (!amdxdna_is_admin())
+		return -EPERM;
+
 	drm_WARN_ON(&xdna->ddev, !mutex_is_locked(&xdna->dev_lock));
 
 	array_args.element_size = sizeof(struct amdxdna_drm_query_hwctx);
@@ -935,6 +939,9 @@ static int aie2_get_telemetry(struct amdxdna_client *client,
 	struct amdxdna_dev *xdna = client->xdna;
 	struct amdxdna_client *tmp_client;
 	int ret;
+
+	if (!amdxdna_is_admin())
+		return -EPERM;
 
 	elem_num = xdna->dev_handle->priv->hwctx_limit;
 	header_sz = struct_size(header, map, elem_num);
@@ -1097,6 +1104,7 @@ static int aie2_query_ctx_status_array(struct amdxdna_client *client,
 static int aie2_get_array(struct amdxdna_client *client,
 			  struct amdxdna_drm_get_array *args)
 {
+	struct amdxdna_dev_hdl *ndev = client->xdna->dev_handle;
 	struct amdxdna_dev *xdna = client->xdna;
 	int ret, idx;
 
@@ -1113,6 +1121,9 @@ static int aie2_get_array(struct amdxdna_client *client,
 		break;
 	case DRM_AMDXDNA_HW_LAST_ASYNC_ERR:
 		ret = aie2_get_array_async_error(xdna->dev_handle, args);
+		break;
+	case DRM_AMDXDNA_AIE_COREDUMP:
+		ret = amdxdna_get_coredump(&ndev->aie, client, args);
 		break;
 	case DRM_AMDXDNA_BO_USAGE:
 		ret = amdxdna_drm_get_bo_usage(&xdna->ddev, args);
@@ -1249,6 +1260,7 @@ const struct amdxdna_dev_ops aie2_ops = {
 	.cmd_submit = aie2_cmd_submit,
 	.hmm_invalidate = amdxdna_hmm_invalidate,
 	.get_array = aie2_get_array,
+	.get_coredump = aie2_get_aie_coredump,
 	.get_dev_revision = aie2_get_dev_rev,
 	.hwctx_heap_expand = aie2_hwctx_heap_expand,
 };

--- a/drivers/accel/amdxdna/aie2_pci.h
+++ b/drivers/accel/amdxdna/aie2_pci.h
@@ -215,6 +215,7 @@ enum aie2_fw_feature {
 	AIE2_ADD_HOST_BUFFER,
 	AIE2_UPDATE_PROPERTY,
 	AIE2_GET_DEV_REVISION,
+	AIE2_GET_COREDUMP,
 	AIE2_FEATURE_MAX
 };
 
@@ -281,6 +282,9 @@ int aie2_query_firmware_version(struct amdxdna_dev_hdl *ndev,
 int aie2_query_app_health(struct amdxdna_dev_hdl *ndev, u32 context_id,
 			  struct app_health_report *report);
 int aie2_get_dev_revision(struct amdxdna_dev_hdl *ndev, enum aie2_dev_revision *rev);
+int aie2_get_aie_coredump(struct amdxdna_dev *xdna,
+			  struct amdxdna_msg_buf_hdl *list_hdl,
+			  struct amdxdna_hwctx *hwctx, u32 num_bufs);
 int aie2_create_context(struct amdxdna_dev_hdl *ndev, struct amdxdna_hwctx *hwctx);
 int aie2_destroy_context(struct amdxdna_dev_hdl *ndev, struct amdxdna_hwctx *hwctx);
 int aie2_map_host_buf(struct amdxdna_dev_hdl *ndev, u32 context_id, u64 addr, u64 size);

--- a/drivers/accel/amdxdna/aie4_message.c
+++ b/drivers/accel/amdxdna/aie4_message.c
@@ -5,11 +5,14 @@
 
 #include "drm/amdxdna_accel.h"
 #include <drm/drm_print.h>
+#include <drm/gpu_scheduler.h>
+#include <linux/bitfield.h>
 #include <linux/mutex.h>
 
 #include "aie.h"
 #include "aie4_msg_priv.h"
 #include "aie4_pci.h"
+#include "amdxdna_ctx.h"
 #include "amdxdna_mailbox.h"
 #include "amdxdna_mailbox_helper.h"
 #include "amdxdna_pci_drv.h"
@@ -77,6 +80,32 @@ int aie4_attach_work_buffer(struct amdxdna_dev_hdl *ndev, dma_addr_t addr, u32 s
 		XDNA_ERR(xdna, "Failed to attach work buffer, ret %d", ret);
 	else
 		XDNA_DBG(xdna, "Attached work buffer, size %d", size);
+
+	return ret;
+}
+
+int aie4_get_aie_coredump(struct amdxdna_dev *xdna,
+			  struct amdxdna_msg_buf_hdl *list_hdl,
+			  struct amdxdna_hwctx *hwctx, u32 num_bufs)
+{
+	struct amdxdna_dev_hdl *ndev = xdna->dev_handle;
+	DECLARE_AIE_MSG(aie4_msg_aie4_coredump, AIE4_MSG_OP_AIE_COREDUMP);
+	int ret;
+
+	if (!AIE_FEATURE_ON(&ndev->aie, AIE4_GET_COREDUMP)) {
+		XDNA_DBG(xdna, "Get coredump unsupported for the device or firmware version");
+		return -EOPNOTSUPP;
+	}
+
+	req.context_id = hwctx->fw_ctx_id;
+	req.pasid = FIELD_PREP(AIE4_MSG_PASID, hwctx->client->pasid) |
+		    FIELD_PREP(AIE4_MSG_PASID_VLD, 1);
+	req.num_buffers = num_bufs;
+	req.buffer_list_addr = to_dma_addr(list_hdl, 0);
+
+	ret = aie_send_mgmt_msg_wait(&ndev->aie, &msg);
+	if (ret)
+		XDNA_ERR(xdna, "Get coredump got status 0x%x", resp.status);
 
 	return ret;
 }

--- a/drivers/accel/amdxdna/aie4_msg_priv.h
+++ b/drivers/accel/amdxdna/aie4_msg_priv.h
@@ -13,6 +13,7 @@
 enum aie4_msg_opcode {
 	AIE4_MSG_OP_SUSPEND                          = 0x10003,
 	AIE4_MSG_OP_ATTACH_WORK_BUFFER               = 0x1000D,
+	AIE4_MSG_OP_AIE_COREDUMP                     = 0x30010,
 
 	AIE4_MSG_OP_CREATE_VFS                       = 0x20001,
 	AIE4_MSG_OP_DESTROY_VFS                      = 0x20002,
@@ -142,6 +143,18 @@ struct aie4_msg_attach_work_buffer_req {
 } __packed;
 
 struct aie4_msg_attach_work_buffer_resp {
+	enum aie4_msg_status status;
+} __packed;
+
+struct aie4_msg_aie4_coredump_req {
+	__u32 context_id;
+	__u32 pasid;
+	__u32 num_buffers;
+	__u32 resvd;
+	__u64 buffer_list_addr;
+} __packed;
+
+struct aie4_msg_aie4_coredump_resp {
 	enum aie4_msg_status status;
 } __packed;
 

--- a/drivers/accel/amdxdna/aie4_pci.c
+++ b/drivers/accel/amdxdna/aie4_pci.c
@@ -290,7 +290,9 @@ static int aie4_pf_hw_start(struct amdxdna_dev_hdl *ndev)
 		goto fw_unload;
 
 	/* Firmware releases the DRAM work buffer internally during suspend_fw */
-	ret = aie4_attach_work_buffer(ndev, ndev->work_buf_addr, ndev->work_buf_size);
+	ret = aie4_attach_work_buffer(ndev,
+				      to_dma_addr(ndev->work_buf_hdl, 0),
+				      to_buf_size(ndev->work_buf_hdl));
 	if (ret)
 		goto mbox_fini;
 
@@ -574,35 +576,30 @@ static int aie4_get_info(struct amdxdna_client *client, struct amdxdna_drm_get_i
 static int aie4_alloc_work_buffer(struct amdxdna_dev_hdl *ndev)
 {
 	struct amdxdna_dev *xdna = ndev->aie.xdna;
-	u32 buf_size = AIE4_WORK_BUFFER_MIN_SIZE;
 
-	ndev->work_buf = amdxdna_alloc_msg_buffer(xdna, &buf_size,
-						  &ndev->work_buf_addr);
-	if (IS_ERR(ndev->work_buf)) {
-		int ret = PTR_ERR(ndev->work_buf);
+	ndev->work_buf_hdl = amdxdna_alloc_msg_buff(xdna, AIE4_WORK_BUFFER_MIN_SIZE);
+	if (IS_ERR(ndev->work_buf_hdl)) {
+		int ret = PTR_ERR(ndev->work_buf_hdl);
 
 		XDNA_ERR(xdna, "Failed to alloc work buffer, size 0x%x",
 			 AIE4_WORK_BUFFER_MIN_SIZE);
-		ndev->work_buf = NULL;
+		ndev->work_buf_hdl = NULL;
 		return ret;
 	}
 
-	ndev->work_buf_size = buf_size;
-	XDNA_DBG(xdna, "Work buffer allocated: size 0x%x", buf_size);
+	XDNA_DBG(xdna, "Work buffer allocated: size 0x%x",
+		 to_buf_size(ndev->work_buf_hdl));
 
 	return 0;
 }
 
 static void aie4_free_work_buffer(struct amdxdna_dev_hdl *ndev)
 {
-	struct amdxdna_dev *xdna = ndev->aie.xdna;
-
-	if (!ndev->work_buf)
+	if (!ndev->work_buf_hdl)
 		return;
 
-	amdxdna_free_msg_buffer(xdna, ndev->work_buf_size, ndev->work_buf,
-				ndev->work_buf_addr);
-	ndev->work_buf = NULL;
+	amdxdna_free_msg_buff(ndev->work_buf_hdl);
+	ndev->work_buf_hdl = NULL;
 }
 
 static int aie4_pf_init(struct amdxdna_dev *xdna)

--- a/drivers/accel/amdxdna/aie4_pci.c
+++ b/drivers/accel/amdxdna/aie4_pci.c
@@ -557,7 +557,14 @@ static int aie4_get_info(struct amdxdna_client *client, struct amdxdna_drm_get_i
 {
 	struct amdxdna_dev *xdna = client->xdna;
 	struct amdxdna_dev_hdl *ndev = xdna->dev_handle;
-	int ret;
+	int ret, idx;
+
+	if (!drm_dev_enter(&xdna->ddev, &idx))
+		return -ENODEV;
+
+	ret = amdxdna_pm_resume_get_locked(xdna);
+	if (ret)
+		goto dev_exit;
 
 	switch (args->param) {
 	case DRM_AMDXDNA_QUERY_AIE_METADATA:
@@ -568,8 +575,11 @@ static int aie4_get_info(struct amdxdna_client *client, struct amdxdna_drm_get_i
 		ret = -EOPNOTSUPP;
 	}
 
+	amdxdna_pm_suspend_put(xdna);
 	XDNA_DBG(xdna, "Got param %d", args->param);
 
+dev_exit:
+	drm_dev_exit(idx);
 	return ret;
 }
 
@@ -654,6 +664,36 @@ const struct amdxdna_dev_ops aie4_pf_ops = {
 	.sriov_configure        = aie4_sriov_configure,
 };
 
+static int aie4_get_array(struct amdxdna_client *client,
+			  struct amdxdna_drm_get_array *args)
+{
+	struct amdxdna_dev_hdl *ndev = client->xdna->dev_handle;
+	struct amdxdna_dev *xdna = client->xdna;
+	int ret, idx;
+
+	if (!drm_dev_enter(&xdna->ddev, &idx))
+		return -ENODEV;
+
+	ret = amdxdna_pm_resume_get_locked(xdna);
+	if (ret)
+		goto dev_exit;
+
+	switch (args->param) {
+	case DRM_AMDXDNA_AIE_COREDUMP:
+		ret = amdxdna_get_coredump(&ndev->aie, client, args);
+		break;
+	default:
+		ret = -EOPNOTSUPP;
+		break;
+	}
+
+	amdxdna_pm_suspend_put(xdna);
+
+dev_exit:
+	drm_dev_exit(idx);
+	return ret;
+}
+
 const struct amdxdna_dev_ops aie4_vf_ops = {
 	.init			= aie4_vf_init,
 	.fini			= aie4_vf_fini,
@@ -662,5 +702,7 @@ const struct amdxdna_dev_ops aie4_vf_ops = {
 	.mmap			= aie4_doorbell_mmap,
 	.cmd_wait		= aie4_cmd_wait,
 	.get_aie_info		= aie4_get_info,
+	.get_array		= aie4_get_array,
+	.get_coredump		= aie4_get_aie_coredump,
 	.hmm_invalidate		= amdxdna_hmm_invalidate,
 };

--- a/drivers/accel/amdxdna/aie4_pci.h
+++ b/drivers/accel/amdxdna/aie4_pci.h
@@ -54,9 +54,7 @@ struct amdxdna_dev_hdl {
 	struct xarray                   cert_comp_xa; /* device level indexed by msix id */
 	struct mutex                    cert_comp_lock; /* protects cert_comp operations*/
 
-	void				*work_buf;
-	dma_addr_t			work_buf_addr;
-	u32				work_buf_size;
+	struct amdxdna_msg_buf_hdl	*work_buf_hdl;
 };
 
 /* aie4_message.c */

--- a/drivers/accel/amdxdna/aie4_pci.h
+++ b/drivers/accel/amdxdna/aie4_pci.h
@@ -80,6 +80,15 @@ static inline int aie4_sriov_stop(struct amdxdna_dev_hdl *ndev)
 }
 #endif
 
+enum aie4_fw_feature {
+	AIE4_GET_COREDUMP,
+	AIE4_FEATURE_MAX
+};
+
+int aie4_get_aie_coredump(struct amdxdna_dev *xdna,
+			  struct amdxdna_msg_buf_hdl *list_hdl,
+			  struct amdxdna_hwctx *hwctx, u32 num_bufs);
+
 extern const struct amdxdna_dev_ops aie4_pf_ops;
 extern const struct amdxdna_dev_ops aie4_vf_ops;
 

--- a/drivers/accel/amdxdna/amdxdna_pci_drv.c
+++ b/drivers/accel/amdxdna/amdxdna_pci_drv.c
@@ -46,9 +46,10 @@ MODULE_FIRMWARE("amdnpu/17f0_11/npu_7.sbin");
  * 0.8: Support BO usage query
  * 0.9: Add new device type AMDXDNA_DEV_TYPE_PF
  * 0.10: Add new device type AMDXDNA_DEV_TYPE_UMQ
+ * 0.11: Support AIE coredump
  */
 #define AMDXDNA_DRIVER_MAJOR		0
-#define AMDXDNA_DRIVER_MINOR		10
+#define AMDXDNA_DRIVER_MINOR		11
 
 /*
  * Bind the driver base on (vendor_id, device_id) pair and later use the

--- a/drivers/accel/amdxdna/amdxdna_pci_drv.h
+++ b/drivers/accel/amdxdna/amdxdna_pci_drv.h
@@ -9,6 +9,7 @@
 #include "drm/amdxdna_accel.h"
 #include <drm/drm_device.h>
 #include <drm/drm_print.h>
+#include <linux/capability.h>
 #include <linux/iommu.h>
 #include <linux/iova.h>
 #include <linux/workqueue.h>
@@ -40,6 +41,11 @@
 
 extern const struct drm_driver amdxdna_drm_drv;
 
+static inline bool amdxdna_is_admin(void)
+{
+	return capable(CAP_SYS_ADMIN);
+}
+
 struct amdxdna_client;
 struct amdxdna_dev;
 struct amdxdna_drm_get_info;
@@ -47,6 +53,7 @@ struct amdxdna_drm_set_state;
 struct amdxdna_gem_obj;
 struct amdxdna_hwctx;
 struct amdxdna_sched_job;
+struct amdxdna_msg_buf_hdl;
 
 /*
  * struct amdxdna_dev_ops - Device hardware operation callbacks
@@ -68,6 +75,9 @@ struct amdxdna_dev_ops {
 	int (*get_aie_info)(struct amdxdna_client *client, struct amdxdna_drm_get_info *args);
 	int (*set_aie_state)(struct amdxdna_client *client, struct amdxdna_drm_set_state *args);
 	int (*get_array)(struct amdxdna_client *client, struct amdxdna_drm_get_array *args);
+	int (*get_coredump)(struct amdxdna_dev *xdna,
+			    struct amdxdna_msg_buf_hdl *list_hdl,
+			    struct amdxdna_hwctx *hwctx, u32 num_bufs);
 	int (*get_dev_revision)(struct amdxdna_dev *xdna, u32 *rev);
 	int (*hwctx_heap_expand)(struct amdxdna_hwctx *hwctx);
 };

--- a/drivers/accel/amdxdna/npu3_regs.c
+++ b/drivers/accel/amdxdna/npu3_regs.c
@@ -39,6 +39,7 @@
 
 static const struct amdxdna_fw_feature_tbl npu3_fw_feature_table[] = {
 	{ .major = 5, .min_minor = 10 },
+	{ .features = BIT_U64(AIE4_GET_COREDUMP), .major = 5, .min_minor = 24 },
 	{ 0 }
 };
 

--- a/include/uapi/drm/amdxdna_accel.h
+++ b/include/uapi/drm/amdxdna_accel.h
@@ -473,10 +473,10 @@ enum amdxdna_drm_get_param {
 	DRM_AMDXDNA_QUERY_AIE_VERSION,
 	DRM_AMDXDNA_QUERY_CLOCK_METADATA,
 	DRM_AMDXDNA_QUERY_SENSORS,
-	DRM_AMDXDNA_QUERY_HW_CONTEXTS,
+	DRM_AMDXDNA_QUERY_HW_CONTEXTS,		/* CAP_SYS_ADMIN required */
 	DRM_AMDXDNA_QUERY_FIRMWARE_VERSION = 8,
 	DRM_AMDXDNA_GET_POWER_MODE,
-	DRM_AMDXDNA_QUERY_TELEMETRY,
+	DRM_AMDXDNA_QUERY_TELEMETRY,		/* CAP_SYS_ADMIN required */
 	DRM_AMDXDNA_GET_FORCE_PREEMPT_STATE,
 	DRM_AMDXDNA_QUERY_RESOURCE_INFO,
 	DRM_AMDXDNA_GET_FRAME_BOUNDARY_PREEMPT_STATE,
@@ -640,11 +640,24 @@ struct amdxdna_drm_bo_usage {
 	__u64 heap_usage;
 };
 
+/**
+ * struct amdxdna_drm_aie_coredump - The data for AIE coredump
+ * @pid: The Process ID of the process that created this context.
+ * @context_id: The ID for this context.
+ * @pad: MBZ.
+ */
+struct amdxdna_drm_aie_coredump {
+	__u64 pid;
+	__u32 context_id;
+	__u32 pad;
+};
+
 /*
  * Supported params in struct amdxdna_drm_get_array
  */
 #define DRM_AMDXDNA_HW_CONTEXT_ALL	0
 #define DRM_AMDXDNA_HW_LAST_ASYNC_ERR	2
+#define DRM_AMDXDNA_AIE_COREDUMP	5
 #define DRM_AMDXDNA_BO_USAGE		6
 
 /**
@@ -661,6 +674,19 @@ struct amdxdna_drm_get_array {
 	 *
 	 * %DRM_AMDXDNA_HW_LAST_ASYNC_ERR:
 	 * Returns last async error.
+	 *
+	 * %DRM_AMDXDNA_AIE_COREDUMP:
+	 * Returns AIE tile memory dump for a hardware context.
+	 *
+	 * Input: num_element must be 1. buffer points to a user buffer whose
+	 * size is element_size bytes. The first sizeof(struct
+	 * amdxdna_drm_aie_coredump) bytes of buffer carry the request
+	 * (pid + context_id). On success the driver writes rows * cols * 1 MB
+	 * of tile dump data into buffer. If the buffer is too small the
+	 * driver sets element_size to the required size and returns -ENOSPC.
+	 *
+	 * Access: context owners may coredump their own contexts;
+	 * CAP_SYS_ADMIN may coredump any context.
 	 *
 	 * %DRM_AMDXDNA_BO_USAGE:
 	 * Returns usage of heap/internal/external BOs.

--- a/test/shim_test/shim_test.cpp
+++ b/test/shim_test/shim_test.cpp
@@ -1057,7 +1057,7 @@ std::vector<test_case> test_list {
   test_case{ "export BO then close device", {},
     TEST_POSITIVE, dev_filter_xdna, TEST_export_bo_then_close_device, {}
   },
-  test_case{ "get AIE coredump and check registers", {~0U, ~0U},
+  test_case{ "get AIE coredump and check registers", {},
     TEST_POSITIVE, dev_filter_is_npu4, TEST_io_coredump, {}
   },
   test_case{ "AIE MEM read/write", {~0U, ~0U},


### PR DESCRIPTION
Add AIE coredump to capture per-context tile memory snapshots for post-mortem debugging via a new DRM_AMDXDNA_AIE_COREDUMP parameter in the GET_ARRAY ioctl, gated behind CAP_SYS_ADMIN.

Patch 1 adds the core infrastructure, DMA buffer abstraction, access control helpers, AIE2 firmware message, and UAPI definitions.
Patch 2 extends coredump to AIE4 (NPU3) with FW >= 5.24 gating. 