### PR TITLE
Build using the configuration of the chosen kernel, not /proc/config.gz

### DIFF
--- a/drivers/accel/tools/configure_kernel.sh
+++ b/drivers/accel/tools/configure_kernel.sh
@@ -67,7 +67,11 @@ try_compile() {
     conftest_c="$tmpdir/conftest.c"
     conftest_mk="$tmpdir/Makefile"
     USE_LLVM=""
-    if [ -e /proc/config.gz ]; then
+    if [ -e "${KERNEL_SRC}/.config" ]; then
+        if grep -q "CONFIG_CC_IS_CLANG=y" "${KERNEL_SRC}/.config" 2>/dev/null; then
+            USE_LLVM="LLVM=1"
+        fi
+    elif [ -e /proc/config.gz ]; then
         if zgrep -q "CONFIG_CC_IS_CLANG=y" /proc/config.gz 2>/dev/null; then
             USE_LLVM="LLVM=1"
         fi

--- a/src/driver/tools/configure_kernel.sh
+++ b/src/driver/tools/configure_kernel.sh
@@ -67,7 +67,11 @@ try_compile() {
     conftest_c="$tmpdir/conftest.c"
     conftest_mk="$tmpdir/Makefile"
     USE_LLVM=""
-    if [ -e /proc/config.gz ]; then
+    if [ -e "${KERNEL_SRC}/.config" ]; then
+        if grep -q "CONFIG_CC_IS_CLANG=y" "${KERNEL_SRC}/.config" 2>/dev/null; then
+            USE_LLVM="LLVM=1"
+        fi
+    elif [ -e /proc/config.gz ]; then
         if zgrep -q "CONFIG_CC_IS_CLANG=y" /proc/config.gz 2>/dev/null; then
             USE_LLVM="LLVM=1"
         fi


### PR DESCRIPTION
This fixes compilation when the compilers for the running kernel and the target kernel differ.

`/proc/config.gz` should not be used as the primary source of configuration values for several reasons:
- A module may be compiled for a kernel that will be booted later
- `/proc/config.gz` may not belong to the target system (e.g., an Arch/Gentoo host with a Clang-built kernel building a deb inside an Ubuntu Docker container with a GCC-based config in `/lib/modules/6.8.0-111-generic/build/.config`)