### PR TITLE
accel/amdxdna: add AIE tile register/memory read/write access

### DIFF
--- a/drivers/accel/amdxdna/aie.c
+++ b/drivers/accel/amdxdna/aie.c
@@ -311,17 +311,6 @@ void amdxdna_hmm_invalidate(struct amdxdna_gem_obj *abo,
 		XDNA_DBG(xdna, "Wait for bo interrupted by signal");
 }
 
-bool amdxdna_hwctx_access_allowed(struct amdxdna_hwctx *hwctx, bool root_only)
-{
-	if (amdxdna_is_admin())
-		return true;
-
-	if (root_only)
-		return false;
-
-	return task_tgid_nr(current) == hwctx->client->pid;
-}
-
 struct amdxdna_msg_buf_hdl *amdxdna_alloc_msg_buff(struct amdxdna_dev *xdna, u32 size)
 {
 	struct amdxdna_msg_buf_hdl *hdl;
@@ -334,30 +323,27 @@ struct amdxdna_msg_buf_hdl *amdxdna_alloc_msg_buff(struct amdxdna_dev *xdna, u32
 	hdl->xdna = xdna;
 	hdl->size = max_t(u32, size, SZ_8K);
 	order = get_order(hdl->size);
-	if (order > MAX_PAGE_ORDER) {
-		kfree(hdl);
-		return ERR_PTR(-EINVAL);
-	}
+	if (order > MAX_PAGE_ORDER)
+		goto free_hdl;
 	hdl->size = PAGE_SIZE << order;
 
 	if (amdxdna_iova_on(xdna)) {
 		hdl->vaddr = amdxdna_iommu_alloc(xdna, hdl->size, &hdl->dma_addr);
+		if (IS_ERR(hdl->vaddr))
+			goto free_hdl;
 	} else {
 		hdl->vaddr = dma_alloc_noncoherent(xdna->ddev.dev, hdl->size,
 						   &hdl->dma_addr,
 						   DMA_FROM_DEVICE, GFP_KERNEL);
 		if (!hdl->vaddr)
-			hdl->vaddr = ERR_PTR(-ENOMEM);
-	}
-
-	if (IS_ERR(hdl->vaddr)) {
-		int ret = PTR_ERR(hdl->vaddr);
-
-		kfree(hdl);
-		return ERR_PTR(ret);
+			goto free_hdl;
 	}
 
 	return hdl;
+
+free_hdl:
+	kfree(hdl);
+	return ERR_PTR(-ENOMEM);
 }
 
 void amdxdna_free_msg_buff(struct amdxdna_msg_buf_hdl *hdl)
@@ -377,18 +363,6 @@ void amdxdna_free_msg_buff(struct amdxdna_msg_buf_hdl *hdl)
 	kfree(hdl);
 }
 
-void amdxdna_clflush_msg_buff(struct amdxdna_msg_buf_hdl *hdl, u32 offset, u32 size)
-{
-	if (!hdl || offset > hdl->size)
-		return;
-	if (!size)
-		size = hdl->size - offset;
-	else if (size > hdl->size - offset)
-		return;
-
-	drm_clflush_virt_range(to_cpu_addr(hdl, offset), size);
-}
-
 int amdxdna_get_coredump(struct aie_device *aie,
 			 struct amdxdna_client *client,
 			 struct amdxdna_drm_get_array *args)
@@ -401,7 +375,7 @@ int amdxdna_get_coredump(struct aie_device *aie,
 	struct amdxdna_dev *xdna = client->xdna;
 	struct amdxdna_hwctx *hwctx = NULL;
 	struct amdxdna_client *tmp_client;
-	u32 data_buf_size = SZ_1M;
+	size_t data_buf_size = SZ_1M;
 	int ret = 0, idx = 0, i;
 	unsigned long hwctx_id;
 	size_t offset = 0;
@@ -411,10 +385,10 @@ int amdxdna_get_coredump(struct aie_device *aie,
 	u32 num_bufs;
 	u32 orig_col;
 
-	if (!xdna->dev_info->ops->get_coredump)
-		return -EOPNOTSUPP;
-
 	drm_WARN_ON(&xdna->ddev, !mutex_is_locked(&xdna->dev_lock));
+
+	if (!aie->msg_ops.get_coredump)
+		return -EOPNOTSUPP;
 
 	if (args->num_element != 1) {
 		XDNA_ERR(xdna, "Invalid num_element %u, expected 1",
@@ -470,7 +444,8 @@ int amdxdna_get_coredump(struct aie_device *aie,
 		return -EINVAL;
 	}
 
-	if (!amdxdna_hwctx_access_allowed(hwctx, false)) {
+	if (!capable(CAP_SYS_ADMIN) &&
+	    task_tgid_nr(current) != hwctx->client->pid) {
 		XDNA_ERR(xdna, "Permission denied for context %u",
 			 config.context_id);
 		ret = -EPERM;
@@ -489,8 +464,7 @@ int amdxdna_get_coredump(struct aie_device *aie,
 		goto unlock_srcu;
 	}
 
-	list_hdl = amdxdna_alloc_msg_buff(xdna,
-					  max_t(u32, num_bufs * sizeof(*buf_list), SZ_8K));
+	list_hdl = amdxdna_alloc_msg_buff(xdna, num_bufs * sizeof(*buf_list));
 	if (IS_ERR(list_hdl)) {
 		XDNA_ERR(xdna, "Failed to allocate buffer list");
 		ret = PTR_ERR(list_hdl);
@@ -516,16 +490,15 @@ int amdxdna_get_coredump(struct aie_device *aie,
 		}
 
 		memset(to_cpu_addr(data_hdls[i], 0), 0, data_buf_size);
-		amdxdna_clflush_msg_buff(data_hdls[i], 0, 0);
+		drm_clflush_virt_range(to_cpu_addr(data_hdls[i], 0), data_buf_size);
 
 		buf_list[i].buf_addr = to_dma_addr(data_hdls[i], 0);
 		buf_list[i].buf_size = data_buf_size;
 	}
 
-	amdxdna_clflush_msg_buff(list_hdl, 0, 0);
+	drm_clflush_virt_range(buf_list, to_buf_size(list_hdl));
 
-	ret = xdna->dev_info->ops->get_coredump(xdna, list_hdl,
-					       hwctx, num_bufs);
+	ret = aie->msg_ops.get_coredump(hwctx, list_hdl, num_bufs);
 	if (ret) {
 		XDNA_ERR(xdna, "Failed to get coredump from firmware, ret=%d",
 			 ret);

--- a/drivers/accel/amdxdna/aie.c
+++ b/drivers/accel/amdxdna/aie.c
@@ -363,27 +363,132 @@ void amdxdna_free_msg_buff(struct amdxdna_msg_buf_hdl *hdl)
 	kfree(hdl);
 }
 
+struct amdxdna_coredump_walk_arg {
+	u64				pid;
+	u32				ctx_id;
+
+	struct aie_device		*aie;
+	struct amdxdna_drm_get_array	*args;
+	u8 __user			*buf;
+	size_t				buf_size;
+};
+
+struct amdxdna_tile_rw_walk_arg {
+	struct aie_device				*aie;
+	const struct amdxdna_drm_aie_tile_access	*access;
+	u8 __user					*buf;
+};
+
+static bool amdxdna_get_coredump_filter(struct amdxdna_hwctx *hwctx, void *arg)
+{
+	struct amdxdna_coredump_walk_arg *wa = arg;
+
+	return hwctx->client->pid == wa->pid && hwctx->id == wa->ctx_id;
+}
+
+static int amdxdna_get_coredump_cb(struct amdxdna_hwctx *hwctx, void *arg)
+{
+	struct amdxdna_dev *xdna = hwctx->client->xdna;
+	struct amdxdna_msg_buf_hdl **data_hdls = NULL;
+	struct amdxdna_msg_buf_hdl *list_hdl = NULL;
+	struct amdxdna_coredump_buf_entry *buf_list;
+	struct amdxdna_coredump_walk_arg *wa = arg;
+	size_t data_buf_size = SZ_1M;
+	size_t offset = 0;
+	size_t total_size;
+	int ret = 0, i;
+	u32 num_bufs;
+	u32 orig_col;
+
+	if (!amdxdna_client_visible(hwctx->client)) {
+		XDNA_ERR(xdna, "Permission denied for context %u", wa->ctx_id);
+		return -EPERM;
+	}
+
+	orig_col = hwctx->num_col - hwctx->num_unused_col;
+	num_bufs = wa->aie->metadata.rows * orig_col;
+	total_size = (size_t)num_bufs * data_buf_size;
+
+	if (wa->buf_size < total_size) {
+		XDNA_DBG(xdna, "Insufficient buffer size %zu, need %zu",
+			 wa->buf_size, total_size);
+		wa->args->element_size = total_size;
+		ret = -ENOSPC;
+		goto out;
+	}
+
+	list_hdl = amdxdna_alloc_msg_buff(xdna, num_bufs * sizeof(*buf_list));
+	if (IS_ERR(list_hdl)) {
+		XDNA_ERR(xdna, "Failed to allocate buffer list");
+		ret = PTR_ERR(list_hdl);
+		list_hdl = NULL;
+		goto out;
+	}
+
+	buf_list = to_cpu_addr(list_hdl, 0);
+	memset(buf_list, 0, to_buf_size(list_hdl));
+
+	data_hdls = kzalloc_objs(*data_hdls, num_bufs);
+	if (!data_hdls) {
+		ret = -ENOMEM;
+		goto free_list_hdl;
+	}
+
+	for (i = 0; i < num_bufs; i++) {
+		data_hdls[i] = amdxdna_alloc_msg_buff(xdna, data_buf_size);
+		if (IS_ERR(data_hdls[i])) {
+			XDNA_ERR(xdna, "Failed to allocate data buffer %d", i);
+			ret = PTR_ERR(data_hdls[i]);
+			data_hdls[i] = NULL;
+			goto free_data_hdls;
+		}
+
+		memset(to_cpu_addr(data_hdls[i], 0), 0, to_buf_size(data_hdls[i]));
+		drm_clflush_virt_range(to_cpu_addr(data_hdls[i], 0), to_buf_size(data_hdls[i]));
+
+		buf_list[i].buf_addr = to_dma_addr(data_hdls[i], 0);
+		buf_list[i].buf_size = data_buf_size;
+	}
+
+	drm_clflush_virt_range(buf_list, to_buf_size(list_hdl));
+
+	ret = wa->aie->msg_ops.get_coredump(hwctx, list_hdl, num_bufs);
+	if (ret) {
+		XDNA_ERR(xdna, "Failed to get coredump from firmware, ret=%d",
+			 ret);
+		goto free_data_hdls;
+	}
+
+	for (i = 0; i < num_bufs; i++) {
+		if (copy_to_user(wa->buf + offset, to_cpu_addr(data_hdls[i], 0),
+				 data_buf_size)) {
+			ret = -EFAULT;
+			goto free_data_hdls;
+		}
+		offset += data_buf_size;
+	}
+
+free_data_hdls:
+	for (i = 0; i < num_bufs; i++)
+		amdxdna_free_msg_buff(data_hdls[i]);
+	kfree(data_hdls);
+free_list_hdl:
+	amdxdna_free_msg_buff(list_hdl);
+out:
+	return ret;
+}
+
 int amdxdna_get_coredump(struct aie_device *aie,
 			 struct amdxdna_client *client,
 			 struct amdxdna_drm_get_array *args)
 {
-	struct amdxdna_msg_buf_hdl **data_hdls = NULL;
 	struct amdxdna_drm_aie_coredump config = {};
-	struct amdxdna_coredump_buf_entry *buf_list;
-	struct amdxdna_msg_buf_hdl *list_hdl = NULL;
-	struct amdxdna_client *ctx_client = NULL;
 	struct amdxdna_dev *xdna = client->xdna;
-	struct amdxdna_hwctx *hwctx = NULL;
+	struct amdxdna_coredump_walk_arg wa;
 	struct amdxdna_client *tmp_client;
-	size_t data_buf_size = SZ_1M;
-	int ret = 0, idx = 0, i;
-	unsigned long hwctx_id;
-	size_t offset = 0;
-	size_t total_size;
 	size_t buf_size;
 	u8 __user *buf;
-	u32 num_bufs;
-	u32 orig_col;
+	int ret;
 
 	drm_WARN_ON(&xdna->ddev, !mutex_is_locked(&xdna->dev_lock));
 
@@ -421,106 +526,383 @@ int amdxdna_get_coredump(struct aie_device *aie,
 	XDNA_DBG(xdna, "AIE Coredump request for context_id=%u pid=%llu",
 		 config.context_id, config.pid);
 
+	wa.ctx_id = config.context_id;
+	wa.buf_size = buf_size;
+	wa.pid = config.pid;
+	wa.args = args;
+	wa.aie = aie;
+	wa.buf = buf;
+
 	amdxdna_for_each_client(xdna, tmp_client) {
-		struct amdxdna_hwctx *hw_ctx;
-
-		idx = srcu_read_lock(&tmp_client->hwctx_srcu);
-		amdxdna_for_each_hwctx(tmp_client, hwctx_id, hw_ctx) {
-			if (config.context_id == hwctx_id &&
-			    config.pid == hw_ctx->client->pid) {
-				hwctx = hw_ctx;
-				ctx_client = tmp_client;
-				break;
-			}
-		}
-		if (hwctx)
+		ret = amdxdna_hwctx_walk(tmp_client, &wa,
+					 amdxdna_get_coredump_filter,
+					 amdxdna_get_coredump_cb);
+		if (ret != -ENOENT)
 			break;
-		srcu_read_unlock(&tmp_client->hwctx_srcu, idx);
 	}
-
-	if (!hwctx) {
+	if (ret == -ENOENT)
 		XDNA_ERR(xdna, "Context %u for pid %llu not found",
 			 config.context_id, config.pid);
+	return ret;
+}
+
+static bool amdxdna_tile_rw_filter(struct amdxdna_hwctx *hwctx, void *arg)
+{
+	struct amdxdna_tile_rw_walk_arg *wa = arg;
+
+	return hwctx->client->pid == wa->access->pid && hwctx->id == wa->access->context_id;
+}
+
+static int amdxdna_aie_tile_read_reg(struct amdxdna_hwctx *hwctx,
+				     struct amdxdna_tile_rw_walk_arg *wa)
+{
+	struct amdxdna_dev *xdna = hwctx->client->xdna;
+	u32 reg_val = 0;
+	int ret;
+
+	if (wa->access->size != sizeof(u32)) {
+		XDNA_ERR(xdna, "REG access requires size == 4 (got %u)",
+			 wa->access->size);
 		return -EINVAL;
 	}
 
-	if (!capable(CAP_SYS_ADMIN) &&
-	    task_tgid_nr(current) != hwctx->client->pid) {
-		XDNA_ERR(xdna, "Permission denied for context %u",
-			 config.context_id);
-		ret = -EPERM;
-		goto unlock_srcu;
-	}
-
-	orig_col = hwctx->num_col - hwctx->num_unused_col;
-	num_bufs = aie->metadata.rows * orig_col;
-	total_size = (size_t)num_bufs * data_buf_size;
-
-	if (buf_size < total_size) {
-		XDNA_DBG(xdna, "Insufficient buffer size %zu, need %zu",
-			 buf_size, total_size);
-		args->element_size = total_size;
-		ret = -ENOSPC;
-		goto unlock_srcu;
-	}
-
-	list_hdl = amdxdna_alloc_msg_buff(xdna, num_bufs * sizeof(*buf_list));
-	if (IS_ERR(list_hdl)) {
-		XDNA_ERR(xdna, "Failed to allocate buffer list");
-		ret = PTR_ERR(list_hdl);
-		goto unlock_srcu;
-	}
-
-	buf_list = to_cpu_addr(list_hdl, 0);
-	memset(buf_list, 0, to_buf_size(list_hdl));
-
-	data_hdls = kzalloc_objs(*data_hdls, num_bufs);
-	if (!data_hdls) {
-		ret = -ENOMEM;
-		goto free_list_hdl;
-	}
-
-	for (i = 0; i < num_bufs; i++) {
-		data_hdls[i] = amdxdna_alloc_msg_buff(xdna, data_buf_size);
-		if (IS_ERR(data_hdls[i])) {
-			XDNA_ERR(xdna, "Failed to allocate data buffer %d", i);
-			ret = PTR_ERR(data_hdls[i]);
-			data_hdls[i] = NULL;
-			goto free_data_hdls;
-		}
-
-		memset(to_cpu_addr(data_hdls[i], 0), 0, data_buf_size);
-		drm_clflush_virt_range(to_cpu_addr(data_hdls[i], 0), data_buf_size);
-
-		buf_list[i].buf_addr = to_dma_addr(data_hdls[i], 0);
-		buf_list[i].buf_size = data_buf_size;
-	}
-
-	drm_clflush_virt_range(buf_list, to_buf_size(list_hdl));
-
-	ret = aie->msg_ops.get_coredump(hwctx, list_hdl, num_bufs);
+	ret = wa->aie->msg_ops.rw_reg(hwctx, true, wa->access->row,
+				      wa->access->col, wa->access->addr,
+				      &reg_val);
 	if (ret) {
-		XDNA_ERR(xdna, "Failed to get coredump from firmware, ret=%d",
-			 ret);
-		goto free_data_hdls;
+		XDNA_ERR(xdna, "AIE register read failed, ret %d", ret);
+		return ret;
 	}
 
-	for (i = 0; i < num_bufs; i++) {
-		if (copy_to_user(buf + offset, to_cpu_addr(data_hdls[i], 0),
-				 data_buf_size)) {
-			ret = -EFAULT;
-			goto free_data_hdls;
-		}
-		offset += data_buf_size;
+	if (copy_to_user(wa->buf, &reg_val, sizeof(reg_val))) {
+		XDNA_ERR(xdna, "Failed to copy register data to user");
+		return -EFAULT;
 	}
 
-free_data_hdls:
-	for (i = 0; i < num_bufs; i++)
-		amdxdna_free_msg_buff(data_hdls[i]);
-	kfree(data_hdls);
-free_list_hdl:
-	amdxdna_free_msg_buff(list_hdl);
-unlock_srcu:
-	srcu_read_unlock(&ctx_client->hwctx_srcu, idx);
+	return 0;
+}
+
+static int amdxdna_aie_tile_read_mem(struct amdxdna_hwctx *hwctx,
+				     struct amdxdna_tile_rw_walk_arg *wa)
+{
+	struct amdxdna_dev *xdna = hwctx->client->xdna;
+	struct amdxdna_msg_buf_hdl *dma_hdl;
+	int ret;
+
+	dma_hdl = amdxdna_alloc_msg_buff(xdna, wa->access->size);
+	if (IS_ERR(dma_hdl)) {
+		XDNA_ERR(xdna, "Failed to allocate DMA buffer, ret %ld",
+			 PTR_ERR(dma_hdl));
+		return PTR_ERR(dma_hdl);
+	}
+
+	memset(to_cpu_addr(dma_hdl, 0), 0, to_buf_size(dma_hdl));
+	drm_clflush_virt_range(to_cpu_addr(dma_hdl, 0), to_buf_size(dma_hdl));
+
+	ret = wa->aie->msg_ops.rw_mem(hwctx, true, wa->access->row,
+				      wa->access->col, wa->access->addr,
+				      to_dma_addr(dma_hdl, 0),
+				      wa->access->size);
+	if (ret) {
+		XDNA_ERR(xdna, "AIE memory read failed, ret %d", ret);
+		goto free_dma;
+	}
+
+	drm_clflush_virt_range(to_cpu_addr(dma_hdl, 0), to_buf_size(dma_hdl));
+
+	if (copy_to_user(wa->buf, to_cpu_addr(dma_hdl, 0), wa->access->size)) {
+		XDNA_ERR(xdna, "Failed to copy data to user");
+		ret = -EFAULT;
+	}
+
+free_dma:
+	amdxdna_free_msg_buff(dma_hdl);
+	return ret;
+}
+
+static int amdxdna_aie_tile_read_cb(struct amdxdna_hwctx *hwctx, void *arg)
+{
+	struct amdxdna_dev *xdna = hwctx->client->xdna;
+	struct amdxdna_tile_rw_walk_arg *wa = arg;
+
+	if (!amdxdna_client_visible(hwctx->client)) {
+		XDNA_ERR(xdna, "Permission denied for context %u", wa->access->context_id);
+		return -EPERM;
+	}
+
+	if (wa->access->col >= hwctx->num_col) {
+		XDNA_ERR(xdna, "Column %u is outside partition range [0, %u)",
+			 wa->access->col, hwctx->num_col);
+		return -EINVAL;
+	}
+
+	switch (wa->access->type) {
+	case AMDXDNA_AIE_TILE_ACCESS_REG:
+		return amdxdna_aie_tile_read_reg(hwctx, wa);
+	case AMDXDNA_AIE_TILE_ACCESS_MEM:
+		return amdxdna_aie_tile_read_mem(hwctx, wa);
+	default:
+		XDNA_ERR(xdna, "Invalid access type %u", wa->access->type);
+		return -EINVAL;
+	}
+}
+
+int amdxdna_aie_tile_read(struct aie_device *aie,
+			  struct amdxdna_client *client,
+			  struct amdxdna_drm_get_array *args)
+{
+	struct amdxdna_drm_aie_tile_access access = {};
+	struct amdxdna_dev *xdna = client->xdna;
+	struct amdxdna_tile_rw_walk_arg wa;
+	struct amdxdna_client *tmp_client;
+	size_t buf_size;
+	u8 __user *buf;
+	int ret;
+
+	drm_WARN_ON(&xdna->ddev, !mutex_is_locked(&xdna->dev_lock));
+
+	if (!aie->msg_ops.rw_reg || !aie->msg_ops.rw_mem)
+		return -EOPNOTSUPP;
+
+	if (args->num_element != 1) {
+		XDNA_ERR(xdna, "Invalid num_element %u, expected 1",
+			 args->num_element);
+		return -EINVAL;
+	}
+
+	buf_size = (size_t)args->num_element * args->element_size;
+	buf = u64_to_user_ptr(args->buffer);
+	if (!access_ok(buf, buf_size)) {
+		XDNA_ERR(xdna, "Failed to access buffer");
+		return -EFAULT;
+	}
+
+	if (buf_size < sizeof(access)) {
+		XDNA_ERR(xdna, "Insufficient buffer size: 0x%zx", buf_size);
+		args->element_size = sizeof(access);
+		return -ENOSPC;
+	}
+
+	if (copy_from_user(&access, buf, sizeof(access))) {
+		XDNA_ERR(xdna, "Failed to copy tile access from user");
+		return -EFAULT;
+	}
+
+	if (access.type > AMDXDNA_AIE_TILE_ACCESS_MEM) {
+		XDNA_ERR(xdna, "Invalid access type %u", access.type);
+		return -EINVAL;
+	}
+
+	if (XDNA_MBZ_DBG(xdna, &access.pad, sizeof(access.pad)))
+		return -EINVAL;
+
+	XDNA_DBG(xdna, "AIE tile read: ctx %u pid %llu col %u row %u addr 0x%x size %u",
+		 access.context_id, access.pid, access.col, access.row,
+		 access.addr, access.size);
+
+	if (!access.size) {
+		XDNA_ERR(xdna, "Zero access size");
+		return -EINVAL;
+	}
+
+	if (buf_size < access.size) {
+		XDNA_ERR(xdna, "Insufficient buffer size: 0x%zx, need 0x%x",
+			 buf_size, access.size);
+		args->element_size = access.size;
+		return -ENOSPC;
+	}
+
+	if (access.row >= aie->metadata.rows) {
+		XDNA_ERR(xdna, "Row %u is outside range [0, %u)",
+			 access.row, aie->metadata.rows);
+		return -EINVAL;
+	}
+
+	wa.access = &access;
+	wa.aie = aie;
+	wa.buf = buf;
+
+	amdxdna_for_each_client(xdna, tmp_client) {
+		ret = amdxdna_hwctx_walk(tmp_client, &wa,
+					 amdxdna_tile_rw_filter,
+					 amdxdna_aie_tile_read_cb);
+		if (ret != -ENOENT)
+			break;
+	}
+	if (ret == -ENOENT)
+		XDNA_ERR(xdna, "Context %u for pid %llu not found",
+			 access.context_id, access.pid);
+	return ret;
+}
+
+static int amdxdna_aie_tile_write_reg(struct amdxdna_hwctx *hwctx,
+				      struct amdxdna_tile_rw_walk_arg *wa)
+{
+	struct amdxdna_dev *xdna = hwctx->client->xdna;
+	u32 reg_val;
+	int ret;
+
+	if (wa->access->size != sizeof(u32)) {
+		XDNA_ERR(xdna, "REG access requires size == 4 (got %u)",
+			 wa->access->size);
+		return -EINVAL;
+	}
+
+	if (copy_from_user(&reg_val, wa->buf + sizeof(wa->access),
+			   sizeof(reg_val))) {
+		XDNA_ERR(xdna, "Failed to copy register data from user");
+		return -EFAULT;
+	}
+
+	ret = wa->aie->msg_ops.rw_reg(hwctx, false, wa->access->row,
+				      wa->access->col, wa->access->addr,
+				      &reg_val);
+	if (ret)
+		XDNA_ERR(xdna, "AIE register write failed, ret %d", ret);
+
+	return ret;
+}
+
+static int amdxdna_aie_tile_write_mem(struct amdxdna_hwctx *hwctx,
+				      struct amdxdna_tile_rw_walk_arg *wa)
+{
+	struct amdxdna_dev *xdna = hwctx->client->xdna;
+	struct amdxdna_msg_buf_hdl *dma_hdl;
+	int ret;
+
+	dma_hdl = amdxdna_alloc_msg_buff(xdna, wa->access->size);
+	if (IS_ERR(dma_hdl)) {
+		XDNA_ERR(xdna, "Failed to allocate DMA buffer, ret %ld",
+			 PTR_ERR(dma_hdl));
+		return PTR_ERR(dma_hdl);
+	}
+
+	if (copy_from_user(to_cpu_addr(dma_hdl, 0),
+			   wa->buf + sizeof(*wa->access), wa->access->size)) {
+		XDNA_ERR(xdna, "Failed to copy data from user");
+		ret = -EFAULT;
+		goto free_dma;
+	}
+
+	drm_clflush_virt_range(to_cpu_addr(dma_hdl, 0), to_buf_size(dma_hdl));
+
+	ret = wa->aie->msg_ops.rw_mem(hwctx, false, wa->access->row,
+				      wa->access->col, wa->access->addr,
+				      to_dma_addr(dma_hdl, 0),
+				      wa->access->size);
+	if (ret)
+		XDNA_ERR(xdna, "AIE memory write failed, ret %d", ret);
+
+free_dma:
+	amdxdna_free_msg_buff(dma_hdl);
+	return ret;
+}
+
+static int amdxdna_aie_tile_write_cb(struct amdxdna_hwctx *hwctx, void *arg)
+{
+	struct amdxdna_dev *xdna = hwctx->client->xdna;
+	struct amdxdna_tile_rw_walk_arg *wa = arg;
+
+	if (!amdxdna_client_visible(hwctx->client)) {
+		XDNA_ERR(xdna, "Permission denied for context %u", wa->access->context_id);
+		return -EPERM;
+	}
+
+	if (wa->access->col >= hwctx->num_col) {
+		XDNA_ERR(xdna, "Column %u is outside partition range [0, %u)",
+			 wa->access->col, hwctx->num_col);
+		return -EINVAL;
+	}
+
+	switch (wa->access->type) {
+	case AMDXDNA_AIE_TILE_ACCESS_REG:
+		return amdxdna_aie_tile_write_reg(hwctx, wa);
+	case AMDXDNA_AIE_TILE_ACCESS_MEM:
+		return amdxdna_aie_tile_write_mem(hwctx, wa);
+	default:
+		XDNA_ERR(xdna, "Invalid access type %u", wa->access->type);
+		return -EINVAL;
+	}
+}
+
+int amdxdna_aie_tile_write(struct aie_device *aie,
+			   struct amdxdna_client *client,
+			   struct amdxdna_drm_set_state *args)
+{
+	struct amdxdna_drm_aie_tile_access access = {};
+	struct amdxdna_dev *xdna = client->xdna;
+	struct amdxdna_tile_rw_walk_arg wa;
+	struct amdxdna_client *tmp_client;
+	u8 __user *buf;
+	int ret;
+
+	drm_WARN_ON(&xdna->ddev, !mutex_is_locked(&xdna->dev_lock));
+
+	if (!aie->msg_ops.rw_reg || !aie->msg_ops.rw_mem)
+		return -EOPNOTSUPP;
+
+	buf = u64_to_user_ptr(args->buffer);
+	if (!access_ok(buf, args->buffer_size)) {
+		XDNA_ERR(xdna, "Failed to access buffer");
+		return -EFAULT;
+	}
+
+	if (args->buffer_size < sizeof(access)) {
+		XDNA_ERR(xdna, "Insufficient buffer size: 0x%x",
+			 args->buffer_size);
+		args->buffer_size = sizeof(access);
+		return -ENOSPC;
+	}
+
+	if (copy_from_user(&access, buf, sizeof(access))) {
+		XDNA_ERR(xdna, "Failed to copy tile access from user");
+		return -EFAULT;
+	}
+
+	if (access.type > AMDXDNA_AIE_TILE_ACCESS_MEM) {
+		XDNA_ERR(xdna, "Invalid access type %u", access.type);
+		return -EINVAL;
+	}
+
+	if (XDNA_MBZ_DBG(xdna, &access.pad, sizeof(access.pad)))
+		return -EINVAL;
+
+	XDNA_DBG(xdna, "AIE tile write: ctx %u pid %llu col %u row %u addr 0x%x size %u",
+		 access.context_id, access.pid, access.col, access.row,
+		 access.addr, access.size);
+
+	if (!access.size) {
+		XDNA_ERR(xdna, "Zero access size");
+		return -EINVAL;
+	}
+
+	if (access.size > args->buffer_size - sizeof(access)) {
+		XDNA_ERR(xdna, "Insufficient buffer size: 0x%x, need 0x%zx",
+			 args->buffer_size,
+			 sizeof(access) + (size_t)access.size);
+		args->buffer_size = sizeof(access) + access.size;
+		return -ENOSPC;
+	}
+
+	if (access.row >= aie->metadata.rows) {
+		XDNA_ERR(xdna, "Row %u is outside range [0, %u)",
+			 access.row, aie->metadata.rows);
+		return -EINVAL;
+	}
+
+	wa.access = &access;
+	wa.aie = aie;
+	wa.buf = buf;
+
+	amdxdna_for_each_client(xdna, tmp_client) {
+		ret = amdxdna_hwctx_walk(tmp_client, &wa,
+					 amdxdna_tile_rw_filter,
+					 amdxdna_aie_tile_write_cb);
+		if (ret != -ENOENT)
+			break;
+	}
+	if (ret == -ENOENT)
+		XDNA_ERR(xdna, "Context %u for pid %llu not found",
+			 access.context_id, access.pid);
 	return ret;
 }

--- a/drivers/accel/amdxdna/aie.h
+++ b/drivers/accel/amdxdna/aie.h
@@ -49,6 +49,15 @@ struct aie_metadata {
 	struct aie_tile_metadata shim;
 };
 
+struct amdxdna_hwctx;
+struct amdxdna_msg_buf_hdl;
+
+struct aie_msg_ops {
+	int (*get_coredump)(struct amdxdna_hwctx *hwctx,
+			    struct amdxdna_msg_buf_hdl *list_hdl,
+			    u32 num_bufs);
+};
+
 struct aie_device {
 	struct amdxdna_dev *xdna;
 	struct mailbox_channel *mgmt_chann;
@@ -63,6 +72,7 @@ struct aie_device {
 	struct smu_device *smu_hdl;
 
 	struct aie_metadata metadata;
+	struct aie_msg_ops msg_ops;
 };
 
 #define DECLARE_AIE_MSG(name, op) \
@@ -136,7 +146,6 @@ int amdxdna_get_metadata(struct aie_device *aie, struct amdxdna_client *client,
 int amdxdna_query_sensors(struct amdxdna_client *client,
 			  struct amdxdna_drm_get_info *args, u32 total_col);
 void amdxdna_hmm_invalidate(struct amdxdna_gem_obj *abo, unsigned long cur_seq);
-bool amdxdna_hwctx_access_allowed(struct amdxdna_hwctx *hwctx, bool root_only);
 
 struct amdxdna_msg_buf_hdl {
 	struct amdxdna_dev	*xdna;
@@ -151,7 +160,6 @@ struct amdxdna_msg_buf_hdl {
 
 struct amdxdna_msg_buf_hdl *amdxdna_alloc_msg_buff(struct amdxdna_dev *xdna, u32 size);
 void amdxdna_free_msg_buff(struct amdxdna_msg_buf_hdl *hdl);
-void amdxdna_clflush_msg_buff(struct amdxdna_msg_buf_hdl *hdl, u32 offset, u32 size);
 
 /*
  * struct amdxdna_coredump_buf_entry - __packed to match firmware buffer_list

--- a/drivers/accel/amdxdna/aie.h
+++ b/drivers/accel/amdxdna/aie.h
@@ -56,6 +56,11 @@ struct aie_msg_ops {
 	int (*get_coredump)(struct amdxdna_hwctx *hwctx,
 			    struct amdxdna_msg_buf_hdl *list_hdl,
 			    u32 num_bufs);
+	int (*rw_reg)(struct amdxdna_hwctx *hwctx, bool is_read,
+		      u8 row, u8 col, u32 addr, u32 *value);
+	int (*rw_mem)(struct amdxdna_hwctx *hwctx, bool is_read,
+		      u8 row, u8 col, u32 aie_addr,
+		      dma_addr_t dram_addr, u32 size);
 };
 
 struct aie_device {
@@ -173,6 +178,12 @@ struct amdxdna_coredump_buf_entry {
 int amdxdna_get_coredump(struct aie_device *aie,
 			 struct amdxdna_client *client,
 			 struct amdxdna_drm_get_array *args);
+int amdxdna_aie_tile_read(struct aie_device *aie,
+			  struct amdxdna_client *client,
+			  struct amdxdna_drm_get_array *args);
+int amdxdna_aie_tile_write(struct aie_device *aie,
+			   struct amdxdna_client *client,
+			   struct amdxdna_drm_set_state *args);
 
 /* aie_psp.c */
 struct psp_device *aiem_psp_create(struct drm_device *ddev, struct psp_config *conf);

--- a/drivers/accel/amdxdna/aie2_ctx.c
+++ b/drivers/accel/amdxdna/aie2_ctx.c
@@ -279,7 +279,7 @@ void aie2_hwctx_suspend(struct amdxdna_client *client)
 	 * and abort all commands.
 	 */
 	drm_WARN_ON(&xdna->ddev, !mutex_is_locked(&xdna->dev_lock));
-	amdxdna_hwctx_walk(client, NULL, aie2_hwctx_suspend_cb);
+	amdxdna_hwctx_walk(client, NULL, NULL, aie2_hwctx_suspend_cb);
 }
 
 static int aie2_hwctx_resume_cb(struct amdxdna_hwctx *hwctx, void *arg)
@@ -296,7 +296,7 @@ int aie2_hwctx_resume(struct amdxdna_client *client)
 	 * regenerated. If this happen, when submit message to this
 	 * mailbox channel, error will return.
 	 */
-	return amdxdna_hwctx_walk(client, NULL, aie2_hwctx_resume_cb);
+	return amdxdna_hwctx_walk(client, NULL, NULL, aie2_hwctx_resume_cb);
 }
 
 static void

--- a/drivers/accel/amdxdna/aie2_message.c
+++ b/drivers/accel/amdxdna/aie2_message.c
@@ -374,7 +374,8 @@ int aie2_query_status(struct amdxdna_dev_hdl *ndev, char __user *buf,
 
 	/* Go through each hardware context and mark the AIE columns that are active */
 	list_for_each_entry(client, &xdna->client_list, node)
-		amdxdna_hwctx_walk(client, &aie_bitmap, amdxdna_hwctx_col_map);
+		amdxdna_hwctx_walk(client, &aie_bitmap, NULL,
+				   amdxdna_hwctx_col_map);
 
 	*cols_filled = 0;
 	req.dump_buff_addr = to_dma_addr(buf_hdl, 0);
@@ -911,6 +912,11 @@ void aie2_msg_init(struct amdxdna_dev_hdl *ndev)
 
 	if (AIE_FEATURE_ON(&ndev->aie, AIE2_GET_COREDUMP))
 		ndev->aie.msg_ops.get_coredump = aie2_get_aie_coredump;
+
+	if (AIE_FEATURE_ON(&ndev->aie, AIE2_RW_ACCESS)) {
+		ndev->aie.msg_ops.rw_reg = aie2_rw_aie_reg;
+		ndev->aie.msg_ops.rw_mem = aie2_rw_aie_mem;
+	}
 }
 
 static inline struct amdxdna_gem_obj *
@@ -1265,8 +1271,8 @@ int aie2_get_aie_coredump(struct amdxdna_hwctx *hwctx,
 			  u32 num_bufs)
 {
 	DECLARE_AIE_MSG(get_coredump, MSG_OP_GET_COREDUMP);
+	struct amdxdna_dev_hdl *ndev = hwctx->client->xdna->dev_handle;
 	struct amdxdna_dev *xdna = hwctx->client->xdna;
-	struct amdxdna_dev_hdl *ndev = xdna->dev_handle;
 	int ret;
 
 	req.context_id = hwctx->fw_ctx_id;
@@ -1284,4 +1290,66 @@ int aie2_get_aie_coredump(struct amdxdna_hwctx *hwctx,
 	}
 
 	return ret;
+}
+
+int aie2_rw_aie_reg(struct amdxdna_hwctx *hwctx, bool is_read,
+		    u8 row, u8 col, u32 addr, u32 *value)
+{
+	DECLARE_AIE_MSG(aie_rw_access, MSG_OP_AIE_RW_ACCESS);
+	struct amdxdna_dev_hdl *ndev = hwctx->client->xdna->dev_handle;
+	struct amdxdna_dev *xdna = hwctx->client->xdna;
+	enum aie2_access_type type;
+	int ret;
+
+	type = is_read ? AIE2_ACCESS_TYPE_REG_READ : AIE2_ACCESS_TYPE_REG_WRITE;
+
+	req.type = type;
+	req.ctx_id = hwctx->fw_ctx_id;
+	req.row = row;
+	req.col = col;
+	req.reg.aie_offset = addr;
+	if (!is_read)
+		req.reg.write_value = *value;
+
+	ret = aie_send_mgmt_msg_wait(&ndev->aie, &msg);
+	if (ret) {
+		XDNA_ERR(xdna, "AIE reg %s failed, ret %d",
+			 is_read ? "read" : "write", ret);
+		return ret;
+	}
+
+	if (is_read)
+		*value = resp.reg_read_value;
+
+	return 0;
+}
+
+int aie2_rw_aie_mem(struct amdxdna_hwctx *hwctx, bool is_read,
+		    u8 row, u8 col, u32 aie_addr,
+		    dma_addr_t dram_addr, u32 size)
+{
+	DECLARE_AIE_MSG(aie_rw_access, MSG_OP_AIE_RW_ACCESS);
+	struct amdxdna_dev_hdl *ndev = hwctx->client->xdna->dev_handle;
+	struct amdxdna_dev *xdna = hwctx->client->xdna;
+	enum aie2_access_type type;
+	int ret;
+
+	type = is_read ? AIE2_ACCESS_TYPE_MEM_READ : AIE2_ACCESS_TYPE_MEM_WRITE;
+
+	req.type = type;
+	req.ctx_id = hwctx->fw_ctx_id;
+	req.row = row;
+	req.col = col;
+	req.mem.aie_offset = aie_addr;
+	req.mem.dram_addr = dram_addr;
+	req.mem.size = size;
+
+	ret = aie_send_mgmt_msg_wait(&ndev->aie, &msg);
+	if (ret) {
+		XDNA_ERR(xdna, "AIE mem %s failed, ret %d",
+			 is_read ? "read" : "write", ret);
+		return ret;
+	}
+
+	return 0;
 }

--- a/drivers/accel/amdxdna/aie2_message.c
+++ b/drivers/accel/amdxdna/aie2_message.c
@@ -382,7 +382,7 @@ int aie2_query_status(struct amdxdna_dev_hdl *ndev, char __user *buf,
 	req.num_cols = hweight32(aie_bitmap);
 	req.aie_bitmap = aie_bitmap;
 
-	amdxdna_clflush_msg_buff(buf_hdl, 0, 0);
+	drm_clflush_virt_range(to_cpu_addr(buf_hdl, 0), to_buf_size(buf_hdl));
 	ret = aie_send_mgmt_msg_wait(&ndev->aie, &msg);
 	if (ret) {
 		XDNA_ERR(xdna, "Error during NPU query, status %d", ret);
@@ -432,7 +432,7 @@ int aie2_query_telemetry(struct amdxdna_dev_hdl *ndev,
 	req.buf_size = to_buf_size(buf_hdl);
 	req.type = header->type;
 
-	amdxdna_clflush_msg_buff(buf_hdl, 0, 0);
+	drm_clflush_virt_range(to_cpu_addr(buf_hdl, 0), to_buf_size(buf_hdl));
 	ret = aie_send_mgmt_msg_wait(&ndev->aie, &msg);
 	if (ret) {
 		XDNA_ERR(xdna, "Query telemetry failed, status %d", ret);
@@ -908,6 +908,9 @@ void aie2_msg_init(struct amdxdna_dev_hdl *ndev)
 		ndev->exec_msg_ops = &npu_exec_message_ops;
 	else
 		ndev->exec_msg_ops = &legacy_exec_message_ops;
+
+	if (AIE_FEATURE_ON(&ndev->aie, AIE2_GET_COREDUMP))
+		ndev->aie.msg_ops.get_coredump = aie2_get_aie_coredump;
 }
 
 static inline struct amdxdna_gem_obj *
@@ -1173,7 +1176,7 @@ int aie2_query_app_health(struct amdxdna_dev_hdl *ndev, u32 context_id,
 	req.context_id = context_id;
 	req.buf_size = to_buf_size(buf_hdl);
 
-	amdxdna_clflush_msg_buff(buf_hdl, 0, 0);
+	drm_clflush_virt_range(to_cpu_addr(buf_hdl, 0), sizeof(*report));
 	ret = aie_send_mgmt_msg_wait(&ndev->aie, &msg);
 	if (ret) {
 		XDNA_ERR(xdna, "Get app health failed, ret %d status 0x%x", ret, resp.status);
@@ -1257,18 +1260,14 @@ int aie2_get_dev_revision(struct amdxdna_dev_hdl *ndev, enum aie2_dev_revision *
 	return 0;
 }
 
-int aie2_get_aie_coredump(struct amdxdna_dev *xdna,
+int aie2_get_aie_coredump(struct amdxdna_hwctx *hwctx,
 			  struct amdxdna_msg_buf_hdl *list_hdl,
-			  struct amdxdna_hwctx *hwctx, u32 num_bufs)
+			  u32 num_bufs)
 {
-	struct amdxdna_dev_hdl *ndev = xdna->dev_handle;
 	DECLARE_AIE_MSG(get_coredump, MSG_OP_GET_COREDUMP);
+	struct amdxdna_dev *xdna = hwctx->client->xdna;
+	struct amdxdna_dev_hdl *ndev = xdna->dev_handle;
 	int ret;
-
-	if (!AIE_FEATURE_ON(&ndev->aie, AIE2_GET_COREDUMP)) {
-		XDNA_DBG(xdna, "Get coredump unsupported for the device or firmware version");
-		return -EOPNOTSUPP;
-	}
 
 	req.context_id = hwctx->fw_ctx_id;
 	req.num_bufs = num_bufs;

--- a/drivers/accel/amdxdna/aie2_msg_priv.h
+++ b/drivers/accel/amdxdna/aie2_msg_priv.h
@@ -37,6 +37,8 @@ enum aie2_msg_opcode {
 	MSG_OP_GET_DEV_REVISION            = 0x117,
 	MSG_OP_GET_COREDUMP                = 0x119,
 	MSG_OP_MAX_DRV_OPCODE,
+	MSG_OP_AIE_RW_ACCESS               = 0x203,
+	MSG_OP_MAX_ASYNC_OPCODE,
 	MSG_OP_GET_PROTOCOL_VERSION        = 0x301,
 	MSG_OP_MAX_OPCODE
 };
@@ -556,6 +558,38 @@ struct get_coredump_resp {
 	enum aie2_msg_status	status;
 	__u32			required_buffer_size;
 	__u32			reserved[7];
+} __packed;
+
+enum aie2_access_type {
+	AIE2_ACCESS_TYPE_MEM_READ,
+	AIE2_ACCESS_TYPE_MEM_WRITE,
+	AIE2_ACCESS_TYPE_REG_READ,
+	AIE2_ACCESS_TYPE_REG_WRITE,
+	AIE2_ACCESS_TYPE_MAX
+};
+
+struct aie_rw_access_req {
+	enum aie2_access_type	type;
+	__u8			ctx_id;
+	__u8			row;
+	__u8			col;
+	__u8			reserved;
+	union {
+		struct {
+			__u64	dram_addr;
+			__u32	aie_offset;
+			__u32	size;
+		} __packed mem;
+		struct {
+			__u32	aie_offset;
+			__u32	write_value;
+		} __packed reg;
+	};
+} __packed;
+
+struct aie_rw_access_resp {
+	enum aie2_msg_status	status;
+	__u32			reg_read_value;
 } __packed;
 
 #endif /* _AIE2_MSG_PRIV_H_ */

--- a/drivers/accel/amdxdna/aie2_pci.c
+++ b/drivers/accel/amdxdna/aie2_pci.c
@@ -820,7 +820,7 @@ static int aie2_get_hwctx_status(struct amdxdna_client *client,
 	list_for_each_entry(tmp_client, &xdna->client_list, node) {
 		if (!amdxdna_client_visible(tmp_client))
 			continue;
-		ret = amdxdna_hwctx_walk(tmp_client, &array_args,
+		ret = amdxdna_hwctx_walk(tmp_client, &array_args, NULL,
 					 aie2_hwctx_status_cb);
 		if (ret)
 			break;
@@ -902,7 +902,7 @@ static int aie2_get_telemetry(struct amdxdna_client *client,
 	list_for_each_entry(tmp_client, &xdna->client_list, node) {
 		if (!amdxdna_client_visible(tmp_client))
 			continue;
-		ret = amdxdna_hwctx_walk(tmp_client, &header->map,
+		ret = amdxdna_hwctx_walk(tmp_client, &header->map, NULL,
 					 aie2_fill_hwctx_map);
 		if (ret)
 			return ret;
@@ -1028,7 +1028,7 @@ static int aie2_query_ctx_status_array(struct amdxdna_client *client,
 	array_args.num_element = args->num_element * args->element_size /
 				array_args.element_size;
 	list_for_each_entry(tmp_client, &xdna->client_list, node) {
-		ret = amdxdna_hwctx_walk(tmp_client, &array_args,
+		ret = amdxdna_hwctx_walk(tmp_client, &array_args, NULL,
 					 aie2_hwctx_status_cb);
 		if (ret)
 			break;
@@ -1067,6 +1067,9 @@ static int aie2_get_array(struct amdxdna_client *client,
 		break;
 	case DRM_AMDXDNA_BO_USAGE:
 		ret = amdxdna_drm_get_bo_usage(&xdna->ddev, args);
+		break;
+	case DRM_AMDXDNA_AIE_TILE_READ:
+		ret = amdxdna_aie_tile_read(&ndev->aie, client, args);
 		break;
 	default:
 		XDNA_ERR(xdna, "Not supported request parameter %u", args->param);
@@ -1141,6 +1144,7 @@ static int aie2_set_preempt_state(struct amdxdna_client *client,
 static int aie2_set_state(struct amdxdna_client *client,
 			  struct amdxdna_drm_set_state *args)
 {
+	struct amdxdna_dev_hdl *ndev = client->xdna->dev_handle;
 	struct amdxdna_dev *xdna = client->xdna;
 	int ret, idx;
 
@@ -1158,6 +1162,9 @@ static int aie2_set_state(struct amdxdna_client *client,
 	case DRM_AMDXDNA_SET_FORCE_PREEMPT:
 	case DRM_AMDXDNA_SET_FRAME_BOUNDARY_PREEMPT:
 		ret = aie2_set_preempt_state(client, args);
+		break;
+	case DRM_AMDXDNA_AIE_TILE_WRITE:
+		ret = amdxdna_aie_tile_write(&ndev->aie, client, args);
 		break;
 	default:
 		XDNA_ERR(xdna, "Not supported request parameter %u", args->param);

--- a/drivers/accel/amdxdna/aie2_pci.c
+++ b/drivers/accel/amdxdna/aie2_pci.c
@@ -812,15 +812,14 @@ static int aie2_get_hwctx_status(struct amdxdna_client *client,
 	struct amdxdna_client *tmp_client;
 	int ret;
 
-	if (!amdxdna_is_admin())
-		return -EPERM;
-
 	drm_WARN_ON(&xdna->ddev, !mutex_is_locked(&xdna->dev_lock));
 
 	array_args.element_size = sizeof(struct amdxdna_drm_query_hwctx);
 	array_args.buffer = args->buffer;
 	array_args.num_element = args->buffer_size / array_args.element_size;
 	list_for_each_entry(tmp_client, &xdna->client_list, node) {
+		if (!amdxdna_client_visible(tmp_client))
+			continue;
 		ret = amdxdna_hwctx_walk(tmp_client, &array_args,
 					 aie2_hwctx_status_cb);
 		if (ret)
@@ -882,9 +881,6 @@ static int aie2_get_telemetry(struct amdxdna_client *client,
 	struct amdxdna_client *tmp_client;
 	int ret;
 
-	if (!amdxdna_is_admin())
-		return -EPERM;
-
 	elem_num = xdna->dev_handle->priv->hwctx_limit;
 	header_sz = struct_size(header, map, elem_num);
 	if (args->buffer_size <= header_sz) {
@@ -904,6 +900,8 @@ static int aie2_get_telemetry(struct amdxdna_client *client,
 
 	header->map_num_elements = elem_num;
 	list_for_each_entry(tmp_client, &xdna->client_list, node) {
+		if (!amdxdna_client_visible(tmp_client))
+			continue;
 		ret = amdxdna_hwctx_walk(tmp_client, &header->map,
 					 aie2_fill_hwctx_map);
 		if (ret)
@@ -1202,7 +1200,6 @@ const struct amdxdna_dev_ops aie2_ops = {
 	.cmd_submit = aie2_cmd_submit,
 	.hmm_invalidate = aie2_hmm_invalidate,
 	.get_array = aie2_get_array,
-	.get_coredump = aie2_get_aie_coredump,
 	.get_dev_revision = aie2_get_dev_rev,
 	.hwctx_heap_expand = aie2_hwctx_heap_expand,
 };

--- a/drivers/accel/amdxdna/aie2_pci.h
+++ b/drivers/accel/amdxdna/aie2_pci.h
@@ -189,6 +189,7 @@ enum aie2_fw_feature {
 	AIE2_UPDATE_PROPERTY,
 	AIE2_GET_DEV_REVISION,
 	AIE2_GET_COREDUMP,
+	AIE2_RW_ACCESS,
 	AIE2_FEATURE_MAX
 };
 
@@ -258,6 +259,11 @@ int aie2_get_dev_revision(struct amdxdna_dev_hdl *ndev, enum aie2_dev_revision *
 int aie2_get_aie_coredump(struct amdxdna_hwctx *hwctx,
 			  struct amdxdna_msg_buf_hdl *list_hdl,
 			  u32 num_bufs);
+int aie2_rw_aie_reg(struct amdxdna_hwctx *hwctx, bool is_read,
+		    u8 row, u8 col, u32 addr, u32 *value);
+int aie2_rw_aie_mem(struct amdxdna_hwctx *hwctx, bool is_read,
+		    u8 row, u8 col, u32 aie_addr,
+		    dma_addr_t dram_addr, u32 size);
 int aie2_create_context(struct amdxdna_dev_hdl *ndev, struct amdxdna_hwctx *hwctx);
 int aie2_destroy_context(struct amdxdna_dev_hdl *ndev, struct amdxdna_hwctx *hwctx);
 int aie2_map_host_buf(struct amdxdna_dev_hdl *ndev, u32 context_id, u64 addr, u64 size);

--- a/drivers/accel/amdxdna/aie2_pci.h
+++ b/drivers/accel/amdxdna/aie2_pci.h
@@ -255,9 +255,9 @@ int aie2_query_firmware_version(struct amdxdna_dev_hdl *ndev,
 int aie2_query_app_health(struct amdxdna_dev_hdl *ndev, u32 context_id,
 			  struct app_health_report *report);
 int aie2_get_dev_revision(struct amdxdna_dev_hdl *ndev, enum aie2_dev_revision *rev);
-int aie2_get_aie_coredump(struct amdxdna_dev *xdna,
+int aie2_get_aie_coredump(struct amdxdna_hwctx *hwctx,
 			  struct amdxdna_msg_buf_hdl *list_hdl,
-			  struct amdxdna_hwctx *hwctx, u32 num_bufs);
+			  u32 num_bufs);
 int aie2_create_context(struct amdxdna_dev_hdl *ndev, struct amdxdna_hwctx *hwctx);
 int aie2_destroy_context(struct amdxdna_dev_hdl *ndev, struct amdxdna_hwctx *hwctx);
 int aie2_map_host_buf(struct amdxdna_dev_hdl *ndev, u32 context_id, u64 addr, u64 size);

--- a/drivers/accel/amdxdna/aie2_tdr.c
+++ b/drivers/accel/amdxdna/aie2_tdr.c
@@ -48,7 +48,8 @@ static bool aie2_legacy_tdr_detect(struct amdxdna_dev *xdna)
 
 	/* Check if there are any pending jobs */
 	amdxdna_for_each_client(xdna, client) {
-		pending = amdxdna_hwctx_walk(client, NULL, aie2_legacy_tdr_hwctx_pending);
+		pending = amdxdna_hwctx_walk(client, NULL, NULL,
+					     aie2_legacy_tdr_hwctx_pending);
 		if (pending)
 			break;
 	}
@@ -153,7 +154,7 @@ static void aie2_tdr_recover_all(struct amdxdna_dev *xdna)
 	struct amdxdna_client *client;
 
 	amdxdna_for_each_client(xdna, client) {
-		amdxdna_hwctx_walk(client, NULL, aie2_tdr_stop_hwctx);
+		amdxdna_hwctx_walk(client, NULL, NULL, aie2_tdr_stop_hwctx);
 		aie2_hwctx_resume(client);
 	}
 }

--- a/drivers/accel/amdxdna/aie4_message.c
+++ b/drivers/accel/amdxdna/aie4_message.c
@@ -89,8 +89,8 @@ int aie4_get_aie_coredump(struct amdxdna_hwctx *hwctx,
 			  u32 num_bufs)
 {
 	DECLARE_AIE_MSG(aie4_msg_aie4_coredump, AIE4_MSG_OP_AIE_COREDUMP);
+	struct amdxdna_dev_hdl *ndev = hwctx->client->xdna->dev_handle;
 	struct amdxdna_dev *xdna = hwctx->client->xdna;
-	struct amdxdna_dev_hdl *ndev = xdna->dev_handle;
 	int ret;
 
 	req.context_id = hwctx->fw_ctx_id;
@@ -106,8 +106,78 @@ int aie4_get_aie_coredump(struct amdxdna_hwctx *hwctx,
 	return ret;
 }
 
+int aie4_rw_aie_reg(struct amdxdna_hwctx *hwctx, bool is_read,
+		    u8 row, u8 col, u32 addr, u32 *value)
+{
+	DECLARE_AIE_MSG(aie4_msg_aie4_debug_access, AIE4_MSG_OP_AIE_RW_ACCESS);
+	struct amdxdna_dev_hdl *ndev = hwctx->client->xdna->dev_handle;
+	struct amdxdna_dev *xdna = hwctx->client->xdna;
+	enum aie4_access_type type;
+	int ret;
+
+	type = is_read ? AIE4_ACCESS_TYPE_REG_READ : AIE4_ACCESS_TYPE_REG_WRITE;
+
+	req.opcode = type;
+	req.context_id = hwctx->fw_ctx_id;
+	req.row = row;
+	req.col = col;
+	req.reg_access.reg_addr = addr;
+	if (!is_read)
+		req.reg_access.reg_wval = *value;
+
+	ret = aie_send_mgmt_msg_wait(&ndev->aie, &msg);
+	if (ret) {
+		XDNA_ERR(xdna, "AIE reg %s failed, ret %d",
+			 is_read ? "read" : "write", ret);
+		return ret;
+	}
+
+	if (is_read)
+		*value = resp.reg_rval;
+
+	return 0;
+}
+
+int aie4_rw_aie_mem(struct amdxdna_hwctx *hwctx, bool is_read,
+		    u8 row, u8 col, u32 aie_addr,
+		    dma_addr_t dram_addr, u32 size)
+{
+	DECLARE_AIE_MSG(aie4_msg_aie4_debug_access, AIE4_MSG_OP_AIE_RW_ACCESS);
+	struct amdxdna_dev_hdl *ndev = hwctx->client->xdna->dev_handle;
+	struct amdxdna_dev *xdna = hwctx->client->xdna;
+	enum aie4_access_type type;
+	int ret;
+
+	type = is_read ? AIE4_ACCESS_TYPE_MEM_READ : AIE4_ACCESS_TYPE_MEM_WRITE;
+
+	req.opcode = type;
+	req.context_id = hwctx->fw_ctx_id;
+	req.row = row;
+	req.col = col;
+	req.mem_access.buffer_addr = dram_addr;
+	req.mem_access.buffer_size = size;
+	req.mem_access.mem_addr = aie_addr;
+	req.mem_access.mem_size = size;
+	req.mem_access.pasid = FIELD_PREP(AIE4_MSG_PASID, hwctx->client->pasid) |
+			       FIELD_PREP(AIE4_MSG_PASID_VLD, 1);
+
+	ret = aie_send_mgmt_msg_wait(&ndev->aie, &msg);
+	if (ret) {
+		XDNA_ERR(xdna, "AIE mem %s failed, ret %d",
+			 is_read ? "read" : "write", ret);
+		return ret;
+	}
+
+	return 0;
+}
+
 void aie4_msg_init(struct amdxdna_dev_hdl *ndev)
 {
 	if (AIE_FEATURE_ON(&ndev->aie, AIE4_GET_COREDUMP))
 		ndev->aie.msg_ops.get_coredump = aie4_get_aie_coredump;
+
+	if (AIE_FEATURE_ON(&ndev->aie, AIE4_RW_ACCESS)) {
+		ndev->aie.msg_ops.rw_reg = aie4_rw_aie_reg;
+		ndev->aie.msg_ops.rw_mem = aie4_rw_aie_mem;
+	}
 }

--- a/drivers/accel/amdxdna/aie4_message.c
+++ b/drivers/accel/amdxdna/aie4_message.c
@@ -84,18 +84,14 @@ int aie4_attach_work_buffer(struct amdxdna_dev_hdl *ndev, dma_addr_t addr, u32 s
 	return ret;
 }
 
-int aie4_get_aie_coredump(struct amdxdna_dev *xdna,
+int aie4_get_aie_coredump(struct amdxdna_hwctx *hwctx,
 			  struct amdxdna_msg_buf_hdl *list_hdl,
-			  struct amdxdna_hwctx *hwctx, u32 num_bufs)
+			  u32 num_bufs)
 {
-	struct amdxdna_dev_hdl *ndev = xdna->dev_handle;
 	DECLARE_AIE_MSG(aie4_msg_aie4_coredump, AIE4_MSG_OP_AIE_COREDUMP);
+	struct amdxdna_dev *xdna = hwctx->client->xdna;
+	struct amdxdna_dev_hdl *ndev = xdna->dev_handle;
 	int ret;
-
-	if (!AIE_FEATURE_ON(&ndev->aie, AIE4_GET_COREDUMP)) {
-		XDNA_DBG(xdna, "Get coredump unsupported for the device or firmware version");
-		return -EOPNOTSUPP;
-	}
 
 	req.context_id = hwctx->fw_ctx_id;
 	req.pasid = FIELD_PREP(AIE4_MSG_PASID, hwctx->client->pasid) |
@@ -108,4 +104,10 @@ int aie4_get_aie_coredump(struct amdxdna_dev *xdna,
 		XDNA_ERR(xdna, "Get coredump got status 0x%x", resp.status);
 
 	return ret;
+}
+
+void aie4_msg_init(struct amdxdna_dev_hdl *ndev)
+{
+	if (AIE_FEATURE_ON(&ndev->aie, AIE4_GET_COREDUMP))
+		ndev->aie.msg_ops.get_coredump = aie4_get_aie_coredump;
 }

--- a/drivers/accel/amdxdna/aie4_msg_priv.h
+++ b/drivers/accel/amdxdna/aie4_msg_priv.h
@@ -13,6 +13,7 @@
 enum aie4_msg_opcode {
 	AIE4_MSG_OP_SUSPEND                          = 0x10003,
 	AIE4_MSG_OP_ATTACH_WORK_BUFFER               = 0x1000D,
+	AIE4_MSG_OP_AIE_RW_ACCESS                    = 0x3000E,
 	AIE4_MSG_OP_AIE_COREDUMP                     = 0x30010,
 
 	AIE4_MSG_OP_CREATE_VFS                       = 0x20001,
@@ -156,6 +157,39 @@ struct aie4_msg_aie4_coredump_req {
 
 struct aie4_msg_aie4_coredump_resp {
 	enum aie4_msg_status status;
+} __packed;
+
+enum aie4_access_type {
+	AIE4_ACCESS_TYPE_MEM_READ,
+	AIE4_ACCESS_TYPE_MEM_WRITE,
+	AIE4_ACCESS_TYPE_REG_READ,
+	AIE4_ACCESS_TYPE_REG_WRITE,
+	AIE4_ACCESS_TYPE_MAX
+};
+
+struct aie4_msg_aie4_debug_access_req {
+	__u8 opcode;
+	__u8 context_id;
+	__u8 row;
+	__u8 col;
+	union {
+		struct {
+			__u64 buffer_addr;
+			__u32 buffer_size;
+			__u32 mem_addr;
+			__u32 mem_size;
+			__u32 pasid;
+		} __packed mem_access;
+		struct {
+			__u32 reg_addr;
+			__u32 reg_wval;
+		} __packed reg_access;
+	};
+} __packed;
+
+struct aie4_msg_aie4_debug_access_resp {
+	enum aie4_msg_status status;
+	__u32 reg_rval;
 } __packed;
 
 #endif /* _AIE4_MSG_PRIV_H_ */

--- a/drivers/accel/amdxdna/aie4_pci.c
+++ b/drivers/accel/amdxdna/aie4_pci.c
@@ -710,6 +710,7 @@ static int aie4_pf_init(struct amdxdna_dev *xdna)
 	if (ret)
 		goto free_work_buf;
 
+	aie4_msg_init(xdna->dev_handle);
 	return 0;
 
 free_work_buf:
@@ -725,7 +726,12 @@ static int aie4_vf_init(struct amdxdna_dev *xdna)
 	if (ret)
 		return ret;
 
-	return aie4_vf_hw_start(xdna->dev_handle);
+	ret = aie4_vf_hw_start(xdna->dev_handle);
+	if (ret)
+		return ret;
+
+	aie4_msg_init(xdna->dev_handle);
+	return 0;
 }
 
 static int aie4_classic_init(struct amdxdna_dev *xdna)
@@ -784,7 +790,6 @@ const struct amdxdna_dev_ops aie4_vf_ops = {
 	.cmd_wait		= aie4_cmd_wait,
 	.get_aie_info		= aie4_get_info,
 	.get_array		= aie4_get_array,
-	.get_coredump		= aie4_get_aie_coredump,
 };
 
 const struct amdxdna_dev_ops aie4_classic_ops = {
@@ -796,5 +801,4 @@ const struct amdxdna_dev_ops aie4_classic_ops = {
 	.cmd_wait		= aie4_cmd_wait,
 	.get_aie_info		= aie4_get_info,
 	.get_array		= aie4_get_array,
-	.get_coredump		= aie4_get_aie_coredump,
 };

--- a/drivers/accel/amdxdna/aie4_pci.c
+++ b/drivers/accel/amdxdna/aie4_pci.c
@@ -682,6 +682,9 @@ static int aie4_get_array(struct amdxdna_client *client,
 	case DRM_AMDXDNA_AIE_COREDUMP:
 		ret = amdxdna_get_coredump(&ndev->aie, client, args);
 		break;
+	case DRM_AMDXDNA_AIE_TILE_READ:
+		ret = amdxdna_aie_tile_read(&ndev->aie, client, args);
+		break;
 	default:
 		ret = -EOPNOTSUPP;
 		break;
@@ -781,6 +784,37 @@ const struct amdxdna_dev_ops aie4_pf_ops = {
 	.sriov_configure        = aie4_sriov_configure,
 };
 
+static int aie4_set_state(struct amdxdna_client *client,
+			  struct amdxdna_drm_set_state *args)
+{
+	struct amdxdna_dev_hdl *ndev = client->xdna->dev_handle;
+	struct amdxdna_dev *xdna = client->xdna;
+	int ret, idx;
+
+	if (!drm_dev_enter(&xdna->ddev, &idx))
+		return -ENODEV;
+
+	ret = amdxdna_pm_resume_get_locked(xdna);
+	if (ret)
+		goto dev_exit;
+
+	switch (args->param) {
+	case DRM_AMDXDNA_AIE_TILE_WRITE:
+		ret = amdxdna_aie_tile_write(&ndev->aie, client, args);
+		break;
+	default:
+		XDNA_ERR(xdna, "Not supported request parameter %u", args->param);
+		ret = -EOPNOTSUPP;
+		break;
+	}
+
+	amdxdna_pm_suspend_put(xdna);
+
+dev_exit:
+	drm_dev_exit(idx);
+	return ret;
+}
+
 const struct amdxdna_dev_ops aie4_vf_ops = {
 	.init			= aie4_vf_init,
 	.fini			= aie4_vf_fini,
@@ -789,6 +823,7 @@ const struct amdxdna_dev_ops aie4_vf_ops = {
 	.mmap			= aie4_doorbell_mmap,
 	.cmd_wait		= aie4_cmd_wait,
 	.get_aie_info		= aie4_get_info,
+	.set_aie_state		= aie4_set_state,
 	.get_array		= aie4_get_array,
 };
 
@@ -800,5 +835,6 @@ const struct amdxdna_dev_ops aie4_classic_ops = {
 	.mmap			= aie4_doorbell_mmap,
 	.cmd_wait		= aie4_cmd_wait,
 	.get_aie_info		= aie4_get_info,
+	.set_aie_state		= aie4_set_state,
 	.get_array		= aie4_get_array,
 };

--- a/drivers/accel/amdxdna/aie4_pci.h
+++ b/drivers/accel/amdxdna/aie4_pci.h
@@ -83,12 +83,18 @@ static inline int aie4_sriov_stop(struct amdxdna_dev_hdl *ndev)
 
 enum aie4_fw_feature {
 	AIE4_GET_COREDUMP,
+	AIE4_RW_ACCESS,
 	AIE4_FEATURE_MAX
 };
 
 int aie4_get_aie_coredump(struct amdxdna_hwctx *hwctx,
 			  struct amdxdna_msg_buf_hdl *list_hdl,
 			  u32 num_bufs);
+int aie4_rw_aie_reg(struct amdxdna_hwctx *hwctx, bool is_read,
+		    u8 row, u8 col, u32 addr, u32 *value);
+int aie4_rw_aie_mem(struct amdxdna_hwctx *hwctx, bool is_read,
+		    u8 row, u8 col, u32 aie_addr,
+		    dma_addr_t dram_addr, u32 size);
 
 extern const struct amdxdna_dev_ops aie4_pf_ops;
 extern const struct amdxdna_dev_ops aie4_vf_ops;

--- a/drivers/accel/amdxdna/aie4_pci.h
+++ b/drivers/accel/amdxdna/aie4_pci.h
@@ -61,6 +61,7 @@ struct amdxdna_dev_hdl {
 int aie4_query_aie_metadata(struct amdxdna_dev_hdl *ndev, struct aie_metadata *metadata);
 int aie4_suspend_fw(struct amdxdna_dev_hdl *ndev);
 int aie4_attach_work_buffer(struct amdxdna_dev_hdl *ndev, dma_addr_t addr, u32 size);
+void aie4_msg_init(struct amdxdna_dev_hdl *ndev);
 
 /* aie4_ctx.c */
 int aie4_hwctx_init(struct amdxdna_hwctx *hwctx);
@@ -85,9 +86,9 @@ enum aie4_fw_feature {
 	AIE4_FEATURE_MAX
 };
 
-int aie4_get_aie_coredump(struct amdxdna_dev *xdna,
+int aie4_get_aie_coredump(struct amdxdna_hwctx *hwctx,
 			  struct amdxdna_msg_buf_hdl *list_hdl,
-			  struct amdxdna_hwctx *hwctx, u32 num_bufs);
+			  u32 num_bufs);
 
 extern const struct amdxdna_dev_ops aie4_pf_ops;
 extern const struct amdxdna_dev_ops aie4_vf_ops;

--- a/drivers/accel/amdxdna/amdxdna_ctx.c
+++ b/drivers/accel/amdxdna/amdxdna_ctx.c
@@ -76,16 +76,27 @@ static void amdxdna_hwctx_destroy_rcu(struct amdxdna_hwctx *hwctx,
 	kfree(hwctx);
 }
 
+/*
+ * Walks @client's hwctxs invoking @walk. If @filter is set, @walk runs
+ * only on the matching hwctx; returns -ENOENT if none matched.
+ * Otherwise @walk runs on every hwctx; halts on the first non-zero return.
+ */
 int amdxdna_hwctx_walk(struct amdxdna_client *client, void *arg,
+		       bool (*filter)(struct amdxdna_hwctx *hwctx, void *arg),
 		       int (*walk)(struct amdxdna_hwctx *hwctx, void *arg))
 {
+	int ret = filter ? -ENOENT : 0;
 	struct amdxdna_hwctx *hwctx;
 	unsigned long hwctx_id;
-	int ret = 0, idx;
+	int idx;
 
 	idx = srcu_read_lock(&client->hwctx_srcu);
 	amdxdna_for_each_hwctx(client, hwctx_id, hwctx) {
+		if (filter && !filter(hwctx, arg))
+			continue;
 		ret = walk(hwctx, arg);
+		if (filter)
+			break;
 		if (ret)
 			break;
 	}

--- a/drivers/accel/amdxdna/amdxdna_ctx.h
+++ b/drivers/accel/amdxdna/amdxdna_ctx.h
@@ -6,6 +6,7 @@
 #ifndef _AMDXDNA_CTX_H_
 #define _AMDXDNA_CTX_H_
 
+#include <drm/gpu_scheduler.h>
 #include <linux/bitfield.h>
 
 #include "amdxdna_gem.h"

--- a/drivers/accel/amdxdna/amdxdna_ctx.h
+++ b/drivers/accel/amdxdna/amdxdna_ctx.h
@@ -204,6 +204,7 @@ int amdxdna_cmd_set_error(struct amdxdna_gem_obj *abo,
 void amdxdna_sched_job_cleanup(struct amdxdna_sched_job *job);
 void amdxdna_hwctx_remove_all(struct amdxdna_client *client);
 int amdxdna_hwctx_walk(struct amdxdna_client *client, void *arg,
+		       bool (*filter)(struct amdxdna_hwctx *hwctx, void *arg),
 		       int (*walk)(struct amdxdna_hwctx *hwctx, void *arg));
 int amdxdna_hwctx_sync_debug_bo(struct amdxdna_client *client, u32 debug_bo_hdl);
 

--- a/drivers/accel/amdxdna/amdxdna_pci_drv.c
+++ b/drivers/accel/amdxdna/amdxdna_pci_drv.c
@@ -56,9 +56,10 @@ MODULE_FIRMWARE("amdnpu/1B0B_10/cert.dev.sbin");
  * 0.10: Add new device type AMDXDNA_DEV_TYPE_UMQ
  * 0.11: Support AIE coredump
  * 0.12: Add classic device type of NPU3
+ * 0.13: Support AIE tile register/memory read/write
  */
 #define AMDXDNA_DRIVER_MAJOR		0
-#define AMDXDNA_DRIVER_MINOR		12
+#define AMDXDNA_DRIVER_MINOR		13
 
 /*
  * Bind the driver base on (vendor_id, device_id) pair and later use the

--- a/drivers/accel/amdxdna/amdxdna_pci_drv.h
+++ b/drivers/accel/amdxdna/amdxdna_pci_drv.h
@@ -8,8 +8,10 @@
 
 #include "drm/amdxdna_accel.h"
 #include <drm/drm_device.h>
+#include <drm/drm_file.h>
 #include <drm/drm_print.h>
 #include <linux/capability.h>
+#include <linux/cred.h>
 #include <linux/iommu.h>
 #include <linux/iova.h>
 #include <linux/workqueue.h>
@@ -41,11 +43,6 @@
 
 extern const struct drm_driver amdxdna_drm_drv;
 
-static inline bool amdxdna_is_admin(void)
-{
-	return capable(CAP_SYS_ADMIN);
-}
-
 struct amdxdna_client;
 struct amdxdna_dev;
 struct amdxdna_drm_get_info;
@@ -75,9 +72,6 @@ struct amdxdna_dev_ops {
 	int (*get_aie_info)(struct amdxdna_client *client, struct amdxdna_drm_get_info *args);
 	int (*set_aie_state)(struct amdxdna_client *client, struct amdxdna_drm_set_state *args);
 	int (*get_array)(struct amdxdna_client *client, struct amdxdna_drm_get_array *args);
-	int (*get_coredump)(struct amdxdna_dev *xdna,
-			    struct amdxdna_msg_buf_hdl *list_hdl,
-			    struct amdxdna_hwctx *hwctx, u32 num_bufs);
 	int (*get_dev_revision)(struct amdxdna_dev *xdna, u32 *rev);
 	int (*hwctx_heap_expand)(struct amdxdna_hwctx *hwctx);
 };
@@ -222,5 +216,12 @@ static inline bool amdxdna_iova_on(struct amdxdna_dev *xdna)
 static inline bool amdxdna_pasid_on(struct amdxdna_client *client)
 {
 	return client->pasid != IOMMU_PASID_INVALID;
+}
+
+/* True if the current task may examine @client's contexts. */
+static inline bool amdxdna_client_visible(struct amdxdna_client *client)
+{
+	return capable(CAP_SYS_ADMIN) ||
+	       uid_eq(current_euid(), client->filp->filp->f_cred->euid);
 }
 #endif /* _AMDXDNA_PCI_DRV_H_ */

--- a/drivers/accel/amdxdna/npu3_regs.c
+++ b/drivers/accel/amdxdna/npu3_regs.c
@@ -40,6 +40,7 @@
 static const struct amdxdna_fw_feature_tbl npu3_fw_feature_table[] = {
 	{ .major = 5, .min_minor = 10 },
 	{ .features = BIT_U64(AIE4_GET_COREDUMP), .major = 5, .min_minor = 24 },
+	{ .features = BIT_U64(AIE4_RW_ACCESS), .major = 5, .min_minor = 24 },
 	{ 0 }
 };
 

--- a/drivers/accel/amdxdna/npu4_regs.c
+++ b/drivers/accel/amdxdna/npu4_regs.c
@@ -99,6 +99,7 @@ const struct amdxdna_fw_feature_tbl npu4_fw_feature_table[] = {
 	{ .features = BIT_U64(AIE2_APP_HEALTH), .major = 6, .min_minor = 18 },
 	{ .features = BIT_U64(AIE2_ADD_HOST_BUFFER), .major = 6, .min_minor = 18 },
 	{ .features = BIT_U64(AIE2_GET_DEV_REVISION), .major = 6, .min_minor = 24 },
+	{ .features = BIT_U64(AIE2_RW_ACCESS), .major = 6, .min_minor = 24 },
 	{ .features = AIE2_ALL_FEATURES, .major = 7 },
 	{ 0 }
 };

--- a/include/uapi/drm/amdxdna_accel.h
+++ b/include/uapi/drm/amdxdna_accel.h
@@ -474,10 +474,10 @@ enum amdxdna_drm_get_param {
 	DRM_AMDXDNA_QUERY_AIE_VERSION,
 	DRM_AMDXDNA_QUERY_CLOCK_METADATA,
 	DRM_AMDXDNA_QUERY_SENSORS,
-	DRM_AMDXDNA_QUERY_HW_CONTEXTS,		/* CAP_SYS_ADMIN required */
+	DRM_AMDXDNA_QUERY_HW_CONTEXTS,		/* admin or matching EUID */
 	DRM_AMDXDNA_QUERY_FIRMWARE_VERSION = 8,
 	DRM_AMDXDNA_GET_POWER_MODE,
-	DRM_AMDXDNA_QUERY_TELEMETRY,		/* CAP_SYS_ADMIN required */
+	DRM_AMDXDNA_QUERY_TELEMETRY,		/* admin or matching EUID */
 	DRM_AMDXDNA_GET_FORCE_PREEMPT_STATE,
 	DRM_AMDXDNA_QUERY_RESOURCE_INFO,
 	DRM_AMDXDNA_GET_FRAME_BOUNDARY_PREEMPT_STATE,
@@ -643,13 +643,13 @@ struct amdxdna_drm_bo_usage {
 
 /**
  * struct amdxdna_drm_aie_coredump - The data for AIE coredump
- * @pid: The Process ID of the process that created this context.
- * @context_id: The ID for this context.
- * @pad: MBZ.
  */
 struct amdxdna_drm_aie_coredump {
+	/** @pid: The Process ID of the process that created this context. */
 	__u64 pid;
+	/** @context_id: Context ID. */
 	__u32 context_id;
+	/** @pad: MBZ. */
 	__u32 pad;
 };
 

--- a/include/uapi/drm/amdxdna_accel.h
+++ b/include/uapi/drm/amdxdna_accel.h
@@ -653,6 +653,38 @@ struct amdxdna_drm_aie_coredump {
 	__u32 pad;
 };
 
+/**
+ * enum amdxdna_aie_tile_access_type - AIE tile access path selector
+ * @AMDXDNA_AIE_TILE_ACCESS_REG: Single 32-bit tile-local register access.
+ * @AMDXDNA_AIE_TILE_ACCESS_MEM: DMA block transfer through firmware buffer.
+ */
+enum amdxdna_aie_tile_access_type {
+	AMDXDNA_AIE_TILE_ACCESS_REG,
+	AMDXDNA_AIE_TILE_ACCESS_MEM,
+};
+
+/**
+ * struct amdxdna_drm_aie_tile_access - The data for AIE tile read/write
+ */
+struct amdxdna_drm_aie_tile_access {
+	/** @pid: The Process ID of the process that created this context. */
+	__u64 pid;
+	/** @context_id: Context ID. */
+	__u32 context_id;
+	/** @col: The AIE column index. */
+	__u32 col;
+	/** @row: The AIE row index. */
+	__u32 row;
+	/** @addr: The AIE tile address to read/write. */
+	__u32 addr;
+	/** @size: The size of bytes to read/write. */
+	__u32 size;
+	/** @type: Access path, one of enum amdxdna_aie_tile_access_type. */
+	__u8  type;
+	/** @pad: MBZ. */
+	__u8  pad[3];
+};
+
 /*
  * Supported params in struct amdxdna_drm_get_array
  */
@@ -660,6 +692,7 @@ struct amdxdna_drm_aie_coredump {
 #define DRM_AMDXDNA_HW_LAST_ASYNC_ERR	2
 #define DRM_AMDXDNA_AIE_COREDUMP	5
 #define DRM_AMDXDNA_BO_USAGE		6
+#define DRM_AMDXDNA_AIE_TILE_READ	9
 
 /**
  * struct amdxdna_drm_get_array - Get information array.
@@ -686,11 +719,31 @@ struct amdxdna_drm_get_array {
 	 * of tile dump data into buffer. If the buffer is too small the
 	 * driver sets element_size to the required size and returns -ENOSPC.
 	 *
-	 * Access: context owners may coredump their own contexts;
-	 * CAP_SYS_ADMIN may coredump any context.
+	 * Access: any process running as the same Linux user as the
+	 * context creator may coredump that context; CAP_SYS_ADMIN may
+	 * coredump any context.
 	 *
 	 * %DRM_AMDXDNA_BO_USAGE:
 	 * Returns usage of heap/internal/external BOs.
+	 *
+	 * %DRM_AMDXDNA_AIE_TILE_READ:
+	 * Read an AIE tile register or memory block.
+	 *
+	 * num_element must be 1. The first sizeof(struct
+	 * amdxdna_drm_aie_tile_access) bytes of buffer carry the request
+	 * (pid, context_id, col, row, addr, size, type). On success the
+	 * driver overwrites the first size bytes of buffer with the data
+	 * read back. If element_size is too small the driver sets it to the
+	 * required size and returns -ENOSPC.
+	 *
+	 * @type selects the access path and must be set explicitly to one
+	 * of enum amdxdna_aie_tile_access_type. REG is a single 32-bit
+	 * tile-local register access (requires size == 4); MEM is a DMA
+	 * block transfer through firmware.
+	 *
+	 * Access: any process running as the same Linux user as the
+	 * context creator may read that context; CAP_SYS_ADMIN may read
+	 * any context.
 	 */
 	__u32 param;
 	/**
@@ -723,18 +776,63 @@ enum amdxdna_drm_set_param {
 	DRM_AMDXDNA_WRITE_AIE_REG,
 	DRM_AMDXDNA_SET_FORCE_PREEMPT,
 	DRM_AMDXDNA_SET_FRAME_BOUNDARY_PREEMPT,
+	DRM_AMDXDNA_AIE_TILE_WRITE = 7,
 };
 
 /**
  * struct amdxdna_drm_set_state - Set the state of the AIE hardware.
- * @param: Value in enum amdxdna_drm_set_param.
- * @buffer_size: Size of the input param.
- * @buffer: Pointer to the input param.
  */
 struct amdxdna_drm_set_state {
-	__u32 param; /* in */
-	__u32 buffer_size; /* in */
-	__u64 buffer; /* in */
+	/**
+	 * @param:
+	 *
+	 * Supported params:
+	 *
+	 * %DRM_AMDXDNA_SET_POWER_MODE:
+	 * Sets the power mode.
+	 *
+	 * %DRM_AMDXDNA_WRITE_AIE_MEM:
+	 * Writes AIE memory (legacy).
+	 *
+	 * %DRM_AMDXDNA_WRITE_AIE_REG:
+	 * Writes AIE register (legacy).
+	 *
+	 * %DRM_AMDXDNA_SET_FORCE_PREEMPT:
+	 * Sets force preempt state.
+	 *
+	 * %DRM_AMDXDNA_SET_FRAME_BOUNDARY_PREEMPT:
+	 * Sets frame boundary preempt state.
+	 *
+	 * %DRM_AMDXDNA_AIE_TILE_WRITE:
+	 * Write an AIE tile register or memory block.
+	 *
+	 * The first sizeof(struct amdxdna_drm_aie_tile_access) bytes of
+	 * buffer carry the request (pid, context_id, col, row, addr, size,
+	 * type). The next size bytes contain the data to write. If
+	 * buffer_size is too small the driver sets it to the required size
+	 * and returns -ENOSPC.
+	 *
+	 * @type selects the access path and must be set explicitly to one
+	 * of enum amdxdna_aie_tile_access_type. REG is a single 32-bit
+	 * tile-local register access (requires size == 4); MEM is a DMA
+	 * block transfer through firmware.
+	 *
+	 * Access: requires CAP_SYS_ADMIN (the carrier SET_STATE ioctl is
+	 * DRM_ROOT_ONLY).
+	 */
+	__u32 param;
+	/**
+	 * @buffer_size:
+	 *
+	 * Size of the input buffer in bytes.
+	 */
+	__u32 buffer_size;
+	/**
+	 * @buffer:
+	 *
+	 * Pointer to the input buffer.
+	 */
+	__u64 buffer;
 };
 
 /**

--- a/src/include/uapi/drm_local/amdxdna_accel.h
+++ b/src/include/uapi/drm_local/amdxdna_accel.h
@@ -746,6 +746,16 @@ struct amdxdna_drm_get_dpt_state {
 };
 
 /**
+ * enum amdxdna_aie_tile_access_type - AIE tile access path selector
+ * @AMDXDNA_AIE_TILE_ACCESS_REG: Single 32-bit tile-local register access.
+ * @AMDXDNA_AIE_TILE_ACCESS_MEM: DMA block transfer through firmware buffer.
+ */
+enum amdxdna_aie_tile_access_type {
+	AMDXDNA_AIE_TILE_ACCESS_REG,
+	AMDXDNA_AIE_TILE_ACCESS_MEM,
+};
+
+/**
  * struct amdxdna_drm_aie_tile_access - The data for AIE memory/register read/write
  * @pid: The Process ID of the process that created this context.
  * @context_id: The hw context id.
@@ -753,6 +763,9 @@ struct amdxdna_drm_get_dpt_state {
  * @row:   The AIE row index
  * @addr:  The AIE memory address to read/write
  * @size:  The size of bytes to read/write
+ * @type:  Access path, one of enum amdxdna_aie_tile_access_type. REG
+ *         requires size == 4; MEM is a DMA block transfer.
+ * @pad:   MBZ.
  *
  * This is used for DRM_AMDXDNA_AIE_TILE_READ and DRM_AMDXDNA_AIE_TILE_WRITE
  * parameters.
@@ -764,7 +777,8 @@ struct amdxdna_drm_aie_tile_access {
 	__u32 row;
 	__u32 addr;
 	__u32 size;
-	__u32 pad;
+	__u8  type;
+	__u8  pad[3];
 };
 
 /**

--- a/src/shim/device.cpp
+++ b/src/shim/device.cpp
@@ -1538,6 +1538,8 @@ struct aie_read
     access->row = static_cast<uint32_t>(args.row);
     access->addr = args.offset;
     access->size = args.size;
+    access->type = (args.type == xrt_core::query::aie_read::access_type::reg) ?
+                   AMDXDNA_AIE_TILE_ACCESS_REG : AMDXDNA_AIE_TILE_ACCESS_MEM;
 
     amdxdna_drm_get_array arg = {
       .param = DRM_AMDXDNA_AIE_TILE_READ,
@@ -1582,6 +1584,8 @@ struct aie_write
     access->row = static_cast<uint32_t>(args.row);
     access->addr = args.offset;
     access->size = args.data.size();
+    access->type = (args.type == xrt_core::query::aie_write::access_type::reg) ?
+                   AMDXDNA_AIE_TILE_ACCESS_REG : AMDXDNA_AIE_TILE_ACCESS_MEM;
 
     std::memcpy(payload.data() + sizeof(amdxdna_drm_aie_tile_access), args.data.data(), args.data.size());
 

--- a/src/shim_ve2/xdna_device.cpp
+++ b/src/shim_ve2/xdna_device.cpp
@@ -393,6 +393,8 @@ struct aie_read
     aie_data->row = static_cast<__u32>(args.row);
     aie_data->addr = args.offset;
     aie_data->size = args.size;
+    aie_data->type = (args.type == xrt_core::query::aie_read::access_type::reg) ?
+                     AMDXDNA_AIE_TILE_ACCESS_REG : AMDXDNA_AIE_TILE_ACCESS_MEM;
 
     amdxdna_drm_get_array arg = {
       .param = DRM_AMDXDNA_AIE_TILE_READ,
@@ -444,6 +446,8 @@ struct aie_write
     aie_data->row = static_cast<__u32>(args.row);
     aie_data->addr = args.offset;
     aie_data->size = args.data.size();
+    aie_data->type = (args.type == xrt_core::query::aie_write::access_type::reg) ?
+                     AMDXDNA_AIE_TILE_ACCESS_REG : AMDXDNA_AIE_TILE_ACCESS_MEM;
 
     amdxdna_drm_set_state arg = {
       .param = DRM_AMDXDNA_AIE_TILE_WRITE,

--- a/test/shim_test/shim_test.cpp
+++ b/test/shim_test/shim_test.cpp
@@ -1060,10 +1060,10 @@ std::vector<test_case> test_list {
   test_case{ "get AIE coredump and check registers", {},
     TEST_POSITIVE, dev_filter_is_npu4, TEST_io_coredump, {}
   },
-  test_case{ "AIE MEM read/write", {~0U, ~0U},
+  test_case{ "AIE MEM read/write", {},
     TEST_POSITIVE, dev_filter_is_npu4, TEST_io_aie_mem, {}
   },
-  test_case{ "AIE REG read/write", {~0U, ~0U},
+  test_case{ "AIE REG read/write", {},
     TEST_POSITIVE, dev_filter_is_npu4, TEST_io_aie_reg, {}
   },
   test_case{ "failed chained command", {},


### PR DESCRIPTION
Add a secure debug interface that lets userspace read or write
individual AIE tile registers (size == 4) and tile memory blocks
(size > 4) via firmware mailbox messages. Reads are exposed through
DRM_AMDXDNA_AIE_TILE_READ on get_array; writes through
DRM_AMDXDNA_AIE_TILE_WRITE on set_state. Access is gated by EUID
match against the context creator (or CAP_SYS_ADMIN), replacing the
previous PID-based check.

Patches:
  1. accel/amdxdna: backport upstream coredump cleanup
     - aligns the existing AIE coredump path with the upstream-bound
       version: direct callback in place of dev_ops indirection,
       inlined CAP_SYS_ADMIN gate, goto-style error paths, kerneldoc
       reformat.
  2. accel/amdxdna: add AIE tile read/write access
     - core tile r/w implementation plus a shared
       amdxdna_hwctx_lookup_locked() helper (also retrofitted into
       the coredump path), AIE2 enablement, UAPI, version bump 0.12.
  3. accel/amdxdna: enable tile read/write for AIE4 devices
     - AIE4 firmware-message + dispatch wiring with PASID forwarding.
  4. test/shim_test: fix tile read/write test drv_ver to always pass
     - lets the new tile r/w shim tests run as positive tests.
