### PR TITLE
treewide: fix typos in comments, log strings, and uapi docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ If you are using Ubuntu 24.04 you may need to update the Linux kernel. You can u
 
 ### Ubuntu 22.04
 
-Since Linux v6.10 offically supports AMD IOMMU SVA, we can work with upstream Linux kernel source.
+Since Linux v6.10 officially supports AMD IOMMU SVA, we can work with upstream Linux kernel source.
 If your system has Linux v6.10 or above installed, check if `CONFIG_AMD_IOMMU` and `CONFIG_DRM_ACCEL` are set. If not, the system is not good for XDNA driver.
 
 If you want to manually build Linux kernel, follow below steps.

--- a/drivers/accel/amdxdna/aie2_ctx.c
+++ b/drivers/accel/amdxdna/aie2_ctx.c
@@ -836,7 +836,7 @@ int aie2_hwctx_init(struct amdxdna_hwctx *hwctx)
 	ret = drm_sched_entity_init(&priv->entity, DRM_SCHED_PRIORITY_NORMAL,
 				    &sched, 1, NULL);
 	if (ret) {
-		XDNA_ERR(xdna, "Failed to initial sched entiry. ret %d", ret);
+		XDNA_ERR(xdna, "Failed to initial sched entity. ret %d", ret);
 		goto free_sched;
 	}
 

--- a/drivers/accel/amdxdna/aie2_ctx.c
+++ b/drivers/accel/amdxdna/aie2_ctx.c
@@ -836,7 +836,7 @@ int aie2_hwctx_init(struct amdxdna_hwctx *hwctx)
 	ret = drm_sched_entity_init(&priv->entity, DRM_SCHED_PRIORITY_NORMAL,
 				    &sched, 1, NULL);
 	if (ret) {
-		XDNA_ERR(xdna, "Failed to initial sched entity. ret %d", ret);
+		XDNA_ERR(xdna, "Failed to initialize sched entity. ret %d", ret);
 		goto free_sched;
 	}
 

--- a/drivers/accel/tools/dkms_driver.sh
+++ b/drivers/accel/tools/dkms_driver.sh
@@ -61,7 +61,7 @@ if [[ $1 == "--install" ]]; then
 		echo "Failed to enable DKMS for ${DKMS_DRV_MODULE_NAME}"
 		exit 1
 	fi
-	echo "Successfully intalled and enabled DKMS for ${DKMS_DRV_MODULE_NAME}"
+	echo "Successfully installed and enabled DKMS for ${DKMS_DRV_MODULE_NAME}"
 else
 # Remove source code from DKMS and clean up
 	echo "Removing driver source: ${DKMS_DRV_MODULE_NAME}..."

--- a/drivers/accel/tools/npu_perf_analyze.sh
+++ b/drivers/accel/tools/npu_perf_analyze.sh
@@ -97,7 +97,7 @@ if [ ${event2_ts_num} -eq 0 ]; then
 fi
 echo "${event2_ts_num} events for: '${event2}'"
 
-# Caculate time difference between two events
+# Calculate time difference between two events
 diffs_event1=()
 diffs_event2=()
 diffs=()

--- a/drivers/accel/tools/npu_perf_trace.sh
+++ b/drivers/accel/tools/npu_perf_trace.sh
@@ -35,7 +35,7 @@ add_sdt_xrt()
 	perf list | grep sdt_xrt > /dev/null && sdt_pre_enabled=1
 	if [[ $sdt_pre_enabled == 1 ]]; then
 		remove_sdt_xrt
-		#trace_warn "XRT SDT had beed added. Skip..."
+		#trace_warn "XRT SDT had been added. Skip..."
 		#return
 	fi
 

--- a/src/driver/amdxdna/aie2_ctx_runqueue.c
+++ b/src/driver/amdxdna/aie2_ctx_runqueue.c
@@ -712,7 +712,7 @@ static void rq_parts_work(struct work_struct *work)
 	/* Partition expanding or trimming is needed */
 	rq->paused = true;
 	if (handle_busy_ctxs(rq)) {
-		XDNA_DBG(xdna, "Wait for disconneting active contexts");
+		XDNA_DBG(xdna, "Wait for disconnecting active contexts");
 		goto out;
 	}
 
@@ -1008,7 +1008,7 @@ aie2_enable_special_case(struct aie2_ctx_rq *rq, struct amdxdna_ctx *ctx)
 	 * 1. The first column of the device is non-zero.
 	 * 2. The columns of context and device are the same.
 	 *
-	 * After spacial case support is enabled,
+	 * After special case support is enabled,
 	 * 1. Other context doesn't use all columns will fail to create.
 	 */
 	if (!xdna->dev_info->first_col) {
@@ -1112,7 +1112,7 @@ int aie2_rq_add(struct aie2_ctx_rq *rq, struct amdxdna_ctx *ctx)
 
 	/* Expand partition is needed*/
 	if (num_col > rq->max_cols) {
-		XDNA_DBG(xdna, "%s request %d colomns, rq max_cols %d",
+		XDNA_DBG(xdna, "%s request %d columns, rq max_cols %d",
 			 ctx->name, num_col, rq->max_cols);
 		wait_parts = true;
 	}

--- a/src/driver/amdxdna/aie2_debugfs.c
+++ b/src/driver/amdxdna/aie2_debugfs.c
@@ -385,7 +385,7 @@ static int aie2_dbgfs_nputest_show(struct seq_file *m, void *unused)
 	seq_puts(m, "\n");
 	seq_puts(m, "test case 2 usage:\n");
 	seq_puts(m, "\techo 2 msg_len resp_len pattern [cnt] > <nputest file>\n");
-	seq_puts(m, "\t\tmsg_len - messge length in words (>= 2)\n");
+	seq_puts(m, "\t\tmsg_len - message length in words (>= 2)\n");
 	seq_puts(m, "\t\tresp_len - response length in words (1 - 28)\n");
 	seq_puts(m, "\t\tpattern - data to fill message and response\n");
 	seq_puts(m, "\t\tcnt - send cnt messages without wait, optional (default 1)\n");

--- a/src/driver/amdxdna/aie2_dpt.c
+++ b/src/driver/amdxdna/aie2_dpt.c
@@ -151,7 +151,7 @@ int aie2_fw_log_init(struct amdxdna_dev *xdna, size_t size, u8 level)
 	mutex_lock(&xdna->dev_handle->aie2_lock);
 	ret = aie2_config_fw_log(xdna->dev_handle, dma_hdl, size, &msi_idx, &msi_address);
 	if (ret) {
-		/* Sliently fail for device generation that don't support FW logging */
+		/* Silently fail for device generation that don't support FW logging */
 		if (ret != -EOPNOTSUPP)
 			XDNA_ERR(xdna, "Failed to init fw log buffer: %d", ret);
 		mutex_unlock(&xdna->dev_handle->aie2_lock);
@@ -213,7 +213,7 @@ int aie2_fw_log_fini(struct amdxdna_dev *xdna)
 	mutex_lock(&xdna->dev_handle->aie2_lock);
 	ret = aie2_set_log_destination(xdna->dev_handle, FW_LOG_DESTINATION_FIXED);
 	if (ret) {
-		/* Sliently fail for device generation that don't support FW logging */
+		/* Silently fail for device generation that don't support FW logging */
 		if (ret != -EOPNOTSUPP)
 			XDNA_ERR(xdna, "Failed to reset fw log destination: %d", ret);
 		mutex_unlock(&xdna->dev_handle->aie2_lock);
@@ -253,7 +253,7 @@ int aie2_fw_trace_init(struct amdxdna_dev *xdna, size_t size, u32 categories)
 	ret = aie2_start_fw_trace(xdna->dev_handle, dma_hdl, size, categories, &msi_idx,
 				  &msi_address);
 	if (ret) {
-		/* Sliently fail for device generation that don't support FW tracing */
+		/* Silently fail for device generation that don't support FW tracing */
 		if (ret != -EOPNOTSUPP)
 			XDNA_ERR(xdna, "Failed to init fw trace buffer: %d", ret);
 		mutex_unlock(&xdna->dev_handle->aie2_lock);

--- a/src/driver/amdxdna/aie2_hwctx.c
+++ b/src/driver/amdxdna/aie2_hwctx.c
@@ -115,7 +115,7 @@ int aie2_hwctx_start(struct amdxdna_ctx *ctx)
 	ret = drm_sched_entity_init(&ctx->priv->entity, DRM_SCHED_PRIORITY_NORMAL,
 				    &sched, 1, NULL);
 	if (ret) {
-		XDNA_ERR(xdna, "Failed to initial sched entiry. ret %d", ret);
+		XDNA_ERR(xdna, "Failed to initial sched entity. ret %d", ret);
 		goto fini_sched;
 	}
 

--- a/src/driver/amdxdna/aie2_hwctx.c
+++ b/src/driver/amdxdna/aie2_hwctx.c
@@ -115,7 +115,7 @@ int aie2_hwctx_start(struct amdxdna_ctx *ctx)
 	ret = drm_sched_entity_init(&ctx->priv->entity, DRM_SCHED_PRIORITY_NORMAL,
 				    &sched, 1, NULL);
 	if (ret) {
-		XDNA_ERR(xdna, "Failed to initial sched entity. ret %d", ret);
+		XDNA_ERR(xdna, "Failed to init sched entity. ret %d", ret);
 		goto fini_sched;
 	}
 

--- a/src/driver/amdxdna/aie4_debugfs.c
+++ b/src/driver/amdxdna/aie4_debugfs.c
@@ -129,7 +129,7 @@ static int test_msg_enum(struct amdxdna_dev_hdl *ndev)
 {
 	struct amdxdna_dev *xdna = ndev->xdna;
 	/*
-	 * Using magic echo to let sideloaded mpnpu enfore some steps which suppose to
+	 * Using magic echo to let sideloaded mpnpu enforce some steps which suppose to
 	 * be done after pcie device is emulated. Sending this ECHO before run any
 	 * tests. This would not affect released version because this step won't not
 	 * be run after released.

--- a/src/driver/amdxdna/aie4_debugfs.c
+++ b/src/driver/amdxdna/aie4_debugfs.c
@@ -129,10 +129,10 @@ static int test_msg_enum(struct amdxdna_dev_hdl *ndev)
 {
 	struct amdxdna_dev *xdna = ndev->xdna;
 	/*
-	 * Using magic echo to let sideloaded mpnpu enforce some steps which suppose to
-	 * be done after pcie device is emulated. Sending this ECHO before run any
-	 * tests. This would not affect released version because this step won't not
-	 * be run after released.
+	 * Using magic echo to let sideloaded mpnpu enforce some steps that are
+	 * supposed to be done after the PCIe device is emulated. Send this ECHO
+	 * before running any tests. This does not affect released versions because
+	 * this step will not be run in released versions.
 	 *
 	 * Note: only send this special echo once on classic EP setup
 	 */

--- a/src/driver/amdxdna/aie4_msg_priv.h
+++ b/src/driver/amdxdna/aie4_msg_priv.h
@@ -1255,7 +1255,7 @@ struct aie4_msg_calibrate_clock_trace_resp {
 	enum aie4_msg_status status;
 };
 
-/** * Event trace destination options.  */
+/** Event trace destination options. */
 enum aie4_msg_event_trace_destination {
 	AIE4_MSG_EVENT_TRACE_DEST_DRAM,
 	AIE4_MSG_EVENT_TRACE_DEST_COUNT

--- a/src/driver/amdxdna/amdxdna_drm.c
+++ b/src/driver/amdxdna/amdxdna_drm.c
@@ -319,7 +319,7 @@ static const struct drm_ioctl_desc amdxdna_drm_ioctls[] = {
 	DRM_IOCTL_DEF_DRV(AMDXDNA_CREATE_BO, amdxdna_drm_create_bo_ioctl, 0),
 	DRM_IOCTL_DEF_DRV(AMDXDNA_GET_BO_INFO, amdxdna_drm_get_bo_info_ioctl, 0),
 	DRM_IOCTL_DEF_DRV(AMDXDNA_SYNC_BO, amdxdna_drm_sync_bo_ioctl, 0),
-	/* Exectuion */
+	/* Execution */
 	DRM_IOCTL_DEF_DRV(AMDXDNA_EXEC_CMD, amdxdna_drm_submit_cmd_ioctl, 0),
 	DRM_IOCTL_DEF_DRV(AMDXDNA_WAIT_CMD, amdxdna_drm_wait_cmd_ioctl, 0),
 	/* AIE hardware */

--- a/src/driver/amdxdna/amdxdna_mailbox.h
+++ b/src/driver/amdxdna/amdxdna_mailbox.h
@@ -119,7 +119,7 @@ xdna_mailbox_create_channel(struct mailbox *mailbox,
  * @mailbox_chann: the handle return from xdna_mailbox_create_channel()
  *
  * Release all resources, including messages, list entries, interrupt etc.
- * After this function all, the channel is not functional at all.
+ * After this function call, the channel is not functional at all.
  * This is added for more complex synchronization scenario.
  */
 void xdna_mailbox_release_channel(struct mailbox_channel *mailbox_chann);

--- a/src/driver/amdxdna/amdxdna_mailbox.h
+++ b/src/driver/amdxdna/amdxdna_mailbox.h
@@ -120,7 +120,7 @@ xdna_mailbox_create_channel(struct mailbox *mailbox,
  *
  * Release all resources, including messages, list entries, interrupt etc.
  * After this function all, the channel is not functional at all.
- * This is added for more complex synchronization secnario.
+ * This is added for more complex synchronization scenario.
  */
 void xdna_mailbox_release_channel(struct mailbox_channel *mailbox_chann);
 

--- a/src/driver/amdxdna/ve2_mgmt.c
+++ b/src/driver/amdxdna/ve2_mgmt.c
@@ -1213,7 +1213,7 @@ static int ve2_create_mgmt_partition(struct amdxdna_dev *xdna,
 
 		mgmtctx->mgmt_aiedev = aie_partition_request(&request);
 		if (IS_ERR(mgmtctx->mgmt_aiedev)) {
-			XDNA_ERR(xdna, "aie parition request failed for part id %d",
+			XDNA_ERR(xdna, "aie partition request failed for part id %d",
 				 request.partition_id);
 			return -ENODEV;
 		}

--- a/src/driver/tools/dkms_driver.sh
+++ b/src/driver/tools/dkms_driver.sh
@@ -61,7 +61,7 @@ if [[ $1 == "--install" ]]; then
 		echo "Failed to enable DKMS for ${DKMS_DRV_MODULE_NAME}"
 		exit 1
 	fi
-	echo "Successfully intalled and enabled DKMS for ${DKMS_DRV_MODULE_NAME}"
+	echo "Successfully installed and enabled DKMS for ${DKMS_DRV_MODULE_NAME}"
 else
 # Remove source code from DKMS and clean up
 	echo "Removing driver source: ${DKMS_DRV_MODULE_NAME}..."

--- a/src/driver/tools/npu_perf_analyze.sh
+++ b/src/driver/tools/npu_perf_analyze.sh
@@ -97,7 +97,7 @@ if [ ${event2_ts_num} -eq 0 ]; then
 fi
 echo "${event2_ts_num} events for: '${event2}'"
 
-# Caculate time difference between two events
+# Calculate time difference between two events
 diffs_event1=()
 diffs_event2=()
 diffs=()

--- a/src/driver/tools/npu_perf_trace.sh
+++ b/src/driver/tools/npu_perf_trace.sh
@@ -35,7 +35,7 @@ add_sdt_xrt()
 	perf list | grep sdt_xrt > /dev/null && sdt_pre_enabled=1
 	if [[ $sdt_pre_enabled == 1 ]]; then
 		remove_sdt_xrt
-		#trace_warn "XRT SDT had beed added. Skip..."
+		#trace_warn "XRT SDT had been added. Skip..."
 		#return
 	fi
 

--- a/src/include/uapi/drm_local/amdxdna_accel.h
+++ b/src/include/uapi/drm_local/amdxdna_accel.h
@@ -338,7 +338,7 @@ struct amdxdna_drm_exec_cmd {
 };
 
 /**
- * struct amdxdna_drm_wait_cmd - Wait exectuion command.
+ * struct amdxdna_drm_wait_cmd - Wait execution command.
  *
  * @ctx: Context handle.
  * @timeout: timeout in ms, 0 implies infinite wait.
@@ -709,7 +709,7 @@ struct amdxdna_async_error {
 
 /**
  * struct amdxdna_dpt_metadata - DPT metadata shared between shim and driver
- * @offset: ever increamenting DPT read pointer
+ * @offset: ever incrementing DPT read pointer
  * @size: size of the buffer
  * @watch: boolean value to indicate if this request can wait in the kernel until new data is
  *	   available

--- a/src/shim/buffer.cpp
+++ b/src/shim/buffer.cpp
@@ -392,7 +392,7 @@ buffer(const pdev& dev, size_t size, int type, void *uptr)
   // both CPU and device may write to it.
   // In case the BO is exported to other process, it has to be aligned on page
   // boundary so that we don't implicitly share more than we need. Page size
-  // alignement is also required on Windows platform.
+  // alignment is also required on Windows platform.
   // Based on the above reasons, we'll enforce the pointer to be page aligned.
   if (!is_page_aligned(m_uptr))
     shim_err(EINVAL, "User pointer %p must be page aligned.", m_uptr);

--- a/src/shim/platform.h
+++ b/src/shim/platform.h
@@ -230,7 +230,7 @@ private:
   // points to the same bo instance in driver. If we have multiple bo
   // instances in shim pointing to the same bo in driver, any one of
   // the bo is destroyed will cause the driver bo to be freed while
-  // other bo intances may still be in-use in shim.
+  // other bo instances may still be in-use in shim.
   mutable std::mutex m_drm_bo_map_lock;
   mutable std::map< uint32_t, std::pair<int, bo_info> > m_drm_bo_map;
 

--- a/src/shim/virtio/platform_virtio.cpp
+++ b/src/shim/virtio/platform_virtio.cpp
@@ -429,7 +429,7 @@ hcall(void *req, void *out_buf, size_t out_size) const
   hcall(req);
   if (rsp_hdr->ret) {
     auto r = reinterpret_cast<vdrm_ccmd_req*>(req);
-    shim_err(rsp_hdr->ret, "%s HCALL received bad reponse", hcall_cmd2name(r->cmd).c_str());
+    shim_err(rsp_hdr->ret, "%s HCALL received bad response", hcall_cmd2name(r->cmd).c_str());
   }
   std::memcpy(out_buf, m_resp_buf->get(), sz);
 }

--- a/src/shim_ve2/xdna_aie_array.h
+++ b/src/shim_ve2/xdna_aie_array.h
@@ -35,9 +35,9 @@ private:
   // XAie_InstDeclare(DevInst, &ConfigPtr) is the interface
   // to initialize DevInst by the AIE driver. But it does not
   // work here because we can not make it as a member of Aie
-  // class to maintain its life cycle. So we declair it here.
+  // class to maintain its life cycle. So we declare it here.
   //
-  // Note: need to evolve when XAie_InstDecalare() evolves.
+  // Note: need to evolve when XAie_InstDeclare() evolves.
   XAie_DevInst dev_inst_obj;
 };
 

--- a/src/shim_ve2/xdna_aie_array.h
+++ b/src/shim_ve2/xdna_aie_array.h
@@ -35,7 +35,7 @@ private:
   // XAie_InstDeclare(DevInst, &ConfigPtr) is the interface
   // to initialize DevInst by the AIE driver. But it does not
   // work here because we can not make it as a member of Aie
-  // class to maintain its life cylce. So we declair it here.
+  // class to maintain its life cycle. So we declair it here.
   //
   // Note: need to evolve when XAie_InstDecalare() evolves.
   XAie_DevInst dev_inst_obj;


### PR DESCRIPTION
A spellcheck pass over the driver, shim, tools, and uapi headers
surfaced ~25 typos in comments, log strings, and one uapi-header doc
comment. All doc-only changes; no functional impact.

Identified via codespell (https://github.com/codespell-project/codespell)
(with kernel-idiom false positives like filp / mapp / HSA filtered out)
and verified by reading each line in context.

Notable highlights:

- README.md: "offically" -> "officially"
- tools/dkms_driver.sh: "Successfully intalled" -> "Successfully installed"
- tools/npu_perf_analyze.sh: "Caculate" -> "Calculate"
- tools/npu_perf_trace.sh: "had beed added" -> "had been added"
- amdxdna/aie2_ctx.c, aie2_hwctx.c: "Failed to initial sched entiry" -> "...entity"
  (drm_sched_entity init context)
- amdxdna/aie2_ctx_runqueue.c: "disconneting" -> "disconnecting",
  "spacial case" -> "special case", "colomns" -> "columns"
- amdxdna/aie2_debugfs.c: "messge" -> "message"
- amdxdna/aie2_dpt.c: "Sliently" -> "Silently" (3 occurrences)
- amdxdna/aie4_debugfs.c: "enfore" -> "enforce"
- amdxdna/amdxdna_drm.c: "Exectuion" -> "Execution"
- amdxdna/amdxdna_mailbox.h: "secnario" -> "scenario"
- amdxdna/ve2_mgmt.c: "parition" -> "partition"
- amdxdna/aie4_msg_priv.h: malformed Doxygen header on the event-trace
  destination enum (/** * Event ... */ -> /** Event ... */)
- include/uapi/drm_local/amdxdna_accel.h: "exectuion" -> "execution",
  "increamenting" -> "incrementing"
- shim/buffer.cpp: "alignement" -> "alignment"
- shim/platform.h: "intances" -> "instances"
- shim/virtio/platform_virtio.cpp: "reponse" -> "response"
- shim_ve2/xdna_aie_array.h: "cylce" -> "cycle"

Parallel changes applied to both src/driver/ and drivers/accel/ trees
where the file exists in both.