### PR TITLE
shim: re-throw unrecognized system_error in partition_info::get

### DIFF
--- a/src/shim/device.cpp
+++ b/src/shim/device.cpp
@@ -354,6 +354,8 @@ struct partition_info
 
         data_size = arg.num_element;
         data = reinterpret_cast<decltype(data)>(updated_payload.data());
+      } else {
+        throw;
       }
     }
 


### PR DESCRIPTION
Fixes #1303.

Catch block special-cases EINVAL and ENOSPC; any other system_error
silently fell through with `data` uninitialized and `data_size` 0,
so the function returned an empty result indistinguishable from "no
hwctx." Re-throw unrecognized codes.

`populate_aie_partition` (the only current in-tree caller) catches
everything and returns an empty ptree on exception, so end-user
xrt-smi output is unchanged today -- this just fixes the shim's
contract so future callers can differentiate failure from emptiness.
