### PR TITLE
accel/amdxdna: add firmware logging and event tracing for AIE2

### DIFF
--- a/drivers/accel/amdxdna/Kbuild
+++ b/drivers/accel/amdxdna/Kbuild
@@ -50,6 +50,7 @@ amdxdna-$(OFT_CONFIG_AMDXDNA_PCI) += \
 	aie4_ctx.o \
 	aie4_message.o \
 	aie4_pci.o \
+	amdxdna_dpt.o \
 	npu1_regs.o \
 	npu3_regs.o \
 	npu4_regs.o \

--- a/drivers/accel/amdxdna/aie.h
+++ b/drivers/accel/amdxdna/aie.h
@@ -29,6 +29,10 @@ struct aie_msg_ops {
 	int  (*fw_log_init)(struct amdxdna_dev *xdna, size_t size, u32 level);
 	int  (*fw_log_config)(struct amdxdna_dev *xdna, u32 level);
 	int  (*fw_log_fini)(struct amdxdna_dev *xdna);
+
+	int  (*fw_trace_init)(struct amdxdna_dev *xdna, size_t size, u32 categories);
+	int  (*fw_trace_config)(struct amdxdna_dev *xdna, u32 categories);
+	int  (*fw_trace_fini)(struct amdxdna_dev *xdna);
 };
 
 struct aie_device {

--- a/drivers/accel/amdxdna/aie.h
+++ b/drivers/accel/amdxdna/aie.h
@@ -25,6 +25,10 @@ struct aie_msg_ops {
 	int (*rw_mem)(struct amdxdna_hwctx *hwctx, bool is_read,
 		      u8 row, u8 col, u32 aie_addr,
 		      dma_addr_t dram_addr, u32 size);
+
+	int  (*fw_log_init)(struct amdxdna_dev *xdna, size_t size, u32 level);
+	int  (*fw_log_config)(struct amdxdna_dev *xdna, u32 level);
+	int  (*fw_log_fini)(struct amdxdna_dev *xdna);
 };
 
 struct aie_device {

--- a/drivers/accel/amdxdna/aie2_message.c
+++ b/drivers/accel/amdxdna/aie2_message.c
@@ -91,6 +91,56 @@ int aie2_assign_mgmt_pasid(struct amdxdna_dev_hdl *ndev, u16 pasid)
 	return aie_send_mgmt_msg_wait(&ndev->aie, &msg);
 }
 
+int aie2_set_log_level(struct amdxdna_dev_hdl *ndev, enum aie2_fw_log_level level)
+{
+	return aie2_set_runtime_cfg(ndev, NPU4_RT_TYPE_LOG_LEVEL, level);
+}
+
+int aie2_set_log_format(struct amdxdna_dev_hdl *ndev, enum aie2_fw_log_format format)
+{
+	return aie2_set_runtime_cfg(ndev, NPU4_RT_TYPE_LOG_FORMAT, format);
+}
+
+int aie2_set_log_destination(struct amdxdna_dev_hdl *ndev,
+			     enum aie2_fw_log_destination destination)
+{
+	return aie2_set_runtime_cfg(ndev, NPU4_RT_TYPE_LOG_DESTINATION, destination);
+}
+
+int aie2_config_fw_log(struct amdxdna_dev_hdl *ndev,
+		       struct amdxdna_msg_buf_hdl *buf_hdl,
+		       size_t size, u32 *msi_idx, u32 *msi_address)
+{
+	DECLARE_AIE_MSG(config_fw_log, MSG_OP_CONFIG_FW_LOG);
+	struct amdxdna_dev *xdna = ndev->aie.xdna;
+	dma_addr_t addr;
+	int ret;
+
+	addr = to_dma_addr(buf_hdl, 0);
+	if (!addr) {
+		XDNA_ERR(xdna, "Invalid DMA address");
+		return -EINVAL;
+	}
+
+	/* Cmd with buf_size == 0 detaches the log buffer from FW. */
+	req.buf_size = size;
+	req.buf_addr = addr;
+
+	ret = aie_send_mgmt_msg_wait(&ndev->aie, &msg);
+	if (ret) {
+		XDNA_ERR(xdna, "Config fw log failed, ret %d status 0x%x",
+			 ret, resp.status);
+		return ret;
+	}
+
+	if (size && msi_idx && msi_address) {
+		*msi_idx = resp.msi_idx;
+		*msi_address = resp.msi_address;
+	}
+
+	return 0;
+}
+
 int aie2_query_aie_version(struct amdxdna_dev_hdl *ndev,
 			   struct amdxdna_drm_query_aie_version *version)
 {
@@ -941,6 +991,12 @@ void aie2_msg_init(struct amdxdna_dev_hdl *ndev)
 	if (AIE_FEATURE_ON(&ndev->aie, AIE2_RW_ACCESS)) {
 		ndev->aie.msg_ops.rw_reg = aie2_rw_aie_reg;
 		ndev->aie.msg_ops.rw_mem = aie2_rw_aie_mem;
+	}
+
+	if (AIE_FEATURE_ON(&ndev->aie, AIE2_FW_LOG)) {
+		ndev->aie.msg_ops.fw_log_init   = aie2_fw_log_init;
+		ndev->aie.msg_ops.fw_log_config = aie2_fw_log_config;
+		ndev->aie.msg_ops.fw_log_fini   = aie2_fw_log_fini;
 	}
 }
 

--- a/drivers/accel/amdxdna/aie2_message.c
+++ b/drivers/accel/amdxdna/aie2_message.c
@@ -12,6 +12,7 @@
 #include <drm/gpu_scheduler.h>
 #include <linux/bitfield.h>
 #include <linux/errno.h>
+#include <linux/ktime.h>
 #include <linux/pci.h>
 #include <linux/types.h>
 #include <linux/xarray.h>
@@ -200,6 +201,27 @@ static u32 aie2_get_context_priority(struct amdxdna_dev_hdl *ndev,
 	default:
 		return PRIORITY_HIGH;
 	}
+}
+
+int aie2_calibrate_clock(struct amdxdna_dev_hdl *ndev)
+{
+	DECLARE_AIE_MSG(calibrate_clock, MSG_OP_CALIBRATE_CLOCK);
+	int ret;
+
+	if (!AIE_FEATURE_ON(&ndev->aie, AIE2_CALIBRATE_CLOCK)) {
+		XDNA_DBG(ndev->aie.xdna, "Calibrate clock not supported, skipped");
+		return 0;
+	}
+
+	req.time_base_ns = ktime_get_real_ns();
+
+	ret = aie_send_mgmt_msg_wait(&ndev->aie, &msg);
+	if (ret) {
+		XDNA_ERR(ndev->aie.xdna, "Calibrate clock failed, ret %d", ret);
+		return ret;
+	}
+
+	return 0;
 }
 
 int aie2_create_context(struct amdxdna_dev_hdl *ndev, struct amdxdna_hwctx *hwctx)

--- a/drivers/accel/amdxdna/aie2_message.c
+++ b/drivers/accel/amdxdna/aie2_message.c
@@ -141,6 +141,42 @@ int aie2_config_fw_log(struct amdxdna_dev_hdl *ndev,
 	return 0;
 }
 
+int aie2_start_fw_trace(struct amdxdna_dev_hdl *ndev,
+			struct amdxdna_msg_buf_hdl *buf_hdl, size_t size,
+			u32 categories, u32 *msi_idx, u32 *msi_address)
+{
+	DECLARE_AIE_MSG(start_fw_trace, MSG_OP_START_FW_TRACE);
+	struct amdxdna_dev *xdna = ndev->aie.xdna;
+	dma_addr_t addr;
+	int ret;
+
+	addr = to_dma_addr(buf_hdl, 0);
+	if (!addr) {
+		XDNA_ERR(xdna, "Invalid DMA address");
+		return -EINVAL;
+	}
+
+	req.destination = AIE2_FW_TRACE_DESTINATION_DRAM;
+	req.timestamp = AIE2_FW_TRACE_TIMESTAMP_FW_CHRONO;
+	req.categories = categories;
+	req.buf_addr = addr;
+	req.buf_size = size;
+
+	ret = aie_send_mgmt_msg_wait(&ndev->aie, &msg);
+	if (ret) {
+		XDNA_ERR(xdna, "Start FW trace failed, ret %d status 0x%x",
+			 ret, resp.status);
+		return ret;
+	}
+
+	if (size && msi_idx && msi_address) {
+		*msi_idx = resp.msi_idx;
+		*msi_address = resp.msi_address;
+	}
+
+	return 0;
+}
+
 int aie2_query_aie_version(struct amdxdna_dev_hdl *ndev,
 			   struct amdxdna_drm_query_aie_version *version)
 {
@@ -997,6 +1033,12 @@ void aie2_msg_init(struct amdxdna_dev_hdl *ndev)
 		ndev->aie.msg_ops.fw_log_init   = aie2_fw_log_init;
 		ndev->aie.msg_ops.fw_log_config = aie2_fw_log_config;
 		ndev->aie.msg_ops.fw_log_fini   = aie2_fw_log_fini;
+	}
+
+	if (AIE_FEATURE_ON(&ndev->aie, AIE2_FW_TRACE)) {
+		ndev->aie.msg_ops.fw_trace_init   = aie2_fw_trace_init;
+		ndev->aie.msg_ops.fw_trace_config = aie2_fw_trace_config;
+		ndev->aie.msg_ops.fw_trace_fini   = aie2_fw_trace_fini;
 	}
 }
 

--- a/drivers/accel/amdxdna/aie2_msg_priv.h
+++ b/drivers/accel/amdxdna/aie2_msg_priv.h
@@ -34,6 +34,7 @@ enum aie2_msg_opcode {
 	MSG_OP_UPDATE_PROPERTY             = 0x113,
 	MSG_OP_GET_APP_HEALTH              = 0x114,
 	MSG_OP_ADD_HOST_BUFFER             = 0x115,
+	MSG_OP_CONFIG_FW_LOG               = 0x116,
 	MSG_OP_GET_DEV_REVISION            = 0x117,
 	MSG_OP_GET_COREDUMP                = 0x119,
 	MSG_OP_CALIBRATE_CLOCK             = 0x11C,
@@ -599,6 +600,45 @@ struct calibrate_clock_req {
 
 struct calibrate_clock_resp {
 	enum aie2_msg_status	status;
+} __packed;
+
+/*
+ * Firmware logging runtime-config type IDs (FW 6.19+). Used as the @type
+ * argument to aie2_set_runtime_cfg().
+ */
+#define NPU4_RT_TYPE_LOG_LEVEL		6
+#define NPU4_RT_TYPE_LOG_FORMAT		7
+#define NPU4_RT_TYPE_LOG_DESTINATION	8
+
+enum aie2_fw_log_level {
+	AIE2_FW_LOG_LEVEL_OFF,
+	AIE2_FW_LOG_LEVEL_ERR,
+	AIE2_FW_LOG_LEVEL_WRN,
+	AIE2_FW_LOG_LEVEL_INF,
+	AIE2_FW_LOG_LEVEL_DBG,
+	AIE2_FW_LOG_LEVEL_MAX
+};
+
+enum aie2_fw_log_format {
+	AIE2_FW_LOG_FORMAT_FULL,
+};
+
+enum aie2_fw_log_destination {
+	AIE2_FW_LOG_DESTINATION_NULL,
+	AIE2_FW_LOG_DESTINATION_DRAM   = 4,
+};
+
+struct config_fw_log_req {
+	__u64	buf_addr;
+	__u32	buf_size;
+	__u32	reserved[5];
+} __packed;
+
+struct config_fw_log_resp {
+	enum aie2_msg_status	status;
+	__u32			msi_idx;
+	__u32			msi_address;
+	__u32			reserved[5];
 } __packed;
 
 #endif /* _AIE2_MSG_PRIV_H_ */

--- a/drivers/accel/amdxdna/aie2_msg_priv.h
+++ b/drivers/accel/amdxdna/aie2_msg_priv.h
@@ -31,6 +31,9 @@ enum aie2_msg_opcode {
 	MSG_OP_SET_RUNTIME_CONFIG          = 0x10A,
 	MSG_OP_GET_RUNTIME_CONFIG          = 0x10B,
 	MSG_OP_REGISTER_ASYNC_EVENT_MSG    = 0x10C,
+	MSG_OP_START_FW_TRACE              = 0x10F,
+	MSG_OP_STOP_FW_TRACE               = 0x110,
+	MSG_OP_SET_FW_TRACE_CATEGORIES     = 0x111,
 	MSG_OP_UPDATE_PROPERTY             = 0x113,
 	MSG_OP_GET_APP_HEALTH              = 0x114,
 	MSG_OP_ADD_HOST_BUFFER             = 0x115,
@@ -639,6 +642,52 @@ struct config_fw_log_resp {
 	__u32			msi_idx;
 	__u32			msi_address;
 	__u32			reserved[5];
+} __packed;
+
+/*
+ * Firmware event tracing. Categories are a free-form bitmask negotiated
+ * between firmware and xrt-smi (no kernel-side semantic knowledge); the
+ * driver simply forwards the u32 the user provided.
+ */
+enum aie2_fw_trace_destination {
+	AIE2_FW_TRACE_DESTINATION_NULL,
+	AIE2_FW_TRACE_DESTINATION_DRAM,
+};
+
+enum aie2_fw_trace_timestamp {
+	AIE2_FW_TRACE_TIMESTAMP_FW_CHRONO,
+	AIE2_FW_TRACE_TIMESTAMP_CPU_CCOUNT,
+};
+
+struct start_fw_trace_req {
+	__u32	categories;
+	__u32	destination;
+	__u32	timestamp;
+	__u64	buf_addr;
+	__u32	buf_size;
+} __packed;
+
+struct start_fw_trace_resp {
+	enum aie2_msg_status	status;
+	__u32			msi_idx;
+	__u64			current_timestamp;
+	__u32			msi_address;
+} __packed;
+
+struct stop_fw_trace_req {
+	__u32	reserved;
+} __packed;
+
+struct stop_fw_trace_resp {
+	enum aie2_msg_status	status;
+} __packed;
+
+struct set_fw_trace_categories_req {
+	__u32	categories;
+} __packed;
+
+struct set_fw_trace_categories_resp {
+	enum aie2_msg_status	status;
 } __packed;
 
 #endif /* _AIE2_MSG_PRIV_H_ */

--- a/drivers/accel/amdxdna/aie2_msg_priv.h
+++ b/drivers/accel/amdxdna/aie2_msg_priv.h
@@ -36,6 +36,7 @@ enum aie2_msg_opcode {
 	MSG_OP_ADD_HOST_BUFFER             = 0x115,
 	MSG_OP_GET_DEV_REVISION            = 0x117,
 	MSG_OP_GET_COREDUMP                = 0x119,
+	MSG_OP_CALIBRATE_CLOCK             = 0x11C,
 	MSG_OP_MAX_DRV_OPCODE,
 	MSG_OP_AIE_RW_ACCESS               = 0x203,
 	MSG_OP_MAX_ASYNC_OPCODE,
@@ -590,6 +591,14 @@ struct aie_rw_access_req {
 struct aie_rw_access_resp {
 	enum aie2_msg_status	status;
 	__u32			reg_read_value;
+} __packed;
+
+struct calibrate_clock_req {
+	__u64			time_base_ns;
+} __packed;
+
+struct calibrate_clock_resp {
+	enum aie2_msg_status	status;
 } __packed;
 
 #endif /* _AIE2_MSG_PRIV_H_ */

--- a/drivers/accel/amdxdna/aie2_pci.c
+++ b/drivers/accel/amdxdna/aie2_pci.c
@@ -29,6 +29,7 @@
 #include "amdxdna_dpt.h"
 #include "amdxdna_gem.h"
 #include "amdxdna_mailbox.h"
+#include "amdxdna_mailbox_helper.h"
 #include "amdxdna_pci_drv.h"
 #include "amdxdna_pm.h"
 #include "amdxdna_sensors.h"
@@ -1067,13 +1068,16 @@ static int aie2_get_array(struct amdxdna_client *client,
 	if (!drm_dev_enter(&xdna->ddev, &idx))
 		return -ENODEV;
 
-	/* FW_LOG paths use SRCU instead of dev_lock so multiple xrt-smi
-	 * watchers can sleep in wait_event_interruptible concurrently while
-	 * an admin can still disable logging via SET_FW_LOG_STATE.
+	/* FW_LOG / FW_TRACE paths use SRCU instead of dev_lock so multiple
+	 * xrt-smi watchers can sleep in wait_event_interruptible concurrently
+	 * while an admin can still disable logging / tracing via the
+	 * corresponding SET state ioctl.
 	 */
 	switch (args->param) {
 	case DRM_AMDXDNA_FW_LOG:
 	case DRM_AMDXDNA_FW_LOG_CONFIG:
+	case DRM_AMDXDNA_FW_TRACE:
+	case DRM_AMDXDNA_FW_TRACE_CONFIG:
 		needs_dev_lock = false;
 		break;
 	default:
@@ -1109,6 +1113,12 @@ static int aie2_get_array(struct amdxdna_client *client,
 		break;
 	case DRM_AMDXDNA_FW_LOG_CONFIG:
 		ret = amdxdna_get_fw_log_configs(&ndev->aie, args);
+		break;
+	case DRM_AMDXDNA_FW_TRACE:
+		ret = amdxdna_get_fw_trace(&ndev->aie, args);
+		break;
+	case DRM_AMDXDNA_FW_TRACE_CONFIG:
+		ret = amdxdna_get_fw_trace_configs(&ndev->aie, args);
 		break;
 	default:
 		XDNA_ERR(xdna, "Not supported request parameter %u", args->param);
@@ -1210,6 +1220,9 @@ static int aie2_set_state(struct amdxdna_client *client,
 		break;
 	case DRM_AMDXDNA_SET_FW_LOG_STATE:
 		ret = amdxdna_set_fw_log_state(&ndev->aie, args);
+		break;
+	case DRM_AMDXDNA_SET_FW_TRACE_STATE:
+		ret = amdxdna_set_fw_trace_state(&ndev->aie, args);
 		break;
 	default:
 		XDNA_ERR(xdna, "Not supported request parameter %u", args->param);
@@ -1327,6 +1340,65 @@ int aie2_fw_log_fini(struct amdxdna_dev *xdna)
 	}
 
 	return 0;
+}
+
+int aie2_fw_trace_init(struct amdxdna_dev *xdna, size_t size, u32 categories)
+{
+	struct amdxdna_dev_hdl *ndev = xdna->dev_handle;
+	u32 msi_idx = 0, msi_address = 0;
+	struct amdxdna_dpt *dpt;
+	int ret;
+
+	dpt = rcu_dereference_protected(xdna->fw_trace,
+					lockdep_is_held(&xdna->dev_lock));
+	if (!dpt) {
+		XDNA_ERR(xdna, "FW trace handle not allocated");
+		return -ENXIO;
+	}
+
+	ret = aie2_start_fw_trace(ndev, dpt->buf, size, categories, &msi_idx,
+				  &msi_address);
+	if (ret) {
+		if (ret != -EOPNOTSUPP)
+			XDNA_ERR(xdna, "Failed to start FW trace: %d", ret);
+		return ret;
+	}
+
+	dpt->io_base = ndev->mbox_base;
+	dpt->msi_address = msi_address & AIE2_DPT_MSI_ADDR_MASK;
+	dpt->msi_idx = msi_idx;
+
+	return 0;
+}
+
+int aie2_fw_trace_config(struct amdxdna_dev *xdna, u32 categories)
+{
+	struct amdxdna_dev_hdl *ndev = xdna->dev_handle;
+	DECLARE_AIE_MSG(set_fw_trace_categories, MSG_OP_SET_FW_TRACE_CATEGORIES);
+	int ret;
+
+	req.categories = categories;
+
+	ret = aie_send_mgmt_msg_wait(&ndev->aie, &msg);
+	if (ret)
+		XDNA_ERR(xdna,
+			 "Set FW trace categories failed, ret %d status 0x%x",
+			 ret, resp.status);
+	return ret;
+}
+
+int aie2_fw_trace_fini(struct amdxdna_dev *xdna)
+{
+	struct amdxdna_dev_hdl *ndev = xdna->dev_handle;
+	DECLARE_AIE_MSG(stop_fw_trace, MSG_OP_STOP_FW_TRACE);
+	int ret;
+
+	ret = aie_send_mgmt_msg_wait(&ndev->aie, &msg);
+	if (ret)
+		XDNA_ERR(xdna,
+			 "Stop FW trace failed, ret %d status 0x%x",
+			 ret, resp.status);
+	return ret;
 }
 
 const struct amdxdna_dev_ops aie2_ops = {

--- a/drivers/accel/amdxdna/aie2_pci.c
+++ b/drivers/accel/amdxdna/aie2_pci.c
@@ -26,6 +26,7 @@
 #include "aie2_pci.h"
 #include "aie2_solver.h"
 #include "amdxdna_ctx.h"
+#include "amdxdna_dpt.h"
 #include "amdxdna_gem.h"
 #include "amdxdna_mailbox.h"
 #include "amdxdna_pci_drv.h"
@@ -1060,14 +1061,32 @@ static int aie2_get_array(struct amdxdna_client *client,
 {
 	struct amdxdna_dev_hdl *ndev = client->xdna->dev_handle;
 	struct amdxdna_dev *xdna = client->xdna;
+	bool needs_dev_lock;
 	int ret, idx;
 
 	if (!drm_dev_enter(&xdna->ddev, &idx))
 		return -ENODEV;
 
-	ret = amdxdna_pm_resume_get_locked(xdna);
+	/* FW_LOG paths use SRCU instead of dev_lock so multiple xrt-smi
+	 * watchers can sleep in wait_event_interruptible concurrently while
+	 * an admin can still disable logging via SET_FW_LOG_STATE.
+	 */
+	switch (args->param) {
+	case DRM_AMDXDNA_FW_LOG:
+	case DRM_AMDXDNA_FW_LOG_CONFIG:
+		needs_dev_lock = false;
+		break;
+	default:
+		needs_dev_lock = true;
+		break;
+	}
+
+	ret = amdxdna_pm_resume_get(xdna);
 	if (ret)
 		goto dev_exit;
+
+	if (needs_dev_lock)
+		mutex_lock(&xdna->dev_lock);
 
 	switch (args->param) {
 	case DRM_AMDXDNA_HW_CONTEXT_ALL:
@@ -1085,10 +1104,19 @@ static int aie2_get_array(struct amdxdna_client *client,
 	case DRM_AMDXDNA_AIE_TILE_READ:
 		ret = amdxdna_aie_tile_read(&ndev->aie, client, args);
 		break;
+	case DRM_AMDXDNA_FW_LOG:
+		ret = amdxdna_get_fw_log(&ndev->aie, args);
+		break;
+	case DRM_AMDXDNA_FW_LOG_CONFIG:
+		ret = amdxdna_get_fw_log_configs(&ndev->aie, args);
+		break;
 	default:
 		XDNA_ERR(xdna, "Not supported request parameter %u", args->param);
 		ret = -EOPNOTSUPP;
 	}
+
+	if (needs_dev_lock)
+		mutex_unlock(&xdna->dev_lock);
 
 	amdxdna_pm_suspend_put(xdna);
 	XDNA_DBG(xdna, "Got param %d", args->param);
@@ -1179,6 +1207,9 @@ static int aie2_set_state(struct amdxdna_client *client,
 		break;
 	case DRM_AMDXDNA_AIE_TILE_WRITE:
 		ret = amdxdna_aie_tile_write(&ndev->aie, client, args);
+		break;
+	case DRM_AMDXDNA_SET_FW_LOG_STATE:
+		ret = amdxdna_set_fw_log_state(&ndev->aie, args);
 		break;
 	default:
 		XDNA_ERR(xdna, "Not supported request parameter %u", args->param);

--- a/drivers/accel/amdxdna/aie2_pci.c
+++ b/drivers/accel/amdxdna/aie2_pci.c
@@ -4,6 +4,7 @@
  */
 
 #include "drm/amdxdna_accel.h"
+#include <drm/drm_cache.h>
 #include <drm/drm_device.h>
 #include <drm/drm_drv.h>
 #include <drm/drm_gem_shmem_helper.h>
@@ -16,6 +17,7 @@
 #include <linux/iommu.h>
 #include <linux/iopoll.h>
 #include <linux/pci.h>
+#include <linux/rcupdate.h>
 #include <linux/xarray.h>
 #include <asm/hypervisor.h>
 
@@ -456,6 +458,7 @@ static int aie2_hw_suspend(struct amdxdna_dev *xdna)
 		aie2_hwctx_suspend(client);
 
 	aie2_hw_stop(xdna);
+	amdxdna_dpt_suspend(&xdna->dev_handle->aie);
 
 	return 0;
 }
@@ -470,6 +473,8 @@ static int aie2_hw_resume(struct amdxdna_dev *xdna)
 		XDNA_ERR(xdna, "Start hardware failed, %d", ret);
 		return ret;
 	}
+
+	amdxdna_dpt_resume(&xdna->dev_handle->aie);
 
 	list_for_each_entry(client, &xdna->client_list, node) {
 		ret = aie2_hwctx_resume(client);
@@ -619,6 +624,7 @@ static int aie2_init(struct amdxdna_dev *xdna)
 
 	release_firmware(fw);
 	aie2_msg_init(ndev);
+	amdxdna_dpt_init(&ndev->aie);
 	amdxdna_vbnv_init(xdna);
 	amdxdna_pm_init(xdna);
 	aie2_tdr_start(xdna);
@@ -636,6 +642,7 @@ static void aie2_fini(struct amdxdna_dev *xdna)
 {
 	aie2_tdr_stop(xdna);
 	amdxdna_pm_fini(xdna);
+	amdxdna_dpt_fini(&xdna->dev_handle->aie);
 	aie2_hw_stop(xdna);
 }
 
@@ -1198,6 +1205,97 @@ static int aie2_get_dev_rev(struct amdxdna_dev *xdna, u32 *rev)
 		*rev = (u32)aie2_rev;
 
 	return ret;
+}
+
+int aie2_fw_log_init(struct amdxdna_dev *xdna, size_t size, u32 level)
+{
+	struct amdxdna_dev_hdl *ndev = xdna->dev_handle;
+	struct amdxdna_dpt *dpt;
+	u32 msi_idx, msi_address;
+	int ret;
+
+	if (level >= AIE2_FW_LOG_LEVEL_MAX) {
+		XDNA_ERR(xdna, "Invalid firmware log level: %d", level);
+		return -EINVAL;
+	}
+
+	dpt = rcu_dereference_protected(xdna->fw_log,
+					lockdep_is_held(&xdna->dev_lock));
+	if (!dpt) {
+		XDNA_ERR(xdna, "FW log handle not allocated");
+		return -ENXIO;
+	}
+
+	ret = aie2_config_fw_log(ndev, dpt->buf, size, &msi_idx, &msi_address);
+	if (ret) {
+		if (ret != -EOPNOTSUPP)
+			XDNA_ERR(xdna, "Failed to init fw log buffer: %d", ret);
+		return ret;
+	}
+
+	ret = aie2_set_log_level(ndev, level);
+	if (ret) {
+		XDNA_ERR(xdna, "Failed to init fw log level: %d", ret);
+		goto detach;
+	}
+
+	ret = aie2_set_log_format(ndev, AIE2_FW_LOG_FORMAT_FULL);
+	if (ret) {
+		XDNA_ERR(xdna, "Failed to init fw log format: %d", ret);
+		goto detach;
+	}
+
+	ret = aie2_set_log_destination(ndev, AIE2_FW_LOG_DESTINATION_DRAM);
+	if (ret) {
+		XDNA_ERR(xdna, "Failed to init fw log destination: %d", ret);
+		goto detach;
+	}
+
+	dpt->io_base = ndev->mbox_base;
+	dpt->msi_address = msi_address & AIE2_DPT_MSI_ADDR_MASK;
+	dpt->msi_idx = msi_idx;
+
+	return 0;
+
+detach:
+	aie2_config_fw_log(ndev, dpt->buf, 0, NULL, NULL);
+	return ret;
+}
+
+int aie2_fw_log_config(struct amdxdna_dev *xdna, u32 level)
+{
+	if (level == AIE2_FW_LOG_LEVEL_OFF || level >= AIE2_FW_LOG_LEVEL_MAX) {
+		XDNA_ERR(xdna, "Invalid firmware log level: %d", level);
+		return -EINVAL;
+	}
+
+	return aie2_set_log_level(xdna->dev_handle, level);
+}
+
+int aie2_fw_log_fini(struct amdxdna_dev *xdna)
+{
+	struct amdxdna_dev_hdl *ndev = xdna->dev_handle;
+	struct amdxdna_dpt *dpt;
+	int ret;
+
+	dpt = rcu_dereference_protected(xdna->fw_log,
+					lockdep_is_held(&xdna->dev_lock));
+	if (!dpt)
+		return 0;
+
+	ret = aie2_set_log_destination(ndev, AIE2_FW_LOG_DESTINATION_NULL);
+	if (ret) {
+		XDNA_ERR(xdna, "Failed to reset fw log destination: %d", ret);
+		return ret;
+	}
+
+	ret = aie2_config_fw_log(ndev, dpt->buf, 0, NULL, NULL);
+	if (ret) {
+		XDNA_ERR(xdna, "Failed to reset fw log buffer: %d", ret);
+		return ret;
+	}
+
+	return 0;
 }
 
 const struct amdxdna_dev_ops aie2_ops = {

--- a/drivers/accel/amdxdna/aie2_pci.c
+++ b/drivers/accel/amdxdna/aie2_pci.c
@@ -202,6 +202,12 @@ static int aie2_mgmt_fw_init(struct amdxdna_dev_hdl *ndev)
 		return ret;
 	}
 
+	ret = aie2_calibrate_clock(ndev);
+	if (ret) {
+		XDNA_ERR(ndev->aie.xdna, "Calibrate system clock failed");
+		return ret;
+	}
+
 	return 0;
 }
 

--- a/drivers/accel/amdxdna/aie2_pci.h
+++ b/drivers/accel/amdxdna/aie2_pci.h
@@ -190,6 +190,7 @@ enum aie2_fw_feature {
 	AIE2_GET_DEV_REVISION,
 	AIE2_GET_COREDUMP,
 	AIE2_RW_ACCESS,
+	AIE2_CALIBRATE_CLOCK,
 	AIE2_FEATURE_MAX
 };
 
@@ -266,6 +267,7 @@ int aie2_rw_aie_reg(struct amdxdna_hwctx *hwctx, bool is_read,
 int aie2_rw_aie_mem(struct amdxdna_hwctx *hwctx, bool is_read,
 		    u8 row, u8 col, u32 aie_addr,
 		    dma_addr_t dram_addr, u32 size);
+int aie2_calibrate_clock(struct amdxdna_dev_hdl *ndev);
 int aie2_create_context(struct amdxdna_dev_hdl *ndev, struct amdxdna_hwctx *hwctx);
 int aie2_destroy_context(struct amdxdna_dev_hdl *ndev, struct amdxdna_hwctx *hwctx);
 int aie2_map_host_buf(struct amdxdna_dev_hdl *ndev, u32 context_id, u64 addr, u64 size);

--- a/drivers/accel/amdxdna/aie2_pci.h
+++ b/drivers/accel/amdxdna/aie2_pci.h
@@ -192,6 +192,7 @@ enum aie2_fw_feature {
 	AIE2_RW_ACCESS,
 	AIE2_CALIBRATE_CLOCK,
 	AIE2_FW_LOG,
+	AIE2_FW_TRACE,
 	AIE2_FEATURE_MAX
 };
 
@@ -279,11 +280,18 @@ int aie2_set_log_destination(struct amdxdna_dev_hdl *ndev,
 int aie2_config_fw_log(struct amdxdna_dev_hdl *ndev,
 		       struct amdxdna_msg_buf_hdl *buf_hdl,
 		       size_t size, u32 *msi_idx, u32 *msi_address);
+int aie2_start_fw_trace(struct amdxdna_dev_hdl *ndev,
+			struct amdxdna_msg_buf_hdl *buf_hdl, size_t size,
+			u32 categories, u32 *msi_idx, u32 *msi_address);
 
 /* aie2_pci.c */
 int aie2_fw_log_init(struct amdxdna_dev *xdna, size_t size, u32 level);
 int aie2_fw_log_config(struct amdxdna_dev *xdna, u32 level);
 int aie2_fw_log_fini(struct amdxdna_dev *xdna);
+
+int aie2_fw_trace_init(struct amdxdna_dev *xdna, size_t size, u32 categories);
+int aie2_fw_trace_config(struct amdxdna_dev *xdna, u32 categories);
+int aie2_fw_trace_fini(struct amdxdna_dev *xdna);
 
 int aie2_create_context(struct amdxdna_dev_hdl *ndev, struct amdxdna_hwctx *hwctx);
 int aie2_destroy_context(struct amdxdna_dev_hdl *ndev, struct amdxdna_hwctx *hwctx);

--- a/drivers/accel/amdxdna/aie2_pci.h
+++ b/drivers/accel/amdxdna/aie2_pci.h
@@ -191,10 +191,14 @@ enum aie2_fw_feature {
 	AIE2_GET_COREDUMP,
 	AIE2_RW_ACCESS,
 	AIE2_CALIBRATE_CLOCK,
+	AIE2_FW_LOG,
 	AIE2_FEATURE_MAX
 };
 
 #define AIE2_ALL_FEATURES	GENMASK_ULL(AIE2_FEATURE_MAX - 1, AIE2_NPU_COMMAND)
+
+/* Mailbox MSI address mask used for the DPT (FW log) IRQ. */
+#define AIE2_DPT_MSI_ADDR_MASK		GENMASK(23, 0)
 
 struct amdxdna_dev_priv {
 	const char			*fw_path;
@@ -268,6 +272,19 @@ int aie2_rw_aie_mem(struct amdxdna_hwctx *hwctx, bool is_read,
 		    u8 row, u8 col, u32 aie_addr,
 		    dma_addr_t dram_addr, u32 size);
 int aie2_calibrate_clock(struct amdxdna_dev_hdl *ndev);
+int aie2_set_log_level(struct amdxdna_dev_hdl *ndev, enum aie2_fw_log_level level);
+int aie2_set_log_format(struct amdxdna_dev_hdl *ndev, enum aie2_fw_log_format format);
+int aie2_set_log_destination(struct amdxdna_dev_hdl *ndev,
+			     enum aie2_fw_log_destination destination);
+int aie2_config_fw_log(struct amdxdna_dev_hdl *ndev,
+		       struct amdxdna_msg_buf_hdl *buf_hdl,
+		       size_t size, u32 *msi_idx, u32 *msi_address);
+
+/* aie2_pci.c */
+int aie2_fw_log_init(struct amdxdna_dev *xdna, size_t size, u32 level);
+int aie2_fw_log_config(struct amdxdna_dev *xdna, u32 level);
+int aie2_fw_log_fini(struct amdxdna_dev *xdna);
+
 int aie2_create_context(struct amdxdna_dev_hdl *ndev, struct amdxdna_hwctx *hwctx);
 int aie2_destroy_context(struct amdxdna_dev_hdl *ndev, struct amdxdna_hwctx *hwctx);
 int aie2_map_host_buf(struct amdxdna_dev_hdl *ndev, u32 context_id, u64 addr, u64 size);

--- a/drivers/accel/amdxdna/aie4_message.c
+++ b/drivers/accel/amdxdna/aie4_message.c
@@ -7,6 +7,7 @@
 #include <drm/drm_print.h>
 #include <drm/gpu_scheduler.h>
 #include <linux/bitfield.h>
+#include <linux/ktime.h>
 #include <linux/mutex.h>
 
 #include "aie.h"
@@ -27,6 +28,27 @@ int aie4_suspend_fw(struct amdxdna_dev_hdl *ndev)
 		XDNA_ERR(ndev->aie.xdna, "Failed to suspend fw, ret %d", ret);
 
 	return ret;
+}
+
+int aie4_calibrate_clock(struct amdxdna_dev_hdl *ndev)
+{
+	DECLARE_AIE_MSG(aie4_msg_calibrate_clock, AIE4_MSG_OP_CALIBRATE_CLOCK);
+	int ret;
+
+	if (!AIE_FEATURE_ON(&ndev->aie, AIE4_CALIBRATE_CLOCK)) {
+		XDNA_DBG(ndev->aie.xdna, "Calibrate clock not supported, skipped");
+		return 0;
+	}
+
+	req.time_base_ns = ktime_get_real_ns();
+
+	ret = aie_send_mgmt_msg_wait(&ndev->aie, &msg);
+	if (ret) {
+		XDNA_ERR(ndev->aie.xdna, "Calibrate clock failed, ret %d", ret);
+		return ret;
+	}
+
+	return 0;
 }
 
 int aie4_query_aie_metadata(struct amdxdna_dev_hdl *ndev,

--- a/drivers/accel/amdxdna/aie4_msg_priv.h
+++ b/drivers/accel/amdxdna/aie4_msg_priv.h
@@ -12,6 +12,7 @@
 
 enum aie4_msg_opcode {
 	AIE4_MSG_OP_SUSPEND                          = 0x10003,
+	AIE4_MSG_OP_CALIBRATE_CLOCK                  = 0x10009,
 	AIE4_MSG_OP_ATTACH_WORK_BUFFER               = 0x1000D,
 	AIE4_MSG_OP_AIE_RW_ACCESS                    = 0x3000E,
 	AIE4_MSG_OP_AIE_COREDUMP                     = 0x30010,
@@ -190,6 +191,14 @@ struct aie4_msg_aie4_debug_access_req {
 struct aie4_msg_aie4_debug_access_resp {
 	enum aie4_msg_status status;
 	__u32 reg_rval;
+} __packed;
+
+struct aie4_msg_calibrate_clock_req {
+	__u64 time_base_ns;
+} __packed;
+
+struct aie4_msg_calibrate_clock_resp {
+	enum aie4_msg_status status;
 } __packed;
 
 #endif /* _AIE4_MSG_PRIV_H_ */

--- a/drivers/accel/amdxdna/aie4_pci.c
+++ b/drivers/accel/amdxdna/aie4_pci.c
@@ -687,9 +687,11 @@ static int aie4_get_array(struct amdxdna_client *client,
 	if (!drm_dev_enter(&xdna->ddev, &idx))
 		return -ENODEV;
 
-	ret = amdxdna_pm_resume_get_locked(xdna);
+	ret = amdxdna_pm_resume_get(xdna);
 	if (ret)
 		goto dev_exit;
+
+	mutex_lock(&xdna->dev_lock);
 
 	switch (args->param) {
 	case DRM_AMDXDNA_AIE_COREDUMP:
@@ -702,6 +704,8 @@ static int aie4_get_array(struct amdxdna_client *client,
 		ret = -EOPNOTSUPP;
 		break;
 	}
+
+	mutex_unlock(&xdna->dev_lock);
 
 	amdxdna_pm_suspend_put(xdna);
 

--- a/drivers/accel/amdxdna/aie4_pci.c
+++ b/drivers/accel/amdxdna/aie4_pci.c
@@ -290,6 +290,12 @@ static int aie4_pf_hw_start(struct amdxdna_dev_hdl *ndev)
 	if (ret)
 		goto fw_unload;
 
+	ret = aie4_calibrate_clock(ndev);
+	if (ret) {
+		XDNA_ERR(ndev->aie.xdna, "Calibrate system clock failed");
+		goto mbox_fini;
+	}
+
 	/* Firmware releases the DRAM work buffer internally during suspend_fw */
 	ret = aie4_attach_work_buffer(ndev,
 				      to_dma_addr(ndev->work_buf_hdl, 0),
@@ -362,6 +368,12 @@ static int aie4_classic_hw_start(struct amdxdna_dev_hdl *ndev)
 	ret = aie4_mailbox_init(ndev);
 	if (ret)
 		goto fw_unload;
+
+	ret = aie4_calibrate_clock(ndev);
+	if (ret) {
+		XDNA_ERR(ndev->aie.xdna, "Calibrate system clock failed");
+		goto mbox_fini;
+	}
 
 	/* Firmware releases the DRAM work buffer internally during suspend_fw */
 	ret = aie4_attach_work_buffer(ndev,

--- a/drivers/accel/amdxdna/aie4_pci.h
+++ b/drivers/accel/amdxdna/aie4_pci.h
@@ -66,6 +66,7 @@ int aie4_query_aie_metadata(struct amdxdna_dev_hdl *ndev,
 			    struct amdxdna_drm_query_aie_metadata *metadata);
 int aie4_suspend_fw(struct amdxdna_dev_hdl *ndev);
 int aie4_attach_work_buffer(struct amdxdna_dev_hdl *ndev, dma_addr_t addr, u32 size);
+int aie4_calibrate_clock(struct amdxdna_dev_hdl *ndev);
 void aie4_msg_init(struct amdxdna_dev_hdl *ndev);
 
 /* aie4_ctx.c */
@@ -92,6 +93,7 @@ static inline int aie4_sriov_stop(struct amdxdna_dev_hdl *ndev)
 enum aie4_fw_feature {
 	AIE4_GET_COREDUMP,
 	AIE4_RW_ACCESS,
+	AIE4_CALIBRATE_CLOCK,
 	AIE4_FEATURE_MAX
 };
 

--- a/drivers/accel/amdxdna/amdxdna_dpt.c
+++ b/drivers/accel/amdxdna/amdxdna_dpt.c
@@ -1,0 +1,691 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Copyright (C) 2026, Advanced Micro Devices, Inc.
+ */
+
+#include "drm/amdxdna_accel.h"
+#include <drm/drm_cache.h>
+#include <drm/drm_drv.h>
+#include <drm/drm_print.h>
+#include <linux/errno.h>
+#include <linux/interrupt.h>
+#include <linux/jiffies.h>
+#include <linux/pci.h>
+#include <linux/rcupdate.h>
+#include <linux/sizes.h>
+#include <linux/slab.h>
+#include <linux/srcu.h>
+#include <linux/timer.h>
+#include <linux/uaccess.h>
+#include <linux/workqueue.h>
+
+#include "aie.h"
+#include "amdxdna_dpt.h"
+#include "amdxdna_pci_drv.h"
+
+const char * const amdxdna_dpt_irq_name[AMDXDNA_DPT_KIND_MAX] = {
+	[AMDXDNA_DPT_FW_LOG] = "xdna_fw_log",
+};
+
+const char *amdxdna_dpt_kind_str(enum amdxdna_dpt_kind kind)
+{
+	static const char * const names[AMDXDNA_DPT_KIND_MAX] = {
+		[AMDXDNA_DPT_FW_LOG] = "fw_log",
+	};
+
+	return (kind < AMDXDNA_DPT_KIND_MAX) ? names[kind] : "fw_???";
+}
+
+static struct amdxdna_dpt __rcu **
+amdxdna_dpt_slot(struct amdxdna_dev *xdna, enum amdxdna_dpt_kind kind)
+{
+	switch (kind) {
+	case AMDXDNA_DPT_FW_LOG:
+		return &xdna->fw_log;
+	case AMDXDNA_DPT_KIND_MAX:
+		break;
+	}
+	return NULL;
+}
+
+struct amdxdna_dpt *
+amdxdna_dpt_enter_kind(struct amdxdna_dev *xdna, enum amdxdna_dpt_kind kind,
+		       int *idx)
+{
+	struct amdxdna_dpt __rcu **slot;
+	struct amdxdna_dpt *dpt;
+
+	slot = amdxdna_dpt_slot(xdna, kind);
+	if (!slot)
+		return NULL;
+
+	*idx = srcu_read_lock(&xdna->dpt_srcu);
+	dpt = srcu_dereference(*slot, &xdna->dpt_srcu);
+	if (!dpt || READ_ONCE(dpt->status) != AMDXDNA_DPT_ACTIVE) {
+		srcu_read_unlock(&xdna->dpt_srcu, *idx);
+		return NULL;
+	}
+	return dpt;
+}
+
+/*
+ * Fetch up to *size bytes from the ring buffer starting at *offset. Returns
+ * the actual bytes copied via *size and advances *offset to the new read
+ * point.
+ */
+static int amdxdna_dpt_fetch_payload(struct amdxdna_dpt *dpt, u8 *buf,
+				     u64 *offset, u32 *size,
+				     int (*cpy)(void *to, const void *from, size_t n))
+{
+	struct amdxdna_msg_buf_hdl *hdl = dpt->buf;
+	size_t req_size, log_size;
+	u32 start, end;
+	u64 tail;
+
+	log_size = to_buf_size(hdl) - AMDXDNA_DPT_FOOTER_SIZE;
+
+	tail = READ_ONCE(dpt->tail);
+
+	if (tail < *offset) {
+		XDNA_DPT_ERR(dpt, "Invalid fetch offset: 0x%llx", *offset);
+		return -EINVAL;
+	}
+
+	if (tail == *offset) {
+		req_size = 0;
+		goto exit;
+	}
+
+	start = *offset % log_size;
+	end = tail % log_size;
+
+	/*
+	 * When the firmware has wrapped past our slot by more than one full
+	 * buffer, re-anchor at the start of the buffer to deliver the most
+	 * recent entries.
+	 */
+	if (tail - *offset >= log_size + start)
+		start = 0;
+
+	if (end > start) {
+		req_size = end - start;
+		if (req_size > *size) {
+			XDNA_DPT_DBG(dpt, "Insufficient buffer size: 0x%zx", req_size);
+			end = start + *size;
+			req_size = *size;
+		}
+	} else {
+		req_size = log_size - start + end;
+		if (req_size > *size) {
+			XDNA_DPT_DBG(dpt, "Insufficient buffer size: 0x%zx", req_size);
+			if (start + *size <= log_size)
+				end = start + *size;
+			else
+				end = *size - (log_size - start);
+			req_size = *size;
+		}
+	}
+
+	if (start > end) {
+		/* First chunk: from start to end of log buffer */
+		drm_clflush_virt_range(to_cpu_addr(hdl, start), log_size - start);
+		if (cpy(buf, to_cpu_addr(hdl, start), log_size - start))
+			return -EFAULT;
+
+		/* Wrap-around chunk: from 0 to end */
+		drm_clflush_virt_range(to_cpu_addr(hdl, 0), end);
+		if (cpy(buf + (log_size - start), to_cpu_addr(hdl, 0), end))
+			return -EFAULT;
+	} else {
+		drm_clflush_virt_range(to_cpu_addr(hdl, start), end - start);
+		if (cpy(buf, to_cpu_addr(hdl, start), end - start))
+			return -EFAULT;
+	}
+exit:
+	*size = req_size;
+	*offset += req_size;
+	return 0;
+}
+
+static bool amdxdna_dpt_update_tail(struct amdxdna_dpt *dpt)
+{
+	struct amdxdna_dpt_footer *footer;
+	u32 offset;
+	u64 tail;
+
+	offset = to_buf_size(dpt->buf) - AMDXDNA_DPT_FOOTER_SIZE;
+	footer = to_cpu_addr(dpt->buf, offset);
+
+	drm_clflush_virt_range(footer, sizeof(*footer));
+
+	/* Extend 32-bit firmware pointer to a 64-bit value to handle wrap. */
+	tail = (dpt->tail & ~GENMASK_ULL(31, 0)) | footer->tail;
+	if (tail < dpt->tail)
+		tail += BIT_ULL(32);
+
+	drm_WARN_ONCE(&dpt->xdna->ddev, tail - dpt->tail > BIT_ULL(31),
+		      "Unexpected jump in tail pointer. Missed IRQ or bug");
+
+	if (dpt->tail != tail) {
+		WRITE_ONCE(dpt->tail, tail);
+		XDNA_DPT_DBG(dpt, "Tail updated: 0x%llx", tail);
+		wake_up(&dpt->wait);
+		return true;
+	}
+	return false;
+}
+
+static void amdxdna_dpt_read_metadata(struct amdxdna_dpt *dpt)
+{
+	struct amdxdna_dpt_footer *footer;
+	u32 offset;
+
+	offset = to_buf_size(dpt->buf) - AMDXDNA_DPT_FOOTER_SIZE;
+	footer = to_cpu_addr(dpt->buf, offset);
+
+	drm_clflush_virt_range(footer, sizeof(*footer));
+
+	dpt->payload_version = footer->payload_version;
+	dpt->minor = footer->minor;
+	dpt->major = footer->major;
+
+	XDNA_DPT_DBG(dpt, "Version: %d.%d payload: 0x%x",
+		     dpt->major, dpt->minor, dpt->payload_version);
+}
+
+static irqreturn_t amdxdna_dpt_irq_handler(int irq, void *data)
+{
+	struct amdxdna_dpt *dpt = data;
+
+	if (dpt->io_base)
+		writel(0, dpt->io_base + dpt->msi_address);
+
+	queue_work(system_wq, &dpt->work);
+	return IRQ_HANDLED;
+}
+
+static int amdxdna_dpt_irq_init(struct amdxdna_dpt *dpt)
+{
+	struct amdxdna_dev *xdna = dpt->xdna;
+	int ret;
+
+	if (!dpt->msi_idx || !dpt->msi_address)
+		return -EINVAL;
+
+	ret = pci_irq_vector(to_pci_dev(xdna->ddev.dev), dpt->msi_idx);
+	if (ret < 0) {
+		dpt->irq = 0;
+		return ret;
+	}
+	dpt->irq = ret;
+
+	ret = request_irq(dpt->irq, amdxdna_dpt_irq_handler, 0,
+			  amdxdna_dpt_irq_name[dpt->kind], dpt);
+	if (ret) {
+		dpt->irq = 0;
+		return ret;
+	}
+
+	return 0;
+}
+
+static void amdxdna_dpt_irq_fini(struct amdxdna_dpt *dpt)
+{
+	if (dpt->irq) {
+		free_irq(dpt->irq, dpt);
+		dpt->irq = 0;
+	}
+	dpt->msi_address = 0;
+	dpt->msi_idx = 0;
+}
+
+/*
+ * Timer refcount. 0 -> 1 starts the polling timer; N -> 0 stops it.
+ * timer_lock serializes the transition decisions. The mod_timer arm
+ * and inner timer_delete_sync are gated on status == ACTIVE so the
+ * suspend path's timer_delete_sync wins exclusively while readers
+ * admitted before SUSPENDING continue to balance their refcount.
+ */
+static void amdxdna_dpt_timer_get(struct amdxdna_dpt *dpt)
+{
+	mutex_lock(&dpt->timer_lock);
+	if (!refcount_read(&dpt->timer_refs)) {
+		refcount_set(&dpt->timer_refs, 1);
+		if (READ_ONCE(dpt->status) == AMDXDNA_DPT_ACTIVE)
+			mod_timer(&dpt->timer,
+				  jiffies + msecs_to_jiffies(AMDXDNA_DPT_POLL_INTERVAL_MS));
+	} else {
+		refcount_inc(&dpt->timer_refs);
+	}
+	mutex_unlock(&dpt->timer_lock);
+}
+
+static void amdxdna_dpt_timer_put(struct amdxdna_dpt *dpt)
+{
+	mutex_lock(&dpt->timer_lock);
+	if (WARN_ON(!refcount_read(&dpt->timer_refs))) {
+		mutex_unlock(&dpt->timer_lock);
+		return;
+	}
+	if (refcount_dec_and_test(&dpt->timer_refs) &&
+	    READ_ONCE(dpt->status) == AMDXDNA_DPT_ACTIVE)
+		timer_delete_sync(&dpt->timer);
+	mutex_unlock(&dpt->timer_lock);
+}
+
+static void amdxdna_dpt_worker(struct work_struct *w)
+{
+	struct amdxdna_dpt *dpt = container_of(w, struct amdxdna_dpt, work);
+
+	amdxdna_dpt_update_tail(dpt);
+}
+
+static void amdxdna_dpt_timer(struct timer_list *t)
+{
+	struct amdxdna_dpt *dpt = container_of(t, struct amdxdna_dpt, timer);
+
+	queue_work(system_wq, &dpt->work);
+	mod_timer(&dpt->timer,
+		  jiffies + msecs_to_jiffies(AMDXDNA_DPT_POLL_INTERVAL_MS));
+}
+
+/*
+ * Tell the firmware to start emitting entries into the @dpt buffer
+ * for the consumer of @dpt->kind. Returns -EOPNOTSUPP when the backend
+ * does not implement this kind so the caller can decide whether that is
+ * fatal.
+ */
+static int amdxdna_dpt_msg_init(struct amdxdna_dpt *dpt)
+{
+	struct aie_device *aie = dpt->aie;
+
+	switch (dpt->kind) {
+	case AMDXDNA_DPT_FW_LOG:
+		if (!aie->msg_ops.fw_log_init)
+			return -EOPNOTSUPP;
+		return aie->msg_ops.fw_log_init(dpt->xdna,
+						to_buf_size(dpt->buf),
+						dpt->config);
+	case AMDXDNA_DPT_KIND_MAX:
+		break;
+	}
+	return -EINVAL;
+}
+
+/*
+ * Drain any in-flight reader that briefly observed @dpt in INACTIVE state,
+ * unpublish, then free buffer + handle. Used by amdxdna_dpt_publish() when
+ * the backend msg_ops init fails after the handle has already been planted.
+ */
+static void amdxdna_dpt_unpublish(struct amdxdna_dpt *dpt)
+{
+	struct amdxdna_dev *xdna = dpt->xdna;
+	struct amdxdna_dpt __rcu **slot;
+
+	slot = amdxdna_dpt_slot(xdna, dpt->kind);
+	if (slot)
+		rcu_assign_pointer(*slot, NULL);
+	synchronize_srcu(&xdna->dpt_srcu);
+
+	mutex_destroy(&dpt->timer_lock);
+	amdxdna_free_msg_buff(dpt->buf);
+	kfree(dpt);
+}
+
+/*
+ * Allocate a fresh dpt handle, plant it in the slot for @kind in INACTIVE
+ * state, DMA-alloc its ring buffer, then ask the backend to start emitting
+ * via amdxdna_dpt_msg_init. On success the handle is fully active: IRQ has
+ * been wired (best-effort), metadata has been read, and status is ACTIVE.
+ * On failure the handle has already been unpublished and an ERR_PTR is
+ * returned.
+ */
+static struct amdxdna_dpt *
+amdxdna_dpt_publish(struct aie_device *aie, enum amdxdna_dpt_kind kind,
+		    size_t buf_size, u32 config)
+{
+	struct amdxdna_dev *xdna = aie->xdna;
+	struct amdxdna_msg_buf_hdl *hdl;
+	struct amdxdna_dpt __rcu **slot;
+	struct amdxdna_dpt *dpt;
+	int ret;
+
+	slot = amdxdna_dpt_slot(xdna, kind);
+	if (!slot)
+		return ERR_PTR(-EINVAL);
+
+	if (rcu_access_pointer(*slot))
+		return ERR_PTR(-EBUSY);
+
+	dpt = kzalloc(sizeof(*dpt), GFP_KERNEL);
+	if (!dpt)
+		return ERR_PTR(-ENOMEM);
+
+	dpt->xdna = xdna;
+	dpt->aie = aie;
+	dpt->kind = kind;
+	dpt->status = AMDXDNA_DPT_INACTIVE;
+	dpt->config = config;
+
+	hdl = amdxdna_alloc_msg_buff(xdna, buf_size);
+	if (IS_ERR(hdl)) {
+		ret = PTR_ERR(hdl);
+		XDNA_DPT_ERR(dpt, "Failed to allocate buffer: %d", ret);
+		kfree(dpt);
+		return ERR_PTR(ret);
+	}
+	dpt->buf = hdl;
+
+	memset(to_cpu_addr(hdl, 0), 0, to_buf_size(hdl));
+	drm_clflush_virt_range(to_cpu_addr(hdl, 0), to_buf_size(hdl));
+
+	mutex_init(&dpt->timer_lock);
+	refcount_set(&dpt->timer_refs, 0);
+	init_waitqueue_head(&dpt->wait);
+	INIT_WORK(&dpt->work, amdxdna_dpt_worker);
+	timer_setup(&dpt->timer, amdxdna_dpt_timer, 0);
+
+	/* Plant the handle in INACTIVE state so the backend's msg_ops init
+	 * can reach the DMA buffer + msi-info slots through xdna->fw_*.
+	 * Readers see status != ACTIVE in amdxdna_dpt_enter_kind and bail out.
+	 */
+	rcu_assign_pointer(*slot, dpt);
+
+	ret = amdxdna_dpt_msg_init(dpt);
+	if (ret) {
+		amdxdna_dpt_unpublish(dpt);
+		return ERR_PTR(ret);
+	}
+
+	/*
+	 * IRQ is best-effort. On failure, on-demand polling driven by
+	 * amdxdna_dpt_timer_get in the watcher and dmesg paths still works.
+	 */
+	if (amdxdna_dpt_irq_init(dpt))
+		XDNA_DPT_WARN(dpt, "IRQ unavailable; tail updates on demand only");
+
+	amdxdna_dpt_read_metadata(dpt);
+
+	WRITE_ONCE(dpt->status, AMDXDNA_DPT_ACTIVE);
+	return dpt;
+}
+
+static int amdxdna_fw_log_init(struct aie_device *aie, u32 level)
+{
+	struct amdxdna_dev *xdna = aie->xdna;
+	struct amdxdna_dpt *dpt;
+	int ret;
+
+	drm_WARN_ON(&xdna->ddev, !mutex_is_locked(&xdna->dev_lock));
+
+	dpt = amdxdna_dpt_publish(aie, AMDXDNA_DPT_FW_LOG,
+				  AMDXDNA_DPT_FW_LOG_SIZE, level);
+	if (IS_ERR(dpt)) {
+		ret = PTR_ERR(dpt);
+		return ret == -EOPNOTSUPP ? 0 : ret;
+	}
+	return 0;
+}
+
+/*
+ * Tell the firmware to stop emitting entries into the @dpt buffer
+ * for the consumer of @dpt->kind. Best-effort: returns the backend
+ * error but it is the caller's responsibility to continue tearing the
+ * handle down regardless.
+ */
+static int amdxdna_dpt_msg_fini(struct amdxdna_dpt *dpt)
+{
+	struct aie_device *aie = dpt->aie;
+
+	switch (dpt->kind) {
+	case AMDXDNA_DPT_FW_LOG:
+		if (aie->msg_ops.fw_log_fini)
+			return aie->msg_ops.fw_log_fini(dpt->xdna);
+		return 0;
+	case AMDXDNA_DPT_KIND_MAX:
+		break;
+	}
+	return -EINVAL;
+}
+
+/*
+ * Tear-down path that delivers -ESHUTDOWN to every sleeping watcher,
+ * waits for them to exit via synchronize_srcu, and only then frees the
+ * handle.
+ */
+static int amdxdna_dpt_fini_kind(struct aie_device *aie, enum amdxdna_dpt_kind kind)
+{
+	struct amdxdna_dev *xdna = aie->xdna;
+	struct amdxdna_dpt __rcu **slot;
+	struct amdxdna_dpt *dpt;
+
+	drm_WARN_ON(&xdna->ddev, !mutex_is_locked(&xdna->dev_lock));
+
+	slot = amdxdna_dpt_slot(xdna, kind);
+	if (!slot)
+		return -EINVAL;
+
+	dpt = rcu_dereference_protected(*slot,
+					lockdep_is_held(&xdna->dev_lock));
+	if (!dpt)
+		return 0;
+
+	/*
+	 * Close the publish gate first (mirrors enter_kind's ptr-then-
+	 * status read order), then mark in-flight readers to bail. After
+	 * this no new srcu_dereference can return this handle, and any
+	 * reader that already loaded the pointer will observe
+	 * SHUTTING_DOWN on its post-wait status check.
+	 */
+	rcu_assign_pointer(*slot, NULL);
+	WRITE_ONCE(dpt->status, AMDXDNA_DPT_SHUTTING_DOWN);
+
+	/*
+	 * Stop the producer first so the firmware stops emitting IRQs
+	 * and tail updates against the soon-to-be-freed ring, then drain
+	 * the host-side pipeline (IRQ -> timer -> worker). After
+	 * cancel_work_sync no path is left that could call
+	 * amdxdna_dpt_update_tail on the detached firmware.
+	 */
+	amdxdna_dpt_msg_fini(dpt);
+	amdxdna_dpt_irq_fini(dpt);
+	timer_shutdown_sync(&dpt->timer);
+	cancel_work_sync(&dpt->work);
+
+	/*
+	 * Release any watcher still parked. Required for the steady-state
+	 * "FW idle, no tail advance" case where amdxdna_dpt_update_tail's
+	 * conditional wake_up did not fire; otherwise the watcher would
+	 * never observe SHUTTING_DOWN and synchronize_srcu would deadlock.
+	 * The flip-before-wake invariant is preserved: status is already
+	 * SHUTTING_DOWN here, so any watcher woken now re-evaluates
+	 * watch_ready, returns true, and exits with -ESHUTDOWN.
+	 */
+	wake_up_all(&dpt->wait);
+
+	/*
+	 * Wait for every reader currently inside a dpt_* helper
+	 * (including any one we just woke) to drop the SRCU read lock
+	 * before freeing the handle.
+	 */
+	synchronize_srcu(&xdna->dpt_srcu);
+
+	mutex_destroy(&dpt->timer_lock);
+	amdxdna_free_msg_buff(dpt->buf);
+	XDNA_DPT_DBG(dpt, "Disabled");
+	kfree(dpt);
+	return 0;
+}
+
+static int amdxdna_dpt_suspend_kind(struct aie_device *aie,
+				    enum amdxdna_dpt_kind kind)
+{
+	struct amdxdna_dev *xdna = aie->xdna;
+	struct amdxdna_dpt __rcu **slot;
+	struct amdxdna_dpt *dpt;
+
+	drm_WARN_ON(&xdna->ddev, !mutex_is_locked(&xdna->dev_lock));
+
+	slot = amdxdna_dpt_slot(xdna, kind);
+	if (!slot)
+		return -EINVAL;
+
+	dpt = rcu_dereference_protected(*slot,
+					lockdep_is_held(&xdna->dev_lock));
+	if (!dpt || READ_ONCE(dpt->status) != AMDXDNA_DPT_ACTIVE)
+		return 0;
+
+	/*
+	 * Do NOT call the msg_ops fini hook here. On firmware suspend the
+	 * firmware persists its ring state (head, tail, seq_number,
+	 * write_count) into a reserved region of the host-allocated
+	 * buffer's footer; on the next attach with the same buffer it
+	 * validates the footer signature and resumes from the saved
+	 * offsets. Detaching the buffer (size=0 attach) makes the firmware
+	 * start a fresh ring with head = tail = 0 on the next attach,
+	 * discarding any saved state.
+	 */
+
+	/*
+	 * Block new entrants and new mod_timer arms before tearing the
+	 * timer down so amdxdna_dpt_timer_get cannot race with us.
+	 * Readers admitted before this transition observe SUSPENDING in
+	 * the post-wait check and are still allowed to drain the final
+	 * batch via fetch_payload.
+	 */
+	WRITE_ONCE(dpt->status, AMDXDNA_DPT_SUSPENDING);
+
+	amdxdna_dpt_irq_fini(dpt);
+
+	/* timer_delete_sync (not _shutdown_sync) so resume can re-arm. */
+	timer_delete_sync(&dpt->timer);
+	cancel_work_sync(&dpt->work);
+
+	/*
+	 * Capture FW's final tail and wake sleeping watchers. They wake
+	 * under the SRCU read lock with status SUSPENDING, exit
+	 * wait_event, and run fetch_payload to copy the final batch to
+	 * user space; synchronize_srcu below waits for those reads to
+	 * finish before we flip status to SUSPENDED.
+	 */
+	amdxdna_dpt_update_tail(dpt);
+	wake_up_all(&dpt->wait);
+
+	synchronize_srcu(&xdna->dpt_srcu);
+
+	WRITE_ONCE(dpt->status, AMDXDNA_DPT_SUSPENDED);
+
+	XDNA_DPT_DBG(dpt, "Suspended");
+	return 0;
+}
+
+static int amdxdna_dpt_resume_kind(struct aie_device *aie,
+				   enum amdxdna_dpt_kind kind)
+{
+	struct amdxdna_dev *xdna = aie->xdna;
+	struct amdxdna_dpt __rcu **slot;
+	struct amdxdna_dpt *dpt;
+	int ret;
+
+	drm_WARN_ON(&xdna->ddev, !mutex_is_locked(&xdna->dev_lock));
+
+	slot = amdxdna_dpt_slot(xdna, kind);
+	if (!slot)
+		return -EINVAL;
+
+	dpt = rcu_dereference_protected(*slot,
+					lockdep_is_held(&xdna->dev_lock));
+	if (!dpt || READ_ONCE(dpt->status) != AMDXDNA_DPT_SUSPENDED)
+		return 0;
+
+	/*
+	 * timer_setup re-init must happen under timer_lock so it cannot
+	 * race with a parallel amdxdna_dpt_timer_get observing the
+	 * pre-suspend timer state. Status flips to ACTIVE only after
+	 * the backend re-arm + IRQ wiring succeeds.
+	 */
+	mutex_lock(&dpt->timer_lock);
+	timer_setup(&dpt->timer, amdxdna_dpt_timer, 0);
+	mutex_unlock(&dpt->timer_lock);
+
+	/*
+	 * Resubmit the same buffer without clearing it. The handle is
+	 * already reachable through xdna->fw_*, so the backend's init
+	 * hook can reach it for msi/io_base storage.
+	 */
+	ret = amdxdna_dpt_msg_init(dpt);
+	if (ret) {
+		if (ret != -EOPNOTSUPP)
+			XDNA_DPT_ERR(dpt, "Failed to resume: %d", ret);
+		return ret;
+	}
+
+	if (amdxdna_dpt_irq_init(dpt))
+		XDNA_DPT_WARN(dpt, "IRQ unavailable post-resume; polling on demand");
+
+	WRITE_ONCE(dpt->status, AMDXDNA_DPT_ACTIVE);
+
+	XDNA_DPT_DBG(dpt, "Resumed");
+	return 0;
+}
+
+int amdxdna_fw_log_set_level(struct aie_device *aie, u32 level)
+{
+	struct amdxdna_dev *xdna = aie->xdna;
+	struct amdxdna_dpt *dpt;
+	int ret;
+
+	drm_WARN_ON(&xdna->ddev, !mutex_is_locked(&xdna->dev_lock));
+
+	dpt = rcu_dereference_protected(xdna->fw_log,
+					lockdep_is_held(&xdna->dev_lock));
+	if (!dpt || READ_ONCE(dpt->status) != AMDXDNA_DPT_ACTIVE)
+		return -EINVAL;
+
+	if (!aie->msg_ops.fw_log_config)
+		return -EOPNOTSUPP;
+
+	ret = aie->msg_ops.fw_log_config(xdna, level);
+	if (ret) {
+		XDNA_ERR(xdna, "Failed to change FW log level to %d: %d",
+			 level, ret);
+		return ret;
+	}
+
+	WRITE_ONCE(dpt->config, level);
+	XDNA_DBG(xdna, "FW log level changed to %d", level);
+	return 0;
+}
+
+/*
+ * Probe-time entry: auto-starts FW_LOG only. FW_TRACE is opt-in via
+ * DRM_AMDXDNA_SET_FW_TRACE_STATE to avoid generating large trace payloads
+ * unconditionally. Best-effort: per-kind failures surface via XDNA_WARN
+ * but the wrapper always returns 0 so callers (per-generation probe paths)
+ * cannot abort device bring-up on a logging failure.
+ */
+int amdxdna_dpt_init(struct aie_device *aie)
+{
+	int ret;
+
+	ret = amdxdna_fw_log_init(aie, AMDXDNA_DPT_FW_LOG_LEVEL_DEFAULT);
+	if (ret)
+		XDNA_WARN(aie->xdna, "Failed to enable FW logging: %d", ret);
+
+	return 0;
+}
+
+int amdxdna_dpt_fini(struct aie_device *aie)
+{
+	return amdxdna_dpt_fini_kind(aie, AMDXDNA_DPT_FW_LOG);
+}
+
+int amdxdna_dpt_suspend(struct aie_device *aie)
+{
+	return amdxdna_dpt_suspend_kind(aie, AMDXDNA_DPT_FW_LOG);
+}
+
+int amdxdna_dpt_resume(struct aie_device *aie)
+{
+	return amdxdna_dpt_resume_kind(aie, AMDXDNA_DPT_FW_LOG);
+}

--- a/drivers/accel/amdxdna/amdxdna_dpt.c
+++ b/drivers/accel/amdxdna/amdxdna_dpt.c
@@ -24,13 +24,15 @@
 #include "amdxdna_pci_drv.h"
 
 const char * const amdxdna_dpt_irq_name[AMDXDNA_DPT_KIND_MAX] = {
-	[AMDXDNA_DPT_FW_LOG] = "xdna_fw_log",
+	[AMDXDNA_DPT_FW_LOG]   = "xdna_fw_log",
+	[AMDXDNA_DPT_FW_TRACE] = "xdna_fw_trace",
 };
 
 const char *amdxdna_dpt_kind_str(enum amdxdna_dpt_kind kind)
 {
 	static const char * const names[AMDXDNA_DPT_KIND_MAX] = {
-		[AMDXDNA_DPT_FW_LOG] = "fw_log",
+		[AMDXDNA_DPT_FW_LOG]   = "fw_log",
+		[AMDXDNA_DPT_FW_TRACE] = "fw_trace",
 	};
 
 	return (kind < AMDXDNA_DPT_KIND_MAX) ? names[kind] : "fw_???";
@@ -42,6 +44,8 @@ amdxdna_dpt_slot(struct amdxdna_dev *xdna, enum amdxdna_dpt_kind kind)
 	switch (kind) {
 	case AMDXDNA_DPT_FW_LOG:
 		return &xdna->fw_log;
+	case AMDXDNA_DPT_FW_TRACE:
+		return &xdna->fw_trace;
 	case AMDXDNA_DPT_KIND_MAX:
 		break;
 	}
@@ -323,6 +327,12 @@ static int amdxdna_dpt_msg_init(struct amdxdna_dpt *dpt)
 		return aie->msg_ops.fw_log_init(dpt->xdna,
 						to_buf_size(dpt->buf),
 						dpt->config);
+	case AMDXDNA_DPT_FW_TRACE:
+		if (!aie->msg_ops.fw_trace_init)
+			return -EOPNOTSUPP;
+		return aie->msg_ops.fw_trace_init(dpt->xdna,
+						  to_buf_size(dpt->buf),
+						  dpt->config);
 	case AMDXDNA_DPT_KIND_MAX:
 		break;
 	}
@@ -558,6 +568,10 @@ static int amdxdna_dpt_msg_fini(struct amdxdna_dpt *dpt)
 		if (aie->msg_ops.fw_log_fini)
 			return aie->msg_ops.fw_log_fini(dpt->xdna);
 		return 0;
+	case AMDXDNA_DPT_FW_TRACE:
+		if (aie->msg_ops.fw_trace_fini)
+			return aie->msg_ops.fw_trace_fini(dpt->xdna);
+		return 0;
 	case AMDXDNA_DPT_KIND_MAX:
 		break;
 	}
@@ -773,6 +787,48 @@ static int amdxdna_fw_log_set_level(struct aie_device *aie, u32 level)
 	return 0;
 }
 
+static int amdxdna_fw_trace_init(struct aie_device *aie, u32 categories)
+{
+	struct amdxdna_dev *xdna = aie->xdna;
+	struct amdxdna_dpt *dpt;
+
+	drm_WARN_ON(&xdna->ddev, !mutex_is_locked(&xdna->dev_lock));
+
+	dpt = amdxdna_dpt_publish(aie, AMDXDNA_DPT_FW_TRACE,
+				  AMDXDNA_DPT_FW_TRACE_SIZE, categories);
+	if (IS_ERR(dpt))
+		return PTR_ERR(dpt);
+	return 0;
+}
+
+static int amdxdna_fw_trace_set_categories(struct aie_device *aie, u32 categories)
+{
+	struct amdxdna_dev *xdna = aie->xdna;
+	struct amdxdna_dpt *dpt;
+	int ret;
+
+	drm_WARN_ON(&xdna->ddev, !mutex_is_locked(&xdna->dev_lock));
+
+	dpt = rcu_dereference_protected(xdna->fw_trace,
+					lockdep_is_held(&xdna->dev_lock));
+	if (!dpt || READ_ONCE(dpt->status) != AMDXDNA_DPT_ACTIVE)
+		return -EINVAL;
+
+	if (!aie->msg_ops.fw_trace_config)
+		return -EOPNOTSUPP;
+
+	ret = aie->msg_ops.fw_trace_config(xdna, categories);
+	if (ret) {
+		XDNA_ERR(xdna, "Failed to change FW trace categories to 0x%x: %d",
+			 categories, ret);
+		return ret;
+	}
+
+	WRITE_ONCE(dpt->config, categories);
+	XDNA_DBG(xdna, "FW trace categories changed to 0x%x", categories);
+	return 0;
+}
+
 /*
  * Probe-time entry: auto-starts FW_LOG only. FW_TRACE is opt-in via
  * DRM_AMDXDNA_SET_FW_TRACE_STATE to avoid generating large trace payloads
@@ -793,17 +849,35 @@ int amdxdna_dpt_init(struct aie_device *aie)
 
 int amdxdna_dpt_fini(struct aie_device *aie)
 {
-	return amdxdna_dpt_fini_kind(aie, AMDXDNA_DPT_FW_LOG);
+	int ret;
+
+	ret = amdxdna_dpt_fini_kind(aie, AMDXDNA_DPT_FW_LOG);
+	if (ret)
+		return ret;
+
+	return amdxdna_dpt_fini_kind(aie, AMDXDNA_DPT_FW_TRACE);
 }
 
 int amdxdna_dpt_suspend(struct aie_device *aie)
 {
-	return amdxdna_dpt_suspend_kind(aie, AMDXDNA_DPT_FW_LOG);
+	int ret;
+
+	ret = amdxdna_dpt_suspend_kind(aie, AMDXDNA_DPT_FW_LOG);
+	if (ret)
+		return ret;
+
+	return amdxdna_dpt_suspend_kind(aie, AMDXDNA_DPT_FW_TRACE);
 }
 
 int amdxdna_dpt_resume(struct aie_device *aie)
 {
-	return amdxdna_dpt_resume_kind(aie, AMDXDNA_DPT_FW_LOG);
+	int ret;
+
+	ret = amdxdna_dpt_resume_kind(aie, AMDXDNA_DPT_FW_LOG);
+	if (ret)
+		return ret;
+
+	return amdxdna_dpt_resume_kind(aie, AMDXDNA_DPT_FW_TRACE);
 }
 
 int amdxdna_get_fw_log(struct aie_device *aie,
@@ -910,4 +984,111 @@ int amdxdna_set_fw_log_state(struct aie_device *aie,
 		return amdxdna_fw_log_init(aie, fw_log.config);
 
 	return amdxdna_fw_log_set_level(aie, fw_log.config);
+}
+
+int amdxdna_get_fw_trace(struct aie_device *aie,
+			 struct amdxdna_drm_get_array *args)
+{
+	struct amdxdna_dev *xdna = aie->xdna;
+	struct amdxdna_dpt *dpt;
+	int ret, idx;
+
+	if (!capable(CAP_SYS_ADMIN))
+		return -EPERM;
+
+	dpt = amdxdna_dpt_enter_kind(xdna, AMDXDNA_DPT_FW_TRACE, &idx);
+	if (!dpt)
+		return -ESHUTDOWN;
+
+	ret = amdxdna_dpt_get_data(dpt, args);
+	srcu_read_unlock(&xdna->dpt_srcu, idx);
+	return ret;
+}
+
+/*
+ * No CAP_SYS_ADMIN check: the (version, status, categories) triple
+ * is unprivileged-readable so non-root xrt-smi can detect feature
+ * presence and current state. The payload (amdxdna_get_fw_trace)
+ * requires CAP_SYS_ADMIN.
+ *
+ * Returns -EOPNOTSUPP if the firmware doesn't support this feature.
+ * Returns success with status == 0 when the firmware supports it but
+ * it is currently disabled.
+ */
+int amdxdna_get_fw_trace_configs(struct aie_device *aie,
+				 struct amdxdna_drm_get_array *args)
+{
+	struct amdxdna_drm_get_dpt_state config = {};
+	struct amdxdna_dev *xdna = aie->xdna;
+	struct amdxdna_dpt *dpt;
+	void __user *buf;
+	size_t buf_size;
+	int idx;
+
+	if (args->num_element != 1)
+		return -EINVAL;
+
+	if (!aie->msg_ops.fw_trace_init)
+		return -EOPNOTSUPP;
+
+	buf_size = args->element_size;
+	buf = u64_to_user_ptr(args->buffer);
+	if (!access_ok(buf, buf_size)) {
+		XDNA_ERR(xdna, "Failed to access buffer, element num %d size 0x%x",
+			 args->num_element, args->element_size);
+		return -EFAULT;
+	}
+
+	if (buf_size < sizeof(config)) {
+		XDNA_ERR(xdna, "Insufficient buffer size: 0x%zx", buf_size);
+		return -ENOSPC;
+	}
+
+	dpt = amdxdna_dpt_enter_kind(xdna, AMDXDNA_DPT_FW_TRACE, &idx);
+	if (dpt) {
+		config.version = dpt->payload_version;
+		config.status = 1;
+		config.config = READ_ONCE(dpt->config);
+		srcu_read_unlock(&xdna->dpt_srcu, idx);
+	}
+
+	if (copy_to_user(buf, &config, sizeof(config)))
+		return -EFAULT;
+	return 0;
+}
+
+int amdxdna_set_fw_trace_state(struct aie_device *aie,
+			       struct amdxdna_drm_set_state *args)
+{
+	struct amdxdna_drm_set_dpt_state fw_trace;
+	struct amdxdna_dev *xdna = aie->xdna;
+
+	drm_WARN_ON(&xdna->ddev, !mutex_is_locked(&xdna->dev_lock));
+
+	if (!aie->msg_ops.fw_trace_init)
+		return -EOPNOTSUPP;
+
+	if (args->buffer_size != sizeof(fw_trace)) {
+		XDNA_ERR(xdna, "Invalid buffer size. Given: %u Need: %zu.",
+			 args->buffer_size, sizeof(fw_trace));
+		return -EINVAL;
+	}
+
+	if (copy_from_user(&fw_trace, u64_to_user_ptr(args->buffer),
+			   sizeof(fw_trace)))
+		return -EFAULT;
+
+	if (XDNA_MBZ_DBG(xdna, &fw_trace.pad, sizeof(fw_trace.pad)))
+		return -EINVAL;
+
+	if (!fw_trace.action)
+		return amdxdna_dpt_fini_kind(aie, AMDXDNA_DPT_FW_TRACE);
+
+	if (!fw_trace.config)
+		return -EINVAL;
+
+	if (!rcu_access_pointer(xdna->fw_trace))
+		return amdxdna_fw_trace_init(aie, fw_trace.config);
+
+	return amdxdna_fw_trace_set_categories(aie, fw_trace.config);
 }

--- a/drivers/accel/amdxdna/amdxdna_dpt.c
+++ b/drivers/accel/amdxdna/amdxdna_dpt.c
@@ -48,7 +48,7 @@ amdxdna_dpt_slot(struct amdxdna_dev *xdna, enum amdxdna_dpt_kind kind)
 	return NULL;
 }
 
-struct amdxdna_dpt *
+static struct amdxdna_dpt *
 amdxdna_dpt_enter_kind(struct amdxdna_dev *xdna, enum amdxdna_dpt_kind kind,
 		       int *idx)
 {
@@ -66,6 +66,23 @@ amdxdna_dpt_enter_kind(struct amdxdna_dev *xdna, enum amdxdna_dpt_kind kind,
 		return NULL;
 	}
 	return dpt;
+}
+
+/*
+ * Wake the watcher when either (a) new log data has been written to
+ * the ring (tail has advanced past the caller's last read offset)
+ * or (b) the session is no longer ACTIVE so the watcher can return
+ * -ESHUTDOWN promptly instead of sleeping forever.
+ */
+static bool amdxdna_dpt_watch_ready(const struct amdxdna_dpt *dpt, u64 offset)
+{
+	return READ_ONCE(dpt->status) != AMDXDNA_DPT_ACTIVE ||
+	       offset != READ_ONCE(dpt->tail);
+}
+
+static int amdxdna_dpt_copy_to_user(void *to, const void *from, size_t n)
+{
+	return copy_to_user((__force void __user *)to, from, n) ? -EFAULT : 0;
 }
 
 /*
@@ -410,6 +427,105 @@ amdxdna_dpt_publish(struct aie_device *aie, enum amdxdna_dpt_kind kind,
 	return dpt;
 }
 
+/*
+ * Watch + fetch path used by amdxdna_get_fw_log. Format matches the
+ * firmware ABI so the xrt-smi consumer in shim works unchanged.
+ */
+static int amdxdna_dpt_get_data(struct amdxdna_dpt *dpt,
+				struct amdxdna_drm_get_array *args)
+{
+	struct amdxdna_dpt_metadata footer = {};
+	void __user *buf;
+	size_t buf_size;
+	int ret = 0;
+	u32 offset;
+
+	if (args->num_element != 1)
+		return -EINVAL;
+
+	buf_size = args->element_size;
+	buf = u64_to_user_ptr(args->buffer);
+	if (!access_ok(buf, buf_size)) {
+		XDNA_DPT_ERR(dpt, "Failed to access buffer, element num %d size 0x%x",
+			     args->num_element, args->element_size);
+		return -EFAULT;
+	}
+
+	if (buf_size < sizeof(footer))
+		return -ENOSPC;
+
+	offset = buf_size - sizeof(footer);
+	if (copy_from_user(&footer, buf + offset, sizeof(footer)))
+		return -EFAULT;
+
+	if (XDNA_DPT_MBZ_DBG(dpt, &footer.pad, sizeof(footer.pad)))
+		return -EINVAL;
+
+	XDNA_DPT_DBG(dpt, "Requested at offset 0x%llx with watch %s",
+		     footer.offset, footer.watch ? "on" : "off");
+
+	if (footer.offset == READ_ONCE(dpt->tail)) {
+		if (footer.watch) {
+			amdxdna_dpt_timer_get(dpt);
+			ret = wait_event_interruptible(dpt->wait,
+						       amdxdna_dpt_watch_ready(dpt, footer.offset));
+			amdxdna_dpt_timer_put(dpt);
+
+			/*
+			 * Woken because we are tearing down or PM-suspending.
+			 * SUSPENDING is permitted so admitted watchers can drain
+			 * the final batch fetch_payload before status flips to
+			 * SUSPENDED.
+			 */
+			if (READ_ONCE(dpt->status) != AMDXDNA_DPT_ACTIVE &&
+			    READ_ONCE(dpt->status) != AMDXDNA_DPT_SUSPENDING) {
+				footer.size = 0;
+				ret = -ESHUTDOWN;
+				goto exit;
+			}
+
+			if (ret) {
+				XDNA_DPT_DBG(dpt, "Wait interrupted by signal: %d", ret);
+				footer.size = 0;
+				goto exit;
+			}
+		} else {
+			footer.size = 0;
+			goto exit;
+		}
+	}
+
+	footer.size = offset;
+	ret = amdxdna_dpt_fetch_payload(dpt, buf, &footer.offset, &footer.size,
+					amdxdna_dpt_copy_to_user);
+	if (ret) {
+		XDNA_DPT_ERR(dpt, "Failed to fetch FW buffer: %d", ret);
+		footer.offset = 0;
+		footer.size = 0;
+		ret = -EINVAL;
+	}
+
+exit:
+	if (ret == 0 || ret == -ESHUTDOWN) {
+		if (copy_to_user(buf + offset, &footer, sizeof(footer))) {
+			/*
+			 * On -ESHUTDOWN preserve the original error: user
+			 * space still gets the zero-size sentinel via the
+			 * footer.size = 0 already set on the shutdown
+			 * branch above, and even if the writeback fails
+			 * the disabled-kind status code must reach the
+			 * caller intact.
+			 */
+			if (ret == 0)
+				ret = -EFAULT;
+		}
+	}
+
+	XDNA_DPT_DBG(dpt, "Returned size 0x%x offset 0x%llx", footer.size,
+		     footer.offset);
+	return ret;
+}
+
 static int amdxdna_fw_log_init(struct aie_device *aie, u32 level)
 {
 	struct amdxdna_dev *xdna = aie->xdna;
@@ -629,7 +745,7 @@ static int amdxdna_dpt_resume_kind(struct aie_device *aie,
 	return 0;
 }
 
-int amdxdna_fw_log_set_level(struct aie_device *aie, u32 level)
+static int amdxdna_fw_log_set_level(struct aie_device *aie, u32 level)
 {
 	struct amdxdna_dev *xdna = aie->xdna;
 	struct amdxdna_dpt *dpt;
@@ -688,4 +804,110 @@ int amdxdna_dpt_suspend(struct aie_device *aie)
 int amdxdna_dpt_resume(struct aie_device *aie)
 {
 	return amdxdna_dpt_resume_kind(aie, AMDXDNA_DPT_FW_LOG);
+}
+
+int amdxdna_get_fw_log(struct aie_device *aie,
+		       struct amdxdna_drm_get_array *args)
+{
+	struct amdxdna_dev *xdna = aie->xdna;
+	struct amdxdna_dpt *dpt;
+	int ret, idx;
+
+	if (!capable(CAP_SYS_ADMIN))
+		return -EPERM;
+
+	dpt = amdxdna_dpt_enter_kind(xdna, AMDXDNA_DPT_FW_LOG, &idx);
+	if (!dpt)
+		return -ESHUTDOWN;
+
+	ret = amdxdna_dpt_get_data(dpt, args);
+	srcu_read_unlock(&xdna->dpt_srcu, idx);
+	return ret;
+}
+
+/*
+ * No CAP_SYS_ADMIN check: the (version, status, level) triple is
+ * unprivileged-readable so non-root xrt-smi can detect feature
+ * presence and current state. The payload (amdxdna_get_fw_log)
+ * requires CAP_SYS_ADMIN.
+ *
+ * Returns -EOPNOTSUPP if the firmware doesn't support this feature.
+ * Returns success with status == 0 when the firmware supports it but
+ * it is currently disabled.
+ */
+int amdxdna_get_fw_log_configs(struct aie_device *aie,
+			       struct amdxdna_drm_get_array *args)
+{
+	struct amdxdna_drm_get_dpt_state config = {};
+	struct amdxdna_dev *xdna = aie->xdna;
+	struct amdxdna_dpt *dpt;
+	void __user *buf;
+	size_t buf_size;
+	int idx;
+
+	if (args->num_element != 1)
+		return -EINVAL;
+
+	if (!aie->msg_ops.fw_log_init)
+		return -EOPNOTSUPP;
+
+	buf_size = args->element_size;
+	buf = u64_to_user_ptr(args->buffer);
+	if (!access_ok(buf, buf_size)) {
+		XDNA_ERR(xdna, "Failed to access buffer, element num %d size 0x%x",
+			 args->num_element, args->element_size);
+		return -EFAULT;
+	}
+
+	if (buf_size < sizeof(config)) {
+		XDNA_ERR(xdna, "Insufficient buffer size: 0x%zx", buf_size);
+		return -ENOSPC;
+	}
+
+	dpt = amdxdna_dpt_enter_kind(xdna, AMDXDNA_DPT_FW_LOG, &idx);
+	if (dpt) {
+		config.version = dpt->payload_version;
+		config.status = 1;
+		config.config = READ_ONCE(dpt->config);
+		srcu_read_unlock(&xdna->dpt_srcu, idx);
+	}
+
+	if (copy_to_user(buf, &config, sizeof(config)))
+		return -EFAULT;
+	return 0;
+}
+
+int amdxdna_set_fw_log_state(struct aie_device *aie,
+			     struct amdxdna_drm_set_state *args)
+{
+	struct amdxdna_drm_set_dpt_state fw_log;
+	struct amdxdna_dev *xdna = aie->xdna;
+
+	drm_WARN_ON(&xdna->ddev, !mutex_is_locked(&xdna->dev_lock));
+
+	if (!aie->msg_ops.fw_log_init)
+		return -EOPNOTSUPP;
+
+	if (args->buffer_size != sizeof(fw_log)) {
+		XDNA_ERR(xdna, "Invalid buffer size. Given: %u Need: %zu.",
+			 args->buffer_size, sizeof(fw_log));
+		return -EINVAL;
+	}
+
+	if (copy_from_user(&fw_log, u64_to_user_ptr(args->buffer), sizeof(fw_log)))
+		return -EFAULT;
+
+	if (XDNA_MBZ_DBG(xdna, &fw_log.pad, sizeof(fw_log.pad)))
+		return -EINVAL;
+
+	if (!fw_log.action)
+		return amdxdna_dpt_fini_kind(aie, AMDXDNA_DPT_FW_LOG);
+
+	if (!fw_log.config || fw_log.config >= AMDXDNA_DPT_FW_LOG_LEVEL_MAX)
+		return -EINVAL;
+
+	if (!rcu_access_pointer(xdna->fw_log))
+		return amdxdna_fw_log_init(aie, fw_log.config);
+
+	return amdxdna_fw_log_set_level(aie, fw_log.config);
 }

--- a/drivers/accel/amdxdna/amdxdna_dpt.h
+++ b/drivers/accel/amdxdna/amdxdna_dpt.h
@@ -20,15 +20,17 @@
  * Firmware Debug/Profile/Trace (DPT) framework.
  *
  * A single struct amdxdna_dpt and one set of amdxdna_dpt_* helpers serve
- * firmware logging (xdna->fw_log). The handle's lifetime is guarded by
- * xdna->dpt_srcu so that disabling logging while N watchers are sleeping
- * inside amdxdna_dpt_get_data delivers -ESHUTDOWN to every one of them
- * and tears down the handle without UAF.
+ * firmware logging (xdna->fw_log) and firmware tracing (xdna->fw_trace).
+ * Each handle's lifetime is guarded by xdna->dpt_srcu so that disabling
+ * a kind while N watchers are sleeping inside amdxdna_dpt_get_data
+ * delivers -ESHUTDOWN to every one of them and tears down the handle
+ * without UAF.
  */
 
 #define AMDXDNA_DPT_FOOTER_SIZE		SZ_4K
 #define AMDXDNA_DPT_POLL_INTERVAL_MS	10
 #define AMDXDNA_DPT_FW_LOG_SIZE		SZ_4M
+#define AMDXDNA_DPT_FW_TRACE_SIZE	SZ_4M
 
 /* Common firmware log level scale used by user space (ioctl).
  * AIE2 and AIE4 firmwares both follow this numeric mapping internally.
@@ -55,6 +57,7 @@ enum amdxdna_dpt_status {
 
 enum amdxdna_dpt_kind {
 	AMDXDNA_DPT_FW_LOG,
+	AMDXDNA_DPT_FW_TRACE,
 	AMDXDNA_DPT_KIND_MAX,
 };
 
@@ -142,5 +145,12 @@ int amdxdna_get_fw_log_configs(struct aie_device *aie,
 			       struct amdxdna_drm_get_array *args);
 int amdxdna_set_fw_log_state(struct aie_device *aie,
 			     struct amdxdna_drm_set_state *args);
+
+int amdxdna_get_fw_trace(struct aie_device *aie,
+			 struct amdxdna_drm_get_array *args);
+int amdxdna_get_fw_trace_configs(struct aie_device *aie,
+				 struct amdxdna_drm_get_array *args);
+int amdxdna_set_fw_trace_state(struct aie_device *aie,
+			       struct amdxdna_drm_set_state *args);
 
 #endif /* _AMDXDNA_DPT_H_ */

--- a/drivers/accel/amdxdna/amdxdna_dpt.h
+++ b/drivers/accel/amdxdna/amdxdna_dpt.h
@@ -8,6 +8,7 @@
 #include <linux/mutex.h>
 #include <linux/refcount.h>
 #include <linux/sizes.h>
+#include <linux/string.h>
 #include <linux/timer.h>
 #include <linux/types.h>
 #include <linux/wait.h>
@@ -71,6 +72,8 @@ extern const char * const amdxdna_dpt_irq_name[AMDXDNA_DPT_KIND_MAX];
 #define XDNA_DPT_INFO(dpt, fmt, args...) XDNA_DPT_PRINTK(INFO, dpt, fmt, ##args)
 #define XDNA_DPT_DBG(dpt,  fmt, args...) XDNA_DPT_PRINTK(DBG,  dpt, fmt, ##args)
 
+#define XDNA_DPT_MBZ_DBG(dpt, ptr, sz)	XDNA_MBZ_DBG((dpt)->xdna, ptr, sz)
+
 /*
  * Layout matches the firmware ABI exactly so the on-the-wire format stays
  * compatible with what shim/xrt-smi already expects.
@@ -133,18 +136,11 @@ int amdxdna_dpt_fini(struct aie_device *aie);
 int amdxdna_dpt_suspend(struct aie_device *aie);
 int amdxdna_dpt_resume(struct aie_device *aie);
 
-/*
- * Look up the live handle for @kind under SRCU. On success returns the
- * handle with the SRCU read-lock held in *idx; the caller must pair with
- * srcu_read_unlock(&xdna->dpt_srcu, idx) once it is done with the handle.
- * Returns NULL with the lock already released when the kind is not
- * currently ACTIVE.
- */
-struct amdxdna_dpt *
-amdxdna_dpt_enter_kind(struct amdxdna_dev *xdna, enum amdxdna_dpt_kind kind,
-		       int *idx);
-
-/* Change the FW log level on a live dpt (requires status == ACTIVE). */
-int amdxdna_fw_log_set_level(struct aie_device *aie, u32 level);
+int amdxdna_get_fw_log(struct aie_device *aie,
+		       struct amdxdna_drm_get_array *args);
+int amdxdna_get_fw_log_configs(struct aie_device *aie,
+			       struct amdxdna_drm_get_array *args);
+int amdxdna_set_fw_log_state(struct aie_device *aie,
+			     struct amdxdna_drm_set_state *args);
 
 #endif /* _AMDXDNA_DPT_H_ */

--- a/drivers/accel/amdxdna/amdxdna_dpt.h
+++ b/drivers/accel/amdxdna/amdxdna_dpt.h
@@ -1,0 +1,150 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+/*
+ * Copyright (C) 2026, Advanced Micro Devices, Inc.
+ */
+#ifndef _AMDXDNA_DPT_H_
+#define _AMDXDNA_DPT_H_
+
+#include <linux/mutex.h>
+#include <linux/refcount.h>
+#include <linux/sizes.h>
+#include <linux/timer.h>
+#include <linux/types.h>
+#include <linux/wait.h>
+#include <linux/workqueue.h>
+
+#include "aie.h"
+
+/*
+ * Firmware Debug/Profile/Trace (DPT) framework.
+ *
+ * A single struct amdxdna_dpt and one set of amdxdna_dpt_* helpers serve
+ * firmware logging (xdna->fw_log). The handle's lifetime is guarded by
+ * xdna->dpt_srcu so that disabling logging while N watchers are sleeping
+ * inside amdxdna_dpt_get_data delivers -ESHUTDOWN to every one of them
+ * and tears down the handle without UAF.
+ */
+
+#define AMDXDNA_DPT_FOOTER_SIZE		SZ_4K
+#define AMDXDNA_DPT_POLL_INTERVAL_MS	10
+#define AMDXDNA_DPT_FW_LOG_SIZE		SZ_4M
+
+/* Common firmware log level scale used by user space (ioctl).
+ * AIE2 and AIE4 firmwares both follow this numeric mapping internally.
+ */
+#define AMDXDNA_DPT_FW_LOG_LEVEL_NONE		0
+#define AMDXDNA_DPT_FW_LOG_LEVEL_ERR		1
+#define AMDXDNA_DPT_FW_LOG_LEVEL_WARN		2
+#define AMDXDNA_DPT_FW_LOG_LEVEL_INFO		3
+#define AMDXDNA_DPT_FW_LOG_LEVEL_DEBUG		4
+#define AMDXDNA_DPT_FW_LOG_LEVEL_MAX		5  /* exclusive upper bound */
+
+#define AMDXDNA_DPT_FW_LOG_LEVEL_DEFAULT	AMDXDNA_DPT_FW_LOG_LEVEL_WARN
+
+enum amdxdna_dpt_status {
+	AMDXDNA_DPT_INACTIVE,		/* kzalloc default */
+	AMDXDNA_DPT_ACTIVE,		/* logging is on; watchers may sleep */
+	AMDXDNA_DPT_SUSPENDING,		/* suspend in progress; admitted readers
+					 * may drain the final batch, new readers
+					 * and new timer arms blocked
+					 */
+	AMDXDNA_DPT_SUSPENDED,		/* paused by PM suspend; buffer preserved */
+	AMDXDNA_DPT_SHUTTING_DOWN,	/* fini in progress; between status write and kfree */
+};
+
+enum amdxdna_dpt_kind {
+	AMDXDNA_DPT_FW_LOG,
+	AMDXDNA_DPT_KIND_MAX,
+};
+
+const char *amdxdna_dpt_kind_str(enum amdxdna_dpt_kind kind);
+extern const char * const amdxdna_dpt_irq_name[AMDXDNA_DPT_KIND_MAX];
+
+#define XDNA_DPT_PRINTK(level, dpt, fmt, args...) do {				\
+	const struct amdxdna_dpt *__d = (dpt);					\
+	XDNA_##level(__d->xdna, "%s: " fmt,					\
+		     amdxdna_dpt_kind_str(__d->kind), ##args);			\
+} while (0)
+
+#define XDNA_DPT_ERR(dpt,  fmt, args...) XDNA_DPT_PRINTK(ERR,  dpt, fmt, ##args)
+#define XDNA_DPT_WARN(dpt, fmt, args...) XDNA_DPT_PRINTK(WARN, dpt, fmt, ##args)
+#define XDNA_DPT_INFO(dpt, fmt, args...) XDNA_DPT_PRINTK(INFO, dpt, fmt, ##args)
+#define XDNA_DPT_DBG(dpt,  fmt, args...) XDNA_DPT_PRINTK(DBG,  dpt, fmt, ##args)
+
+/*
+ * Layout matches the firmware ABI exactly so the on-the-wire format stays
+ * compatible with what shim/xrt-smi already expects.
+ */
+struct amdxdna_dpt_footer {
+	u8	minor;
+	u8	major;
+	u8	type;
+	u8	reserved1;
+	u32	payload_version;
+	u8	reserved2[56];
+	u32	tail;
+} __packed;
+
+struct amdxdna_dpt {
+	struct amdxdna_dev		*xdna;
+	struct aie_device		*aie;
+	enum amdxdna_dpt_kind		 kind;
+	enum amdxdna_dpt_status		 status;
+	/*
+	 * Kind-specific configuration: log level for FW_LOG,
+	 * category bitmask for FW_TRACE.
+	 */
+	u32				 config;
+
+	/* FW-reported metadata (filled once by amdxdna_dpt_read_metadata) */
+	u8				 major;
+	u8				 minor;
+	u32				 payload_version;
+
+	/* DMA ring buffer (FW writes, host reads) */
+	struct amdxdna_msg_buf_hdl	*buf;
+	u64				 tail;		/* kernel cache of FW write pointer */
+
+	/* MSI / IRQ wiring (irq == 0 means request_irq failed) */
+	void __iomem			*io_base;
+	int				 irq;
+	u32				 msi_idx;
+	u32				 msi_address;
+
+	/* deferred work + on-demand polling timer */
+	struct work_struct		 work;
+	struct timer_list		 timer;
+	struct mutex			 timer_lock;	/* timer_refs / timer_delete_sync */
+	refcount_t			 timer_refs;
+
+	/* xrt-smi watchers park here */
+	struct wait_queue_head		 wait;
+};
+
+/*
+ * Top-level DPT lifecycle. Entry points called from per-generation
+ * init/fini/suspend/resume after aie->msg_ops has been populated.
+ * amdxdna_dpt_init auto-starts FW_LOG only; FW_TRACE remains inactive
+ * at probe and is opt-in via the DRM_AMDXDNA_SET_FW_TRACE_STATE ioctl
+ * to avoid generating large trace payloads unconditionally.
+ */
+int amdxdna_dpt_init(struct aie_device *aie);
+int amdxdna_dpt_fini(struct aie_device *aie);
+int amdxdna_dpt_suspend(struct aie_device *aie);
+int amdxdna_dpt_resume(struct aie_device *aie);
+
+/*
+ * Look up the live handle for @kind under SRCU. On success returns the
+ * handle with the SRCU read-lock held in *idx; the caller must pair with
+ * srcu_read_unlock(&xdna->dpt_srcu, idx) once it is done with the handle.
+ * Returns NULL with the lock already released when the kind is not
+ * currently ACTIVE.
+ */
+struct amdxdna_dpt *
+amdxdna_dpt_enter_kind(struct amdxdna_dev *xdna, enum amdxdna_dpt_kind kind,
+		       int *idx);
+
+/* Change the FW log level on a live dpt (requires status == ACTIVE). */
+int amdxdna_fw_log_set_level(struct aie_device *aie, u32 level);
+
+#endif /* _AMDXDNA_DPT_H_ */

--- a/drivers/accel/amdxdna/amdxdna_pci_drv.c
+++ b/drivers/accel/amdxdna/amdxdna_pci_drv.c
@@ -373,6 +373,7 @@ static void amdxdna_xdna_drm_release(struct drm_device *drm, void *res)
 	struct amdxdna_dev *xdna = res;
 
 	amdxdna_carveout_fini(xdna);
+	cleanup_srcu_struct(&xdna->dpt_srcu);
 }
 
 static int amdxdna_probe(struct pci_dev *pdev, const struct pci_device_id *id)
@@ -396,9 +397,15 @@ static int amdxdna_probe(struct pci_dev *pdev, const struct pci_device_id *id)
 	INIT_LIST_HEAD(&xdna->client_list);
 	pci_set_drvdata(pdev, xdna);
 
-	ret = drmm_add_action(ddev, amdxdna_xdna_drm_release, xdna);
+	ret = init_srcu_struct(&xdna->dpt_srcu);
 	if (ret)
 		return ret;
+
+	ret = drmm_add_action(ddev, amdxdna_xdna_drm_release, xdna);
+	if (ret) {
+		cleanup_srcu_struct(&xdna->dpt_srcu);
+		return ret;
+	}
 
 	if (IS_ENABLED(CONFIG_LOCKDEP)) {
 		fs_reclaim_acquire(GFP_KERNEL);

--- a/drivers/accel/amdxdna/amdxdna_pci_drv.c
+++ b/drivers/accel/amdxdna/amdxdna_pci_drv.c
@@ -60,9 +60,10 @@ MODULE_FIRMWARE("amdnpu/1B0B_10/cert.dev.sbin");
  * 0.13: Support AIE tile register/memory read/write
  * 0.14: Expose firmware log GET/GET_CONFIG/SET_STATE ioctls and
  *       struct amdxdna_dpt_metadata, _set_dpt_state, _get_dpt_state
+ * 0.15: Expose firmware trace GET/GET_CONFIG/SET_STATE ioctls
  */
 #define AMDXDNA_DRIVER_MAJOR		0
-#define AMDXDNA_DRIVER_MINOR		14
+#define AMDXDNA_DRIVER_MINOR		15
 
 /*
  * Bind the driver base on (vendor_id, device_id) pair and later use the

--- a/drivers/accel/amdxdna/amdxdna_pci_drv.c
+++ b/drivers/accel/amdxdna/amdxdna_pci_drv.c
@@ -58,9 +58,11 @@ MODULE_FIRMWARE("amdnpu/1B0B_10/cert.dev.sbin");
  * 0.11: Support AIE coredump
  * 0.12: Add classic device type of NPU3
  * 0.13: Support AIE tile register/memory read/write
+ * 0.14: Expose firmware log GET/GET_CONFIG/SET_STATE ioctls and
+ *       struct amdxdna_dpt_metadata, _set_dpt_state, _get_dpt_state
  */
 #define AMDXDNA_DRIVER_MAJOR		0
-#define AMDXDNA_DRIVER_MINOR		13
+#define AMDXDNA_DRIVER_MINOR		14
 
 /*
  * Bind the driver base on (vendor_id, device_id) pair and later use the
@@ -233,7 +235,11 @@ static int amdxdna_drm_get_array_ioctl(struct drm_device *dev, void *data,
 	if (args->pad || !args->num_element || !args->element_size)
 		return -EINVAL;
 
-	guard(mutex)(&xdna->dev_lock);
+	/* dev_lock is NOT held across this call. Cases that need it take
+	 * it themselves; the FW_LOG watch path uses SRCU instead so that
+	 * multiple xrt-smi watchers can sleep concurrently inside
+	 * wait_event_interruptible.
+	 */
 	return xdna->dev_info->ops->get_array(client, args);
 }
 

--- a/drivers/accel/amdxdna/amdxdna_pci_drv.h
+++ b/drivers/accel/amdxdna/amdxdna_pci_drv.h
@@ -14,6 +14,7 @@
 #include <linux/cred.h>
 #include <linux/iommu.h>
 #include <linux/iova.h>
+#include <linux/srcu.h>
 #include <linux/workqueue.h>
 #include <linux/xarray.h>
 
@@ -115,6 +116,7 @@ struct amdxdna_fw_ver {
 };
 
 struct amdxdna_carveout;
+struct amdxdna_dpt;
 
 struct amdxdna_dev {
 	struct drm_device		ddev;
@@ -135,6 +137,14 @@ struct amdxdna_dev {
 	const char			*vbnv;
 
 	struct amdxdna_carveout		*carveout;
+
+	/* Firmware Debug/Profile/Trace (DPT) framework. dpt_srcu guards the
+	 * lifetime of every dpt handle hung off this device; on disable we
+	 * synchronize_srcu so kfree of the handle is provably ordered after
+	 * any watcher's srcu_read_unlock.
+	 */
+	struct srcu_struct		dpt_srcu;
+	struct amdxdna_dpt __rcu	*fw_log;
 };
 
 /*

--- a/drivers/accel/amdxdna/amdxdna_pci_drv.h
+++ b/drivers/accel/amdxdna/amdxdna_pci_drv.h
@@ -145,6 +145,7 @@ struct amdxdna_dev {
 	 */
 	struct srcu_struct		dpt_srcu;
 	struct amdxdna_dpt __rcu	*fw_log;
+	struct amdxdna_dpt __rcu	*fw_trace;
 };
 
 /*

--- a/drivers/accel/amdxdna/npu3_regs.c
+++ b/drivers/accel/amdxdna/npu3_regs.c
@@ -41,6 +41,7 @@ static const struct amdxdna_fw_feature_tbl npu3_fw_feature_table[] = {
 	{ .major = 5, .min_minor = 10 },
 	{ .features = BIT_U64(AIE4_GET_COREDUMP), .major = 5, .min_minor = 24 },
 	{ .features = BIT_U64(AIE4_RW_ACCESS), .major = 5, .min_minor = 24 },
+	{ .features = BIT_U64(AIE4_CALIBRATE_CLOCK), .major = 5, .min_minor = 24 },
 	{ 0 }
 };
 

--- a/drivers/accel/amdxdna/npu4_regs.c
+++ b/drivers/accel/amdxdna/npu4_regs.c
@@ -99,6 +99,7 @@ const struct amdxdna_fw_feature_tbl npu4_fw_feature_table[] = {
 	{ .features = BIT_U64(AIE2_UPDATE_PROPERTY), .major = 6, .min_minor = 15 },
 	{ .features = BIT_U64(AIE2_APP_HEALTH), .major = 6, .min_minor = 18 },
 	{ .features = BIT_U64(AIE2_ADD_HOST_BUFFER), .major = 6, .min_minor = 18 },
+	{ .features = BIT_U64(AIE2_FW_LOG), .major = 6, .min_minor = 19 },
 	{ .features = BIT_U64(AIE2_GET_DEV_REVISION), .major = 6, .min_minor = 24 },
 	{ .features = BIT_U64(AIE2_RW_ACCESS), .major = 6, .min_minor = 24 },
 	{ .features = BIT_U64(AIE2_CALIBRATE_CLOCK), .major = 6, .min_minor = 24 },

--- a/drivers/accel/amdxdna/npu4_regs.c
+++ b/drivers/accel/amdxdna/npu4_regs.c
@@ -101,6 +101,7 @@ const struct amdxdna_fw_feature_tbl npu4_fw_feature_table[] = {
 	{ .features = BIT_U64(AIE2_ADD_HOST_BUFFER), .major = 6, .min_minor = 18 },
 	{ .features = BIT_U64(AIE2_GET_DEV_REVISION), .major = 6, .min_minor = 24 },
 	{ .features = BIT_U64(AIE2_RW_ACCESS), .major = 6, .min_minor = 24 },
+	{ .features = BIT_U64(AIE2_CALIBRATE_CLOCK), .major = 6, .min_minor = 24 },
 	{ .features = AIE2_ALL_FEATURES, .major = 7 },
 	{ 0 }
 };

--- a/drivers/accel/amdxdna/npu4_regs.c
+++ b/drivers/accel/amdxdna/npu4_regs.c
@@ -100,6 +100,7 @@ const struct amdxdna_fw_feature_tbl npu4_fw_feature_table[] = {
 	{ .features = BIT_U64(AIE2_APP_HEALTH), .major = 6, .min_minor = 18 },
 	{ .features = BIT_U64(AIE2_ADD_HOST_BUFFER), .major = 6, .min_minor = 18 },
 	{ .features = BIT_U64(AIE2_FW_LOG), .major = 6, .min_minor = 19 },
+	{ .features = BIT_U64(AIE2_FW_TRACE), .major = 6, .min_minor = 19 },
 	{ .features = BIT_U64(AIE2_GET_DEV_REVISION), .major = 6, .min_minor = 24 },
 	{ .features = BIT_U64(AIE2_RW_ACCESS), .major = 6, .min_minor = 24 },
 	{ .features = BIT_U64(AIE2_CALIBRATE_CLOCK), .major = 6, .min_minor = 24 },

--- a/include/uapi/drm/amdxdna_accel.h
+++ b/include/uapi/drm/amdxdna_accel.h
@@ -685,13 +685,73 @@ struct amdxdna_drm_aie_tile_access {
 	__u8  pad[3];
 };
 
+/**
+ * struct amdxdna_dpt_metadata - DPT metadata shared between shim and driver.
+ */
+struct amdxdna_dpt_metadata {
+	/**
+	 * @offset: [in/out] DPT read pointer. In: where in the FW ring to
+	 * start reading. Out: updated to the next read position.
+	 */
+	__u64 offset;
+	/**
+	 * @size: [out] Number of bytes the kernel wrote into the payload
+	 * area. The input value is ignored.
+	 */
+	__u32 size;
+	/**
+	 * @watch: [in] If non-zero, the request may wait in the kernel
+	 * until new data is available.
+	 */
+	__u8  watch;
+	/** @pad: MBZ. */
+	__u8  pad[3];
+};
+
+/**
+ * struct amdxdna_drm_set_dpt_state - Structure to configure DPT.
+ */
+struct amdxdna_drm_set_dpt_state {
+	/** @action: 1 to enable, 0 to disable. */
+	__u32 action;
+	/** @config: For firmware logging this value indicates log level. */
+	__u32 config;
+	/** @pad: MBZ. */
+	__u64 pad;
+};
+
+/**
+ * struct amdxdna_drm_get_dpt_state - Structure to get current DPT state.
+ *
+ * Convention used by the corresponding DRM_AMDXDNA_FW_*_CONFIG GET ioctl:
+ *   Ioctl returns -EOPNOTSUPP: firmware doesn't support this feature.
+ *   @status == 1: feature is enabled; @version and @config are valid.
+ *   @status == 0: feature is supported but currently disabled;
+ *                 @version and @config are zero-filled and MUST NOT be
+ *                 interpreted by user space.
+ */
+struct amdxdna_drm_get_dpt_state {
+	/** @version: Payload version. Valid only when @status == 1. */
+	__u32 version;
+	/** @status: 1 implies enabled, 0 implies disabled. */
+	__u32 status;
+	/** @config: Kind-specific configuration (log level for FW_LOG,
+	 *  category bitmask for FW_TRACE). Valid only when @status == 1.
+	 */
+	__u32 config;
+	/** @pad: MBZ. */
+	__u32 pad;
+};
+
 /*
  * Supported params in struct amdxdna_drm_get_array
  */
 #define DRM_AMDXDNA_HW_CONTEXT_ALL	0
 #define DRM_AMDXDNA_HW_LAST_ASYNC_ERR	2
+#define DRM_AMDXDNA_FW_LOG		3
 #define DRM_AMDXDNA_AIE_COREDUMP	5
 #define DRM_AMDXDNA_BO_USAGE		6
+#define DRM_AMDXDNA_FW_LOG_CONFIG	7
 #define DRM_AMDXDNA_AIE_TILE_READ	9
 
 /**
@@ -744,6 +804,28 @@ struct amdxdna_drm_get_array {
 	 * Access: any process running as the same Linux user as the
 	 * context creator may read that context; CAP_SYS_ADMIN may read
 	 * any context.
+	 *
+	 * %DRM_AMDXDNA_FW_LOG:
+	 * Returns firmware log payload plus metadata.
+	 *
+	 * num_element must be 1. buffer points to a user buffer whose size
+	 * is element_size bytes. The last sizeof(struct amdxdna_dpt_metadata)
+	 * bytes of buffer carry the request/reply metadata (offset, size,
+	 * watch); the remainder receives the payload. When @watch is set the
+	 * call sleeps in the kernel until new data is available, logging is
+	 * disabled, or a signal arrives.
+	 *
+	 * Access: requires CAP_SYS_ADMIN.
+	 *
+	 * %DRM_AMDXDNA_FW_LOG_CONFIG:
+	 * Returns the current firmware log configuration as
+	 * struct amdxdna_drm_get_dpt_state.
+	 *
+	 * num_element must be 1. element_size must be at least
+	 * sizeof(struct amdxdna_drm_get_dpt_state).
+	 *
+	 * Access: unprivileged. Returns -EOPNOTSUPP if firmware doesn't
+	 * support this feature.
 	 */
 	__u32 param;
 	/**
@@ -776,6 +858,7 @@ enum amdxdna_drm_set_param {
 	DRM_AMDXDNA_WRITE_AIE_REG,
 	DRM_AMDXDNA_SET_FORCE_PREEMPT,
 	DRM_AMDXDNA_SET_FRAME_BOUNDARY_PREEMPT,
+	DRM_AMDXDNA_SET_FW_LOG_STATE,
 	DRM_AMDXDNA_AIE_TILE_WRITE = 7,
 };
 
@@ -818,6 +901,17 @@ struct amdxdna_drm_set_state {
 	 * block transfer through firmware.
 	 *
 	 * Access: requires CAP_SYS_ADMIN (the carrier SET_STATE ioctl is
+	 * DRM_ROOT_ONLY).
+	 *
+	 * %DRM_AMDXDNA_SET_FW_LOG_STATE:
+	 * Enable, disable, or change the level of firmware logging.
+	 *
+	 * buffer points to struct amdxdna_drm_set_dpt_state. action=0
+	 * disables logging; action=1 enables it (or, if already enabled,
+	 * changes the level to @config). @config must be in
+	 * [1, AMDXDNA_DPT_FW_LOG_LEVEL_MAX).
+	 *
+	 * Access: requires CAP_SYS_ADMIN (the SET_STATE ioctl is
 	 * DRM_ROOT_ONLY).
 	 */
 	__u32 param;

--- a/include/uapi/drm/amdxdna_accel.h
+++ b/include/uapi/drm/amdxdna_accel.h
@@ -714,7 +714,11 @@ struct amdxdna_dpt_metadata {
 struct amdxdna_drm_set_dpt_state {
 	/** @action: 1 to enable, 0 to disable. */
 	__u32 action;
-	/** @config: For firmware logging this value indicates log level. */
+	/**
+	 * @config: For firmware logging this value indicates log level.
+	 * For DRM_AMDXDNA_SET_FW_TRACE_STATE on enable, a non-zero category
+	 * bitmask is mandatory; passing 0 returns -EINVAL.
+	 */
 	__u32 config;
 	/** @pad: MBZ. */
 	__u64 pad;
@@ -749,9 +753,11 @@ struct amdxdna_drm_get_dpt_state {
 #define DRM_AMDXDNA_HW_CONTEXT_ALL	0
 #define DRM_AMDXDNA_HW_LAST_ASYNC_ERR	2
 #define DRM_AMDXDNA_FW_LOG		3
+#define DRM_AMDXDNA_FW_TRACE		4
 #define DRM_AMDXDNA_AIE_COREDUMP	5
 #define DRM_AMDXDNA_BO_USAGE		6
 #define DRM_AMDXDNA_FW_LOG_CONFIG	7
+#define DRM_AMDXDNA_FW_TRACE_CONFIG	8
 #define DRM_AMDXDNA_AIE_TILE_READ	9
 
 /**
@@ -826,6 +832,28 @@ struct amdxdna_drm_get_array {
 	 *
 	 * Access: unprivileged. Returns -EOPNOTSUPP if firmware doesn't
 	 * support this feature.
+	 *
+	 * %DRM_AMDXDNA_FW_TRACE:
+	 * Returns firmware event trace payload plus metadata.
+	 *
+	 * num_element must be 1. buffer points to a user buffer whose size
+	 * is element_size bytes. The last sizeof(struct amdxdna_dpt_metadata)
+	 * bytes of buffer carry the request/reply metadata (offset, size,
+	 * watch); the remainder receives the payload. When @watch is set the
+	 * call sleeps in the kernel until new data is available, tracing is
+	 * disabled, or a signal arrives.
+	 *
+	 * Access: requires CAP_SYS_ADMIN.
+	 *
+	 * %DRM_AMDXDNA_FW_TRACE_CONFIG:
+	 * Returns the current firmware trace configuration as
+	 * struct amdxdna_drm_get_dpt_state.
+	 *
+	 * num_element must be 1. element_size must be at least
+	 * sizeof(struct amdxdna_drm_get_dpt_state).
+	 *
+	 * Access: unprivileged. Returns -EOPNOTSUPP if firmware doesn't
+	 * support this feature.
 	 */
 	__u32 param;
 	/**
@@ -859,7 +887,8 @@ enum amdxdna_drm_set_param {
 	DRM_AMDXDNA_SET_FORCE_PREEMPT,
 	DRM_AMDXDNA_SET_FRAME_BOUNDARY_PREEMPT,
 	DRM_AMDXDNA_SET_FW_LOG_STATE,
-	DRM_AMDXDNA_AIE_TILE_WRITE = 7,
+	DRM_AMDXDNA_SET_FW_TRACE_STATE,
+	DRM_AMDXDNA_AIE_TILE_WRITE,
 };
 
 /**
@@ -910,6 +939,18 @@ struct amdxdna_drm_set_state {
 	 * disables logging; action=1 enables it (or, if already enabled,
 	 * changes the level to @config). @config must be in
 	 * [1, AMDXDNA_DPT_FW_LOG_LEVEL_MAX).
+	 *
+	 * Access: requires CAP_SYS_ADMIN (the SET_STATE ioctl is
+	 * DRM_ROOT_ONLY).
+	 *
+	 * %DRM_AMDXDNA_SET_FW_TRACE_STATE:
+	 * Enable, disable, or change the category bitmask of firmware
+	 * event tracing.
+	 *
+	 * buffer points to struct amdxdna_drm_set_dpt_state. action=0
+	 * disables tracing; action=1 enables it (or, if already enabled,
+	 * replaces the category bitmask). @config must be a non-zero
+	 * bitmask; passing 0 returns -EINVAL.
 	 *
 	 * Access: requires CAP_SYS_ADMIN (the SET_STATE ioctl is
 	 * DRM_ROOT_ONLY).

--- a/src/shim/device.cpp
+++ b/src/shim/device.cpp
@@ -657,7 +657,7 @@ struct event_trace
   put(const xrt_core::device* device, key_type key, const std::any& any)
   {
     auto config = std::any_cast<xrt_core::query::event_trace_state::value_type>(any);
-    amdxdna_drm_set_dpt_state fw_trace;
+    amdxdna_drm_set_dpt_state fw_trace = {};
     fw_trace.action = !!config.action;
     fw_trace.config = config.categories;
 
@@ -780,7 +780,7 @@ struct firmware_log
   put(const xrt_core::device* device, key_type key, const std::any& any)
   {
     auto config = std::any_cast<xrt_core::query::firmware_log_state::value_type>(any);
-    amdxdna_drm_set_dpt_state fw_log;
+    amdxdna_drm_set_dpt_state fw_log = {};
     fw_log.action = !!config.action;
     fw_log.config = config.log_level;
 


### PR DESCRIPTION
Add a common firmware Debug/Profile/Trace (DPT) framework and the AIE2
backend wiring for firmware logging and event tracing, exposed to user
space via DRM ioctls (driver minor 0.13 → 0.15). The framework owns a
SRCU-protected DMA ring per consumer slot with an MSI-driven worker and
on-demand polling fallback, auto-starts firmware logging at probe at the
default WARN level, leaves event tracing opt-in, and preserves firmware
state across PM suspend/resume. AIE4 backend support, the dmesg-dump
consumer plus debugfs controls, and a smoke/soak test script will follow
in three separate PRs.