### PR TITLE
[XRT-SMI] Submodule update and shim implementation

### DIFF
--- a/src/shim/device.cpp
+++ b/src/shim/device.cpp
@@ -1853,7 +1853,7 @@ struct xrt_smi_lists
   }
 
   static result_type
-  get(const xrt_core::device* /*device*/, key_type key, const std::any& reqType)
+  get(const xrt_core::device* device, key_type key, const std::any& reqType)
   {
     if (key != key_type::xrt_smi_lists)
       throw xrt_core::query::no_such_key(key, "Not implemented");
@@ -1866,6 +1866,8 @@ struct xrt_smi_lists
       return xrt_core::smi::get_list("examine", "report");
     case xrt_core::query::xrt_smi_lists::type::configure_option_options:
       return xrt_core::smi::get_option_options("configure");
+    case xrt_core::query::xrt_smi_lists::type::subcommands:
+      return xrt_core::smi::ryzen::get_subcommands_list(device);
     default:
       throw xrt_core::query::no_such_key(key, "Not implemented");
     }

--- a/tools/info.json
+++ b/tools/info.json
@@ -1,11 +1,7 @@
 {
 	"copyright": "Copyright (C) 2023-2026 Advanced Micro Devices, Inc. All rights reserved.",
 	"xrt" : {
-<<<<<<< HEAD
 		"version": "202610.2.23.237",
-=======
-		"version": "202610.2.23.235",
->>>>>>> bf04e44 (submodule update)
 		"os_rel": ["22.04", "24.04"]
 	},
 	"firmwares": [

--- a/tools/info.json
+++ b/tools/info.json
@@ -1,7 +1,11 @@
 {
 	"copyright": "Copyright (C) 2023-2026 Advanced Micro Devices, Inc. All rights reserved.",
 	"xrt" : {
+<<<<<<< HEAD
 		"version": "202610.2.23.237",
+=======
+		"version": "202610.2.23.235",
+>>>>>>> bf04e44 (submodule update)
 		"os_rel": ["22.04", "24.04"]
 	},
 	"firmwares": [


### PR DESCRIPTION
This PR updates the xrt submodule to update to latest XRT code containing https://github.com/Xilinx/XRT/pull/9795 and adds the shims query to fulfil get subcommands query.