### PR TITLE
accel/amdxdna: Print no pmf sensor support as warning, instead of error

### DIFF
--- a/drivers/accel/amdxdna/amdxdna_sensors.c
+++ b/drivers/accel/amdxdna/amdxdna_sensors.c
@@ -234,7 +234,7 @@ void amdxdna_hwmon_init(struct amdxdna_dev *xdna)
 
 	ret = amdxdna_get_sensors(&npu_metrics);
 	if (ret) {
-		XDNA_ERR(xdna, "No HWMON support due to missing PMF sensor support.");
+		XDNA_WARN(xdna, "No HWMON support due to missing PMF sensor support.");
 		return;
 	}
 


### PR DESCRIPTION
This change amends 438d6576b322eeb103a977aa44a770c7b273eefc