### PR TITLE
vxdna: guest userptr BO coalesce, DEV_HEAP arena, and staging driver fixes for virtio

### DIFF
--- a/drivers/accel/amdxdna/aie2_ctx.c
+++ b/drivers/accel/amdxdna/aie2_ctx.c
@@ -957,20 +957,45 @@ static void aie2_cmd_wait(struct amdxdna_hwctx *hwctx, u64 seq)
 	dma_fence_put(out_fence);
 }
 
+static int aie2_drv_cmd_submit_wait(struct amdxdna_hwctx *hwctx,
+				    struct amdxdna_client *client,
+				    struct amdxdna_drv_cmd *cmd,
+				    u32 *bo_hdls, u32 bo_cnt)
+{
+	u64 seq;
+	int ret;
+
+	ret = amdxdna_cmd_submit(client, cmd, AMDXDNA_INVALID_BO_HANDLE,
+				 bo_hdls, bo_cnt, hwctx->id, &seq);
+	if (ret)
+		return ret;
+
+	aie2_cmd_wait(hwctx, seq);
+	wait_event(hwctx->priv->job_free_wq,
+		   atomic64_read(&hwctx->job_submit_cnt) ==
+		   atomic64_read(&hwctx->job_free_cnt));
+
+	return 0;
+}
+
 static int aie2_hwctx_cfg_debug_bo(struct amdxdna_hwctx *hwctx, u32 bo_hdl,
 				   bool attach)
 {
 	struct amdxdna_client *client = hwctx->client;
 	struct amdxdna_dev *xdna = client->xdna;
-	struct amdxdna_drv_cmd cmd = { 0 };
+	struct amdxdna_drv_cmd *cmd;
 	struct amdxdna_gem_obj *abo;
-	u64 seq;
 	int ret;
+
+	cmd = kzalloc_obj(*cmd);
+	if (!cmd)
+		return -ENOMEM;
 
 	abo = amdxdna_gem_get_obj(client, bo_hdl, AMDXDNA_BO_DEV);
 	if (!abo) {
 		XDNA_ERR(xdna, "Get bo %d failed", bo_hdl);
-		return -EINVAL;
+		ret = -EINVAL;
+		goto free_cmd;
 	}
 
 	if (attach) {
@@ -978,25 +1003,24 @@ static int aie2_hwctx_cfg_debug_bo(struct amdxdna_hwctx *hwctx, u32 bo_hdl,
 			ret = -EBUSY;
 			goto put_obj;
 		}
-		cmd.opcode = ATTACH_DEBUG_BO;
+		cmd->opcode = ATTACH_DEBUG_BO;
 	} else {
 		if (abo->assigned_hwctx != hwctx->id) {
 			ret = -EINVAL;
 			goto put_obj;
 		}
-		cmd.opcode = DETACH_DEBUG_BO;
+		cmd->opcode = DETACH_DEBUG_BO;
 	}
 
-	ret = amdxdna_cmd_submit(client, &cmd, AMDXDNA_INVALID_BO_HANDLE,
-				 &bo_hdl, 1, hwctx->id, &seq);
+	ret = aie2_drv_cmd_submit_wait(hwctx, client, cmd, &bo_hdl, 1);
 	if (ret) {
 		XDNA_ERR(xdna, "Submit command failed");
 		goto put_obj;
 	}
 
-	aie2_cmd_wait(hwctx, seq);
-	if (cmd.result) {
-		XDNA_ERR(xdna, "Response failure 0x%x", cmd.result);
+	if (cmd->result) {
+		XDNA_ERR(xdna, "Response failure 0x%x", cmd->result);
+		ret = -EINVAL;
 		goto put_obj;
 	}
 
@@ -1009,6 +1033,8 @@ static int aie2_hwctx_cfg_debug_bo(struct amdxdna_hwctx *hwctx, u32 bo_hdl,
 
 put_obj:
 	amdxdna_gem_put_obj(abo);
+free_cmd:
+	kfree(cmd);
 	return ret;
 }
 
@@ -1034,25 +1060,29 @@ int aie2_hwctx_sync_debug_bo(struct amdxdna_hwctx *hwctx, u32 debug_bo_hdl)
 {
 	struct amdxdna_client *client = hwctx->client;
 	struct amdxdna_dev *xdna = client->xdna;
-	struct amdxdna_drv_cmd cmd = { 0 };
-	u64 seq;
+	struct amdxdna_drv_cmd *cmd;
 	int ret;
 
-	cmd.opcode = SYNC_DEBUG_BO;
-	ret = amdxdna_cmd_submit(client, &cmd, AMDXDNA_INVALID_BO_HANDLE,
-				 &debug_bo_hdl, 1, hwctx->id, &seq);
+	cmd = kzalloc_obj(*cmd);
+	if (!cmd)
+		return -ENOMEM;
+
+	cmd->opcode = SYNC_DEBUG_BO;
+	ret = aie2_drv_cmd_submit_wait(hwctx, client, cmd, &debug_bo_hdl, 1);
 	if (ret) {
 		XDNA_ERR(xdna, "Submit command failed");
-		return ret;
+		goto free_cmd;
 	}
 
-	aie2_cmd_wait(hwctx, seq);
-	if (cmd.result) {
-		XDNA_ERR(xdna, "Response failure 0x%x", cmd.result);
-		return -EINVAL;
+	if (cmd->result) {
+		XDNA_ERR(xdna, "Response failure 0x%x", cmd->result);
+		ret = -EINVAL;
+		goto free_cmd;
 	}
 
-	return 0;
+free_cmd:
+	kfree(cmd);
+	return ret;
 }
 
 static int aie2_populate_range(struct amdxdna_gem_obj *abo)

--- a/drivers/accel/amdxdna/amdxdna_dpt.c
+++ b/drivers/accel/amdxdna/amdxdna_dpt.c
@@ -601,23 +601,28 @@ static int amdxdna_dpt_fini_kind(struct aie_device *aie, enum amdxdna_dpt_kind k
 		return 0;
 
 	/*
-	 * Close the publish gate first (mirrors enter_kind's ptr-then-
-	 * status read order), then mark in-flight readers to bail. After
-	 * this no new srcu_dereference can return this handle, and any
-	 * reader that already loaded the pointer will observe
-	 * SHUTTING_DOWN on its post-wait status check.
+	 * Stop the firmware producer while the RCU slot is still
+	 * published so msg_ops fini hooks (e.g. fw_log_fini) can look up
+	 * xdna->fw_log / fw_trace. Detach must complete before the buffer
+	 * is unmapped below.
+	 */
+	amdxdna_dpt_msg_fini(dpt);
+
+	/*
+	 * Close the publish gate (mirrors enter_kind's ptr-then-status read
+	 * order), then mark in-flight readers to bail. After this no new
+	 * srcu_dereference can return this handle, and any reader that
+	 * already loaded the pointer will observe SHUTTING_DOWN on its
+	 * post-wait status check.
 	 */
 	rcu_assign_pointer(*slot, NULL);
 	WRITE_ONCE(dpt->status, AMDXDNA_DPT_SHUTTING_DOWN);
 
 	/*
-	 * Stop the producer first so the firmware stops emitting IRQs
-	 * and tail updates against the soon-to-be-freed ring, then drain
-	 * the host-side pipeline (IRQ -> timer -> worker). After
+	 * Drain the host-side pipeline (IRQ -> timer -> worker). After
 	 * cancel_work_sync no path is left that could call
 	 * amdxdna_dpt_update_tail on the detached firmware.
 	 */
-	amdxdna_dpt_msg_fini(dpt);
 	amdxdna_dpt_irq_fini(dpt);
 	timer_shutdown_sync(&dpt->timer);
 	cancel_work_sync(&dpt->work);

--- a/drivers/accel/amdxdna/amdxdna_gem.c
+++ b/drivers/accel/amdxdna/amdxdna_gem.c
@@ -61,10 +61,15 @@ amdxdna_init_dev_bo(struct amdxdna_gem_obj *dev_bo)
 
 	heap_id--;
 	heap = xa_load(&client->dev_heap_xa, heap_id);
-	exp_heap_uva = amdxdna_gem_uva(heap);
 	heap_addr = amdxdna_gem_dev_addr(heap);
 	dev_bo->heap_start_id = heap_id;
-	dev_bo->mem.uva = dev_bo->mm_node.start - heap_addr + exp_heap_uva;
+
+	if (amdxdna_pasid_on(client)) {
+		exp_heap_uva = amdxdna_gem_uva(heap);
+		dev_bo->mem.uva = dev_bo->mm_node.start - heap_addr + exp_heap_uva;
+	} else {
+		dev_bo->mem.uva = AMDXDNA_INVALID_ADDR;
+	}
 
 	for (; heap_id < client->dev_heap_nid; heap_id++) {
 		heap = xa_load(&client->dev_heap_xa, heap_id);
@@ -72,22 +77,29 @@ amdxdna_init_dev_bo(struct amdxdna_gem_obj *dev_bo)
 			XDNA_ERR(xdna, "Failed to load heap %d", heap_id);
 			return -EINVAL;
 		}
-		heap_addr = amdxdna_gem_uva(heap);
-		if (heap_addr == AMDXDNA_INVALID_ADDR) {
-			XDNA_ERR(xdna, "Heap %d is not mapped", heap_id);
-			return -EAGAIN;
-		}
 
-		if (heap_addr != exp_heap_uva) {
-			XDNA_ERR(xdna, "Heap %d uva is not contiguous", heap_id);
-			return -EINVAL;
+		if (amdxdna_pasid_on(client)) {
+			heap_addr = amdxdna_gem_uva(heap);
+			if (heap_addr == AMDXDNA_INVALID_ADDR) {
+				XDNA_ERR(xdna, "Heap %d is not mapped", heap_id);
+				return -EAGAIN;
+			}
+			if (heap_addr != exp_heap_uva) {
+				XDNA_ERR(xdna, "Heap %d uva is not contiguous", heap_id);
+				return -EINVAL;
+			}
+		} else if (amdxdna_iova_on(xdna) &&
+			   heap->mem.dma_addr == AMDXDNA_INVALID_ADDR) {
+			XDNA_ERR(xdna, "Heap %d is not dma mapped", heap_id);
+			return -EAGAIN;
 		}
 
 		if (heap->dev_addr + heap->mem.size >=
 		    dev_bo->mm_node.start + dev_bo->mem.size)
 			break;
 
-		exp_heap_uva += heap->mem.size;
+		if (amdxdna_pasid_on(client))
+			exp_heap_uva += heap->mem.size;
 	}
 
 	if (heap_id == client->dev_heap_nid) {

--- a/drivers/accel/amdxdna/amdxdna_gem.c
+++ b/drivers/accel/amdxdna/amdxdna_gem.c
@@ -826,6 +826,20 @@ amdxdna_gem_create_ubuf_object(struct drm_device *dev, struct amdxdna_drm_create
 	abo = to_xdna_obj(gobj);
 	abo->pri = true;
 
+	/*
+	 * Userptr imports do not use drm_gem_mmap(); record the first va_tbl
+	 * entry so GET_BO_INFO and PASID dev-heap checks see the CPU UVA
+	 * (e.g. vxdna guest coalesce path).
+	 */
+	if (va_tbl.num_entries) {
+		struct amdxdna_drm_va_entry ent;
+
+		if (!copy_from_user(&ent,
+				    u64_to_user_ptr(args->vaddr + sizeof(va_tbl)),
+				    sizeof(ent)) && ent.vaddr)
+			abo->mem.uva = ent.vaddr;
+	}
+
 	return abo;
 }
 

--- a/drivers/accel/amdxdna/amdxdna_ubuf.c
+++ b/drivers/accel/amdxdna/amdxdna_ubuf.c
@@ -7,6 +7,8 @@
 #include <drm/drm_device.h>
 #include <drm/drm_print.h>
 #include <linux/dma-buf.h>
+#include <linux/iosys-map.h>
+#include <linux/limits.h>
 #include <linux/overflow.h>
 #include <linux/pagemap.h>
 #include <linux/vmalloc.h>
@@ -87,6 +89,29 @@ static const struct vm_operations_struct amdxdna_ubuf_vm_ops = {
 	.fault = amdxdna_ubuf_vm_fault,
 };
 
+static int amdxdna_ubuf_vmap(struct dma_buf *dbuf, struct iosys_map *map)
+{
+	struct amdxdna_ubuf_priv *ubuf = dbuf->priv;
+	void *kva;
+
+	if (ubuf->nr_pages > UINT_MAX)
+		return -EINVAL;
+
+	kva = vmap(ubuf->pages, (unsigned int)ubuf->nr_pages, VM_MAP, PAGE_KERNEL);
+	if (!kva)
+		return -ENOMEM;
+
+	iosys_map_set_vaddr(map, kva);
+	return 0;
+}
+
+static void amdxdna_ubuf_vunmap(struct dma_buf *dbuf, struct iosys_map *map)
+{
+	if (map->vaddr)
+		vunmap(map->vaddr);
+	iosys_map_clear(map);
+}
+
 static const struct dma_buf_ops amdxdna_ubuf_dmabuf_ops = {
 #ifdef HAVE_cache_sgt_mapping
 	.cache_sgt_mapping = true,
@@ -94,6 +119,8 @@ static const struct dma_buf_ops amdxdna_ubuf_dmabuf_ops = {
 	.map_dma_buf = amdxdna_ubuf_map,
 	.unmap_dma_buf = amdxdna_ubuf_unmap,
 	.release = amdxdna_ubuf_release,
+	.vmap = amdxdna_ubuf_vmap,
+	.vunmap = amdxdna_ubuf_vunmap,
 };
 
 static int readonly_va_entry(struct amdxdna_drm_va_entry *va_ent)

--- a/src/vxdna/src/vaccel_amdxdna.cpp
+++ b/src/vxdna/src/vaccel_amdxdna.cpp
@@ -167,7 +167,7 @@ mmap_aligned_coalesce_backing(size_t total, const struct iovec *iov, uint32_t n,
     }
 
     /* Pre-mremap: aligned coalesce window must not overlap any iov slice. */
-    if (iov_table_overlaps(aligned, total, iov, n)) {
+    if (n && iov_table_overlaps(aligned, total, iov, n)) {
         munmap(p, map_sz);
         VACCEL_THROW_MSG(-ENOMEM,
                          "64MiB-aligned coalesce VA overlaps guest iovec mappings; retry BO create");
@@ -216,12 +216,12 @@ struct coalesce_backing {
 };
 
 /*
- * Guest-backed userptr BOs (SHARE, CMD, DEV_HEAP, …): sum iovec lengths, reserve
- * one coalesced VMA, and duplicate every slice into it with mremap(old_size=0).
- * DEV_HEAP additionally requires a 64 MiB-aligned coalesce base.
+ * Guest-backed userptr BOs (SHARE, CMD, …): sum iovec lengths, reserve one
+ * coalesced VMA, and duplicate every slice into it with mremap(old_size=0).
+ * DEV_HEAP chunks use a slice of the context's 64 MiB-aligned arena instead.
  */
 coalesce_backing
-reserve_coalesce_backing(const struct iovec *iov, uint32_t n, bool heap_align)
+reserve_coalesce_backing(const struct iovec *iov, uint32_t n)
 {
     if (!n)
         VACCEL_THROW_MSG(-EINVAL, "Resource has no iovecs for user-pointer BO create");
@@ -240,12 +240,7 @@ reserve_coalesce_backing(const struct iovec *iov, uint32_t n, bool heap_align)
         total += len;
     }
 
-    void *va;
-
-    if (heap_align)
-        va = mmap_aligned_coalesce_backing(total, iov, n, k_dev_heap_uva_align);
-    else
-        va = mmap_coalesce_backing(total, iov, n);
+    void *va = mmap_coalesce_backing(total, iov, n);
 
     return { va, total };
 }
@@ -321,15 +316,44 @@ vxdna_bo(int ctx_fd_in, const struct amdxdna_ccmd_create_bo_req *req)
     vxdna_dbg("Created bo: ctx_fd=%d, handle=%u, xdna_addr=%lu", m_ctx_fd, m_bo_handle, m_xdna_addr);
 }
 
+void *
+vxdna_context::
+ensure_heap_arena()
+{
+    if (m_heap_arena_va)
+        return m_heap_arena_va;
+
+    const size_t arena_cap = static_cast<size_t>(HEAP_MAX_SIZE);
+
+    m_heap_arena_va = mmap_aligned_coalesce_backing(arena_cap, nullptr, 0,
+                                                    k_dev_heap_uva_align);
+    m_heap_arena_cap = arena_cap;
+    vxdna_dbg("Context %u: heap arena at %p size 0x%zx", get_id(), m_heap_arena_va,
+              m_heap_arena_cap);
+    return m_heap_arena_va;
+}
+
+void
+vxdna_context::
+release_heap_arena() noexcept
+{
+    if (!m_heap_arena_va || !m_heap_arena_cap)
+        return;
+    if (munmap(m_heap_arena_va, m_heap_arena_cap) != 0)
+        vxdna_err("munmap heap arena failed errno %d", errno);
+    m_heap_arena_va = nullptr;
+    m_heap_arena_cap = 0;
+}
+
 vxdna_bo::
-vxdna_bo(const std::shared_ptr<vaccel_resource> &res, int ctx_fd_in,
+vxdna_bo(const std::shared_ptr<vaccel_resource> &res, vxdna_context &ctx,
          const struct amdxdna_ccmd_create_bo_req *req)
          : m_opaque_handle(res->get_opaque_handle())
 {
     struct amdxdna_drm_get_bo_info bo_info = {};
     int ret;
 
-    m_ctx_fd = ctx_fd_in;
+    m_ctx_fd = ctx.get_fd();
     m_bo_type = req->bo_type;
     m_size = req->size;
     m_iov_bytes = 0;
@@ -346,27 +370,53 @@ vxdna_bo(const std::shared_ptr<vaccel_resource> &res, int ctx_fd_in,
 
     bool created_here = false;
     if (m_opaque_handle == AMDXDNA_INVALID_BO_HANDLE) {
-        const bool heap_align = (m_bo_type == AMDXDNA_BO_DEV_HEAP);
-        auto backing = reserve_coalesce_backing(iovecs, num_iovs, heap_align);
-        void *coalesce = backing.va;
-        const size_t total = backing.len;
+        const bool heap_chunk = (m_bo_type == AMDXDNA_BO_DEV_HEAP);
+        void *coalesce = nullptr;
+        size_t total = 0;
 
-        if (m_size > total)
+        for (uint32_t i = 0; i < num_iovs; i++)
+            total += iovecs[i].iov_len;
+
+        if (heap_chunk) {
+            if (m_size != static_cast<uint64_t>(total))
+                VACCEL_THROW_MSG(-EINVAL,
+                                 "DEV_HEAP size 0x%lx must equal iovec total 0x%zx",
+                                 static_cast<unsigned long>(m_size), total);
+
+            void *arena = ctx.ensure_heap_arena();
+            const uint64_t off = ctx.m_heap_committed;
+
+            if (off + m_size > vxdna_context::HEAP_MAX_SIZE)
+                VACCEL_THROW_MSG(-ENOSPC,
+                                 "heap chunk at 0x%llx + 0x%lx exceeds arena 0x%llx",
+                                 static_cast<unsigned long long>(off),
+                                 static_cast<unsigned long>(m_size),
+                                 static_cast<unsigned long long>(
+                                     vxdna_context::HEAP_MAX_SIZE));
+            coalesce = static_cast<char *>(arena) + static_cast<size_t>(off);
+        } else {
+            auto backing = reserve_coalesce_backing(iovecs, num_iovs);
+            coalesce = backing.va;
+            total = backing.len;
+            m_coalesce_va = coalesce;
+            m_coalesce_len = total;
+        }
+
+        if (!heap_chunk && m_size > total)
             VACCEL_THROW_MSG(-EINVAL,
                              "create_bo size 0x%lx exceeds resource backing 0x%zx",
                              static_cast<unsigned long>(m_size), total);
 
-        if (heap_align)
-            vxdna_dbg("Heap BO: coalesce UVA 64MiB-aligned at %p size %zu", coalesce, total);
-
         try {
             mremap_iovs_into_coalesce(coalesce, iovecs, num_iovs);
         } catch (...) {
-            munmap(coalesce, total);
+            if (m_coalesce_va && m_coalesce_len) {
+                munmap(m_coalesce_va, m_coalesce_len);
+                m_coalesce_va = nullptr;
+                m_coalesce_len = 0;
+            }
             throw;
         }
-        m_coalesce_va = coalesce;
-        m_coalesce_len = total;
         m_iov_bytes = total;
         m_vaddr = static_cast<uint64_t>(reinterpret_cast<uintptr_t>(coalesce));
 
@@ -378,7 +428,7 @@ vxdna_bo(const std::shared_ptr<vaccel_resource> &res, int ctx_fd_in,
         tbl->num_entries = 1;
         tbl->va_entries[0].vaddr =
             static_cast<uint64_t>(reinterpret_cast<uintptr_t>(coalesce));
-        tbl->va_entries[0].len = static_cast<uint64_t>(total);
+        tbl->va_entries[0].len = static_cast<uint64_t>(m_size);
 
         struct amdxdna_drm_create_bo args = {};
         args.vaddr = static_cast<uint64_t>(reinterpret_cast<uintptr_t>(buf_vec.data()));
@@ -386,9 +436,11 @@ vxdna_bo(const std::shared_ptr<vaccel_resource> &res, int ctx_fd_in,
         args.type = m_bo_type;
         ret = ioctl(m_ctx_fd, DRM_IOCTL_AMDXDNA_CREATE_BO, &args);
         if (ret) {
-            munmap(m_coalesce_va, m_coalesce_len);
-            m_coalesce_va = nullptr;
-            m_coalesce_len = 0;
+            if (m_coalesce_va && m_coalesce_len) {
+                munmap(m_coalesce_va, m_coalesce_len);
+                m_coalesce_va = nullptr;
+                m_coalesce_len = 0;
+            }
             VACCEL_THROW_MSG(-errno, "Create bo failed ret %d, errno %d, %s", ret, errno, strerror(errno));
         }
         m_bo_handle = args.handle;
@@ -414,8 +466,8 @@ vxdna_bo(const std::shared_ptr<vaccel_resource> &res, int ctx_fd_in,
     m_map_offset = bo_info.map_offset;
     m_xdna_addr = bo_info.xdna_addr;
 
-    /* Coalesced userptr BOs: CPU UVA is the coalesce mapping, not GET_BO_INFO. */
-    if (!m_coalesce_va) {
+    /* Opaque import: CPU UVA from GET_BO_INFO. Created userptr BOs keep coalesce UVA. */
+    if (!created_here) {
         m_vaddr = bo_info.vaddr;
         if (m_vaddr == AMDXDNA_INVALID_ADDR || m_vaddr == 0)
             VACCEL_THROW_MSG(-EINVAL,
@@ -641,11 +693,17 @@ create_bo(const struct amdxdna_ccmd_create_bo_req *req)
         VACCEL_THROW_MSG(-EINVAL, "Heap destroyed, cannot allocate type %u", req->bo_type);
 
     if (req->bo_type == AMDXDNA_BO_DEV_HEAP) {
-        if (!req->size || req->size > HEAP_MAX_SIZE - m_heap_committed)
+        if (!req->size || (req->size % k_dev_heap_uva_align) != 0)
+            VACCEL_THROW_MSG(-EINVAL,
+                             "DEV_HEAP size 0x%lx must be non-zero and 0x%zx aligned "
+                             "(dev_mem_size)",
+                             static_cast<unsigned long>(req->size), k_dev_heap_uva_align);
+        if (req->size > HEAP_MAX_SIZE - m_heap_committed)
             VACCEL_THROW_MSG(-ENOSPC,
-                             "Heap expansion rejected: size 0x%lx, remaining 0x%zx",
-                             (unsigned long)req->size,
-                             static_cast<size_t>(HEAP_MAX_SIZE - m_heap_committed));
+                             "Heap expansion rejected: size 0x%lx, remaining 0x%llx",
+                             static_cast<unsigned long>(req->size),
+                             static_cast<unsigned long long>(HEAP_MAX_SIZE -
+                                                             m_heap_committed));
     }
 
     std::shared_ptr<vxdna_bo> xdna_bo;
@@ -654,7 +712,7 @@ create_bo(const struct amdxdna_ccmd_create_bo_req *req)
         if (!res)
             VACCEL_THROW_MSG(-EINVAL, "Res: %u not found", req->res_id);
 
-        xdna_bo = std::make_shared<vxdna_bo>(res, get_fd(), req);
+        xdna_bo = std::make_shared<vxdna_bo>(res, *this, req);
     } else {
         xdna_bo = std::make_shared<vxdna_bo>(get_fd(), req);
     }

--- a/src/vxdna/src/vaccel_amdxdna.cpp
+++ b/src/vxdna/src/vaccel_amdxdna.cpp
@@ -1,6 +1,10 @@
 // SPDX-License-Identifier: MIT
 // Copyright (C) 2025 - 2026, Advanced Micro Devices, Inc. All rights reserved.
 
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+
 /*
  * AMDXDNA Device Management
  * Provides device initialization, buffer object management, context handling,
@@ -17,6 +21,8 @@
 #include <filesystem>
 #include <fstream>
 #include <climits>
+#include <limits>
+#include <unistd.h>
 #include <sstream>
 #include <sys/stat.h>
 #include <thread>
@@ -38,10 +44,228 @@
 #include "vaccel_amdxdna.h"
 #include "../util/vxdna_debug.h"
 
-/**
- * @brief Helper to close a DRM GEM handle (used for cleanup on exception)
+namespace {
+
+/* Host driver notifies FW in dev_mem_size chunks (typically 64 MiB). UVA must align. */
+constexpr size_t k_dev_heap_uva_align = 64UL << 20;
+
+size_t
+page_size()
+{
+    static size_t ps = 0;
+
+    if (!ps) {
+        long r = sysconf(_SC_PAGESIZE);
+
+        ps = (r > 0) ? static_cast<size_t>(r) : 4096;
+    }
+    return ps;
+}
+
+/*
+ * Helpers for iov_table_overlaps(): detect whether the coalesce destination
+ * [base, base+len) intersects any guest iovec before mremap(old_size=0).  Overlap
+ * would make dest and source the same VA range; mremap would fail (typically
+ * EINVAL) — we fail early with a clear error instead of inside mremap_dup_to_fixed.
  */
-static void
+bool
+uintptr_range_end(uintptr_t base, size_t len, uintptr_t *end_out)
+{
+    if (len > std::numeric_limits<uintptr_t>::max() || base > std::numeric_limits<uintptr_t>::max() - len)
+        return false;
+    *end_out = base + len;
+    return true;
+}
+
+bool
+uintptr_ranges_overlap(uintptr_t a0, uintptr_t a1, uintptr_t b0, uintptr_t b1)
+{
+    return a0 < b1 && b0 < a1;
+}
+
+/*
+ * True if coalesce destination [base, base+len) intersects any iovec (mremap source).
+ * Called from mmap_coalesce_backing() / mmap_aligned_coalesce_backing() immediately
+ * after reserving the arena and before mremap_iovs_into_coalesce().  On arithmetic
+ * overflow, returns true so callers fail closed.
+ */
+bool
+iov_table_overlaps(uintptr_t base, size_t len, const struct iovec *iov, uint32_t n)
+{
+    uintptr_t end;
+
+    if (!uintptr_range_end(base, len, &end))
+        return true;
+
+    for (uint32_t i = 0; i < n; i++) {
+        uintptr_t a = reinterpret_cast<uintptr_t>(iov[i].iov_base);
+        uintptr_t b;
+
+        if (!uintptr_range_end(a, iov[i].iov_len, &b))
+            return true;
+        if (uintptr_ranges_overlap(base, end, a, b))
+            return true;
+    }
+    return false;
+}
+
+void *
+mmap_coalesce_backing(size_t total, const struct iovec *iov, uint32_t n)
+{
+    for (int attempt = 0; attempt < 24; attempt++) {
+        void *p = mmap(nullptr, total, PROT_READ | PROT_WRITE,
+                       MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+
+        if (p == MAP_FAILED)
+            VACCEL_THROW_MSG(-errno, "mmap for coalesced userptr BO failed");
+
+        /* Pre-mremap: coalesce VA must not overlap any iov_base slice. */
+        if (!iov_table_overlaps(reinterpret_cast<uintptr_t>(p), total, iov, n))
+            return p;
+        munmap(p, total);
+    }
+    VACCEL_THROW_MSG(-ENOMEM,
+                     "Could not reserve VA for coalesced userptr BO without overlapping iovecs");
+}
+
+/*
+ * Like mmap_coalesce_backing(), but after mmap trims to a @uva_align-aligned
+ * subrange of length @total (head/tail munmap). Required for AMDXDNA_BO_DEV_HEAP
+ * so MAP_HOST_BUFFER sees a 64 MiB-aligned user VA (matches kernel dev_mem_size).
+ */
+void *
+mmap_aligned_coalesce_backing(size_t total, const struct iovec *iov, uint32_t n,
+                               size_t uva_align)
+{
+    const size_t ps = page_size();
+
+    if (uva_align < ps || (uva_align % ps) != 0)
+        VACCEL_THROW_MSG(-EINVAL, "UVA alignment %zu must be a multiple of page size %zu",
+                         uva_align, ps);
+
+    const size_t slack = uva_align - 1;
+    size_t map_sz = total + slack;
+
+    if (map_sz < total)
+        VACCEL_THROW_MSG(-EINVAL, "aligned coalesce map size overflow");
+
+    map_sz = (map_sz + ps - 1) / ps * ps;
+
+    void *p = mmap(nullptr, map_sz, PROT_READ | PROT_WRITE,
+                   MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+
+    if (p == MAP_FAILED)
+        VACCEL_THROW_MSG(-errno, "mmap for aligned coalesced userptr BO failed");
+
+    const uintptr_t pb = reinterpret_cast<uintptr_t>(p);
+    const uintptr_t aligned = (pb + uva_align - 1) & ~(uva_align - 1);
+
+    if (aligned < pb || aligned + total < aligned ||
+        aligned + total > pb + map_sz) {
+        munmap(p, map_sz);
+        VACCEL_THROW_MSG(-EINVAL, "aligned coalesce internal size error");
+    }
+
+    /* Pre-mremap: aligned coalesce window must not overlap any iov slice. */
+    if (iov_table_overlaps(aligned, total, iov, n)) {
+        munmap(p, map_sz);
+        VACCEL_THROW_MSG(-ENOMEM,
+                         "64MiB-aligned coalesce VA overlaps guest iovec mappings; retry BO create");
+    }
+
+    const uintptr_t tail = aligned + total;
+    const uintptr_t end = pb + map_sz;
+
+    if (aligned > pb) {
+        if (munmap(p, aligned - pb) != 0) {
+            munmap(p, map_sz);
+            VACCEL_THROW_MSG(-errno, "munmap head trim for aligned coalesce failed");
+        }
+    }
+
+    if (tail < end) {
+        if (munmap(reinterpret_cast<void *>(tail), end - tail) != 0) {
+            munmap(reinterpret_cast<void *>(aligned), end - aligned);
+            VACCEL_THROW_MSG(-errno, "munmap tail trim for aligned coalesce failed");
+        }
+    }
+
+    return reinterpret_cast<void *>(aligned);
+}
+
+void
+mremap_dup_to_fixed(void *old_base, size_t len, void *new_base)
+{
+    /*
+     * Only MAP_SHARED (or other shareable) sources are supported: old_size==0
+     * duplicates the same physical pages at new_base while keeping the original
+     * mapping. Private anonymous / bounce buffers fail with EINVAL (no fallback).
+     */
+    void *ret = mremap(old_base, 0, len, MREMAP_MAYMOVE | MREMAP_FIXED, new_base);
+
+    if (ret == MAP_FAILED)
+        VACCEL_THROW_MSG(-errno,
+                         "mremap coalesce failed (need shareable mapping, old_size=0): "
+                         "old=%p len=%zu new=%p",
+                         old_base, len, new_base);
+}
+
+struct coalesce_backing {
+    void *va;
+    size_t len;
+};
+
+/*
+ * Guest-backed userptr BOs (SHARE, CMD, DEV_HEAP, …): sum iovec lengths, reserve
+ * one coalesced VMA, and duplicate every slice into it with mremap(old_size=0).
+ * DEV_HEAP additionally requires a 64 MiB-aligned coalesce base.
+ */
+coalesce_backing
+reserve_coalesce_backing(const struct iovec *iov, uint32_t n, bool heap_align)
+{
+    if (!n)
+        VACCEL_THROW_MSG(-EINVAL, "Resource has no iovecs for user-pointer BO create");
+
+    const size_t ps = page_size();
+    size_t total = 0;
+
+    for (uint32_t i = 0; i < n; i++) {
+        const uintptr_t base = reinterpret_cast<uintptr_t>(iov[i].iov_base);
+        const size_t len = iov[i].iov_len;
+
+        if ((base % ps) != 0 || (len % ps) != 0)
+            VACCEL_THROW_MSG(-EINVAL,
+                             "iovec %u must be page-aligned for userptr BO (base=0x%lx len=%zu)",
+                             i, static_cast<unsigned long>(base), len);
+        total += len;
+    }
+
+    void *va;
+
+    if (heap_align)
+        va = mmap_aligned_coalesce_backing(total, iov, n, k_dev_heap_uva_align);
+    else
+        va = mmap_coalesce_backing(total, iov, n);
+
+    return { va, total };
+}
+
+void
+mremap_iovs_into_coalesce(void *coalesce, const struct iovec *iov, uint32_t n)
+{
+    size_t off = 0;
+
+    for (uint32_t i = 0; i < n; i++) {
+        void *oldb = iov[i].iov_base;
+        size_t len = iov[i].iov_len;
+        void *newb = static_cast<char *>(coalesce) + off;
+
+        mremap_dup_to_fixed(oldb, len, newb);
+        off += len;
+    }
+}
+
+void
 close_gem_handle(int fd, uint32_t handle)
 {
     if (handle != AMDXDNA_INVALID_BO_HANDLE) {
@@ -50,6 +274,8 @@ close_gem_handle(int fd, uint32_t handle)
         ioctl(fd, DRM_IOCTL_GEM_CLOSE, &arg);
     }
 }
+
+} // namespace
 
 vxdna_bo::
 vxdna_bo(int ctx_fd_in, const struct amdxdna_ccmd_create_bo_req *req)
@@ -62,10 +288,16 @@ vxdna_bo(int ctx_fd_in, const struct amdxdna_ccmd_create_bo_req *req)
     m_ctx_fd = ctx_fd_in;
     m_bo_type = req->bo_type;
     m_size = req->size;
-    m_map_size = 0;
+    m_iov_bytes = 0;
     m_map_offset = 0;
     m_vaddr = AMDXDNA_INVALID_ADDR;
     m_xdna_addr = AMDXDNA_INVALID_ADDR;
+
+    if (m_bo_type != AMDXDNA_BO_DEV)
+        VACCEL_THROW_MSG(-EINVAL,
+                         "Device-local create supports AMDXDNA_BO_DEV only, not type %u",
+                         m_bo_type);
+
     args.size = m_size;
     args.type = m_bo_type;
     vxdna_dbg("Create bo: ctx_fd=%d, type=%d, size=%lu", m_ctx_fd, m_bo_type, m_size);
@@ -91,8 +323,7 @@ vxdna_bo(int ctx_fd_in, const struct amdxdna_ccmd_create_bo_req *req)
 
 vxdna_bo::
 vxdna_bo(const std::shared_ptr<vaccel_resource> &res, int ctx_fd_in,
-         const struct amdxdna_ccmd_create_bo_req *req,
-         void *mmap_target)
+         const struct amdxdna_ccmd_create_bo_req *req)
          : m_opaque_handle(res->get_opaque_handle())
 {
     struct amdxdna_drm_get_bo_info bo_info = {};
@@ -101,136 +332,107 @@ vxdna_bo(const std::shared_ptr<vaccel_resource> &res, int ctx_fd_in,
     m_ctx_fd = ctx_fd_in;
     m_bo_type = req->bo_type;
     m_size = req->size;
-    m_map_size = 0;
-    const struct iovec *iovecs;
+    m_iov_bytes = 0;
+    m_map_offset = 0;
+    m_vaddr = AMDXDNA_INVALID_ADDR;
+    m_xdna_addr = AMDXDNA_INVALID_ADDR;
+
+    if (m_bo_type == AMDXDNA_BO_DEV)
+        VACCEL_THROW_MSG(-EINVAL,
+                         "AMDXDNA_BO_DEV must use device-local create (no resource/iovec)");
+
+    const struct iovec *iovecs = nullptr;
     auto num_iovs = res->get_iovecs(&iovecs);
 
-    // Use vector to avoid VLA and potential stack overflow
-    if (num_iovs > ((UINT32_MAX - sizeof(amdxdna_drm_va_tbl)) / sizeof(amdxdna_drm_va_entry)))
-        VACCEL_THROW_MSG(-EINVAL, "Too many iovecs: %u", num_iovs);
-    size_t buf_size = sizeof(amdxdna_drm_va_tbl) + sizeof(amdxdna_drm_va_entry) * num_iovs;
-    std::vector<uint8_t> buf_vec(buf_size);
-    auto tbl = reinterpret_cast<amdxdna_drm_va_tbl*>(buf_vec.data());
-    tbl->udma_fd = -1;
-    tbl->num_entries = num_iovs;
-    for (uint32_t i = 0; i < num_iovs; i++) {
-        tbl->va_entries[i].vaddr = static_cast<uint64_t>(reinterpret_cast<uintptr_t>(iovecs[i].iov_base));
-        tbl->va_entries[i].len = static_cast<uint64_t>(iovecs[i].iov_len);
-        m_map_size += tbl->va_entries[i].len;
-    }
-
-    // Track whether we created the BO (for cleanup on exception)
-    bool has_created_bo = false;
+    bool created_here = false;
     if (m_opaque_handle == AMDXDNA_INVALID_BO_HANDLE) {
+        const bool heap_align = (m_bo_type == AMDXDNA_BO_DEV_HEAP);
+        auto backing = reserve_coalesce_backing(iovecs, num_iovs, heap_align);
+        void *coalesce = backing.va;
+        const size_t total = backing.len;
+
+        if (m_size > total)
+            VACCEL_THROW_MSG(-EINVAL,
+                             "create_bo size 0x%lx exceeds resource backing 0x%zx",
+                             static_cast<unsigned long>(m_size), total);
+
+        if (heap_align)
+            vxdna_dbg("Heap BO: coalesce UVA 64MiB-aligned at %p size %zu", coalesce, total);
+
+        try {
+            mremap_iovs_into_coalesce(coalesce, iovecs, num_iovs);
+        } catch (...) {
+            munmap(coalesce, total);
+            throw;
+        }
+        m_coalesce_va = coalesce;
+        m_coalesce_len = total;
+        m_iov_bytes = total;
+        m_vaddr = static_cast<uint64_t>(reinterpret_cast<uintptr_t>(coalesce));
+
+        size_t buf_size = sizeof(amdxdna_drm_va_tbl) + sizeof(amdxdna_drm_va_entry);
+        std::vector<uint8_t> buf_vec(buf_size);
+        auto tbl = reinterpret_cast<amdxdna_drm_va_tbl *>(buf_vec.data());
+
+        tbl->udma_fd = -1;
+        tbl->num_entries = 1;
+        tbl->va_entries[0].vaddr =
+            static_cast<uint64_t>(reinterpret_cast<uintptr_t>(coalesce));
+        tbl->va_entries[0].len = static_cast<uint64_t>(total);
+
         struct amdxdna_drm_create_bo args = {};
         args.vaddr = static_cast<uint64_t>(reinterpret_cast<uintptr_t>(buf_vec.data()));
         args.size = m_size;
         args.type = m_bo_type;
         ret = ioctl(m_ctx_fd, DRM_IOCTL_AMDXDNA_CREATE_BO, &args);
-        if (ret)
-            VACCEL_THROW_MSG(-errno, "Create bo failed ret %d, errno %d, %s", ret, -errno, strerror(errno));
+        if (ret) {
+            munmap(m_coalesce_va, m_coalesce_len);
+            m_coalesce_va = nullptr;
+            m_coalesce_len = 0;
+            VACCEL_THROW_MSG(-errno, "Create bo failed ret %d, errno %d, %s", ret, errno, strerror(errno));
+        }
         m_bo_handle = args.handle;
-        has_created_bo = true;
+        created_here = true;
     } else {
-        m_bo_handle = m_opaque_handle;
+        m_bo_handle = static_cast<uint32_t>(m_opaque_handle);
     }
 
     bo_info.handle = m_bo_handle;
     ret = ioctl(m_ctx_fd, DRM_IOCTL_AMDXDNA_GET_BO_INFO, &bo_info);
     if (ret) {
-        // Clean up the handle we created before throwing (only if we created it)
-        if (has_created_bo) {
+        if (created_here) {
             close_gem_handle(m_ctx_fd, m_bo_handle);
+            if (m_coalesce_va && m_coalesce_len) {
+                munmap(m_coalesce_va, m_coalesce_len);
+                m_coalesce_va = nullptr;
+                m_coalesce_len = 0;
+            }
         }
         VACCEL_THROW_MSG(-errno, "Get bo info failed ret %d", ret);
     }
 
     m_map_offset = bo_info.map_offset;
     m_xdna_addr = bo_info.xdna_addr;
-    m_vaddr = bo_info.vaddr;
 
-    if (m_map_offset == AMDXDNA_INVALID_ADDR) {
-        // TODO: In case of HOST memory, there is no iovecs; however, the current amdxdna driver
-        // requires BOs to be backed by a user pointer. As a result, we still need to mmap the BO
-        // here to provide a user pointer to the driver. See the AMDXDNA BO creation ABI
-        // (struct amdxdna_drm_create_bo and DRM_IOCTL_AMDXDNA_CREATE_BO) in
-        // drm_local/amdxdna_accel.h. Once the driver supports HOST BOs without a user pointer,
-        // this mmap requirement and the associated workaround can be removed.
-        if (m_bo_type != AMDXDNA_BO_DEV) {
-            // Clean up if we created the BO
-            if (has_created_bo) {
-                close_gem_handle(m_ctx_fd, m_bo_handle);
-            }
-            VACCEL_THROW_MSG(-EINVAL, "Non-DEV BO without map offset! handle=%u, type=%u", m_bo_handle, m_bo_type);
-        }
-        vxdna_dbg("No need to mmap for memory type, no map offset: handle=%u, xdna_addr=%lx, vaddr=%lx",
-                  m_bo_handle, m_xdna_addr, m_vaddr);
-        return;
-    }
-
-    if (!m_map_size)
-        m_map_size = m_size;
-
-    vxdna_dbg("mmap is required for handle: res_id=%u, handle=%u, opaque_handle=%d, vaddr=%lx, xdna_addr=%lx",
-              res->get_res_id(), m_bo_handle, res->get_opaque_handle(), m_vaddr, m_xdna_addr);
-    uint64_t resv_vaddr = 0, resv_size = 0, va_to_map = 0;
-    void *resv_va = nullptr;
-    int flags = MAP_SHARED | MAP_LOCKED;
-    if (mmap_target) {
-        va_to_map = reinterpret_cast<uint64_t>(mmap_target);
-        if (req->map_align && (va_to_map & (req->map_align - 1))) {
-            if (has_created_bo)
-                close_gem_handle(m_ctx_fd, m_bo_handle);
+    /* Coalesced userptr BOs: CPU UVA is the coalesce mapping, not GET_BO_INFO. */
+    if (!m_coalesce_va) {
+        m_vaddr = bo_info.vaddr;
+        if (m_vaddr == AMDXDNA_INVALID_ADDR || m_vaddr == 0)
             VACCEL_THROW_MSG(-EINVAL,
-                             "mmap_target %p not aligned to 0x%lx",
-                             mmap_target, (unsigned long)req->map_align);
-        }
-        flags |= MAP_FIXED;
-    } else if (req->map_align) {
-        resv_va = ::mmap(0, m_map_size + req->map_align, PROT_READ | PROT_WRITE,
-                         MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
-        if (resv_va == MAP_FAILED) {
-            if (has_created_bo)
-                close_gem_handle(m_ctx_fd, m_bo_handle);
-            VACCEL_THROW_MSG(-ENOMEM, "Reserve vaddr range failed, map_align=%zu", req->map_align);
-        }
-
-        resv_size = m_map_size + req->map_align;
-        resv_vaddr = reinterpret_cast<uint64_t>(resv_va);
-        va_to_map = (resv_vaddr + req->map_align - 1) & ~(req->map_align - 1);
-        flags |= MAP_FIXED;
+                             "Pre-imported BO without CPU UVA from GET_BO_INFO: handle=%u, type=%u",
+                             m_bo_handle, m_bo_type);
     }
-    void *va = ::mmap(reinterpret_cast<void *>(va_to_map), m_map_size, PROT_READ | PROT_WRITE,
-                           flags, m_ctx_fd, m_map_offset);
 
-    if (va == MAP_FAILED) {
-        int saved_errno = errno;
-        if (resv_va && resv_va != MAP_FAILED)
-            ::munmap(resv_va, resv_size);
-        if (has_created_bo)
-            close_gem_handle(m_ctx_fd, m_bo_handle);
-        VACCEL_THROW_MSG(-saved_errno,
-                         "Map bo failed, errno %d, %s, to map startaddr 0x%lx, map_offset 0x%lx, map_size 0x%lx",
-                         saved_errno, strerror(saved_errno), va_to_map, m_map_offset, m_map_size);
-    }
-    m_vaddr = reinterpret_cast<uint64_t>(va);
-
-    if (!mmap_target && req->map_align && m_vaddr > resv_vaddr)
-        ::munmap(resv_va, static_cast<size_t>(m_vaddr - resv_vaddr));
-    if (!mmap_target && resv_vaddr + resv_size > m_vaddr + m_map_size)
-        munmap(reinterpret_cast<void *>(m_vaddr + m_map_size),
-               static_cast<size_t>(resv_vaddr + resv_size - m_vaddr - m_map_size));
-    vxdna_dbg("Created BO with resource: type=%u, res_id=%u, vaddr=0x%lx",
-              req->bo_type, req->res_id, m_vaddr);
+    vxdna_dbg("Resource BO: res_id=%u, handle=%u, vaddr=0x%lx, xdna_addr=0x%lx, iov_bytes=%lu (coalesced UVA)",
+              res->get_res_id(), m_bo_handle, m_vaddr, m_xdna_addr,
+              static_cast<unsigned long>(m_iov_bytes));
 }
 
 vxdna_bo::
 ~vxdna_bo() noexcept
 {
-    vxdna_dbg("vxdna Destroying bo: ctx_fd=%d, handle=%u, vaddr=%lx, map_size=%lu",
-               m_ctx_fd, m_bo_handle, m_vaddr, m_map_size);
-    if (m_vaddr != AMDXDNA_INVALID_ADDR)
-        munmap(reinterpret_cast<void *>(m_vaddr), static_cast<size_t>(m_map_size));
+    vxdna_dbg("vxdna Destroying bo: ctx_fd=%d, handle=%u, vaddr=%lx, iov_bytes=%lu",
+              m_ctx_fd, m_bo_handle, m_vaddr, static_cast<unsigned long>(m_iov_bytes));
     if (m_bo_handle != AMDXDNA_INVALID_BO_HANDLE) {
         struct drm_gem_close arg = {};
         arg.handle = m_bo_handle;
@@ -238,6 +440,12 @@ vxdna_bo::
         auto ret = ioctl(m_ctx_fd, DRM_IOCTL_GEM_CLOSE, &arg);
         if (ret)
             vxdna_err("Close vxdna bo failed ret %d", ret);
+    }
+    if (m_coalesce_va && m_coalesce_len > 0) {
+        if (munmap(m_coalesce_va, m_coalesce_len) != 0)
+            vxdna_err("munmap coalesce va failed errno %d", errno);
+        m_coalesce_va = nullptr;
+        m_coalesce_len = 0;
     }
 }
 
@@ -432,46 +640,21 @@ create_bo(const struct amdxdna_ccmd_create_bo_req *req)
         (req->bo_type == AMDXDNA_BO_DEV || req->bo_type == AMDXDNA_BO_DEV_HEAP))
         VACCEL_THROW_MSG(-EINVAL, "Heap destroyed, cannot allocate type %u", req->bo_type);
 
+    if (req->bo_type == AMDXDNA_BO_DEV_HEAP) {
+        if (!req->size || req->size > HEAP_MAX_SIZE - m_heap_committed)
+            VACCEL_THROW_MSG(-ENOSPC,
+                             "Heap expansion rejected: size 0x%lx, remaining 0x%zx",
+                             (unsigned long)req->size,
+                             static_cast<size_t>(HEAP_MAX_SIZE - m_heap_committed));
+    }
+
     std::shared_ptr<vxdna_bo> xdna_bo;
     if (req->bo_type != AMDXDNA_BO_DEV) {
         auto res = get_device().get_resource(req->res_id);
         if (!res)
             VACCEL_THROW_MSG(-EINVAL, "Res: %u not found", req->res_id);
 
-        void *mmap_target = nullptr;
-        if (req->bo_type == AMDXDNA_BO_DEV_HEAP) {
-            if (!m_heap_base) {
-                size_t align = req->map_align ? req->map_align : 1;
-                size_t resv_sz = HEAP_MAX_SIZE + align;
-                void *p = ::mmap(0, resv_sz, PROT_NONE,
-                                 MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
-                if (p == MAP_FAILED) {
-                    VACCEL_THROW_MSG(-ENOMEM,
-                                     "Failed to reserve heap VA range (%zu bytes)",
-                                     resv_sz);
-                }
-                auto base = reinterpret_cast<uintptr_t>(p);
-                auto aligned = (base + align - 1) & ~(align - 1);
-
-                if (aligned > base)
-                    ::munmap(p, aligned - base);
-                size_t tail = (base + resv_sz) - (aligned + HEAP_MAX_SIZE);
-                if (tail > 0)
-                    ::munmap(reinterpret_cast<void *>(aligned + HEAP_MAX_SIZE), tail);
-
-                m_heap_base = reinterpret_cast<void *>(aligned);
-                vxdna_dbg("Reserved heap VA range: base=%p, size=0x%zx, align=0x%zx",
-                          m_heap_base, HEAP_MAX_SIZE, align);
-            }
-            if (!req->size || req->size > HEAP_MAX_SIZE - m_heap_cur_offset)
-                VACCEL_THROW_MSG(-ENOSPC,
-                                 "Heap expansion rejected: size 0x%lx, remaining 0x%zx",
-                                 (unsigned long)req->size,
-                                 HEAP_MAX_SIZE - m_heap_cur_offset);
-            mmap_target = static_cast<char *>(m_heap_base) + m_heap_cur_offset;
-        }
-
-        xdna_bo = std::make_shared<vxdna_bo>(res, get_fd(), req, mmap_target);
+        xdna_bo = std::make_shared<vxdna_bo>(res, get_fd(), req);
     } else {
         xdna_bo = std::make_shared<vxdna_bo>(get_fd(), req);
     }
@@ -488,7 +671,7 @@ create_bo(const struct amdxdna_ccmd_create_bo_req *req)
     add_bo(std::move(xdna_bo));
 
     if (req->bo_type == AMDXDNA_BO_DEV_HEAP)
-        m_heap_cur_offset += req->size;
+        m_heap_committed += req->size;
     vxdna_dbg("Created bo: handle=%u, xdna_addr=%lu", rsp.handle, rsp.xdna_addr);
 }
 

--- a/src/vxdna/src/vaccel_amdxdna.cpp
+++ b/src/vxdna/src/vaccel_amdxdna.cpp
@@ -62,6 +62,14 @@ page_size()
     return ps;
 }
 
+size_t
+page_roundup(size_t size)
+{
+    const size_t ps = page_size();
+
+    return (size + ps - 1) & ~(ps - 1);
+}
+
 /*
  * Helpers for iov_table_overlaps(): detect whether the coalesce destination
  * [base, base+len) intersects any guest iovec before mremap(old_size=0).  Overlap
@@ -216,8 +224,8 @@ struct coalesce_backing {
 };
 
 /*
- * Guest-backed userptr BOs (SHARE, CMD, …): sum iovec lengths, reserve one
- * coalesced VMA, and duplicate every slice into it with mremap(old_size=0).
+ * Guest-backed userptr BOs (SHARE, CMD, …): one iovec uses backing UVA directly;
+ * multiple iovs reserve one coalesced VMA and duplicate slices with mremap.
  * DEV_HEAP chunks use a slice of the context's 64 MiB-aligned arena instead.
  */
 coalesce_backing
@@ -388,12 +396,23 @@ vxdna_bo(const std::shared_ptr<vaccel_resource> &res, vxdna_context &ctx,
 
             if (off + m_size > vxdna_context::HEAP_MAX_SIZE)
                 VACCEL_THROW_MSG(-ENOSPC,
-                                 "heap chunk at 0x%llx + 0x%lx exceeds arena 0x%llx",
+                                 "heap chunk at 0x%llx + 0x%llx exceeds arena 0x%llx",
                                  static_cast<unsigned long long>(off),
-                                 static_cast<unsigned long>(m_size),
+                                 static_cast<unsigned long long>(m_size),
                                  static_cast<unsigned long long>(
                                      vxdna_context::HEAP_MAX_SIZE));
             coalesce = static_cast<char *>(arena) + static_cast<size_t>(off);
+        } else if (num_iovs == 1) {
+            const uintptr_t base = reinterpret_cast<uintptr_t>(iovecs[0].iov_base);
+            const size_t len = iovecs[0].iov_len;
+            const size_t ps = page_size();
+
+            if ((base % ps) != 0 || (len % ps) != 0)
+                VACCEL_THROW_MSG(-EINVAL,
+                                 "single iovec must be page-aligned (base=0x%lx len=%zu)",
+                                 static_cast<unsigned long>(base), len);
+            coalesce = iovecs[0].iov_base;
+            total = len;
         } else {
             auto backing = reserve_coalesce_backing(iovecs, num_iovs);
             coalesce = backing.va;
@@ -402,20 +421,24 @@ vxdna_bo(const std::shared_ptr<vaccel_resource> &res, vxdna_context &ctx,
             m_coalesce_len = total;
         }
 
-        if (!heap_chunk && m_size > total)
+        const size_t pin_len = page_roundup(m_size);
+        if (pin_len > total)
             VACCEL_THROW_MSG(-EINVAL,
-                             "create_bo size 0x%lx exceeds resource backing 0x%zx",
-                             static_cast<unsigned long>(m_size), total);
+                             "create_bo pin size 0x%zx exceeds resource backing 0x%zx "
+                             "(bo size 0x%lx)",
+                             pin_len, total, static_cast<unsigned long>(m_size));
 
-        try {
-            mremap_iovs_into_coalesce(coalesce, iovecs, num_iovs);
-        } catch (...) {
-            if (m_coalesce_va && m_coalesce_len) {
-                munmap(m_coalesce_va, m_coalesce_len);
-                m_coalesce_va = nullptr;
-                m_coalesce_len = 0;
+        if (heap_chunk || num_iovs > 1) {
+            try {
+                mremap_iovs_into_coalesce(coalesce, iovecs, num_iovs);
+            } catch (...) {
+                if (m_coalesce_va && m_coalesce_len) {
+                    munmap(m_coalesce_va, m_coalesce_len);
+                    m_coalesce_va = nullptr;
+                    m_coalesce_len = 0;
+                }
+                throw;
             }
-            throw;
         }
         m_iov_bytes = total;
         m_vaddr = static_cast<uint64_t>(reinterpret_cast<uintptr_t>(coalesce));
@@ -428,7 +451,7 @@ vxdna_bo(const std::shared_ptr<vaccel_resource> &res, vxdna_context &ctx,
         tbl->num_entries = 1;
         tbl->va_entries[0].vaddr =
             static_cast<uint64_t>(reinterpret_cast<uintptr_t>(coalesce));
-        tbl->va_entries[0].len = static_cast<uint64_t>(m_size);
+        tbl->va_entries[0].len = static_cast<uint64_t>(pin_len);
 
         struct amdxdna_drm_create_bo args = {};
         args.vaddr = static_cast<uint64_t>(reinterpret_cast<uintptr_t>(buf_vec.data()));

--- a/src/vxdna/src/vaccel_amdxdna.h
+++ b/src/vxdna/src/vaccel_amdxdna.h
@@ -26,6 +26,8 @@
 #include "vaccel_internal.h"
 #include "../util/vxdna_debug.h"
 
+class vxdna_context;
+
 /**
  * @brief AMDXDNA Buffer Object wrapper
  *
@@ -54,7 +56,7 @@ public:
      * resources may supply a pre-created GEM handle (opaque).  CPU access
      * uses GET_BO_INFO vaddr; this path does not mmap the DRM device node.
      */
-    vxdna_bo(const std::shared_ptr<vaccel_resource> &res, int ctx_fd_in,
+    vxdna_bo(const std::shared_ptr<vaccel_resource> &res, vxdna_context &ctx,
              const struct amdxdna_ccmd_create_bo_req *req);
 
     /**
@@ -153,7 +155,11 @@ class vxdna;
  * @note Non-copyable and non-movable.
  */
 class vxdna_context : public vaccel_context<vxdna_context, vxdna> {
+    friend class vxdna_bo;
+
 public:
+    static constexpr uint64_t HEAP_MAX_SIZE = 512ULL << 20;
+
     using base_type = vaccel_context<vxdna_context, vxdna>;
 
     /**
@@ -173,8 +179,13 @@ public:
     ~vxdna_context() {
         vxdna_dbg("Context destroying: ctx_id=%u, fd=%d", get_id(), get_fd());
         m_bo_table.clear();
+        release_heap_arena();
         close(get_fd());
     }
+
+    /** One 64 MiB-aligned arena for all DEV_HEAP chunks (contiguous UVAs). */
+    void *ensure_heap_arena();
+    void release_heap_arena() noexcept;
 
     /**
      * @brief Set the response resource for ccmd responses
@@ -511,10 +522,11 @@ private:
     vaccel_map<uint32_t, std::shared_ptr<vxdna_bo>> m_bo_table;
     vaccel_map<uint32_t, std::shared_ptr<vxdna_hwctx>> m_hwctx_table;
 
-    static constexpr size_t HEAP_MAX_SIZE = 512UL << 20;
     /** Cumulative DEV_HEAP size committed on this context (bytes). */
-    size_t m_heap_committed = 0;
+    uint64_t m_heap_committed = 0;
     bool m_heap_destroyed = false;
+    void *m_heap_arena_va = nullptr;
+    size_t m_heap_arena_cap = 0;
 };
 
 /**

--- a/src/vxdna/src/vaccel_amdxdna.h
+++ b/src/vxdna/src/vaccel_amdxdna.h
@@ -42,19 +42,20 @@
 class vxdna_bo {
 public:
     /**
-     * @brief Construct BO backed by guest resource
+     * @brief Construct BO backed by guest or host resource
      *
-     * Creates a buffer object using memory from a vaccel_resource.
-     * The resource's IO vectors provide the backing memory.
-     *
-     * @param res Shared pointer to the backing resource
-     * @param ctx_fd_in Context file descriptor for DRM ioctls
-     * @param req BO creation request with type, size, and alignment
-     * @throws vaccel_error on DRM ioctl failure
+     * Creates or reuses a DRM GEM for the resource.  Guest memory uses a
+     * user-pointer va_tbl: guest resource iovecs (SHARE, CMD, DEV_HEAP, …)
+     * are duplicated into one contiguous mapping via mremap(old_size==0).
+     * DEV_HEAP uses a 64 MiB-aligned coalesce base; other types use a plain
+     * anonymous arena.  AMDXDNA_BO_DEV is not valid here (see vxdna_bo(ctx_fd)).
+     * req->size must not exceed the summed iovec length.
+     * Host blob
+     * resources may supply a pre-created GEM handle (opaque).  CPU access
+     * uses GET_BO_INFO vaddr; this path does not mmap the DRM device node.
      */
     vxdna_bo(const std::shared_ptr<vaccel_resource> &res, int ctx_fd_in,
-             const struct amdxdna_ccmd_create_bo_req *req,
-             void *mmap_target = nullptr);
+             const struct amdxdna_ccmd_create_bo_req *req);
 
     /**
      * @brief Construct device-local BO
@@ -69,7 +70,7 @@ public:
     vxdna_bo(int ctx_fd_in, const struct amdxdna_ccmd_create_bo_req *req);
 
     /**
-     * @brief Destructor - unmaps memory and closes GEM handle
+     * @brief Destructor - closes GEM handle (no DRM mmap in this module)
      */
     ~vxdna_bo() noexcept;
 
@@ -115,14 +116,16 @@ public:
 
 private:
     uint64_t m_size = 0;          /**< Buffer size in bytes */
-    uint64_t m_vaddr = 0;         /**< Virtual address (after mmap) */
-    uint64_t m_map_offset = 0;    /**< Offset for mmap() from DRM */
+    uint64_t m_vaddr = 0;         /**< CPU VA: coalesce mapping or GET_BO_INFO (opaque import) */
+    uint64_t m_map_offset = 0;    /**< From GET_BO_INFO (DRM mmap offset; not used for mmap here) */
     uint64_t m_xdna_addr = 0;     /**< NPU device address */
-    uint64_t m_map_size = 0;      /**< Size of mapped region */
+    uint64_t m_iov_bytes = 0;     /**< Sum of iovec lengths (guest backing size) */
     uint32_t m_bo_handle = 0;     /**< DRM GEM handle */
     uint32_t m_bo_type = 0;       /**< BO type (DEV, SHMEM, CMD) */
-    int m_opaque_handle = -1;     /**< Opaque handle from resource */
+    int m_opaque_handle = 0;     /**< Opaque DRM GEM handle from resource, or 0 */
     int m_ctx_fd = -1;            /**< Context file descriptor */
+    void *m_coalesce_va = nullptr; /**< Contiguous VA for userptr CREATE_BO; munmap in dtor */
+    size_t m_coalesce_len = 0;
 };
 
 
@@ -169,10 +172,6 @@ public:
      */
     ~vxdna_context() {
         vxdna_dbg("Context destroying: ctx_id=%u, fd=%d", get_id(), get_fd());
-        if (m_heap_base) {
-            ::munmap(m_heap_base, HEAP_MAX_SIZE);
-            m_heap_base = nullptr;
-        }
         m_bo_table.clear();
         close(get_fd());
     }
@@ -513,8 +512,8 @@ private:
     vaccel_map<uint32_t, std::shared_ptr<vxdna_hwctx>> m_hwctx_table;
 
     static constexpr size_t HEAP_MAX_SIZE = 512UL << 20;
-    void *m_heap_base = nullptr;
-    size_t m_heap_cur_offset = 0;
+    /** Cumulative DEV_HEAP size committed on this context (bytes). */
+    size_t m_heap_committed = 0;
     bool m_heap_destroyed = false;
 };
 

--- a/test/shim_test/shim_test.cpp
+++ b/test/shim_test/shim_test.cpp
@@ -19,8 +19,14 @@
 #include "core/common/device.h"
 
 #include <array>
+#include <algorithm>
+#include <cctype>
+#include <cerrno>
+#include <cstdlib>
+#include <cstring>
 #include <filesystem>
 #include <fstream>
+#include <optional>
 #include <vector>
 #include <iostream>
 #include <sstream>
@@ -103,6 +109,7 @@ usage(const std::string& prog)
   std::cout << "\t" << "-h" << ": print this help message and available test cases\n";
   std::cout << "\t" << "-k" << ": evaluate test result based on driver version\n";
   std::cout << "\t" << "-x <xclbin_path>" << ": run test cases with specified xclbin file\n";
+  std::cout << "Device node: <bus>/devices/<dev>/accel; PCI also drm/renderD* (virtio guest)\n";
   std::cout << std::endl;
 }
 
@@ -265,49 +272,148 @@ static void TEST_async_error_io_any(device::id_type id, std::shared_ptr<device>&
 }
 
 std::string
-get_sysfs_path(device* dev)
+get_device_sysfs(device* dev)
 {
   query::sub_device_path::args query_arg = {std::string(""), 0};
-  std::string sysfs = device_query<query::sub_device_path>(dev, query_arg);
-  return sysfs + "/accel";
+  return device_query<query::sub_device_path>(dev, query_arg);
 }
+
+std::string
+get_sysfs_path(device* dev)
+{
+  return get_device_sysfs(dev) + "/accel";
+}
+
+namespace {
+
+namespace fs = std::filesystem;
+
+static std::string
+sysfs_device_basename(const std::string& device_sysfs)
+{
+  const auto pos = device_sysfs.find_last_of('/');
+  return (pos == std::string::npos) ? device_sysfs : device_sysfs.substr(pos + 1);
+}
+
+static bool
+sysfs_dir_exists(const std::string& path)
+{
+  std::error_code ec;
+  return fs::is_directory(fs::path(path), ec);
+}
+
+/*
+ * Resolve .../sys/bus/<bus>/devices/<name> for the NPU device.
+ * Prefer the path from sub_device_path when it exists; otherwise probe pci,
+ * platform, and rpmsg buses using the same device name.
+ */
+static std::optional<std::string>
+resolve_device_sysfs(device* dev)
+{
+  static const char* const bus_roots[] = {
+    "/sys/bus/pci/devices/",
+    "/sys/bus/platform/devices/",
+    "/sys/bus/rpmsg/devices/",
+  };
+
+  const std::string from_query = get_device_sysfs(dev);
+  if (sysfs_dir_exists(from_query))
+    return from_query;
+
+  const std::string name = sysfs_device_basename(from_query);
+  if (name.empty())
+    return std::nullopt;
+
+  for (const char* root : bus_roots) {
+    const std::string candidate = std::string(root) + name;
+    if (sysfs_dir_exists(candidate))
+      return candidate;
+  }
+  return std::nullopt;
+}
+
+/*
+ * First sysfs child under <device_sysfs>/<subsys> whose name starts with @prefix.
+ * @dev_root is prepended to that name (/dev/accel/ or /dev/dri/).
+ * When @numeric_suffix is true, the part after @prefix must be digits (renderD128).
+ */
+static std::optional<std::string>
+bus_subsys_devnode(const std::string& device_sysfs, const char* subsys,
+                   const char* prefix, const char* dev_root,
+                   bool numeric_suffix)
+{
+  const std::string dir = device_sysfs + "/" + subsys;
+  DIR* raw = opendir(dir.c_str());
+  if (!raw)
+    return std::nullopt;
+  struct dir_guard {
+    DIR* d;
+    explicit dir_guard(DIR* p) : d(p) {}
+    ~dir_guard() { if (d) closedir(d); }
+  } guard(raw);
+  const size_t psz = strlen(prefix);
+
+  while (auto entry = readdir(guard.d)) {
+    const std::string name{entry->d_name};
+    if (name == "." || name == "..")
+      continue;
+    if (name.size() <= psz || name.compare(0, psz, prefix) != 0)
+      continue;
+    if (numeric_suffix) {
+      const std::string suffix = name.substr(psz);
+      if (suffix.empty() ||
+          !std::all_of(suffix.begin(), suffix.end(),
+                       [](unsigned char c) { return std::isdigit(c); }))
+        continue;
+    }
+    return std::string(dev_root) + name;
+  }
+  return std::nullopt;
+}
+
+static bool
+is_pci_sysfs_device(const std::string& device_sysfs)
+{
+  static constexpr char k_pci_prefix[] = "/sys/bus/pci/devices/";
+  return device_sysfs.compare(0, sizeof(k_pci_prefix) - 1, k_pci_prefix) == 0;
+}
+
+} // namespace
 
 // Returns an open fd for the accel device node corresponding to dev. Caller must close(fd).
 // Throws std::runtime_error on failure (opendir, missing accel entry, or open).
 int
 open_accel_fd(device* dev)
 {
-  // FIXME: reimplement this when query key is defined in xrt
-  std::string accel_path = get_sysfs_path(dev);
-
-  struct dir_guard {
-    DIR* d;
-    explicit dir_guard(DIR* p) : d(p) {}
-    ~dir_guard() { if (d) closedir(d); }
-    DIR* get() const { return d; }
-    explicit operator bool() const { return d != nullptr; }
-  };
-  dir_guard dp(opendir(accel_path.c_str()));
-  if (!dp) {
-    throw std::runtime_error("opendir failed: " + accel_path);
+  const auto device_sysfs = resolve_device_sysfs(dev);
+  if (!device_sysfs) {
+    throw std::runtime_error(
+      "Failed to resolve device sysfs (tried sub_device_path and "
+      "/sys/bus/pci|platform|rpmsg/devices/<name>)");
   }
 
-  std::string accel_node;
-  while (auto entry = readdir(dp.get())) {
-    std::string dirname{entry->d_name};
-    if (dirname.find("accel") == 0) {
-      accel_node = "/dev/accel/" + dirname;
-      break;
-    }
-  }
+  const std::string& sysfs = *device_sysfs;
+  const bool pci = is_pci_sysfs_device(sysfs);
 
-  if (accel_node.empty()) {
-    throw std::runtime_error("Failed to find accel node under " + accel_path + " for device");
-  }
+  /* platform/rpmsg and bare-metal PCI amdxdna: .../accel/accel* -> /dev/accel/accel* */
+  std::optional<std::string> node =
+    bus_subsys_devnode(sysfs, "accel", "accel", "/dev/accel/", false);
+  /* PCI only: KVM virtio-gpu NPU exposes .../drm/renderD* -> /dev/dri/renderD* */
+  if (!node && pci)
+    node = bus_subsys_devnode(sysfs, "drm", "renderD", "/dev/dri/", true);
 
-  int fd = open(accel_node.c_str(), O_RDONLY);
+  if (!node) {
+    std::string tried = sysfs + "/accel";
+    if (pci)
+      tried += ", " + sysfs + "/drm/renderD*";
+    throw std::runtime_error("Failed to resolve device node for " + sysfs + " (tried " + tried + ")");
+  }
+  const std::string& accel_node = *node;
+
+  const int flags = (accel_node.rfind("/dev/dri/", 0) == 0) ? O_RDWR : O_RDONLY;
+  int fd = open(accel_node.c_str(), flags);
   if (fd < 0) {
-    throw std::runtime_error("open failed: " + accel_node);
+    throw std::runtime_error("open failed: " + accel_node + ": " + std::string(std::strerror(errno)));
   }
   return fd;
 }


### PR DESCRIPTION

This branch enables virtio-guest **user-pointer buffer objects** to be created on the host through vxdna, with correct **DEV_HEAP (PASID)** placement, and fixes several **staging `drivers/accel/amdxdna`** issues needed for KVM testing.

- **shim_test** discovers the accel device on bare metal (`pci/.../accel`) and KVM virtio-gpu (`pci/.../drm/renderD*`), with `/sys/class/accel` fallback and `SHIM_TEST_ACCEL_NODE` override.
- **Staging driver**: restore ubuf dma-buf vmap; fix AIE2 debug-BO scheduler UAF; record CPU UVA at userptr import so PASID dev-heap checks work before mmap.
- **vxdna**: coalesce guest iovecs for `CREATE_BO` (mremap when shareable); 64 MiB-aligned DEV_HEAP arena per context; single-iovec fast path (no mremap, live guest backing); `page_roundup(bo size)` for `va_tbl` pin length.

### Files changed
- `src/vxdna/src/vaccel_amdxdna.cpp`, `vaccel_amdxdna.h`
- `drivers/accel/amdxdna/amdxdna_gem.c`, `amdxdna_ubuf.c`, `aie2_ctx.c`
- `test/shim_test/shim_test.cpp`

### Known limitations (follow-ups)
- Multi-iovec `mremap` coalesce fails when QEMU `dma_memory_map` views are not shareable; prefer guest huge-page blobs (single iov) or future scatter `va_tbl`.

### Tests
* QEMU KVM Guest shim_test
* QEMU KVM Guest xrt_unlimited_bo test
* host shim test, and host xrt_unlimited_bo test

QEMU option to use (We need to use VM_SHARED for guest memory allocation otherwise we cannot use mremap to keep the old mapping and have the new mapping and the old mapping point to the same memory):
```
-object memory-backend-memfd,id=mem0,size=16G,share=on \
-machine q35,memory-backend=mem0,accel=kvm \
-enable-kvm \
-device virtio-accel-pci,accel-node=accel0 \
...
```

QEMU shim test log:
```
shim_test.elf -k

3       test(s) skipped: 54 55 56
70      test(s) executed
12      test(s) FAILED: 29 30 57 61 62 64 65 66 69 70 71 72

===== 29: create and free debug bo started =====
loaded /xdna-driver/build/Release/bins/bin/../local_shim_test_data/npu4/1x4/1x4.xclbin
sync_bo (err=95): Operation not supported
====== 29: create and free debug bo FAILED =====

====== 30: create and free large debug bo started =====
loaded /xdna-driver/build/Release/bins/bin/../local_shim_test_data/npu4/1x4/1x4.xclbin
sync_bo (err=95): Operation not supported
====== 30: create and free large debug bo FAILED =====

====== 57: multi-command preempt full ELF io test real kernel good run started =====
Optimized HEADER version detected
Optimized HEADER version detected
Optimized HEADER version detected
Optimized HEADER version detected
Optimized HEADER version detected
Optimized HEADER version detected
Optimized HEADER version detected
Optimized HEADER version detected
Optimized HEADER version detected
Optimized HEADER version detected
Optimized HEADER version detected
Optimized HEADER version detected
Optimized HEADER version detected
Optimized HEADER version detected
Optimized HEADER version detected
Optimized HEADER version detected
loaded /xdna-driver/build/Release/bins/bin/../local_shim_test_data/npu4/preempt_full_elf/yolo_fullelf_aximm.elf
Preemption counter does not match expectation!
====== 57: multi-command preempt full ELF io test real kernel good run FAILED =====

====== 61: gemm and debug BO started =====
loaded /xdna-driver/build/Release/bins/bin/../local_shim_test_data/npu4/gemm/gemm.xclbin
[VXDNA] ERROR: ccmd failed: [/proj/rdi/staff/wendlian/xdna-driver/src/vxdna/src/vaccel_amdxdna.cpp:803] HW context not found handle 1
sync_bo (err=95): Operation not supported
====== 61: gemm and debug BO FAILED =====

====== 62: create and free internal bo started =====
ioctl(DRM_IOCTL_AMDXDNA_GET_ARRAY) failed
====== 62: create and free internal bo FAILED =====

====== 64: get AIE coredump and check registers started =====
loaded /xdna-driver/build/Release/bins/bin/../local_shim_test_data/npu4/aie_debug/verify_4x4.xclbin
[VXDNA] ERROR: ccmd failed: [/proj/rdi/staff/wendlian/xdna-driver/src/vxdna/src/vaccel_amdxdna.cpp:895] Get info failed ret -1, errno 2
AMDXDNA_CCMD_GET_INFO HCALL received bad response (err=-2): No such file or directory
====== 64: get AIE coredump and check registers FAILED =====

====== 65: AIE MEM read/write started =====
loaded /xdna-driver/build/Release/bins/bin/../local_shim_test_data/npu4/aie_debug/verify_4x4.xclbin
[VXDNA] ERROR: ccmd failed: [/proj/rdi/staff/wendlian/xdna-driver/src/vxdna/src/vaccel_amdxdna.cpp:895] Get info failed ret -1, errno 2
AMDXDNA_CCMD_GET_INFO HCALL received bad response (err=-2): No such file or directory
====== 65: AIE MEM read/write FAILED =====
(This failure is due to we passed guest PID to host kernel, VXDNA will need to update to pass the host PID instead)

====== 66: AIE REG read/write started =====
loaded /xdna-driver/build/Release/bins/bin/../local_shim_test_data/npu4/aie_debug/verify_4x4.xclbin
[VXDNA] ERROR: ccmd failed: [/proj/rdi/staff/wendlian/xdna-driver/src/vxdna/src/vaccel_amdxdna.cpp:895] Get info failed ret -1, errno 2
AMDXDNA_CCMD_GET_INFO HCALL received bad response (err=-2): No such file or directory
====== 66: AIE REG read/write FAILED =====
(This failure is due to we passed guest PID to host kernel, VXDNA will need to update to pass the host PID instead)

====== 69: create and free user ptr BO with mmapped ptr started =====
create_uptr_bo (err=95): Operation not supported
mmaped user ptr BO test has failed
====== 69: create and free user ptr BO with mmapped ptr FAILED =====

====== 70: DPM noop (no QoS) started =====
ioctl(SET_POWER_MODE) failed for mode 0
====== 70: DPM noop (no QoS) FAILED =====

====== 71: DPM refcount scaling started =====
  Platform info: col_opc=4096 num_col=4 max_opc=16384 sys_eff_factor=2
  Level 0: hclk=792 raw_cap=12976 eff_cap=6488 target_gops=1
  Level 1: hclk=1056 raw_cap=17301 eff_cap=8650 target_gops=6489
  Level 2: hclk=1152 raw_cap=18874 eff_cap=9437 target_gops=8651
  Level 3: hclk=1267 raw_cap=20758 eff_cap=10379 target_gops=9438
  Level 4: hclk=1267 raw_cap=20758 eff_cap=10379 target_gops=10379
  Level 5: hclk=1408 raw_cap=23068 eff_cap=11534 target_gops=10380
  Level 6: hclk=1584 raw_cap=25952 eff_cap=12976 target_gops=11535
  Level 7: hclk=1800 raw_cap=29491 eff_cap=14745 target_gops=12977
ioctl(SET_POWER_MODE) failed for mode 0
====== 71: DPM refcount scaling FAILED =====

====== 72: DPM power modes started =====
ioctl(SET_POWER_MODE) failed for mode 4
====== 72: DPM power modes FAILED =====

0       test(s) skipped:
12      test(s) executed
12      test(s) FAILED: 29 30 57 61 62 64 65 66 69 70 71 72
```

This PR enables the shim test on QEMU KVM. 

QEMU KVM guest xrt_unlimited_bo test log:
```
INFO: TEST PASSED
                                       .--.
                _______             .-"  .'
        .---u"""       """"---._  ."    %
      .'                        "--.    %
 __.--'  o                          "".. "
(____.                                  ":
 `----.__                                 ".
         `----------__                     ".
               ".   . ""--.                 ".
                 ". ". bIt ""-.              ".
                   "-.)        ""-.           ".
                                   "".         ".
                                      "".       ".
                                         "".      ".
                                            "".    ".
                      ^~^~^~^~^~^~^~^~^~^~^~^~^"".  "^~^~^~^~^
                                            ^~^~^~^  ~^~
                                                 ^~^~^~


=== PASSED: configs/runlist_bo_on_another_bank.ini ===

===============================
Results: 15 passed, 0 failed out of 15 total
===============================
```




