### PR TITLE
test/shim_test: add uc_log BO shim test for KERNBUF flag

### DIFF
--- a/test/shim_test/shim_test.cpp
+++ b/test/shim_test/shim_test.cpp
@@ -523,6 +523,21 @@ TEST_create_free_debug_bo(device::id_type id, std::shared_ptr<device>& sdev, arg
 }
 
 void
+TEST_create_free_uc_log_bo(device::id_type id, std::shared_ptr<device>& sdev, arg_type& arg)
+{
+  auto dev = sdev.get();
+  auto boflags = XRT_BO_FLAGS_CARVEOUT;
+  auto ext_boflags = XRT_BO_USE_LOG << 4;
+  auto size = static_cast<size_t>(arg[0]);
+
+  hw_ctx hwctx{dev};
+  auto bo = hwctx.get()->alloc_bo(size, get_bo_flags(boflags, ext_boflags));
+
+  auto buf = static_cast<uint8_t *>(bo->map(buffer_handle::map_type::write));
+  std::memset(buf, 0, size);
+}
+
+void
 get_and_show_bo_properties(device* dev, buffer_handle *boh)
 {
   buffer_handle::properties properties = boh->get_properties();
@@ -969,6 +984,12 @@ std::vector<test_case> test_list {
   },
   test_case{ "create and free large debug bo", {},
     TEST_POSITIVE, dev_filter_xdna, TEST_create_free_debug_bo, { 0x100000 }
+  },
+  test_case{ "create and free uc_log bo", {},
+    TEST_POSITIVE, dev_filter_is_aie4, TEST_create_free_uc_log_bo, { 0x10000 }
+  },
+  test_case{ "create and free large uc_log bo", {},
+    TEST_POSITIVE, dev_filter_is_aie4, TEST_create_free_uc_log_bo, { 0x100000 }
   },
   test_case{ "multi-command io test real kernel good run", {},
     TEST_POSITIVE, dev_filter_xdna, TEST_io, { IO_TEST_NORMAL_RUN, 3 }


### PR DESCRIPTION
Add two test cases that exercise the per-uC CERT log buffer allocation path used by XRT for xrt::bo::use::log: XRT_BO_FLAGS_CARVEOUT (== XCL_BO_FLAGS_KERNBUF) combined with XRT_BO_USE_LOG.

Test run result -
1> With the shim fix for carveout BO -

```
xdna-driver/build/Release/bins/bin# ./shim_test.sh 31 32
====== 31: create and free uc_log bo started =====
loaded /scratch/sdonwalk_2/sd_xdna/xdna-driver/build/Release/bins/bin/../local_shim_test_data/npu3/vadd/vadd.elf
====== 31: create and free uc_log bo passed  =====

====== 32: create and free large uc_log bo started =====
loaded /scratch/sdonwalk_2/sd_xdna/xdna-driver/build/Release/bins/bin/../local_shim_test_data/npu3/vadd/vadd.elf
====== 32: create and free large uc_log bo passed  =====

0       test(s) skipped:
2       test(s) executed
ALL 2 executed test(s) PASSED!
```

2> Without the shim fix for carveout BO-

```
xdna-driver/build/Release/bins/bin# ./shim_test.sh 31 32
====== 31: create and free uc_log bo started =====
loaded /scratch/sdonwalk_2/sd_xdna/xdna-driver/build/Release/bins/bin/../local_shim_test_data/npu3/vadd/vadd.elf
Bad BO type. (err=22): Invalid argument
====== 31: create and free uc_log bo FAILED =====

====== 32: create and free large uc_log bo started =====
loaded /scratch/sdonwalk_2/sd_xdna/xdna-driver/build/Release/bins/bin/../local_shim_test_data/npu3/vadd/vadd.elf
Bad BO type. (err=22): Invalid argument
====== 32: create and free large uc_log bo FAILED =====

0       test(s) skipped:
2       test(s) executed
2       test(s) FAILED: 31 32
```
This shows that the test captures the carveout BO change successfully.
