### PR TITLE
amdxdna: fix NULL-deref flushing timed-out mailbox messages

### DIFF
--- a/drivers/accel/amdxdna/amdxdna_mailbox_helper.c
+++ b/drivers/accel/amdxdna/amdxdna_mailbox_helper.c
@@ -21,6 +21,21 @@ int xdna_msg_cb(void *handle, void __iomem *data, size_t size)
 	struct xdna_notify *cb_arg = handle;
 	int ret;
 
+	/*
+	 * A NULL handle means no sender is waiting on this message -- there is
+	 * nothing to complete and nowhere to store a response. Under the
+	 * current design every sender path either holds a valid handle or
+	 * sends fire-and-forget with handle == NULL by construction; this
+	 * guard catches the second case on channel teardown. Log loudly if a
+	 * response actually arrived (data != NULL): that would mean a synchronous
+	 * sender bookkeeping invariant has broken.
+	 */
+	if (unlikely(!cb_arg)) {
+		if (data)
+			pr_err_ratelimited("Mailbox response dropped: no waiter for message\n");
+		return 0;
+	}
+
 	if (unlikely(!data))
 		goto out;
 


### PR DESCRIPTION
Fixes #1347.

v2 per maintainer review (maxzhen): drops xdna_mailbox_cancel_msg()
-- the mailbox layer should not take action on timeout, leaving
ownership reclamation to the channel-type-specific caller. The
remaining change is a NULL-handle guard in xdna_msg_cb() with
pr_err() logging if the invariant ever breaks.

Validated on Phoenix/NPU1: modprobe -r on a firmware-wedged device
unloads cleanly instead of oopsing.