### PR TITLE
Fix imported dma-buf mmap EINVAL error in qemu virtio path

### DIFF
--- a/src/driver/amdxdna/amdxdna_gem.c
+++ b/src/driver/amdxdna/amdxdna_gem.c
@@ -611,6 +611,7 @@ static int amdxdna_gem_shmem_insert_pages(struct amdxdna_gem_obj *abo,
 
 	vma->vm_private_data = NULL;
 	vma->vm_ops = NULL;
+	vma->vm_pgoff = 0;
 	ret = dma_buf_mmap(abo->dma_buf, vma, 0);
 	if (ret) {
 		XDNA_ERR(xdna, "Failed to mmap dma buf %d", ret);


### PR DESCRIPTION
Fixes mmap failure for imported BOs seen in qemu virtio (Failed to mmap dma buf -22).

Root cause:  imported dma-buf mmap was using DRM’s fake vm_pgoff instead of a buffer-relative offset.

Fix:  set vma->vm_pgoff = 0 before dma_buf_mmap() in the imported mmap path.

Scope: imported dma-buf mapping only; non-imported shmem path is unchanged.

Result: imported mmap succeeds, no -EINVAL in this flow.