### PR TITLE
accel/amdxdna: explicitly disable runtime pm for aie4

### DIFF
--- a/drivers/accel/amdxdna/aie4_pci.c
+++ b/drivers/accel/amdxdna/aie4_pci.c
@@ -9,6 +9,7 @@
 #include <drm/drm_print.h>
 #include <linux/firmware.h>
 #include <linux/sizes.h>
+#include <linux/pm_runtime.h>
 
 #include "aie.h"
 #include "aie4_pci.h"
@@ -618,6 +619,8 @@ static int aie4m_pcidev_init(struct amdxdna_dev *xdna)
 		return ret;
 
 	amdxdna_vbnv_init(xdna);
+
+	pm_runtime_disable(&pdev->dev);
 	XDNA_DBG(xdna, "init finished");
 
 	return 0;

--- a/drivers/accel/amdxdna/amdxdna_pm.c
+++ b/drivers/accel/amdxdna/amdxdna_pm.c
@@ -42,6 +42,9 @@ int amdxdna_pm_resume_get(struct amdxdna_dev *xdna)
 	struct device *dev = xdna->ddev.dev;
 	int ret;
 
+	if (!pm_runtime_enabled(dev))
+		return 0;
+
 	ret = pm_runtime_resume_and_get(dev);
 	if (ret) {
 		XDNA_ERR(xdna, "Resume failed: %d", ret);
@@ -54,6 +57,9 @@ int amdxdna_pm_resume_get(struct amdxdna_dev *xdna)
 void amdxdna_pm_suspend_put(struct amdxdna_dev *xdna)
 {
 	struct device *dev = xdna->ddev.dev;
+
+	if (!pm_runtime_enabled(dev))
+		return;
 
 	pm_runtime_mark_last_busy(dev);
 	pm_runtime_put_autosuspend(dev);


### PR DESCRIPTION
call pm_runtime_disable to avoid ops being called during S4