### PR TITLE
shim,driver: fix UC firmware buffer metadata wire format

### DIFF
--- a/src/driver/amdxdna/aie4_hwctx.c
+++ b/src/driver/amdxdna/aie4_hwctx.c
@@ -961,7 +961,7 @@ static int aie4_ctx_config_debug_bo(struct amdxdna_ctx *ctx, u32 bo_hdl, int att
 	struct amdxdna_dev_hdl *ndev = xdna->dev_handle;
 	struct amdxdna_gem_obj *meta_bo;
 	struct amdxdna_gem_obj *log_bo;
-	struct fw_buffer_metadata *meta_buffer;
+	struct amdxdna_fw_buffer_metadata *meta_buffer;
 	u32 config_property;
 	u32 prev_size;
 	int ret;
@@ -975,7 +975,19 @@ static int aie4_ctx_config_debug_bo(struct amdxdna_ctx *ctx, u32 bo_hdl, int att
 
 	nctx->meta_bo_hdl = attach ? bo_hdl : AMDXDNA_INVALID_BO_HANDLE;
 
-	meta_buffer = (struct fw_buffer_metadata *)amdxdna_gem_vmap(meta_bo);
+	meta_buffer = (struct amdxdna_fw_buffer_metadata *)amdxdna_gem_vmap(meta_bo);
+	if (!meta_buffer) {
+		XDNA_ERR(xdna, "Vmap meta_bo %d failed", bo_hdl);
+		ret = -ENOMEM;
+		goto put_meta_bo;
+	}
+	if (meta_buffer->num_ucs > MAX_NUM_CERTS ||
+	    struct_size(meta_buffer, uc_info, meta_buffer->num_ucs) > meta_bo->mem.size) {
+		XDNA_ERR(xdna, "Invalid num_ucs %u (max %d, meta_bo size %zu)",
+			 meta_buffer->num_ucs, MAX_NUM_CERTS, meta_bo->mem.size);
+		ret = -EINVAL;
+		goto put_meta_bo;
+	}
 
 	switch (meta_buffer->buf_type) {
 	case AMDXDNA_FW_BUF_LOG:
@@ -1000,23 +1012,23 @@ static int aie4_ctx_config_debug_bo(struct amdxdna_ctx *ctx, u32 bo_hdl, int att
 		log_bo = amdxdna_gem_get_obj(client, meta_buffer->bo_handle, AMDXDNA_BO_SHARE);
 		break;
 	default:
-		XDNA_ERR(xdna, "unsupported buffer type %d bo %lld",
+		XDNA_ERR(xdna, "unsupported buffer type %d bo %u",
 			 meta_buffer->buf_type, meta_buffer->bo_handle);
 		ret = -EOPNOTSUPP;
 		goto put_meta_bo;
 	}
 
 	if (!log_bo) {
-		XDNA_ERR(xdna, "Get log_bo %lld failed", meta_buffer->bo_handle);
+		XDNA_ERR(xdna, "Get log_bo %u failed", meta_buffer->bo_handle);
 		ret = -EINVAL;
 		goto put_meta_bo;
 	}
-	XDNA_DBG(xdna, "Found bo %lld", meta_buffer->bo_handle);
+	XDNA_DBG(xdna, "Found bo %u", meta_buffer->bo_handle);
 
 	/* assign dev_addr + offse to firmware */
 	prev_size = 0;
 	for (int i = 0; i < meta_buffer->num_ucs; i++) {
-		struct uc_info_entry *entry = &meta_buffer->uc_info[i];
+		struct amdxdna_uc_info_entry *entry = &meta_buffer->uc_info[i];
 		u32 index = entry->index;
 		u64 off_addr;
 

--- a/src/driver/amdxdna/ve2_hwctx.c
+++ b/src/driver/amdxdna/ve2_hwctx.c
@@ -1620,7 +1620,7 @@ int ve2_hwctx_config(struct amdxdna_ctx *hwctx, u32 type, u64 mdata_hdl, void *b
 	struct amdxdna_dev *xdna = hwctx->client->xdna;
 	struct amdxdna_client *client = hwctx->client;
 	struct amdxdna_gem_obj *abo, *mdata_abo = NULL;
-	struct fw_buffer_metadata *mdata;
+	struct amdxdna_fw_buffer_metadata *mdata;
 	u32 prev_buf_sz = 0;
 	u32 op_timeout;
 	u64 buf_paddr;
@@ -1636,17 +1636,23 @@ int ve2_hwctx_config(struct amdxdna_ctx *hwctx, u32 type, u64 mdata_hdl, void *b
 				 __func__, mdata_hdl, type);
 			return -EINVAL;
 		}
-		mdata = (struct fw_buffer_metadata *)(amdxdna_gem_vmap(mdata_abo));
+		mdata = (struct amdxdna_fw_buffer_metadata *)(amdxdna_gem_vmap(mdata_abo));
 		if (!mdata) {
 			XDNA_ERR(xdna, "%s: Failed to vmap metadata BO %lld for type %d",
 				 __func__, mdata_hdl, type);
 			amdxdna_gem_put_obj(mdata_abo);
 			return -EINVAL;
 		}
-
+		if (struct_size(mdata, uc_info, hwctx->num_col) > mdata_abo->mem.size) {
+			XDNA_ERR(xdna,
+				 "%s: metadata BO too small for %u uc entries (BO size %zu)",
+				 __func__, hwctx->num_col, mdata_abo->mem.size);
+			amdxdna_gem_put_obj(mdata_abo);
+			return -EINVAL;
+		}
 		abo = amdxdna_gem_get_obj(client, mdata->bo_handle, AMDXDNA_BO_SHARE);
 		if (!abo) {
-			XDNA_ERR(xdna, "%s: Failed to get BO %lld for type %d",
+			XDNA_ERR(xdna, "%s: Failed to get BO %u for type %d",
 				 __func__, mdata->bo_handle, type);
 			amdxdna_gem_put_obj(mdata_abo);
 			return -EINVAL;
@@ -1668,7 +1674,7 @@ int ve2_hwctx_config(struct amdxdna_ctx *hwctx, u32 type, u64 mdata_hdl, void *b
 			}
 			prev_buf_sz += buf_sz;
 		}
-		XDNA_DBG(xdna, "Attached buf_type %d BO %lld to hwctx %s",
+		XDNA_DBG(xdna, "Attached buf_type %d BO %u to hwctx %s",
 			 mdata->buf_type, mdata->bo_handle, hwctx->name);
 
 		amdxdna_gem_put_obj(abo);
@@ -1683,7 +1689,7 @@ int ve2_hwctx_config(struct amdxdna_ctx *hwctx, u32 type, u64 mdata_hdl, void *b
 				 __func__, mdata_hdl, type);
 			return -EINVAL;
 		}
-		mdata = (struct fw_buffer_metadata *)(amdxdna_gem_vmap(mdata_abo));
+		mdata = (struct amdxdna_fw_buffer_metadata *)(amdxdna_gem_vmap(mdata_abo));
 		if (!mdata) {
 			XDNA_ERR(xdna, "%s: Failed to vmap metadata BO %lld for type %d",
 				 __func__, mdata_hdl, type);
@@ -1694,14 +1700,14 @@ int ve2_hwctx_config(struct amdxdna_ctx *hwctx, u32 type, u64 mdata_hdl, void *b
 			ret = ve2_update_handshake_pkt(hwctx, mdata->buf_type, 0, 0, col, false);
 			if (ret) {
 				XDNA_ERR(xdna,
-					 "%s: detach fail type=%d BO=%lld ctx=%s col=%u ret=%d",
+					 "%s: detach fail type=%d BO=%u ctx=%s col=%u ret=%d",
 					 __func__, mdata->buf_type, mdata->bo_handle,
 					 hwctx->name, col, ret);
 				amdxdna_gem_put_obj(mdata_abo);
 				return ret;
 			}
 		}
-		XDNA_DBG(xdna, "Detached buf_type %d BO %lld from hwctx %s",
+		XDNA_DBG(xdna, "Detached buf_type %d BO %u from hwctx %s",
 			 mdata->buf_type, mdata->bo_handle, hwctx->name);
 
 		amdxdna_gem_put_obj(mdata_abo);

--- a/src/include/uapi/drm_local/amdxdna_accel.h
+++ b/src/include/uapi/drm_local/amdxdna_accel.h
@@ -172,36 +172,36 @@ struct amdxdna_hwctx_param_config_cu {
 };
 
 /**
- * struct uc_info_entry: Holds uc index & buffer size allotment info
+ * struct amdxdna_uc_info_entry: Holds uc index & buffer size allotment info
  * @index: uc index
  *     On aie2ps, uc index is same to column index
  *     On aie4, uc index is mapped as 0->0_A, 1->0_B, 2->1_A, 3->1_B, 4->2_A, 5->2_B
  * @size: buffer size in bytes for this uc
  */
-struct uc_info_entry {
+struct amdxdna_uc_info_entry {
 	__u32 index;
 	__u32 size;
 };
 
 /**
- * struct fw_buffer_metadata - Holds buffer configuration.
+ * struct amdxdna_fw_buffer_metadata - Holds buffer configuration.
  * @buf_type: buffer type set to fw
  * @num_ucs: total ucs to config
- * @command_id: command id used for trace
  * @bo_handle: actual bo handle
- * @uc_info_entry: uc index & buffer size mapping info
+ * @command_id: command id used for trace
+ * @uc_info: uc index & buffer size mapping info
  */
-struct fw_buffer_metadata {
+struct amdxdna_fw_buffer_metadata {
 #define AMDXDNA_FW_BUF_DEBUG	0
 #define AMDXDNA_FW_BUF_TRACE	1
 #define AMDXDNA_FW_BUF_DBG_Q	2
 #define AMDXDNA_FW_BUF_LOG	3
 	__u8 buf_type;
 	__u8 num_ucs;
-	__u8 pad[48];
+	__u8 pad[2];
+	__u32 bo_handle;
 	__u64 command_id;
-	__u64 bo_handle;
-	struct uc_info_entry uc_info[];
+	struct amdxdna_uc_info_entry uc_info[];
 };
 
 /**

--- a/src/shim/buffer.cpp
+++ b/src/shim/buffer.cpp
@@ -4,6 +4,7 @@
 // Disable debug print in this file.
 //#undef XDNA_SHIM_DEBUG
 
+#include <cstring>
 #include <iostream>
 
 #include "buffer.h"
@@ -870,10 +871,11 @@ void
 uc_dbg_buffer::
 config(const xrt_core::hwctx_handle* hwctx, const std::map<uint32_t, size_t>& buf_sizes)
 {
-  auto meta_buf_size = offsetof(struct fw_buffer_metadata, uc_info)
-     + buf_sizes.size() * sizeof(struct uc_info_entry);
+  auto meta_buf_size = offsetof(amdxdna_fw_buffer_metadata, uc_info)
+     + buf_sizes.size() * sizeof(amdxdna_uc_info_entry);
   m_metadata_bo = std::make_unique<dbg_buffer>(m_pdev, meta_buf_size, AMDXDNA_BO_CMD);
-  auto metadata = reinterpret_cast<fw_buffer_metadata *>(m_metadata_bo->vaddr());
+  auto metadata = reinterpret_cast<amdxdna_fw_buffer_metadata *>(m_metadata_bo->vaddr());
+  std::memset(metadata, 0, meta_buf_size);
   metadata->bo_handle = id().handle;
   metadata->command_id = 0; //support this later
   auto f = xcl_bo_flags{get_flags()};

--- a/src/shim_ve2/xdna_bo.cpp
+++ b/src/shim_ve2/xdna_bo.cpp
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (C) 2025, Advanced Micro Devices, Inc. All rights reserved.
 
+#include <cstring>
 #include <unistd.h>
 
 #include "core/common/query_requests.h"
@@ -15,9 +16,12 @@ init_metadata_buffer(xdna_bo& mdata_base_bo,
 		     std::map<uint32_t, size_t> buf_sizes,
 		     bool attach)
 {
-  struct fw_buffer_metadata *mdata =
-      reinterpret_cast<struct fw_buffer_metadata*>(mdata_base_bo.map(xrt_core::buffer_handle::map_type::write));
+  struct amdxdna_fw_buffer_metadata *mdata =
+      reinterpret_cast<struct amdxdna_fw_buffer_metadata*>(mdata_base_bo.map(xrt_core::buffer_handle::map_type::write));
 
+  auto mdata_size = sizeof(struct amdxdna_fw_buffer_metadata)
+                    + total_cols * sizeof(struct amdxdna_uc_info_entry);
+  std::memset(mdata, 0, mdata_size);
   if (flag == XRT_BO_USE_DEBUG || flag == XRT_BO_USE_UC_DEBUG)
     mdata->buf_type = AMDXDNA_FW_BUF_DEBUG;
   if (flag == XRT_BO_USE_DTRACE)
@@ -439,7 +443,7 @@ config(const xrt_core::hwctx_handle* ctx, const std::map<uint32_t, size_t>& buf_
 
   auto boh = get_drm_bo_handle();
   auto total_cols = get_total_cols(m_core_device, ctx_id);
-  auto mdata_size = sizeof(struct fw_buffer_metadata) + total_cols * sizeof(struct uc_info_entry);
+  auto mdata_size = sizeof(struct amdxdna_fw_buffer_metadata) + total_cols * sizeof(struct amdxdna_uc_info_entry);
 
   auto xdev = static_cast<const device_xdna*>(m_core_device);
   xdna_bo mdata_bo = xdna_bo(*xdev, ctx_id, mdata_size, XCL_BO_FLAGS_CACHEABLE, AMDXDNA_BO_SHARE);
@@ -467,7 +471,7 @@ attach_to_ctx(uint32_t flag)
   for (int i = 0; i < total_cols; ++i)
     buf_sizes[i] = buf_size / total_cols;
 
-  auto mdata_size = sizeof(struct fw_buffer_metadata) + total_cols * sizeof(struct uc_info_entry);
+  auto mdata_size = sizeof(struct amdxdna_fw_buffer_metadata) + total_cols * sizeof(struct amdxdna_uc_info_entry);
   auto xdev = static_cast<const device_xdna*>(m_core_device);
   xdna_bo mdata_bo = xdna_bo(*xdev, m_owner_ctx_id, mdata_size, XCL_BO_FLAGS_CACHEABLE, AMDXDNA_BO_SHARE);
   init_metadata_buffer(mdata_bo, boh, total_cols, flag, buf_sizes, true);
@@ -483,7 +487,7 @@ detach_from_ctx(uint32_t flag)
     return;
 
   auto boh = get_drm_bo_handle();
-  auto mdata_size = sizeof(struct fw_buffer_metadata);
+  auto mdata_size = sizeof(struct amdxdna_fw_buffer_metadata);
   auto xdev = static_cast<const device_xdna*>(m_core_device);
   xdna_bo mdata_bo = xdna_bo(*xdev, m_owner_ctx_id, mdata_size, XCL_BO_FLAGS_CACHEABLE, AMDXDNA_BO_SHARE);
   init_metadata_buffer(mdata_bo, 0, 0, flag, std::map<uint32_t, size_t>{}, false);


### PR DESCRIPTION
shim,driver: fix UC firmware buffer metadata wire format

1. Rename `fw_buffer_metadata` -> `amdxdna_fw_buffer_metadata` and
`uc_info_entry` -> `amdxdna_uc_info_entry` in the OOT UAPI to match the
naming convention of other structs in the file. 
2. Shrink `bo_handle` to `__u32` from `__u64` 
3. Fix existing padding issue `pad[48]`  shoul be `pad[6]` for struct alignment.
Furthermore, rearrange the struct members, as bo_handle is __u32 now, so
that the final padding needed is just 2 bytes pad[2] thereby saving struct size.
6. Update the OOT AIE4 and VE2 driver paths and the shim accordingly 
so that cert log buffer creation works end-to-end.

Tested:
  - xrt_test (npu3 suite, 9/9 PASSED) on amdxdna.ko
  - uc_log_*.txt files generated as expected