### PR TITLE
accel/amdxdna: drop running-kernel LLVM probe from DKMS Makefile

### DIFF
--- a/drivers/accel/amdxdna/Makefile
+++ b/drivers/accel/amdxdna/Makefile
@@ -37,13 +37,6 @@ DEFINES := -DAMDXDNA_DEVEL
 XDNA_DRIVER_VERSION ?= 2.21.0
 XDNA_DATE ?= $(shell date +%Y%m%d)
 XDNA_HASH ?= $(shell git rev-parse HEAD)
-# Detect if kernel was built with Clang - check /proc/config.gz first, then /boot/config-*
-USE_LLVM ?= $(shell \
-    if [ -e /proc/config.gz ]; then \
-        zgrep -q "CONFIG_CC_IS_CLANG=y" /proc/config.gz 2>/dev/null && echo -n "LLVM=1"; \
-    elif [ -e /boot/config-$(KERNEL_VER) ]; then \
-        grep -q "CONFIG_CC_IS_CLANG=y" /boot/config-$(KERNEL_VER) 2>/dev/null && echo -n "LLVM=1"; \
-    fi)
 
 ifndef MODULE_VER_STR
 MODULE_VER_STR := $(XDNA_DRIVER_VERSION)_$(XDNA_DATE),$(XDNA_HASH)
@@ -51,11 +44,12 @@ endif
 
 DEFINES += -DMODULE_VER_STR='\"$(MODULE_VER_STR)\"'
 
+# Compiler (gcc/clang) comes from the LLVM= kbuild var set by DKMS/caller, not probed here (#1377)
 ifeq ($(XDNA_BUS_TYPE), of)
 DEFINES += -DAMDXDNA_OF
 # Generate config_kernel.h when building directly (Yocto/DKMS flow)
 modules: $(SRC_DIR)/config_kernel.h
-	$(MAKE) -C $(KERNEL_SRC) M=$(SRC_DIR) CFLAGS_MODULE="$(DEFINES)" OFT_CONFIG_AMDXDNA_PCI=$(PCI) OFT_CONFIG_AMDXDNA_OF=$(OF) $(USE_LLVM) modules
+	$(MAKE) -C $(KERNEL_SRC) M=$(SRC_DIR) CFLAGS_MODULE="$(DEFINES)" OFT_CONFIG_AMDXDNA_PCI=$(PCI) OFT_CONFIG_AMDXDNA_OF=$(OF) modules
 
 $(SRC_DIR)/config_kernel.h:
 	@echo "[INFO] Generating config_kernel.h for OF build..."
@@ -63,7 +57,7 @@ $(SRC_DIR)/config_kernel.h:
 else
 # PCI builds: CMake generates config_kernel.h
 modules:
-	$(MAKE) -C $(KERNEL_SRC) M=$(SRC_DIR) CFLAGS_MODULE="$(DEFINES)" OFT_CONFIG_AMDXDNA_PCI=$(PCI) OFT_CONFIG_AMDXDNA_OF=$(OF) $(USE_LLVM) modules
+	$(MAKE) -C $(KERNEL_SRC) M=$(SRC_DIR) CFLAGS_MODULE="$(DEFINES)" OFT_CONFIG_AMDXDNA_PCI=$(PCI) OFT_CONFIG_AMDXDNA_OF=$(OF) modules
 endif
 
 modules_install:

--- a/src/driver/amdxdna/Makefile
+++ b/src/driver/amdxdna/Makefile
@@ -36,13 +36,6 @@ DEFINES := -DAMDXDNA_DEVEL
 # Driver version
 XDNA_DATE ?= $(shell date +%Y%m%d)
 XDNA_HASH ?= $(shell git rev-parse HEAD)
-# Detect if kernel was built with Clang - check /proc/config.gz first, then /boot/config-*
-USE_LLVM ?= $(shell \
-    if [ -e /proc/config.gz ]; then \
-        zgrep -q "CONFIG_CC_IS_CLANG=y" /proc/config.gz 2>/dev/null && echo -n "LLVM=1"; \
-    elif [ -e /boot/config-$(KERNEL_VER) ]; then \
-        grep -q "CONFIG_CC_IS_CLANG=y" /boot/config-$(KERNEL_VER) 2>/dev/null && echo -n "LLVM=1"; \
-    fi)
 
 ifndef MODULE_VER_STR
 MODULE_VER_STR := $(XDNA_DRIVER_VERSION)_$(XDNA_DATE),$(XDNA_HASH)
@@ -50,13 +43,14 @@ endif
 
 DEFINES += -DMODULE_VER_STR='\"$(MODULE_VER_STR)\"'
 
+# Compiler (gcc/clang) comes from the LLVM= kbuild var set by DKMS/caller, not probed here (#1377)
 ifeq ($(XDNA_BUS_TYPE), of)
 DEFINES += -DAMDXDNA_OF
 endif
 
 # Generate config_kernel.h if not already present (CMake or direct build)
 modules: $(SRC_DIR)/config_kernel.h
-	$(MAKE) -C $(KERNEL_SRC) M=$(SRC_DIR) CFLAGS_MODULE="$(DEFINES)" OFT_CONFIG_AMDXDNA_PCI=$(PCI) OFT_CONFIG_AMDXDNA_OF=$(OF) $(USE_LLVM) modules
+	$(MAKE) -C $(KERNEL_SRC) M=$(SRC_DIR) CFLAGS_MODULE="$(DEFINES)" OFT_CONFIG_AMDXDNA_PCI=$(PCI) OFT_CONFIG_AMDXDNA_OF=$(OF) modules
 
 $(SRC_DIR)/config_kernel.h:
 	@echo "[INFO] Generating config_kernel.h..."


### PR DESCRIPTION
Fixes #1377.

The `USE_LLVM` probe in `drivers/accel/amdxdna/Makefile` detected the compiler from the **running** kernel (`/proc/config.gz`, else `/boot/config-$(uname -r)`), not the **build target**. On a host booted on a clang-built kernel that builds the module for a gcc target (e.g. a DKMS autoinstall during a distro kernel upgrade), the probe forced `LLVM=1` onto the gcc build and clang rejected the kernel's gcc-only flags.

The probe is also redundant: DKMS appends `LLVM=1` to its `make` invocation when the *target* kernel is clang-built, and that command-line variable propagates to the inner kernel build via `MAKEFLAGS`. This drops the probe and the two `$(USE_LLVM)` tokens, letting the standard `LLVM=` kbuild variable flow through. Manual builds against a clang kernel pass `LLVM=1` by hand, per the usual out-of-tree convention.

Per @maxzhen's note on the issue, this targets the active `drivers/accel/amdxdna/Makefile`; the obsolete `src/driver` copy is left untouched.

### Testing
Real builds on the reporter's configuration — clang-booted host, no `/proc/config.gz`, both clang and gcc target kernels installed (gcc 15.2.0 / clang 21.1.8):

| Case | Result |
|---|---|
| gcc target, no `LLVM=1` (as DKMS does) | builds with gcc, produces `amdxdna.ko` |
| clang target, `LLVM=1` (as DKMS adds) | builds with clang |
| gcc target + spurious `LLVM=1` (old probe's behavior) | reproduces the report's exact failure (`-mpreferred-stack-boundary=3`, `-fconserve-stack`, `-mrecord-mcount`, …) |