### PR TITLE
Cherry-pick context health fix and misc

### DIFF
--- a/drivers/accel/amdxdna/aie.c
+++ b/drivers/accel/amdxdna/aie.c
@@ -280,8 +280,7 @@ void amdxdna_free_msg_buff(struct amdxdna_msg_buf_hdl *hdl)
 }
 
 struct amdxdna_coredump_walk_arg {
-	u64				pid;
-	u32				ctx_id;
+	struct amdxdna_hwctx_key	key;
 
 	struct aie_device		*aie;
 	struct amdxdna_drm_get_array	*args;
@@ -289,18 +288,21 @@ struct amdxdna_coredump_walk_arg {
 	size_t				buf_size;
 };
 
+/* amdxdna_hwctx_match() casts the walk arg to struct amdxdna_hwctx_key. */
+static_assert(offsetof(struct amdxdna_coredump_walk_arg, key) == 0,
+	      "key must be the first member for amdxdna_hwctx_match()");
+
 struct amdxdna_tile_rw_walk_arg {
+	struct amdxdna_hwctx_key			key;
+
 	struct aie_device				*aie;
 	const struct amdxdna_drm_aie_tile_access	*access;
 	u8 __user					*buf;
 };
 
-static bool amdxdna_get_coredump_filter(struct amdxdna_hwctx *hwctx, void *arg)
-{
-	struct amdxdna_coredump_walk_arg *wa = arg;
-
-	return hwctx->client->pid == wa->pid && hwctx->id == wa->ctx_id;
-}
+/* amdxdna_hwctx_match() casts the walk arg to struct amdxdna_hwctx_key. */
+static_assert(offsetof(struct amdxdna_tile_rw_walk_arg, key) == 0,
+	      "key must be the first member for amdxdna_hwctx_match()");
 
 static int amdxdna_get_coredump_cb(struct amdxdna_hwctx *hwctx, void *arg)
 {
@@ -317,7 +319,7 @@ static int amdxdna_get_coredump_cb(struct amdxdna_hwctx *hwctx, void *arg)
 	u32 orig_col;
 
 	if (!amdxdna_client_visible(hwctx->client)) {
-		XDNA_ERR(xdna, "Permission denied for context %u", wa->ctx_id);
+		XDNA_ERR(xdna, "Permission denied for context %u", wa->key.ctx_id);
 		return -EPERM;
 	}
 
@@ -442,16 +444,16 @@ int amdxdna_get_coredump(struct aie_device *aie,
 	XDNA_DBG(xdna, "AIE Coredump request for context_id=%u pid=%llu",
 		 config.context_id, config.pid);
 
-	wa.ctx_id = config.context_id;
+	wa.key.ctx_id = config.context_id;
+	wa.key.pid = config.pid;
 	wa.buf_size = buf_size;
-	wa.pid = config.pid;
 	wa.args = args;
 	wa.aie = aie;
 	wa.buf = buf;
 
 	amdxdna_for_each_client(xdna, tmp_client) {
 		ret = amdxdna_hwctx_walk(tmp_client, &wa,
-					 amdxdna_get_coredump_filter,
+					 amdxdna_hwctx_match,
 					 amdxdna_get_coredump_cb);
 		if (ret != -ENOENT)
 			break;
@@ -460,13 +462,6 @@ int amdxdna_get_coredump(struct aie_device *aie,
 		XDNA_ERR(xdna, "Context %u for pid %llu not found",
 			 config.context_id, config.pid);
 	return ret;
-}
-
-static bool amdxdna_tile_rw_filter(struct amdxdna_hwctx *hwctx, void *arg)
-{
-	struct amdxdna_tile_rw_walk_arg *wa = arg;
-
-	return hwctx->client->pid == wa->access->pid && hwctx->id == wa->access->context_id;
 }
 
 static int amdxdna_aie_tile_read_reg(struct amdxdna_hwctx *hwctx,
@@ -634,13 +629,15 @@ int amdxdna_aie_tile_read(struct aie_device *aie,
 		return -EINVAL;
 	}
 
+	wa.key.ctx_id = access.context_id;
+	wa.key.pid = access.pid;
 	wa.access = &access;
 	wa.aie = aie;
 	wa.buf = buf;
 
 	amdxdna_for_each_client(xdna, tmp_client) {
 		ret = amdxdna_hwctx_walk(tmp_client, &wa,
-					 amdxdna_tile_rw_filter,
+					 amdxdna_hwctx_match,
 					 amdxdna_aie_tile_read_cb);
 		if (ret != -ENOENT)
 			break;
@@ -806,13 +803,15 @@ int amdxdna_aie_tile_write(struct aie_device *aie,
 		return -EINVAL;
 	}
 
+	wa.key.ctx_id = access.context_id;
+	wa.key.pid = access.pid;
 	wa.access = &access;
 	wa.aie = aie;
 	wa.buf = buf;
 
 	amdxdna_for_each_client(xdna, tmp_client) {
 		ret = amdxdna_hwctx_walk(tmp_client, &wa,
-					 amdxdna_tile_rw_filter,
+					 amdxdna_hwctx_match,
 					 amdxdna_aie_tile_write_cb);
 		if (ret != -ENOENT)
 			break;

--- a/drivers/accel/amdxdna/aie2_pci.c
+++ b/drivers/accel/amdxdna/aie2_pci.c
@@ -727,7 +727,7 @@ static int aie2_get_clock_metadata(struct amdxdna_client *client,
 	return ret;
 }
 
-static int aie2_hwctx_status_cb(struct amdxdna_hwctx *hwctx, void *arg)
+static int aie2_fill_hwctx_status_entry(struct amdxdna_hwctx *hwctx, void *arg)
 {
 	struct amdxdna_drm_hwctx_entry *tmp __free(kfree) = NULL;
 	struct amdxdna_drm_get_array *array_args = arg;
@@ -737,8 +737,13 @@ static int aie2_hwctx_status_cb(struct amdxdna_hwctx *hwctx, void *arg)
 	u32 size;
 	int ret;
 
+	/*
+	 * Out of output slots. This is a benign "buffer full" condition (the
+	 * caller reports the entries that fit), distinct from a real failure
+	 * like -EFAULT below, so the walk caller can tell them apart.
+	 */
 	if (!array_args->num_element)
-		return -EINVAL;
+		return -ENOSPC;
 
 	tmp = kzalloc_obj(*tmp);
 	if (!tmp)
@@ -783,6 +788,19 @@ static int aie2_hwctx_status_cb(struct amdxdna_hwctx *hwctx, void *arg)
 	return 0;
 }
 
+/*
+ * Visibility-gated emitter shared by the HW_CONTEXT_ALL and HW_CONTEXT_BY_ID
+ * walks: a context the caller may not see (different Linux user without
+ * CAP_SYS_ADMIN) is silently skipped so its existence is not disclosed.
+ */
+static int aie2_hwctx_status_cb(struct amdxdna_hwctx *hwctx, void *arg)
+{
+	if (!amdxdna_client_visible(hwctx->client))
+		return 0;
+
+	return aie2_fill_hwctx_status_entry(hwctx, arg);
+}
+
 static int aie2_get_hwctx_status(struct amdxdna_client *client,
 				 struct amdxdna_drm_get_info *args)
 {
@@ -796,9 +814,7 @@ static int aie2_get_hwctx_status(struct amdxdna_client *client,
 	array_args.element_size = sizeof(struct amdxdna_drm_query_hwctx);
 	array_args.buffer = args->buffer;
 	array_args.num_element = args->buffer_size / array_args.element_size;
-	list_for_each_entry(tmp_client, &xdna->client_list, node) {
-		if (!amdxdna_client_visible(tmp_client))
-			continue;
+	amdxdna_for_each_client(xdna, tmp_client) {
 		ret = amdxdna_hwctx_walk(tmp_client, &array_args, NULL,
 					 aie2_hwctx_status_cb);
 		if (ret)
@@ -878,7 +894,7 @@ static int aie2_get_telemetry(struct amdxdna_client *client,
 	}
 
 	header->map_num_elements = elem_num;
-	list_for_each_entry(tmp_client, &xdna->client_list, node) {
+	amdxdna_for_each_client(xdna, tmp_client) {
 		if (!amdxdna_client_visible(tmp_client))
 			continue;
 		ret = amdxdna_hwctx_walk(tmp_client, &header->map, NULL,
@@ -991,7 +1007,7 @@ static int aie2_query_ctx_status_array(struct amdxdna_client *client,
 	struct amdxdna_drm_get_array array_args;
 	struct amdxdna_dev *xdna = client->xdna;
 	struct amdxdna_client *tmp_client;
-	int ret;
+	int ret = 0;
 
 	drm_WARN_ON(&xdna->ddev, !mutex_is_locked(&xdna->dev_lock));
 
@@ -1006,16 +1022,123 @@ static int aie2_query_ctx_status_array(struct amdxdna_client *client,
 	array_args.buffer = args->buffer;
 	array_args.num_element = args->num_element * args->element_size /
 				array_args.element_size;
-	list_for_each_entry(tmp_client, &xdna->client_list, node) {
+	amdxdna_for_each_client(xdna, tmp_client) {
 		ret = amdxdna_hwctx_walk(tmp_client, &array_args, NULL,
 					 aie2_hwctx_status_cb);
 		if (ret)
 			break;
 	}
 
+	/*
+	 * -ENOSPC just means the output buffer filled up; report the entries
+	 * that fit. Any other error (e.g. -EFAULT from copy_to_user) is a real
+	 * failure and must be propagated instead of a partial success.
+	 */
+	if (ret && ret != -ENOSPC)
+		return ret;
+
 	args->element_size = array_args.element_size;
 	args->num_element = (u32)((array_args.buffer - args->buffer) /
 				  args->element_size);
+
+	return 0;
+}
+
+struct aie2_hwctx_status_walk_arg {
+	struct amdxdna_hwctx_key	key;
+	struct amdxdna_drm_get_array	*array_args;
+};
+
+/* amdxdna_hwctx_match() casts the walk arg to struct amdxdna_hwctx_key. */
+static_assert(offsetof(struct aie2_hwctx_status_walk_arg, key) == 0,
+	      "key must be the first member for amdxdna_hwctx_match()");
+
+/*
+ * BY_ID adapter: amdxdna_hwctx_match() has already selected the (pid, ctx_id)
+ * target, so just forward to the shared gated emitter, which skips the entry
+ * when the caller may not see it.
+ */
+static int aie2_hwctx_by_id_cb(struct amdxdna_hwctx *hwctx, void *arg)
+{
+	struct aie2_hwctx_status_walk_arg *wa = arg;
+
+	return aie2_hwctx_status_cb(hwctx, wa->array_args);
+}
+
+static int aie2_query_ctx_status_by_id(struct amdxdna_client *client,
+				       struct amdxdna_drm_get_array *args)
+{
+	struct amdxdna_drm_hwctx_entry input = {};
+	struct amdxdna_dev *xdna = client->xdna;
+	struct amdxdna_drm_get_array array_args;
+	struct aie2_hwctx_status_walk_arg wa;
+	struct amdxdna_client *tmp_client;
+	int ret = -ENOENT;
+	size_t buf_size;
+
+	drm_WARN_ON(&xdna->ddev, !mutex_is_locked(&xdna->dev_lock));
+
+	if (args->num_element != 1) {
+		XDNA_ERR(xdna, "Invalid num_element %u, expected 1",
+			 args->num_element);
+		return -EINVAL;
+	}
+
+	if (args->element_size > SZ_4K) {
+		XDNA_DBG(xdna, "Invalid element size %u", args->element_size);
+		return -EINVAL;
+	}
+
+	buf_size = (size_t)args->num_element * args->element_size;
+	if (buf_size < sizeof(input)) {
+		XDNA_ERR(xdna, "Insufficient buffer size: 0x%zx", buf_size);
+		return -EINVAL;
+	}
+
+	if (copy_from_user(&input, u64_to_user_ptr(args->buffer), sizeof(input))) {
+		XDNA_ERR(xdna, "Failed to copy hwctx entry from user");
+		return -EFAULT;
+	}
+
+	if (!input.context_id || !input.pid) {
+		XDNA_ERR(xdna, "Invalid context ID %u or PID %lld",
+			 input.context_id, input.pid);
+		return -EINVAL;
+	}
+
+	array_args.element_size = min_t(size_t, args->element_size,
+					sizeof(struct amdxdna_drm_hwctx_entry));
+	array_args.buffer = args->buffer;
+	array_args.num_element = 1;
+
+	wa.array_args = &array_args;
+	wa.key.ctx_id = input.context_id;
+	wa.key.pid = input.pid;
+
+	amdxdna_for_each_client(xdna, tmp_client) {
+		ret = amdxdna_hwctx_walk(tmp_client, &wa,
+					 amdxdna_hwctx_match,
+					 aie2_hwctx_by_id_cb);
+		if (ret != -ENOENT)
+			break;
+	}
+
+	/*
+	 * A matched context that the caller may not see is skipped by the gated
+	 * emitter (nothing emitted, num_element stays 1). Do not disclose its
+	 * existence: report it as not found, same as a genuinely missing context.
+	 */
+	if (!ret && array_args.num_element)
+		ret = -ENOENT;
+
+	if (ret == -ENOENT)
+		XDNA_DBG(xdna, "Context %u for pid %lld not found",
+			 input.context_id, input.pid);
+	if (ret)
+		return ret;
+
+	args->element_size = array_args.element_size;
+	args->num_element = 1;
 
 	return 0;
 }
@@ -1058,6 +1181,9 @@ static int aie2_get_array(struct amdxdna_client *client,
 	switch (args->param) {
 	case DRM_AMDXDNA_HW_CONTEXT_ALL:
 		ret = aie2_query_ctx_status_array(client, args);
+		break;
+	case DRM_AMDXDNA_HW_CONTEXT_BY_ID:
+		ret = aie2_query_ctx_status_by_id(client, args);
 		break;
 	case DRM_AMDXDNA_HW_LAST_ASYNC_ERR:
 		ret = aie2_get_array_async_error(xdna->dev_handle, args);

--- a/drivers/accel/amdxdna/amdxdna_ctx.c
+++ b/drivers/accel/amdxdna/amdxdna_ctx.c
@@ -122,6 +122,13 @@ int amdxdna_hwctx_walk(struct amdxdna_client *client, void *arg,
 	return ret;
 }
 
+bool amdxdna_hwctx_match(struct amdxdna_hwctx *hwctx, void *arg)
+{
+	struct amdxdna_hwctx_key *key = arg;
+
+	return hwctx->client->pid == key->pid && hwctx->id == key->ctx_id;
+}
+
 void *amdxdna_cmd_get_payload(struct amdxdna_gem_obj *abo, u32 *size)
 {
 	struct amdxdna_cmd *cmd = amdxdna_gem_vmap(abo);

--- a/drivers/accel/amdxdna/amdxdna_ctx.c
+++ b/drivers/accel/amdxdna/amdxdna_ctx.c
@@ -95,9 +95,10 @@ static void amdxdna_hwctx_destroy_rcu(struct amdxdna_hwctx *hwctx,
 }
 
 /*
- * Walks @client's hwctxs invoking @walk. If @filter is set, @walk runs
- * only on the matching hwctx; returns -ENOENT if none matched.
- * Otherwise @walk runs on every hwctx; halts on the first non-zero return.
+ * Walks @client's hwctxs invoking @walk. If @filter is set, @walk runs on
+ * every matching hwctx (not just the first); returns -ENOENT if none matched.
+ * Otherwise @walk runs on every hwctx. In both modes it halts on the first
+ * non-zero @walk return.
  */
 int amdxdna_hwctx_walk(struct amdxdna_client *client, void *arg,
 		       bool (*filter)(struct amdxdna_hwctx *hwctx, void *arg),
@@ -113,8 +114,6 @@ int amdxdna_hwctx_walk(struct amdxdna_client *client, void *arg,
 		if (filter && !filter(hwctx, arg))
 			continue;
 		ret = walk(hwctx, arg);
-		if (filter)
-			break;
 		if (ret)
 			break;
 	}

--- a/drivers/accel/amdxdna/amdxdna_ctx.h
+++ b/drivers/accel/amdxdna/amdxdna_ctx.h
@@ -207,6 +207,17 @@ void amdxdna_hwctx_remove_all(struct amdxdna_client *client);
 int amdxdna_hwctx_walk(struct amdxdna_client *client, void *arg,
 		       bool (*filter)(struct amdxdna_hwctx *hwctx, void *arg),
 		       int (*walk)(struct amdxdna_hwctx *hwctx, void *arg));
+
+/*
+ * Key for matching a hwctx by (pid, ctx_id). Embed it as the first member
+ * of an amdxdna_hwctx_walk() arg struct to reuse amdxdna_hwctx_match().
+ */
+struct amdxdna_hwctx_key {
+	s64	pid;
+	u32	ctx_id;
+};
+
+bool amdxdna_hwctx_match(struct amdxdna_hwctx *hwctx, void *arg);
 int amdxdna_hwctx_sync_debug_bo(struct amdxdna_client *client, u32 debug_bo_hdl);
 int amdxdna_update_heap(struct amdxdna_client *client, struct amdxdna_hwctx *hwctx);
 

--- a/drivers/accel/amdxdna/amdxdna_pci_drv.c
+++ b/drivers/accel/amdxdna/amdxdna_pci_drv.c
@@ -131,7 +131,8 @@ static void amdxdna_sva_fini(struct amdxdna_client *client)
 static int amdxdna_drm_open(struct drm_device *ddev, struct drm_file *filp)
 {
 	struct amdxdna_dev *xdna = to_xdna_dev(ddev);
-	struct amdxdna_client *client;
+	struct amdxdna_client *tmp, *client;
+	int ret;
 
 	client = kzalloc_obj(*client);
 	if (!client)
@@ -156,6 +157,14 @@ static int amdxdna_drm_open(struct drm_device *ddev, struct drm_file *filp)
 	mutex_init(&client->mm_lock);
 
 	mutex_lock(&xdna->dev_lock);
+	amdxdna_for_each_client(xdna, tmp) {
+		if (tmp->pid == client->pid) {
+			mutex_unlock(&xdna->dev_lock);
+			XDNA_WARN(xdna, "pid %d already opened the device", client->pid);
+			ret = -EBUSY;
+			goto fail;
+		}
+	}
 	list_add_tail(&client->node, &xdna->client_list);
 	mutex_unlock(&xdna->dev_lock);
 
@@ -166,6 +175,17 @@ static int amdxdna_drm_open(struct drm_device *ddev, struct drm_file *filp)
 
 	XDNA_DBG(xdna, "pid %d opened", client->pid);
 	return 0;
+
+fail:
+	drm_mm_takedown(&client->dev_heap_mm);
+	xa_destroy(&client->dev_heap_xa);
+	xa_destroy(&client->hwctx_xa);
+	cleanup_srcu_struct(&client->hwctx_srcu);
+	mutex_destroy(&client->mm_lock);
+	mmdrop(client->mm);
+	amdxdna_sva_fini(client);
+	kfree(client);
+	return ret;
 }
 
 static void amdxdna_client_cleanup(struct amdxdna_client *client)

--- a/include/uapi/drm/amdxdna_accel.h
+++ b/include/uapi/drm/amdxdna_accel.h
@@ -802,6 +802,7 @@ struct amdxdna_drm_get_dpt_state {
  * Supported params in struct amdxdna_drm_get_array
  */
 #define DRM_AMDXDNA_HW_CONTEXT_ALL	0
+#define DRM_AMDXDNA_HW_CONTEXT_BY_ID	1
 #define DRM_AMDXDNA_HW_LAST_ASYNC_ERR	2
 #define DRM_AMDXDNA_FW_LOG		3
 #define DRM_AMDXDNA_FW_TRACE		4
@@ -821,7 +822,22 @@ struct amdxdna_drm_get_array {
 	 * Supported params:
 	 *
 	 * %DRM_AMDXDNA_HW_CONTEXT_ALL:
-	 * Returns all created hardware contexts.
+	 * Returns the created hardware contexts the caller is allowed to see:
+	 * contexts owned by other Linux users are omitted unless the caller has
+	 * CAP_SYS_ADMIN, which sees all contexts.
+	 *
+	 * %DRM_AMDXDNA_HW_CONTEXT_BY_ID:
+	 * Returns a single hardware context selected by (pid, context_id).
+	 * num_element must be 1. The first sizeof(struct
+	 * amdxdna_drm_hwctx_entry) bytes of buffer carry the request
+	 * (context_id + pid); on success the driver overwrites that entry
+	 * with the matching context. Both fields must be set: context_id
+	 * must be non-zero (0 is the reserved invalid context handle) and
+	 * pid must be non-zero, otherwise -EINVAL is returned. Access: a
+	 * process running as the same Linux user as the context creator (or
+	 * CAP_SYS_ADMIN) may query the context; a caller that may not see the
+	 * target gets -ENOENT, indistinguishable from a genuinely missing
+	 * context, so another user's contexts are not disclosed.
 	 *
 	 * %DRM_AMDXDNA_HW_LAST_ASYNC_ERR:
 	 * Returns last async error.

--- a/test/shim_test/io_test.cpp
+++ b/test/shim_test/io_test.cpp
@@ -9,6 +9,10 @@
 #include "io_param.h"
 
 #include "core/common/device.h"
+#include "core/common/system.h"
+#include "core/common/query_requests.h"
+#include "core/include/ert.h"
+#include "xrt/detail/xclbin.h"
 #include <fstream>
 #include <sstream>
 #include <string>
@@ -451,39 +455,36 @@ constexpr uint32_t SYS_EFF_FACTOR = 2;
 uint32_t
 query_hclk(device* dev)
 {
-  int fd = open_accel_fd(dev);
-  amdxdna_drm_query_clock_metadata clock = {};
-  amdxdna_drm_get_info arg = {
-    .param = DRM_AMDXDNA_QUERY_CLOCK_METADATA,
-    .buffer_size = sizeof(clock),
-    .buffer = reinterpret_cast<uintptr_t>(&clock),
-  };
+  // Use the in-process shim device query (no second open of the node).
+  auto raw = device_query<query::clock_freq_topology_raw>(dev);
 
-  int ret = ::ioctl(fd, DRM_IOCTL_AMDXDNA_GET_INFO, &arg);
-  close(fd);
-  if (ret == -1)
-    throw std::runtime_error("ioctl(QUERY_CLOCK_METADATA) failed");
+  // Validate the raw payload before trusting m_count and indexing the
+  // flexible m_clock_freq[] array. sizeof(clock_freq_topology) already
+  // accounts for one clock_freq entry.
+  if (raw.size() < sizeof(clock_freq_topology))
+    throw std::runtime_error("clock_freq_topology payload too small: " +
+      std::to_string(raw.size()) + " bytes");
+  auto topology = reinterpret_cast<const clock_freq_topology*>(raw.data());
+  const int count = topology->m_count;
+  const size_t needed = (count <= 0) ? sizeof(clock_freq_topology) :
+    sizeof(clock_freq_topology) + static_cast<size_t>(count - 1) * sizeof(clock_freq);
+  if (count < 0 || raw.size() < needed)
+    throw std::runtime_error("clock_freq_topology payload truncated for " +
+      std::to_string(count) + " entries");
 
-  return clock.h_clock.freq_mhz;
+  for (int i = 0; i < count; i++) {
+    if (std::string(topology->m_clock_freq[i].m_name) == "H Clock")
+      return topology->m_clock_freq[i].m_freq_Mhz;
+  }
+  throw std::runtime_error("H Clock not found in clock frequency topology");
 }
 
 void
 set_power_mode(device* dev, int mode)
 {
-  int fd = open_accel_fd(dev);
-  amdxdna_drm_set_power_mode pm = {};
-  pm.power_mode = static_cast<uint8_t>(mode);
-
-  amdxdna_drm_set_state arg = {
-    .param = DRM_AMDXDNA_SET_POWER_MODE,
-    .buffer_size = sizeof(pm),
-    .buffer = reinterpret_cast<uintptr_t>(&pm),
-  };
-
-  int ret = ::ioctl(fd, DRM_IOCTL_AMDXDNA_SET_STATE, &arg);
-  close(fd);
-  if (ret == -1)
-    throw std::runtime_error("ioctl(SET_POWER_MODE) failed for mode " + std::to_string(mode));
+  // POWER_MODE_* values map 1:1 to query::performance_mode::power_type.
+  device_update<query::performance_mode>(dev,
+    static_cast<query::performance_mode::power_type>(mode));
 }
 
 bool

--- a/test/shim_test/shim_test.cpp
+++ b/test/shim_test/shim_test.cpp
@@ -21,6 +21,9 @@
 #include <array>
 #include <filesystem>
 #include <fstream>
+#include <functional>
+#include <optional>
+#include <type_traits>
 #include <vector>
 #include <iostream>
 #include <sstream>
@@ -31,6 +34,7 @@
 #include <libgen.h>
 #include <sys/utsname.h>
 #include <unistd.h>
+#include <sys/wait.h>
 #include <sys/mman.h>
 #include <fcntl.h>
 #include <sys/ioctl.h>
@@ -274,6 +278,11 @@ get_sysfs_path(device* dev)
 
 // Returns an open fd for the accel device node corresponding to dev. Caller must close(fd).
 // Throws std::runtime_error on failure (opendir, missing accel entry, or open).
+//
+// NOTE: single-open-per-process means this MUST NOT be called from a process
+// that already holds the device open via the shim - the driver rejects the
+// second open with EBUSY. The bo_usage / driver_version helpers below call it
+// only from a short-lived forked child (distinct pid), so the open succeeds.
 int
 open_accel_fd(device* dev)
 {
@@ -312,24 +321,96 @@ open_accel_fd(device* dev)
   return fd;
 }
 
+// Run op(fd) in a short-lived forked child and return its POD result.
+//
+// Some helpers need a raw ioctl, but the shim already holds the device open and
+// the driver allows only one open per process, so a second open() from this
+// process is rejected with EBUSY. The child has a distinct pid, so its open()
+// of the node is allowed. The child opens a fresh fd via open_accel_fd(),
+// touches nothing else of the inherited shim state, computes the result, and
+// pipes it back to the parent as raw bytes (hence the trivially-copyable
+// requirement). Per-pid/per-fd ioctls (BO_USAGE filters by the pid argument,
+// drm_version is generic) return the same data from the child as the parent.
+template <typename T>
+T
+fork_query(device* dev, const std::function<T(int fd)>& op)
+{
+  static_assert(std::is_trivially_copyable<T>::value,
+    "fork_query<T>: T crosses a pipe as raw bytes and must be trivially copyable");
+
+  int pipefd[2];
+  if (pipe(pipefd) == -1)
+    throw std::runtime_error(std::string("pipe() failed: ") + std::strerror(errno));
+
+  pid_t child = fork();
+  if (child == -1) {
+    close(pipefd[0]);
+    close(pipefd[1]);
+    throw std::runtime_error(std::string("fork() failed: ") + std::strerror(errno));
+  }
+
+  if (child == 0) {
+    // Child: do not touch any inherited shim state beyond a fresh fd.
+    close(pipefd[0]);
+    int rc = 1;
+    try {
+      int fd = open_accel_fd(dev);
+      T result = op(fd);
+      close(fd);
+      if (write(pipefd[1], &result, sizeof(result)) == static_cast<ssize_t>(sizeof(result)))
+        rc = 0;
+    } catch (...) {
+      rc = 1;
+    }
+    close(pipefd[1]);
+    _exit(rc);
+  }
+
+  // Parent: read the full result (EINTR/short-read safe), then reap the child
+  // on every path so there is no fd leak or unreaped child even on error.
+  close(pipefd[1]);
+  T result{};
+  auto buf = reinterpret_cast<char*>(&result);
+  size_t got = 0;
+  while (got < sizeof(result)) {
+    ssize_t n = read(pipefd[0], buf + got, sizeof(result) - got);
+    if (n < 0) {
+      if (errno == EINTR)
+        continue;
+      break;            // real read error
+    }
+    if (n == 0)
+      break;            // premature EOF: child exited before writing all
+    got += static_cast<size_t>(n);
+  }
+  close(pipefd[0]);
+
+  int status = 0;
+  while (waitpid(child, &status, 0) == -1 && errno == EINTR)
+    ;
+
+  if (got != sizeof(result) || !WIFEXITED(status) || WEXITSTATUS(status) != 0)
+    throw std::runtime_error("forked query child failed");
+
+  return result;
+}
+
+// Query BO usage for the given pid via a forked child (see fork_query).
 std::tuple<uint64_t, uint64_t, uint64_t>
 get_bo_usage(device* dev, int pid)
 {
-  // FIXME: reimplement this when query key is defined in xrt
-  int fd = open_accel_fd(dev);
-
-  amdxdna_drm_bo_usage usage = { .pid = pid };
-  amdxdna_drm_get_array arg = {
-    .param = DRM_AMDXDNA_BO_USAGE,
-    .element_size = sizeof(usage),
-    .num_element = 1,
-    .buffer = reinterpret_cast<uintptr_t>(&usage)
-  };
-  int ret = ::ioctl(fd, DRM_IOCTL_AMDXDNA_GET_ARRAY, &arg);
-  close(fd);
-  if (ret == -1) {
-    throw std::runtime_error("ioctl(DRM_IOCTL_AMDXDNA_GET_ARRAY) failed");
-  }
+  auto usage = fork_query<amdxdna_drm_bo_usage>(dev, [pid](int fd) {
+    amdxdna_drm_bo_usage u = { .pid = pid };
+    amdxdna_drm_get_array arg = {
+      .param = DRM_AMDXDNA_BO_USAGE,
+      .element_size = sizeof(u),
+      .num_element = 1,
+      .buffer = reinterpret_cast<uintptr_t>(&u)
+    };
+    if (::ioctl(fd, DRM_IOCTL_AMDXDNA_GET_ARRAY, &arg) == -1)
+      throw std::runtime_error("ioctl(DRM_IOCTL_AMDXDNA_GET_ARRAY) failed");
+    return u;
+  });
 
   return {usage.total_usage, usage.internal_usage, usage.heap_usage};
 }
@@ -1212,32 +1293,37 @@ run_all_test(std::vector<int>& tests)
   }
 }
 
+struct drv_version { unsigned int major; unsigned int minor; };
+
 int
 get_driver_version(unsigned int *major, unsigned int *minor, device::id_type device_index = 0)
 {
+  // Resolve the node via a shim device, then read drm_version from a forked
+  // child (distinct pid -> open() allowed under single-open). drm_version is a
+  // generic per-fd ioctl, so any fd to the node returns the same KMD version.
   auto sdev = get_userpf_device(device_index);
-  int fd = open_accel_fd(sdev.get());
 
-  drm_version version = {};
-  char name[128];
-  char date[128];
-  char desc[256];
+  auto ver = fork_query<drv_version>(sdev.get(), [](int fd) {
+    drm_version version = {};
+    char name[128];
+    char date[128];
+    char desc[256];
+    version.name_len = sizeof(name);
+    version.name = name;
+    version.date_len = sizeof(date);
+    version.date = date;
+    version.desc_len = sizeof(desc);
+    version.desc = desc;
+    if (::ioctl(fd, DRM_IOCTL_VERSION, &version) == -1)
+      throw std::runtime_error("ioctl(DRM_IOCTL_VERSION) failed");
+    return drv_version{
+      static_cast<unsigned int>(version.version_major),
+      static_cast<unsigned int>(version.version_minor)
+    };
+  });
 
-  version.name_len = sizeof(name);
-  version.name = name;
-  version.date_len = sizeof(date);
-  version.date = date;
-  version.desc_len = sizeof(desc);
-  version.desc = desc;
-
-  int result = ::ioctl(fd, DRM_IOCTL_VERSION, &version);
-  close(fd);
-  if (result) {
-    throw std::runtime_error("ioctl(DRM_IOCTL_VERSION) failed");
-  }
-
-  *major = version.version_major;
-  *minor = version.version_minor;
+  *major = ver.major;
+  *minor = ver.minor;
 
   return 0;
 }


### PR DESCRIPTION
Cherry-pick the following main branch commits for 1.8:

f8fd0ff accel/amdxdna: reject a second device open from the same process
3d89d37 accel/amdxdna: add per-context hw-context status/health query
c721596 accel/amdxdna: run amdxdna_hwctx_walk filter across all matching contexts