### PR TITLE
accel/amdxdna: scale DPM by context priority and boot at lowest level

### DIFF
--- a/drivers/accel/amdxdna/aie2_pm.c
+++ b/drivers/accel/amdxdna/aie2_pm.c
@@ -64,10 +64,11 @@ int aie2_pm_start(struct amdxdna_dev_hdl *ndev)
 		ndev->max_dpm_level++;
 	ndev->max_dpm_level--;
 
-	ret = ndev->priv->hw_ops->set_dpm(&ndev->aie, ndev->max_dpm_level);
+	/* Boot at the lowest DPM level. The first context raises it. */
+	ret = ndev->priv->hw_ops->set_dpm(&ndev->aie, 0);
 	if (ret)
 		return ret;
-	ndev->dpm_level = ndev->max_dpm_level;
+	ndev->dpm_level = 0;
 
 	ret = aie2_pm_set_clk_gating(ndev, AIE2_CLK_GATING_ENABLE);
 	if (ret)

--- a/drivers/accel/amdxdna/aie2_solver.c
+++ b/drivers/accel/amdxdna/aie2_solver.c
@@ -10,6 +10,7 @@
 #include <linux/bitmap.h>
 #include <linux/slab.h>
 
+#include "drm/amdxdna_accel.h"
 #include "aie2_solver.h"
 
 struct partition_node {
@@ -111,35 +112,45 @@ static bool is_valid_qos_dpm_params(struct aie_qos *rqos)
 
 static int set_dpm_level(struct solver_state *xrs, struct alloc_requests *req, u32 *dpm_level)
 {
+	u32 freq, max_dpm_level, level, dev_level;
 	struct solver_rgroup *rgp = &xrs->rgp;
 	struct cdo_parts *cdop = &req->cdo;
 	struct aie_qos *rqos = &req->rqos;
-	u32 freq, max_dpm_level, level;
 	struct solver_node *node;
 
 	max_dpm_level = xrs->cfg.clk_list.num_levels - 1;
-	/* If no QoS parameters are passed, set it to the max DPM level */
-	if (!is_valid_qos_dpm_params(rqos)) {
+
+	if (rqos->priority == AMDXDNA_QOS_LOW_PRIORITY) {
+		/*
+		 * Idle clients run at the lowest DPM level, ignoring the
+		 * gops/fps/latency hints.
+		 */
+		level = 0;
+	} else if (!is_valid_qos_dpm_params(rqos)) {
+		/* If no QoS parameters are passed, set it to the max DPM level */
 		level = max_dpm_level;
-		goto set_dpm;
+	} else {
+		/* Find one CDO group that meets the GOPs requirement. */
+		for (level = 0; level < max_dpm_level; level++) {
+			freq = xrs->cfg.clk_list.cu_clk_list[level];
+			if (!qos_meet(xrs, rqos, cdop->qos_cap.opc * freq / 1000))
+				break;
+		}
 	}
 
-	/* Find one CDO group that meet the GOPs requirement. */
-	for (level = 0; level < max_dpm_level; level++) {
-		freq = xrs->cfg.clk_list.cu_clk_list[level];
-		if (!qos_meet(xrs, rqos, cdop->qos_cap.opc * freq / 1000))
-			break;
-	}
-
-	/* set the dpm level which fits all the sessions */
+	/* Device runs at the highest DPM level requested across active sessions. */
+	dev_level = level;
 	list_for_each_entry(node, &rgp->node_list, list) {
-		if (node->dpm_level > level)
-			level = node->dpm_level;
+		if (node->dpm_level > dev_level)
+			dev_level = node->dpm_level;
 	}
 
-set_dpm:
+	drm_dbg(xrs->cfg.ddev, "priority 0x%x level %u dev_level %u\n",
+		rqos->priority, level, dev_level);
+
+	/* Store this request's own level; program the aggregated device level. */
 	*dpm_level = level;
-	return xrs->cfg.actions->set_dft_dpm_level(xrs->cfg.ddev, level);
+	return xrs->cfg.actions->set_dft_dpm_level(xrs->cfg.ddev, dev_level);
 }
 
 static struct solver_node *rg_search_node(struct solver_rgroup *rgp, u64 rid)


### PR DESCRIPTION
Improve aie2 DPM management in two ways.

First, honor the QoS priority during context creation: a context with AMDXDNA_QOS_LOW_PRIORITY now requests the lowest DPM level (DPM0), ignoring its gops/fps/latency hints. Other priorities are unchanged.

Second, boot the NPU at the lowest DPM level instead of the maximum. The first hardware context raises the level via the solver.

To make the per-context level meaningful, set_dpm_level() now stores each request's own level in its solver node and programs the aggregated maximum across active sessions to hardware. Previously the node was populated with the aggregated level, so a context created while a higher-demand context was active recorded that higher level too; once the high-demand context was destroyed, xrs_release_resource() re-derived the device level from those inflated values and could leave the device stuck at the higher DPM level.