### PR TITLE
accel/amdxdna: wait for clock to settle on power-mode override

### DIFF
--- a/drivers/accel/amdxdna/aie2_pm.c
+++ b/drivers/accel/amdxdna/aie2_pm.c
@@ -7,13 +7,60 @@
 #include <drm/drm_device.h>
 #include <drm/drm_print.h>
 #include <drm/gpu_scheduler.h>
+#include <linux/iopoll.h>
 
 #include "aie2_pci.h"
 #include "amdxdna_pci_drv.h"
 #include "amdxdna_pm.h"
+#include "amdxdna_sensors.h"
 
 #define AIE2_CLK_GATING_ENABLE	1
 #define AIE2_CLK_GATING_DISABLE	0
+
+/* Allow the NPU clock to ramp to a power-override DPM level before returning. */
+#define AIE2_DPM_SETTLE_TIMEOUT_US	2000000
+#define AIE2_DPM_SETTLE_INTERVAL_US	1000
+
+/*
+ * Setting a DPM level via the SMU only defines the allowed clock range; the
+ * actual NPU clock is demand-driven and ramps to the requested level over
+ * time. For an explicit power-mode override the caller expects the requested
+ * performance to be in effect on return, so poll until PMF telemetry reports
+ * the MP-NPU clock has reached the target.
+ *
+ * Only the ramp-up direction is waited on: a downclocking override (e.g. to
+ * LOW) is an explicit request for lower performance and has nothing to settle.
+ *
+ * PMF NPU telemetry is only available on kernels with amd-pmf support (>= 7.0);
+ * amdxdna_get_sensors() returns an error otherwise, in which case the wait is
+ * skipped. The wait is bounded by a timeout.
+ */
+static void aie2_pm_wait_for_dpm(struct amdxdna_dev_hdl *ndev, u32 dpm_level)
+{
+	struct amdxdna_sensors npu_metrics;
+	int err, ret;
+	u32 target;
+
+	/* Telemetry can plateau just below the table value; accept within ~5%. */
+	target = ndev->priv->dpm_clk_tbl[dpm_level].npuclk;
+	target -= target / 20;
+
+	ret = read_poll_timeout(amdxdna_get_sensors, err,
+				err || npu_metrics.mpnpuclk_freq >= target,
+				AIE2_DPM_SETTLE_INTERVAL_US,
+				AIE2_DPM_SETTLE_TIMEOUT_US, false, &npu_metrics);
+
+	if (err) {
+		if (err != -EOPNOTSUPP)
+			XDNA_DBG(ndev->aie.xdna, "PMF sensor read failed (%d), skip DPM wait", err);
+		return;
+	}
+
+	if (ret)
+		XDNA_WARN(ndev->aie.xdna,
+			  "Timed out waiting for MP-NPU clock %u, got %u",
+			  target, npu_metrics.mpnpuclk_freq);
+}
 
 static int aie2_pm_set_clk_gating(struct amdxdna_dev_hdl *ndev, u32 val)
 {
@@ -119,6 +166,14 @@ int aie2_pm_set_mode(struct amdxdna_dev_hdl *ndev, enum amdxdna_power_mode_type 
 	ret = aie2_pm_set_dpm(ndev, dpm_level);
 	if (ret)
 		return ret;
+
+	/*
+	 * For an explicit power override, wait for the clock to actually reach
+	 * the requested level so the next workload runs at the intended
+	 * frequency instead of during the ramp.
+	 */
+	if (target != POWER_MODE_DEFAULT)
+		aie2_pm_wait_for_dpm(ndev, dpm_level);
 
 	ret = aie2_pm_set_clk_gating(ndev, clk_gating);
 	if (ret)


### PR DESCRIPTION
Setting a DPM level via the SMU only defines the allowed clock range; the actual NPU clock is demand-driven and ramps to the requested level over time. After an explicit power-mode override the device can spend the first workload running during the clock ramp instead of at the requested frequency, which shows up as degraded performance (for example a low GEMM TOPS number from the first xrt-smi validate run).

Block aie2_pm_set_mode() until PMF telemetry reports the MP-NPU clock has reached the requested level (within a small tolerance, since the telemetry can plateau just below the table value) before returning, so the next workload runs at the intended frequency. The wait is interruptible and bounded by a timeout, and only applies to explicit overrides, not the default per-context DPM path.

PMF NPU telemetry is only available on kernels with amd-pmf support; amdxdna_get_sensors() returns an error otherwise, in which case the wait is skipped and behavior is unchanged.