### PR TITLE
DPM changes for 1.8

### DIFF
--- a/drivers/accel/amdxdna/aie2_pm.c
+++ b/drivers/accel/amdxdna/aie2_pm.c
@@ -64,10 +64,11 @@ int aie2_pm_start(struct amdxdna_dev_hdl *ndev)
 		ndev->max_dpm_level++;
 	ndev->max_dpm_level--;
 
-	ret = ndev->priv->hw_ops->set_dpm(&ndev->aie, ndev->max_dpm_level);
+	/* Boot at the lowest DPM level. The first context raises it. */
+	ret = ndev->priv->hw_ops->set_dpm(&ndev->aie, 0);
 	if (ret)
 		return ret;
-	ndev->dpm_level = ndev->max_dpm_level;
+	ndev->dpm_level = 0;
 
 	ret = aie2_pm_set_clk_gating(ndev, AIE2_CLK_GATING_ENABLE);
 	if (ret)

--- a/drivers/accel/amdxdna/aie2_pm.c
+++ b/drivers/accel/amdxdna/aie2_pm.c
@@ -7,13 +7,60 @@
 #include <drm/drm_device.h>
 #include <drm/drm_print.h>
 #include <drm/gpu_scheduler.h>
+#include <linux/iopoll.h>
 
 #include "aie2_pci.h"
 #include "amdxdna_pci_drv.h"
 #include "amdxdna_pm.h"
+#include "amdxdna_sensors.h"
 
 #define AIE2_CLK_GATING_ENABLE	1
 #define AIE2_CLK_GATING_DISABLE	0
+
+/* Allow the NPU clock to ramp to a power-override DPM level before returning. */
+#define AIE2_DPM_SETTLE_TIMEOUT_US	2000000
+#define AIE2_DPM_SETTLE_INTERVAL_US	1000
+
+/*
+ * Setting a DPM level via the SMU only defines the allowed clock range; the
+ * actual NPU clock is demand-driven and ramps to the requested level over
+ * time. For an explicit power-mode override the caller expects the requested
+ * performance to be in effect on return, so poll until PMF telemetry reports
+ * the MP-NPU clock has reached the target.
+ *
+ * Only the ramp-up direction is waited on: a downclocking override (e.g. to
+ * LOW) is an explicit request for lower performance and has nothing to settle.
+ *
+ * PMF NPU telemetry is only available on kernels with amd-pmf support (>= 7.0);
+ * amdxdna_get_sensors() returns an error otherwise, in which case the wait is
+ * skipped. The wait is bounded by a timeout.
+ */
+static void aie2_pm_wait_for_dpm(struct amdxdna_dev_hdl *ndev, u32 dpm_level)
+{
+	struct amdxdna_sensors npu_metrics;
+	int err, ret;
+	u32 target;
+
+	/* Telemetry can plateau just below the table value; accept within ~5%. */
+	target = ndev->priv->dpm_clk_tbl[dpm_level].npuclk;
+	target -= target / 20;
+
+	ret = read_poll_timeout(amdxdna_get_sensors, err,
+				err || npu_metrics.mpnpuclk_freq >= target,
+				AIE2_DPM_SETTLE_INTERVAL_US,
+				AIE2_DPM_SETTLE_TIMEOUT_US, false, &npu_metrics);
+
+	if (err) {
+		if (err != -EOPNOTSUPP)
+			XDNA_DBG(ndev->aie.xdna, "PMF sensor read failed (%d), skip DPM wait", err);
+		return;
+	}
+
+	if (ret)
+		XDNA_WARN(ndev->aie.xdna,
+			  "Timed out waiting for MP-NPU clock %u, got %u",
+			  target, npu_metrics.mpnpuclk_freq);
+}
 
 static int aie2_pm_set_clk_gating(struct amdxdna_dev_hdl *ndev, u32 val)
 {
@@ -119,6 +166,14 @@ int aie2_pm_set_mode(struct amdxdna_dev_hdl *ndev, enum amdxdna_power_mode_type 
 	ret = aie2_pm_set_dpm(ndev, dpm_level);
 	if (ret)
 		return ret;
+
+	/*
+	 * For an explicit power override, wait for the clock to actually reach
+	 * the requested level so the next workload runs at the intended
+	 * frequency instead of during the ramp.
+	 */
+	if (target != POWER_MODE_DEFAULT)
+		aie2_pm_wait_for_dpm(ndev, dpm_level);
 
 	ret = aie2_pm_set_clk_gating(ndev, clk_gating);
 	if (ret)

--- a/drivers/accel/amdxdna/aie2_solver.c
+++ b/drivers/accel/amdxdna/aie2_solver.c
@@ -10,6 +10,7 @@
 #include <linux/bitmap.h>
 #include <linux/slab.h>
 
+#include "drm/amdxdna_accel.h"
 #include "aie2_solver.h"
 
 struct partition_node {
@@ -111,35 +112,45 @@ static bool is_valid_qos_dpm_params(struct aie_qos *rqos)
 
 static int set_dpm_level(struct solver_state *xrs, struct alloc_requests *req, u32 *dpm_level)
 {
+	u32 freq, max_dpm_level, level, dev_level;
 	struct solver_rgroup *rgp = &xrs->rgp;
 	struct cdo_parts *cdop = &req->cdo;
 	struct aie_qos *rqos = &req->rqos;
-	u32 freq, max_dpm_level, level;
 	struct solver_node *node;
 
 	max_dpm_level = xrs->cfg.clk_list.num_levels - 1;
-	/* If no QoS parameters are passed, set it to the max DPM level */
-	if (!is_valid_qos_dpm_params(rqos)) {
+
+	if (rqos->priority == AMDXDNA_QOS_LOW_PRIORITY) {
+		/*
+		 * Idle clients run at the lowest DPM level, ignoring the
+		 * gops/fps/latency hints.
+		 */
+		level = 0;
+	} else if (!is_valid_qos_dpm_params(rqos)) {
+		/* If no QoS parameters are passed, set it to the max DPM level */
 		level = max_dpm_level;
-		goto set_dpm;
+	} else {
+		/* Find one CDO group that meets the GOPs requirement. */
+		for (level = 0; level < max_dpm_level; level++) {
+			freq = xrs->cfg.clk_list.cu_clk_list[level];
+			if (!qos_meet(xrs, rqos, cdop->qos_cap.opc * freq / 1000))
+				break;
+		}
 	}
 
-	/* Find one CDO group that meet the GOPs requirement. */
-	for (level = 0; level < max_dpm_level; level++) {
-		freq = xrs->cfg.clk_list.cu_clk_list[level];
-		if (!qos_meet(xrs, rqos, cdop->qos_cap.opc * freq / 1000))
-			break;
-	}
-
-	/* set the dpm level which fits all the sessions */
+	/* Device runs at the highest DPM level requested across active sessions. */
+	dev_level = level;
 	list_for_each_entry(node, &rgp->node_list, list) {
-		if (node->dpm_level > level)
-			level = node->dpm_level;
+		if (node->dpm_level > dev_level)
+			dev_level = node->dpm_level;
 	}
 
-set_dpm:
+	drm_dbg(xrs->cfg.ddev, "priority 0x%x level %u dev_level %u\n",
+		rqos->priority, level, dev_level);
+
+	/* Store this request's own level; program the aggregated device level. */
 	*dpm_level = level;
-	return xrs->cfg.actions->set_dft_dpm_level(xrs->cfg.ddev, level);
+	return xrs->cfg.actions->set_dft_dpm_level(xrs->cfg.ddev, dev_level);
 }
 
 static struct solver_node *rg_search_node(struct solver_rgroup *rgp, u64 rid)


### PR DESCRIPTION
Cherry-pick: 
928ce6f accel/amdxdna: wait for clock to settle on power-mode override
94df46e accel/amdxdna: scale DPM by context priority and boot at lowest level