### PR TITLE
accel/amdxdna: Fix SMU command execution on platforms without interrupt trigger

### DIFF
--- a/drivers/accel/amdxdna/aie.h
+++ b/drivers/accel/amdxdna/aie.h
@@ -119,6 +119,7 @@ struct aie_bar_off_pair {
 
 struct smu_config {
 	void __iomem    *smu_regs[SMU_MAX_REGS];
+	bool		intr_enabled;
 };
 
 struct psp_config {

--- a/drivers/accel/amdxdna/aie2_pci.c
+++ b/drivers/accel/amdxdna/aie2_pci.c
@@ -596,6 +596,7 @@ static int aie2_init(struct amdxdna_dev *xdna)
 
 	for (i = 0; i < SMU_MAX_REGS; i++)
 		smu_conf.smu_regs[i] = tbl[SMU_REG_BAR(ndev, i)] + SMU_REG_OFF(ndev, i);
+	smu_conf.intr_enabled = ndev->priv->smu_intr_enabled;
 	ndev->aie.smu_hdl = aiem_smu_create(&xdna->ddev, &smu_conf);
 	if (!ndev->aie.smu_hdl) {
 		XDNA_ERR(xdna, "failed to create smu");

--- a/drivers/accel/amdxdna/aie2_pci.h
+++ b/drivers/accel/amdxdna/aie2_pci.h
@@ -194,6 +194,7 @@ struct amdxdna_dev_priv {
 	struct aie_bar_off_pair		sram_offs[SRAM_MAX_INDEX];
 	struct aie_bar_off_pair		psp_regs_off[PSP_MAX_REGS];
 	struct aie_bar_off_pair		smu_regs_off[SMU_MAX_REGS];
+	bool				smu_intr_enabled;
 	const struct aie_hw_ops		*hw_ops;
 };
 

--- a/drivers/accel/amdxdna/aie4_pci.c
+++ b/drivers/accel/amdxdna/aie4_pci.c
@@ -523,8 +523,8 @@ static int aie4_prepare_firmware(struct amdxdna_dev_hdl *ndev,
 				 void __iomem *tbl[PCI_NUM_RESOURCES])
 {
 	struct amdxdna_dev *xdna = ndev->aie.xdna;
+	struct smu_config smu_conf = {};
 	struct psp_config psp_conf;
-	struct smu_config smu_conf;
 	int i;
 
 	psp_conf.fw_size = npufw->size;

--- a/drivers/accel/amdxdna/aie_smu.c
+++ b/drivers/accel/amdxdna/aie_smu.c
@@ -26,22 +26,31 @@
 
 struct smu_device {
 	struct drm_device	*ddev;
-	struct smu_config	conf;
 	void __iomem		*smu_regs[SMU_MAX_REGS];
+	bool			intr_enabled;
 };
 
 static int aie_smu_exec(struct smu_device *smu, u32 reg_cmd, u32 reg_arg, u32 *out)
 {
-	u32 resp;
+	u32 resp, intr;
 	int ret;
+
+	if (smu->intr_enabled) {
+		ret = readx_poll_timeout(readl, SMU_REG(smu, SMU_INTR_REG), intr,
+					 !(intr & 0x2), AIE_INTERVAL, AIE_TIMEOUT);
+		if (ret) {
+			drm_err(smu->ddev, "wait for smu intr idle timed out: %d", intr);
+			return ret;
+		}
+	}
 
 	writel(0, SMU_REG(smu, SMU_RESP_REG));
 	writel(reg_arg, SMU_REG(smu, SMU_ARG_REG));
 	writel(reg_cmd, SMU_REG(smu, SMU_CMD_REG));
 
-	/* Clear and set SMU_INTR_REG to kick off */
-	writel(0, SMU_REG(smu, SMU_INTR_REG));
-	writel(1, SMU_REG(smu, SMU_INTR_REG));
+	/* Set SMU_INTR_REG to kick off */
+	if (smu->intr_enabled)
+		writel(1, SMU_REG(smu, SMU_INTR_REG));
 
 	ret = readx_poll_timeout(readl, SMU_REG(smu, SMU_RESP_REG), resp,
 				 resp, AIE_INTERVAL, AIE_TIMEOUT);
@@ -148,6 +157,7 @@ struct smu_device *aiem_smu_create(struct drm_device *ddev, struct smu_config *c
 
 	smu->ddev = ddev;
 	memcpy(smu->smu_regs, conf->smu_regs, sizeof(smu->smu_regs));
+	smu->intr_enabled = conf->intr_enabled;
 
 	return smu;
 }

--- a/drivers/accel/amdxdna/npu1_regs.c
+++ b/drivers/accel/amdxdna/npu1_regs.c
@@ -124,6 +124,7 @@ static const struct amdxdna_dev_priv npu1_dev_priv = {
 		DEFINE_BAR_OFFSET(SMU_RESP_REG, NPU1_SMU, MPNPU_PUB_SCRATCH6),
 		DEFINE_BAR_OFFSET(SMU_OUT_REG,  NPU1_SMU, MPNPU_PUB_SCRATCH7),
 	},
+	.smu_intr_enabled = true,
 	.hw_ops		= &(const struct aie_hw_ops) {
 		.set_dpm = npu1_set_dpm,
 	},


### PR DESCRIPTION
There has been a few CI failures on xlix-birman-15 recently. In dmesg log, I can see SMU command timeout error messages. I can reproduce this issue locally with shim test #60 (auto suspend test). I can see the issue once out of 100+ runs.

According to the SMU code in Windows driver, among all aie4/stx/phx platforms, only phx requires interrupt trigger. And on phx platform, driver should just write 0x1 to the intr trigger register once, not twice with 0x0 and 0x1. I'm not sure if the existing double trigger code is causing some issues or not. But, after I aligned the code with Windows driver, I can't reproduce the issue on phx after 1000+ runs.

I can't say for sure that the issue is fixed, but I'd like to merge this change to align SMU command execution code with Windows' implementation. @xdavidz , @houlz0507 , @NishadSaraf , please review and let me know what you think.