### PR TITLE
accel: amdxdna: ve2: add solver enhancements, hwctx_config, and coredump support

### DIFF
--- a/drivers/accel/amdxdna/amdxdna_ctx.c
+++ b/drivers/accel/amdxdna/amdxdna_ctx.c
@@ -350,6 +350,7 @@ int amdxdna_drm_config_hwctx_ioctl(struct drm_device *dev, void *data, struct dr
 		break;
 	case DRM_AMDXDNA_HWCTX_ASSIGN_DBG_BUF:
 	case DRM_AMDXDNA_HWCTX_REMOVE_DBG_BUF:
+	case DRM_AMDXDNA_HWCTX_CONFIG_OPCODE_TIMEOUT:
 		/* For those types that param_val is a value */
 		buf = NULL;
 		buf_size = 0;

--- a/drivers/accel/amdxdna/amdxdna_solver.c
+++ b/drivers/accel/amdxdna/amdxdna_solver.c
@@ -8,6 +8,7 @@
 #include <drm/drm_managed.h>
 #include <drm/drm_print.h>
 #include <linux/bitmap.h>
+#include <linux/mutex.h>
 #include <linux/slab.h>
 
 #include "amdxdna_ctx.h"
@@ -38,7 +39,7 @@ struct solver_rgroup {
 	u32				nnode;
 	u32				npartition_node;
 
-	DECLARE_BITMAP(resbit, XRS_MAX_COL);
+	unsigned long			*resbit;	/* dynamic bitmap, size = total_col */
 	struct list_head		node_list;
 	struct list_head		pt_node_list;
 };
@@ -47,6 +48,7 @@ struct solver_state {
 	struct solver_rgroup		rgp;
 	struct init_config		cfg;
 	struct xrs_action_ops		*actions;
+	struct mutex			xrs_lock;	/* serialise alloc/release */
 };
 
 static u32 calculate_gops(struct aie_qos *rqos)
@@ -168,27 +170,35 @@ static struct solver_node *rg_search_node(struct solver_rgroup *rgp, u64 rid)
 }
 
 static void remove_partition_node(struct solver_rgroup *rgp,
-				  struct partition_node *pt_node)
+				  struct partition_node *pt_node,
+				  struct xrs_action_load *action)
 {
 	pt_node->nshared--;
-	if (pt_node->nshared > 0)
+	if (pt_node->nshared > 0) {
+		if (action)
+			action->release_aie_part = false;
 		return;
+	}
 
 	list_del(&pt_node->list);
 	rgp->npartition_node--;
 
 	bitmap_clear(rgp->resbit, pt_node->start_col, pt_node->ncols);
 	kfree(pt_node);
+
+	if (action)
+		action->release_aie_part = true;
 }
 
 static void remove_solver_node(struct solver_rgroup *rgp,
-			       struct solver_node *node)
+			       struct solver_node *node,
+			       struct xrs_action_load *action)
 {
 	list_del(&node->list);
 	rgp->nnode--;
 
 	if (node->pt_node)
-		remove_partition_node(rgp, node->pt_node);
+		remove_partition_node(rgp, node->pt_node, action);
 
 	kfree(node);
 }
@@ -197,13 +207,14 @@ static int get_free_partition(struct solver_state *xrs,
 			      struct solver_node *snode,
 			      struct alloc_requests *req)
 {
+	u32 total_col = xrs->cfg.total_col;
 	struct partition_node *pt_node;
 	u32 ncols = req->cdo.ncols;
 	u32 col, i;
 
 	for (i = 0; i < snode->cols_len; i++) {
 		col = snode->start_cols[i];
-		if (find_next_bit(xrs->rgp.resbit, XRS_MAX_COL, col) >= col + ncols)
+		if (find_next_bit(xrs->rgp.resbit, total_col, col) >= col + ncols)
 			break;
 	}
 
@@ -217,11 +228,7 @@ static int get_free_partition(struct solver_state *xrs,
 	pt_node->nshared = 1;
 	pt_node->start_col = col;
 	pt_node->ncols = ncols;
-
-	/*
-	 * Always set exclusive to false for now.
-	 */
-	pt_node->exclusive = false;
+	pt_node->exclusive = req->rqos.exclusive;
 
 	list_add_tail(&pt_node->list, &xrs->rgp.pt_node_list);
 	xrs->rgp.npartition_node++;
@@ -242,6 +249,10 @@ static int allocate_partition(struct solver_state *xrs,
 	ret = get_free_partition(xrs, snode, req);
 	if (!ret)
 		return ret;
+
+	/* Exclusive requests must get a free partition; never share. */
+	if (req->rqos.exclusive)
+		return -ENODEV;
 
 	/* try to get a share-able partition */
 	list_for_each_entry(pt_node, &xrs->rgp.pt_node_list, list) {
@@ -309,6 +320,7 @@ static void fill_load_action(struct solver_node *snode,
 	action->rid = snode->rid;
 	action->part.start_col = snode->pt_node->start_col;
 	action->part.ncols = snode->pt_node->ncols;
+	action->create_aie_part = (snode->pt_node->nshared == 1);
 }
 
 int xrs_allocate_resource(void *hdl, struct alloc_requests *req, void *cb_arg,
@@ -332,6 +344,10 @@ int xrs_allocate_resource(void *hdl, struct alloc_requests *req, void *cb_arg,
 		drm_err(xrs->cfg.ddev, "rid %lld is in-use", req->rid);
 		return -EEXIST;
 	}
+
+	/* Real-time priority requires an exclusive partition. */
+	if (req->rqos.priority == AMDXDNA_QOS_REALTIME_PRIORITY)
+		req->rqos.exclusive = true;
 
 	snode = create_solver_node(xrs, req);
 	if (IS_ERR(snode))
@@ -360,7 +376,7 @@ int xrs_allocate_resource(void *hdl, struct alloc_requests *req, void *cb_arg,
 	return 0;
 
 free_node:
-	remove_solver_node(&xrs->rgp, snode);
+	remove_solver_node(&xrs->rgp, snode, NULL);
 
 	return ret;
 }
@@ -370,7 +386,7 @@ int xrs_release_resource(void *hdl, u64 rid, struct xrs_action_load *action)
 	struct solver_state *xrs = hdl;
 	struct solver_node *node;
 
-	if (!xrs || action)
+	if (!xrs)
 		return -EINVAL;
 
 	node = rg_search_node(&xrs->rgp, rid);
@@ -383,7 +399,7 @@ int xrs_release_resource(void *hdl, u64 rid, struct xrs_action_load *action)
 	if (xrs->cfg.actions)
 		xrs->cfg.actions->unload(node->cb_arg);
 
-	remove_solver_node(&xrs->rgp, node);
+	remove_solver_node(&xrs->rgp, node, action);
 	return 0;
 }
 
@@ -391,16 +407,20 @@ void *xrsm_init(struct init_config *cfg)
 {
 	struct solver_rgroup *rgp;
 	struct solver_state *xrs;
+	size_t bitmap_size;
 
-	xrs = drmm_kzalloc(cfg->ddev, sizeof(*xrs), GFP_KERNEL);
+	bitmap_size = BITS_TO_LONGS(cfg->total_col) * sizeof(unsigned long);
+	xrs = drmm_kzalloc(cfg->ddev, sizeof(*xrs) + bitmap_size, GFP_KERNEL);
 	if (!xrs)
 		return NULL;
 
 	memcpy(&xrs->cfg, cfg, sizeof(*cfg));
 
 	rgp = &xrs->rgp;
+	rgp->resbit = (unsigned long *)(xrs + 1);
 	INIT_LIST_HEAD(&rgp->node_list);
 	INIT_LIST_HEAD(&rgp->pt_node_list);
+	mutex_init(&xrs->xrs_lock);
 
 	return xrs;
 }
@@ -427,6 +447,7 @@ int amdxdna_alloc_resource(struct amdxdna_hwctx *hwctx)
 	xrs_req->rqos.latency = hwctx->qos.latency;
 	xrs_req->rqos.exec_time = hwctx->qos.frame_exec_time;
 	xrs_req->rqos.priority = hwctx->qos.priority;
+	xrs_req->rqos.exclusive = (hwctx->qos.priority == AMDXDNA_QOS_REALTIME_PRIORITY);
 
 	xrs_req->rid = (uintptr_t)hwctx;
 

--- a/drivers/accel/amdxdna/amdxdna_solver.h
+++ b/drivers/accel/amdxdna/amdxdna_solver.h
@@ -67,6 +67,8 @@ struct alloc_requests {
 struct xrs_action_load {
 	u32			rid;
 	struct aie_part		part;
+	bool			create_aie_part;
+	bool			release_aie_part;
 };
 
 /*

--- a/drivers/accel/amdxdna/ve2_aux.c
+++ b/drivers/accel/amdxdna/ve2_aux.c
@@ -233,6 +233,7 @@ const struct amdxdna_dev_ops ve2_ops = {
 	.fini			= ve2_aux_fini,
 	.hwctx_init		= ve2_hwctx_init,
 	.hwctx_fini		= ve2_hwctx_fini,
+	.hwctx_config		= ve2_hwctx_config,
 	.cmd_submit		= ve2_cmd_submit,
 	.cmd_wait		= ve2_cmd_wait,
 	.get_array		= ve2_debug_get_array,

--- a/drivers/accel/amdxdna/ve2_debug.c
+++ b/drivers/accel/amdxdna/ve2_debug.c
@@ -12,6 +12,7 @@
 #include <linux/minmax.h>
 #include <linux/slab.h>
 #include <linux/uaccess.h>
+#include <linux/vmalloc.h>
 
 #include "drm/amdxdna_accel.h"
 
@@ -19,6 +20,7 @@
 #include "amdxdna_drv.h"
 #include "ve2_debug.h"
 #include "ve2_hwctx.h"
+#include "ve2_mgmt.h"
 
 static int ve2_hwctx_status_cb(struct amdxdna_hwctx *hwctx, void *arg)
 {
@@ -129,6 +131,104 @@ static int ve2_get_hwctx_mem_bitmap(struct amdxdna_client *client,
 	return 0;
 }
 
+static int ve2_coredump_read(struct amdxdna_client *client, struct amdxdna_drm_get_array *args)
+{
+	struct amdxdna_drm_aie_coredump footer = {};
+	struct amdxdna_dev *xdna = client->xdna;
+	struct amdxdna_hwctx *hwctx = NULL;
+	struct amdxdna_client *tmp_client;
+	struct amdxdna_mgmtctx *mgmtctx;
+	struct amdxdna_ctx_priv *vp;
+	u32 buf_size, rel_size;
+	void *local_buf;
+	u32 offset;
+	int ret;
+
+	buf_size = (u32)args->num_element * args->element_size;
+	if (buf_size < sizeof(footer))
+		return -EINVAL;
+
+	/* Footer is at the tail of the user buffer — contains context_id + pid. */
+	offset = buf_size - sizeof(footer);
+	if (copy_from_user(&footer, u64_to_user_ptr(args->buffer) + offset, sizeof(footer))) {
+		XDNA_ERR(xdna, "Failed to copy coredump request from user");
+		return -EFAULT;
+	}
+
+	XDNA_DBG(xdna, "Coredump read: ctx_id=%u, pid=%llu, buf_size=%u", footer.context_id,
+		 footer.pid, buf_size);
+
+	/* Find the hwctx matching the requested context_id and pid. */
+	drm_WARN_ON(&xdna->ddev, !mutex_is_locked(&xdna->dev_lock));
+	list_for_each_entry(tmp_client, &xdna->client_list, node) {
+		struct amdxdna_hwctx *hx;
+		unsigned long hx_id;
+		int srcu_idx;
+
+		srcu_idx = srcu_read_lock(&tmp_client->hwctx_srcu);
+		xa_for_each(&tmp_client->hwctx_xa, hx_id, hx) {
+			if (hx->id == footer.context_id && (u64)hx->client->pid == footer.pid) {
+				hwctx = hx;
+				break;
+			}
+		}
+		srcu_read_unlock(&tmp_client->hwctx_srcu, srcu_idx);
+		if (hwctx)
+			break;
+	}
+
+	if (!hwctx) {
+		XDNA_ERR(xdna, "Cannot get coredump: Hardware context %u with pid %llu not found",
+			 footer.context_id, footer.pid);
+		return -EINVAL;
+	}
+
+	XDNA_DBG(xdna, "cl_pid: %u, hwctx_id: %u, start_col %u, ncol %u\n", hwctx->client->pid,
+		 hwctx->id, hwctx->start_col, hwctx->num_col);
+
+	vp = ve2_hw_priv(hwctx);
+	if (!vp || !vp->mgmtctx) {
+		XDNA_ERR(xdna, "Coredump: hwctx %u has no management partition", hwctx->id);
+		return -EINVAL;
+	}
+
+	mgmtctx = vp->mgmtctx;
+
+	if (mgmtctx->active_ctx != hwctx) {
+		XDNA_ERR(xdna, "Coredump: hwctx %u is not the active context", hwctx->id);
+		return -EPERM;
+	}
+
+	/* Required buffer: num_col * num_rows * tile_size */
+	rel_size = hwctx->num_col * mgmtctx->num_rows * TILE_ADDRESS_SPACE;
+	if (rel_size > buf_size) {
+		XDNA_DBG(xdna, "Coredump buffer too small: need %u got %u", rel_size, buf_size);
+		args->element_size = rel_size;
+		return -ENOBUFS;
+	}
+
+	local_buf = vmalloc(rel_size);
+	if (!local_buf)
+		return -ENOMEM;
+
+	ret = aie_partition_coredump(mgmtctx->aie_dev, rel_size, local_buf);
+	if (ret < 0) {
+		XDNA_ERR(xdna, "aie_partition_coredump failed: %d", ret);
+		vfree(local_buf);
+		return ret;
+	}
+
+	if (copy_to_user(u64_to_user_ptr(args->buffer), local_buf, ret)) {
+		XDNA_ERR(xdna, "Coredump copy_to_user failed");
+		vfree(local_buf);
+		return -EFAULT;
+	}
+
+	XDNA_DBG(xdna, "Coredump: copied %d bytes for hwctx %u", ret, hwctx->id);
+	vfree(local_buf);
+	return 0;
+}
+
 int ve2_debug_get_array(struct amdxdna_client *client, struct amdxdna_drm_get_array *args)
 {
 	struct amdxdna_dev *xdna = client->xdna;
@@ -149,6 +249,9 @@ int ve2_debug_get_array(struct amdxdna_client *client, struct amdxdna_drm_get_ar
 		break;
 	case DRM_AMDXDNA_HWCTX_MEM_BITMAP:
 		ret = ve2_get_hwctx_mem_bitmap(client, args);
+		break;
+	case DRM_AMDXDNA_AIE_COREDUMP:
+		ret = ve2_coredump_read(client, args);
 		break;
 	default:
 		XDNA_ERR(xdna, "Not supported GET_ARRAY param %u", args->param);

--- a/drivers/accel/amdxdna/ve2_hwctx.c
+++ b/drivers/accel/amdxdna/ve2_hwctx.c
@@ -97,8 +97,8 @@ hsa_queue_reserve_slot(struct amdxdna_dev *xdna, struct amdxdna_ctx_priv *vp, u6
 	struct ve2_hsa_queue *queue = &vp->hsa_queue;
 	struct host_queue_header *header = &queue->hsa_queue_p->hq_header;
 	u32 capacity = header->capacity;
-	u32 slot_idx;
 	u64 outstanding;
+	u32 slot_idx;
 
 	mutex_lock(&queue->hq_lock);
 	hsa_queue_sync_read_index_for_read(queue);
@@ -127,11 +127,11 @@ hsa_queue_reserve_slot(struct amdxdna_dev *xdna, struct amdxdna_ctx_priv *vp, u6
 static void hsa_queue_commit_slot(struct amdxdna_hwctx *hwctx, u64 seq)
 {
 	struct amdxdna_ctx_priv *vp = ve2_hw_priv(hwctx);
-	struct ve2_hsa_queue *queue;
 	struct host_queue_header *header;
+	struct host_queue_packet *pkt;
+	struct ve2_hsa_queue *queue;
 	u32 capacity;
 	u32 slot_idx;
-	struct host_queue_packet *pkt;
 
 	queue = &vp->hsa_queue;
 	header = &queue->hsa_queue_p->hq_header;
@@ -158,11 +158,10 @@ static void hsa_queue_commit_slot(struct amdxdna_hwctx *hwctx, u64 seq)
 	mutex_unlock(&queue->hq_lock);
 }
 
-static int submit_command(struct amdxdna_hwctx *hwctx, void *cmd_data, u64 *seq,
-			  bool last_cmd)
+static int submit_command(struct amdxdna_hwctx *hwctx, void *cmd_data, u64 *seq, bool last_cmd)
 {
-	struct amdxdna_dev *xdna = hwctx->client->xdna;
 	struct amdxdna_ctx_priv *vp = ve2_hw_priv(hwctx);
+	struct amdxdna_dev *xdna = hwctx->client->xdna;
 	struct ve2_dpu_data *dpu = cmd_data;
 	struct host_queue_packet *pkt;
 	struct xrt_packet_header *hdr;
@@ -204,8 +203,8 @@ static int ve2_submit_cmd_single(struct amdxdna_hwctx *hwctx, struct amdxdna_sch
 				 u64 *seq)
 {
 	struct amdxdna_dev *xdna = hwctx->client->xdna;
-	void *cmd_data;
 	u32 cmd_data_len;
+	void *cmd_data;
 	int ret;
 
 	cmd_data = amdxdna_cmd_get_payload(job->cmd_bo, &cmd_data_len);
@@ -366,10 +365,17 @@ int ve2_hwctx_init(struct amdxdna_hwctx *hwctx)
 
 	ve2_auto_select_mem_bitmap(xdna, hwctx);
 
+	/* Allocate per-column config array (zero-initialised = no buffers attached). */
+	vp->hwctx_config = kcalloc(hwctx->num_col, sizeof(*vp->hwctx_config), GFP_KERNEL);
+	if (!vp->hwctx_config) {
+		ret = -ENOMEM;
+		goto destroy_partition;
+	}
+
 	ret = ve2_create_host_queue(hwctx);
 	if (ret) {
 		XDNA_ERR(xdna, "Host queue alloc failed, ret %d", ret);
-		goto destroy_partition;
+		goto free_hwctx_config;
 	}
 
 	if (!hwctx->max_opc)	/* default to max number of commands */
@@ -384,6 +390,9 @@ int ve2_hwctx_init(struct amdxdna_hwctx *hwctx)
 	}
 	return 0;
 
+free_hwctx_config:
+	kfree(vp->hwctx_config);
+	vp->hwctx_config = NULL;
 destroy_partition:
 	ve2_mgmt_destroy_partition(hwctx);
 free_priv:
@@ -413,6 +422,8 @@ void ve2_hwctx_fini(struct amdxdna_hwctx *hwctx)
 	if (vp) {
 		if (enable_polling)
 			del_timer_sync(&vp->event_timer);
+		kfree(vp->hwctx_config);
+		vp->hwctx_config = NULL;
 		mutex_destroy(&vp->privctx_lock);
 		kfree(vp);
 		priv->hw_priv = NULL;
@@ -424,11 +435,11 @@ void ve2_hwctx_fini(struct amdxdna_hwctx *hwctx)
 
 int ve2_cmd_submit(struct amdxdna_hwctx *hwctx, struct amdxdna_sched_job *job, u64 *seq)
 {
-	struct amdxdna_dev *xdna = hwctx->client->xdna;
 	struct amdxdna_ctx_priv *vp = ve2_hw_priv(hwctx);
+	struct amdxdna_dev *xdna = hwctx->client->xdna;
 	struct amdxdna_gem_obj *cmd_bo = job->cmd_bo;
-	u32 op;
 	int ret;
+	u32 op;
 
 	op = amdxdna_cmd_get_op(cmd_bo);
 	if (op != ERT_START_DPU) {
@@ -492,15 +503,15 @@ static bool check_read_index(struct amdxdna_hwctx *hwctx, u64 seq)
 	return read_index > seq;
 }
 
-static void ve2_process_hqc_completion(struct amdxdna_hwctx *hwctx,
-				       struct amdxdna_sched_job *job, u64 seq)
+static void ve2_process_hqc_completion(struct amdxdna_hwctx *hwctx, struct amdxdna_sched_job *job,
+				       u64 seq)
 {
-	struct amdxdna_dev *xdna = hwctx->client->xdna;
 	struct amdxdna_ctx_priv *vp = ve2_hw_priv(hwctx);
 	u32 capacity = vp->hsa_queue.hsa_queue_p->hq_header.capacity;
+	struct amdxdna_dev *xdna = hwctx->client->xdna;
 	u32 slot = seq % capacity;
-	u32 comp;
 	enum ert_cmd_state state;
+	u32 comp;
 
 	hsa_queue_sync_completion_for_read(&vp->hsa_queue, slot);
 	comp = (u32)vp->hsa_queue.hq_complete.hqc_mem[slot];
@@ -565,4 +576,126 @@ int ve2_cmd_wait(struct amdxdna_hwctx *hwctx, u64 seq, u32 timeout_ms)
 out:
 	mutex_unlock(&vp->hsa_queue.hq_lock);
 	return ret > 0 ? 0 : ret;
+}
+
+/* ---- ctx_config ---------------------------------------------------------- */
+
+static int ve2_update_handshake_pkt(struct amdxdna_hwctx *hwctx, u8 buf_type, u64 paddr, u32 sz,
+				    u32 col)
+{
+	struct amdxdna_ctx_priv *vp = ve2_hw_priv(hwctx);
+
+	switch (buf_type) {
+	case AMDXDNA_FW_BUF_DEBUG:
+		vp->hwctx_config[col].debug_buf_addr = paddr;
+		vp->hwctx_config[col].debug_buf_size = sz;
+		break;
+	case AMDXDNA_FW_BUF_TRACE:
+		vp->hwctx_config[col].dtrace_addr = paddr;
+		break;
+	case AMDXDNA_FW_BUF_LOG:
+		vp->hwctx_config[col].log_buf_addr = paddr;
+		vp->hwctx_config[col].log_buf_size = sz;
+		break;
+	default:
+		struct amdxdna_dev *xdna = hwctx->client->xdna;
+
+		XDNA_ERR(xdna, "Unknown fw buf_type %u", buf_type);
+		return -EOPNOTSUPP;
+	}
+	return 0;
+}
+
+static int ve2_config_assign_dbg_buf(struct amdxdna_hwctx *hwctx, u64 mdata_hdl, bool attach)
+{
+	struct amdxdna_client *client = hwctx->client;
+	struct amdxdna_fw_buffer_metadata *mdata;
+	struct amdxdna_dev *xdna = client->xdna;
+	struct amdxdna_gem_obj *mdata_abo, *abo;
+	u32 col, prev_sz = 0;
+	u64 base_paddr = 0;
+	int ret = 0;
+
+	/*
+	 * The metadata BO is allocated by the shim as AMDXDNA_BO_CMD, so use
+	 * AMDXDNA_BO_INVALID to accept any type when looking it up.
+	 */
+	mdata_abo = amdxdna_gem_get_obj(client, (u32)mdata_hdl, AMDXDNA_BO_INVALID);
+	if (!mdata_abo) {
+		XDNA_ERR(xdna, "Failed to get metadata BO %llu", mdata_hdl);
+		return -EINVAL;
+	}
+
+	mdata = amdxdna_gem_vmap(mdata_abo);
+	if (!mdata) {
+		XDNA_ERR(xdna, "Failed to vmap metadata BO %llu", mdata_hdl);
+		ret = -EINVAL;
+		goto put_mdata;
+	}
+
+	abo = NULL;
+	if (attach) {
+		abo = amdxdna_gem_get_obj(client, mdata->bo_handle, AMDXDNA_BO_SHARE);
+		if (!abo) {
+			XDNA_ERR(xdna, "Failed to get payload BO %u", mdata->bo_handle);
+			ret = -EINVAL;
+			goto put_mdata;
+		}
+		base_paddr = amdxdna_gem_dev_addr(abo);
+	}
+
+	for (col = 0; col < hwctx->num_col && col < mdata->num_ucs; col++) {
+		u32 sz = attach ? mdata->uc_info[col].size : 0;
+		u64 paddr = attach ? (base_paddr + prev_sz) : 0;
+
+		if (sz == 0 && attach)
+			continue;
+
+		ret = ve2_update_handshake_pkt(hwctx, mdata->buf_type, paddr, sz, col);
+		if (ret) {
+			XDNA_ERR(xdna, "col %u config failed: buf_type=%u ret=%d",
+				 col, mdata->buf_type, ret);
+			break;
+		}
+		prev_sz += sz;
+	}
+
+	if (abo)
+		amdxdna_gem_put_obj(abo);
+put_mdata:
+	amdxdna_gem_put_obj(mdata_abo);
+	return ret;
+}
+
+int ve2_hwctx_config(struct amdxdna_hwctx *hwctx, u32 type, u64 value, void *buf, u32 size)
+{
+	struct amdxdna_ctx_priv *vp = ve2_hw_priv(hwctx);
+	struct amdxdna_dev *xdna = hwctx->client->xdna;
+	u32 op_timeout;
+	u32 col;
+
+	if (!vp || !vp->hwctx_config)
+		return -EINVAL;
+
+	switch (type) {
+	case DRM_AMDXDNA_HWCTX_ASSIGN_DBG_BUF:
+		return ve2_config_assign_dbg_buf(hwctx, value, true);
+
+	case DRM_AMDXDNA_HWCTX_REMOVE_DBG_BUF:
+		return ve2_config_assign_dbg_buf(hwctx, value, false);
+
+	case DRM_AMDXDNA_HWCTX_CONFIG_OPCODE_TIMEOUT:
+		if (copy_from_user(&op_timeout, u64_to_user_ptr(value), sizeof(u32))) {
+			XDNA_ERR(xdna, "Failed to copy opcode timeout from user");
+			return -EFAULT;
+		}
+		for (col = 0; col < hwctx->num_col; col++)
+			vp->hwctx_config[col].opcode_timeout_config = op_timeout;
+		XDNA_DBG(xdna, "hwctx %p: opcode timeout set to %u", hwctx, op_timeout);
+		return 0;
+
+	default:
+		XDNA_ERR(xdna, "Unsupported config type %u", type);
+		return -EOPNOTSUPP;
+	}
 }

--- a/drivers/accel/amdxdna/ve2_hwctx.h
+++ b/drivers/accel/amdxdna/ve2_hwctx.h
@@ -18,6 +18,15 @@
 #include "amdxdna_ctx.h"
 #include "ve2_host_queue.h"
 
+struct ve2_config_hwctx {
+	u64	log_buf_addr;
+	u32	log_buf_size;
+	u64	debug_buf_addr;
+	u32	debug_buf_size;
+	u64	dtrace_addr;
+	u32	opcode_timeout_config;
+};
+
 /* VE2-specific per-hwctx state. Lives at hwctx->priv->hw_priv. */
 struct amdxdna_ctx_priv {
 	struct mutex			privctx_lock;	/* protect VE2 hwctx state */
@@ -37,6 +46,8 @@ struct amdxdna_ctx_priv {
 
 	/* AIE partition management context backend. */
 	struct amdxdna_mgmtctx		*mgmtctx;
+
+	struct ve2_config_hwctx		*hwctx_config;	/* [num_col] */
 };
 
 static inline struct amdxdna_ctx_priv *ve2_hw_priv(struct amdxdna_hwctx *hwctx)
@@ -46,6 +57,7 @@ static inline struct amdxdna_ctx_priv *ve2_hw_priv(struct amdxdna_hwctx *hwctx)
 
 int ve2_hwctx_init(struct amdxdna_hwctx *hwctx);
 void ve2_hwctx_fini(struct amdxdna_hwctx *hwctx);
+int ve2_hwctx_config(struct amdxdna_hwctx *hwctx, u32 type, u64 value, void *buf, u32 size);
 int ve2_cmd_submit(struct amdxdna_hwctx *hwctx, struct amdxdna_sched_job *job, u64 *seq);
 int ve2_cmd_wait(struct amdxdna_hwctx *hwctx, u64 seq, u32 timeout_ms);
 

--- a/drivers/accel/amdxdna/ve2_mgmt.c
+++ b/drivers/accel/amdxdna/ve2_mgmt.c
@@ -28,15 +28,31 @@ static void cert_setup_partition(struct amdxdna_mgmtctx *mgmtctx,
 				 struct handshake *cert_hs)
 {
 	struct amdxdna_ctx_priv *vp = ve2_hw_priv(hwctx);
+	struct ve2_config_hwctx *cfg = NULL;
 	u64 hsa_addr = U64_MAX;
 
 	if (col == 0 && vp && vp->hsa_queue.hsa_queue_dma_addr)
 		hsa_addr = vp->hsa_queue.hsa_queue_dma_addr;
 
+	if (vp && vp->hwctx_config && col < hwctx->num_col)
+		cfg = &vp->hwctx_config[col];
+
 	cert_hs->partition_base_address = VE2_ADDR(mgmtctx->start_col, 0, 0);
 	cert_hs->aie_info.partition_size = mgmtctx->num_col;
 	cert_hs->hsa_addr_high = upper_32_bits(hsa_addr);
 	cert_hs->hsa_addr_low = lower_32_bits(hsa_addr);
+
+	if (cfg) {
+		cert_hs->log_addr_high = upper_32_bits(cfg->log_buf_addr);
+		cert_hs->log_addr_low = lower_32_bits(cfg->log_buf_addr);
+		cert_hs->log_buf_size = cfg->log_buf_size;
+		cert_hs->dbg_buf.dbg_buf_addr_high = upper_32_bits(cfg->debug_buf_addr);
+		cert_hs->dbg_buf.dbg_buf_addr_low = lower_32_bits(cfg->debug_buf_addr);
+		cert_hs->dbg_buf.size = cfg->debug_buf_size;
+		cert_hs->trace.dtrace_addr_high = upper_32_bits(cfg->dtrace_addr);
+		cert_hs->trace.dtrace_addr_low = lower_32_bits(cfg->dtrace_addr);
+		cert_hs->opcode_timeout_config = cfg->opcode_timeout_config;
+	}
 
 	cert_hs->ctx_switch_req = 0;
 	cert_hs->hsa_location = 0;
@@ -131,10 +147,11 @@ int ve2_xrs_request(struct amdxdna_dev *xdna, struct amdxdna_hwctx *hwctx)
 {
 	struct amdxdna_dev_hdl *hdl = ve2_dev_hdl(xdna);
 	struct amdxdna_ctx_priv *vp = ve2_hw_priv(hwctx);
+	struct solver_state *xrs = xdna->xrs_hdl;
 	u32 partition_id = 0;
 	int ret;
 
-	if (!vp || !hdl)
+	if (!vp || !hdl || !xrs)
 		return -EINVAL;
 
 	/* Build the candidate start-column list, then let XRS place the partition. */
@@ -142,9 +159,10 @@ int ve2_xrs_request(struct amdxdna_dev *xdna, struct amdxdna_hwctx *hwctx)
 	if (ret)
 		return ret;
 
-	/* default to num_tiles for now, can be overridden by XRS load action callback */
 	hwctx->num_col = hwctx->num_tiles;
+	mutex_lock(&xrs->xrs_lock);
 	ret = amdxdna_alloc_resource(hwctx);
+	mutex_unlock(&xrs->xrs_lock);
 	kfree(hwctx->col_list);
 	hwctx->col_list = NULL;
 	if (ret) {
@@ -156,7 +174,9 @@ int ve2_xrs_request(struct amdxdna_dev *xdna, struct amdxdna_hwctx *hwctx)
 					&partition_id);
 	if (ret) {
 		XDNA_ERR(xdna, "Creating AIE partition failed, ret %d", ret);
+		mutex_lock(&xrs->xrs_lock);
 		amdxdna_release_resource(hwctx);
+		mutex_unlock(&xrs->xrs_lock);
 		return ret;
 	}
 
@@ -428,6 +448,7 @@ static int ve2_create_mgmt_partition(struct amdxdna_dev *xdna, struct amdxdna_hw
 	mgmtctx->xdna = xdna;
 	mgmtctx->start_col = start_col;
 	mgmtctx->num_col = num_col;
+	mgmtctx->num_rows = xdna_hdl->aie_dev_info.rows;
 	mgmtctx->active_ctx = NULL;
 	INIT_LIST_HEAD(&mgmtctx->ctx_command_fifo_head);
 	mutex_init(&mgmtctx->ctx_lock);
@@ -473,8 +494,15 @@ int ve2_mgmt_destroy_partition(struct amdxdna_hwctx *hwctx)
 	mgmtctx = vp ? vp->mgmtctx : NULL;
 	if (!mgmtctx) {
 		/* No partition was created; still release any XRS reservation. */
-		if (hwctx)
-			amdxdna_release_resource(hwctx);
+		if (hwctx) {
+			struct solver_state *xrs = hwctx->client->xdna->xrs_hdl;
+
+			if (xrs) {
+				mutex_lock(&xrs->xrs_lock);
+				amdxdna_release_resource(hwctx);
+				mutex_unlock(&xrs->xrs_lock);
+			}
+		}
 		return -EINVAL;
 	}
 
@@ -504,7 +532,15 @@ int ve2_mgmt_destroy_partition(struct amdxdna_hwctx *hwctx)
 	kfree(mgmtctx);
 	vp->mgmtctx = NULL;
 
-	amdxdna_release_resource(hwctx);
+	{
+		struct solver_state *xrs = hwctx->client->xdna->xrs_hdl;
+
+		if (xrs) {
+			mutex_lock(&xrs->xrs_lock);
+			amdxdna_release_resource(hwctx);
+			mutex_unlock(&xrs->xrs_lock);
+		}
+	}
 
 	return 0;
 }

--- a/drivers/accel/amdxdna/ve2_mgmt.h
+++ b/drivers/accel/amdxdna/ve2_mgmt.h
@@ -11,6 +11,7 @@
 
 #include <linux/list.h>
 #include <linux/mutex.h>
+#include <linux/xlnx-ai-engine.h>
 
 struct amdxdna_dev;
 struct amdxdna_hwctx;
@@ -27,6 +28,9 @@ struct amdxdna_hwctx;
 /* VE2 AIE partition column granularity (partitions are 4-column aligned). */
 #define VE2_MIN_COL_SUPPORT		4
 
+/* Size of one AIE tile's address space used for coredump reads. */
+#define TILE_ADDRESS_SPACE		0x100000
+
 struct ve2_ctx_fifo_entry {
 	struct amdxdna_hwctx		*ctx;
 	u64				command_index;
@@ -42,6 +46,7 @@ struct amdxdna_mgmtctx {
 	struct mutex			ctx_lock;/* protects active_ctx, scheduler, fifo */
 	u32				start_col;
 	u32				num_col;
+	u32				num_rows;
 	struct amdxdna_dev		*xdna;
 };
 

--- a/include/uapi/drm/amdxdna_accel.h
+++ b/include/uapi/drm/amdxdna_accel.h
@@ -138,6 +138,56 @@ enum amdxdna_drm_config_hwctx_param {
 	DRM_AMDXDNA_HWCTX_CONFIG_CU,
 	DRM_AMDXDNA_HWCTX_ASSIGN_DBG_BUF,
 	DRM_AMDXDNA_HWCTX_REMOVE_DBG_BUF,
+	DRM_AMDXDNA_HWCTX_CONFIG_OPCODE_TIMEOUT,
+};
+
+/**
+ * enum amdxdna_fw_buf_type - CERT firmware buffer type.
+ * @AMDXDNA_FW_BUF_DEBUG: CERT debug buffer.
+ * @AMDXDNA_FW_BUF_TRACE: CERT trace/dtrace buffer.
+ * @AMDXDNA_FW_BUF_DBG_Q: CERT debug queue buffer.
+ * @AMDXDNA_FW_BUF_LOG:   CERT log buffer.
+ *
+ * Values must match the shim's fw_buffer_metadata.buf_type encoding.
+ */
+enum amdxdna_fw_buf_type {
+	AMDXDNA_FW_BUF_DEBUG = 0,
+	AMDXDNA_FW_BUF_TRACE = 1,
+	AMDXDNA_FW_BUF_DBG_Q = 2,
+	AMDXDNA_FW_BUF_LOG   = 3,
+};
+
+/**
+ * struct amdxdna_uc_info_entry - per-uC slice descriptor in
+ *                                struct amdxdna_fw_buffer_metadata.
+ * @index: uC (column) index within the context partition.
+ * @size:  Per-uC slice size in bytes. Entries with size == 0 are ignored.
+ */
+struct amdxdna_uc_info_entry {
+	__u32 index;
+	__u32 size;
+};
+
+/**
+ * struct amdxdna_fw_buffer_metadata - per-hwctx CERT buffer description.
+ * @buf_type:   One of enum amdxdna_fw_buf_type.
+ * @num_ucs:    Number of valid entries in @uc_info.
+ * @pad:        MBZ. Reserved for ABI growth.
+ * @bo_handle:  Handle of the payload BO (AMDXDNA_BO_SHARE) holding the
+ *              concatenated per-uC slices.
+ * @command_id: User tag for trace correlation.
+ * @uc_info:    Per-uC slice descriptors in payload BO layout order.
+ *
+ * Passed via struct amdxdna_drm_config_hwctx.param_val (as a BO handle) for
+ * %DRM_AMDXDNA_HWCTX_ASSIGN_DBG_BUF and %DRM_AMDXDNA_HWCTX_REMOVE_DBG_BUF.
+ */
+struct amdxdna_fw_buffer_metadata {
+	__u8  buf_type;
+	__u8  num_ucs;
+	__u8  pad[2];
+	__u32 bo_handle;
+	__u64 command_id;
+	struct amdxdna_uc_info_entry uc_info[];
 };
 
 /**


### PR DESCRIPTION
Enhance the shared resource logic.
Added support for configuring opcode timeout.
Added support for log/debug buffer feature.
Added support for coredump feature.

Following additional tests passed
log_buf | vadd_userptr | dtrace_single_col | coredump | memory_leak