### PR TITLE
cmake: add Void Linux to recognized package flavors

### DIFF
--- a/CMake/pkg.cmake
+++ b/CMake/pkg.cmake
@@ -123,9 +123,10 @@ elseif("${XDNA_CPACK_LINUX_PKG_FLAVOR}" MATCHES "fedora")
   endif()
 elseif("${XDNA_CPACK_LINUX_PKG_FLAVOR}" MATCHES "arch|void")
   set(CPACK_GENERATOR "TGZ")
-  # Source-based distros (Arch, Void) have no native deb/rpm in this flow, so we
-  # generate a tarball that can be repackaged into a native package (e.g. the
-  # provided Arch PKGBUILD, whose install hooks handle post-install/pre-remove).
+  # Arch and Void are binary distros, but this packaging flow has no native
+  # deb/rpm generator for them, so we emit a tarball that can be repackaged into
+  # a native package (e.g. the provided Arch PKGBUILD, whose install hooks handle
+  # post-install/pre-remove).
   set(CPACK_ARCHIVE_COMPONENT_INSTALL ON)
   message(STATUS "Arch/Void Linux detected - generating TGZ package")
   if(NOT SKIP_KMOD)

--- a/CMake/pkg.cmake
+++ b/CMake/pkg.cmake
@@ -121,13 +121,13 @@ elseif("${XDNA_CPACK_LINUX_PKG_FLAVOR}" MATCHES "fedora")
     set(CPACK_RPM_POST_INSTALL_SCRIPT_FILE "${CMAKE_CURRENT_BINARY_DIR}/package/postinst")
     set(CPACK_RPM_PRE_UNINSTALL_SCRIPT_FILE "${CMAKE_CURRENT_BINARY_DIR}/package/prerm")
   endif()
-elseif("${XDNA_CPACK_LINUX_PKG_FLAVOR}" MATCHES "arch")
+elseif("${XDNA_CPACK_LINUX_PKG_FLAVOR}" MATCHES "arch|void")
   set(CPACK_GENERATOR "TGZ")
-  # For Arch Linux, we generate a tarball that can be repackaged into a proper
-  # Arch package using the provided PKGBUILD. When using the PKGBUILD, install
-  # hooks handle post-install/pre-remove automatically via pacman.
+  # Source-based distros (Arch, Void) have no native deb/rpm in this flow, so we
+  # generate a tarball that can be repackaged into a native package (e.g. the
+  # provided Arch PKGBUILD, whose install hooks handle post-install/pre-remove).
   set(CPACK_ARCHIVE_COMPONENT_INSTALL ON)
-  message(STATUS "Arch Linux detected - generating TGZ package")
+  message(STATUS "Arch/Void Linux detected - generating TGZ package")
   if(NOT SKIP_KMOD)
     message(STATUS "Post-install script: ${CMAKE_CURRENT_BINARY_DIR}/package/postinst")
     message(STATUS "Pre-remove script: ${CMAKE_CURRENT_BINARY_DIR}/package/prerm")


### PR DESCRIPTION
## What

Add Void Linux to the recognized Linux package flavors in `CMake/pkg.cmake`.

On Void, `build.sh -release` aborts at configure time:

```
CMake Error at CMake/pkg.cmake:137 (message):
  Unknown Linux package flavor: void.  Supported distributions: Debian/Ubuntu
  (deb), Fedora/RHEL (rpm), Arch Linux (TGZ).
```

Void's `/etc/os-release` `ID` is `void` (with empty `ID_LIKE`), so it matched no branch.

## Fix

Route `void` to the same `TGZ` generator already used for Arch — both are
source-based distros with no native `deb`/`rpm` in this flow — and make the
comment/status message distro-neutral. The behavioral change is one line
(`MATCHES "arch"` → `MATCHES "arch|void"`).

## Validation

Tested on Void Linux (glibc 2.41, kernel 7.0.11, in-tree `amdxdna` driver).
With this change `build.sh -release -nokmod` configures cleanly and produces
`xrt_plugin.*-amdxdna.tar.gz`. Installed alongside an XRT base built from the
`xrt` submodule, `xrt-smi examine` then enumerates the Phoenix NPU
(`RyzenAI-npu1`) and mlir-aie example kernels run on it — i.e. the SHIM-only
path the README documents for kernel >= 6.14 (in-tree driver) now works on Void.

`checkpatch.pl` is not applicable (CMake-only change).
