### PR TITLE
accel/amdxdna: use a fixed delay to settle power-override clock

### DIFF
--- a/drivers/accel/amdxdna/aie2_pci.c
+++ b/drivers/accel/amdxdna/aie2_pci.c
@@ -1226,7 +1226,7 @@ dev_exit:
 }
 
 static int aie2_set_power_mode(struct amdxdna_client *client,
-			       struct amdxdna_drm_set_state *args)
+			       struct amdxdna_drm_set_state *args, u32 *settle_ms)
 {
 	struct amdxdna_drm_set_power_mode power_state;
 	enum amdxdna_power_mode_type power_mode;
@@ -1247,7 +1247,7 @@ static int aie2_set_power_mode(struct amdxdna_client *client,
 		return -EINVAL;
 	}
 
-	return aie2_pm_set_mode(xdna->dev_handle, power_mode);
+	return aie2_pm_set_mode(xdna->dev_handle, power_mode, settle_ms);
 }
 
 static int aie2_set_preempt_state(struct amdxdna_client *client,
@@ -1283,7 +1283,7 @@ static int aie2_set_preempt_state(struct amdxdna_client *client,
 }
 
 static int aie2_set_state(struct amdxdna_client *client,
-			  struct amdxdna_drm_set_state *args)
+			  struct amdxdna_drm_set_state *args, u32 *settle_ms)
 {
 	struct amdxdna_dev_hdl *ndev = client->xdna->dev_handle;
 	struct amdxdna_dev *xdna = client->xdna;
@@ -1298,7 +1298,7 @@ static int aie2_set_state(struct amdxdna_client *client,
 
 	switch (args->param) {
 	case DRM_AMDXDNA_SET_POWER_MODE:
-		ret = aie2_set_power_mode(client, args);
+		ret = aie2_set_power_mode(client, args, settle_ms);
 		break;
 	case DRM_AMDXDNA_SET_FORCE_PREEMPT:
 	case DRM_AMDXDNA_SET_FRAME_BOUNDARY_PREEMPT:

--- a/drivers/accel/amdxdna/aie2_pci.h
+++ b/drivers/accel/amdxdna/aie2_pci.h
@@ -213,7 +213,8 @@ extern const struct aie_hw_ops npu4_hw_ops;
 
 /* aie2_pm.c */
 int aie2_pm_start(struct amdxdna_dev_hdl *ndev);
-int aie2_pm_set_mode(struct amdxdna_dev_hdl *ndev, enum amdxdna_power_mode_type target);
+int aie2_pm_set_mode(struct amdxdna_dev_hdl *ndev, enum amdxdna_power_mode_type target,
+		     u32 *settle_ms);
 int aie2_pm_set_dpm(struct amdxdna_dev_hdl *ndev, u32 dpm_level);
 
 /* aie2_error.c */

--- a/drivers/accel/amdxdna/aie2_pm.c
+++ b/drivers/accel/amdxdna/aie2_pm.c
@@ -7,60 +7,13 @@
 #include <drm/drm_device.h>
 #include <drm/drm_print.h>
 #include <drm/gpu_scheduler.h>
-#include <linux/iopoll.h>
 
 #include "aie2_pci.h"
 #include "amdxdna_pci_drv.h"
 #include "amdxdna_pm.h"
-#include "amdxdna_sensors.h"
 
 #define AIE2_CLK_GATING_ENABLE	1
 #define AIE2_CLK_GATING_DISABLE	0
-
-/* Allow the NPU clock to ramp to a power-override DPM level before returning. */
-#define AIE2_DPM_SETTLE_TIMEOUT_US	2000000
-#define AIE2_DPM_SETTLE_INTERVAL_US	1000
-
-/*
- * Setting a DPM level via the SMU only defines the allowed clock range; the
- * actual NPU clock is demand-driven and ramps to the requested level over
- * time. For an explicit power-mode override the caller expects the requested
- * performance to be in effect on return, so poll until PMF telemetry reports
- * the MP-NPU clock has reached the target.
- *
- * Only the ramp-up direction is waited on: a downclocking override (e.g. to
- * LOW) is an explicit request for lower performance and has nothing to settle.
- *
- * PMF NPU telemetry is only available on kernels with amd-pmf support (>= 7.0);
- * amdxdna_get_sensors() returns an error otherwise, in which case the wait is
- * skipped. The wait is bounded by a timeout.
- */
-static void aie2_pm_wait_for_dpm(struct amdxdna_dev_hdl *ndev, u32 dpm_level)
-{
-	struct amdxdna_sensors npu_metrics;
-	int err, ret;
-	u32 target;
-
-	/* Telemetry can plateau just below the table value; accept within ~5%. */
-	target = ndev->priv->dpm_clk_tbl[dpm_level].npuclk;
-	target -= target / 20;
-
-	ret = read_poll_timeout(amdxdna_get_sensors, err,
-				err || npu_metrics.mpnpuclk_freq >= target,
-				AIE2_DPM_SETTLE_INTERVAL_US,
-				AIE2_DPM_SETTLE_TIMEOUT_US, false, &npu_metrics);
-
-	if (err) {
-		if (err != -EOPNOTSUPP)
-			XDNA_DBG(ndev->aie.xdna, "PMF sensor read failed (%d), skip DPM wait", err);
-		return;
-	}
-
-	if (ret)
-		XDNA_WARN(ndev->aie.xdna,
-			  "Timed out waiting for MP-NPU clock %u, got %u",
-			  target, npu_metrics.mpnpuclk_freq);
-}
 
 static int aie2_pm_set_clk_gating(struct amdxdna_dev_hdl *ndev, u32 val)
 {
@@ -166,14 +119,6 @@ int aie2_pm_set_mode(struct amdxdna_dev_hdl *ndev, enum amdxdna_power_mode_type 
 	ret = aie2_pm_set_dpm(ndev, dpm_level);
 	if (ret)
 		return ret;
-
-	/*
-	 * For an explicit power override, wait for the clock to actually reach
-	 * the requested level so the next workload runs at the intended
-	 * frequency instead of during the ramp.
-	 */
-	if (target != POWER_MODE_DEFAULT)
-		aie2_pm_wait_for_dpm(ndev, dpm_level);
 
 	ret = aie2_pm_set_clk_gating(ndev, clk_gating);
 	if (ret)

--- a/drivers/accel/amdxdna/aie2_pm.c
+++ b/drivers/accel/amdxdna/aie2_pm.c
@@ -15,6 +15,9 @@
 #define AIE2_CLK_GATING_ENABLE	1
 #define AIE2_CLK_GATING_DISABLE	0
 
+/* Time for the NPU clock to ramp to a power-override DPM level. */
+#define AIE2_DPM_SETTLE_DELAY_MS	3500
+
 static int aie2_pm_set_clk_gating(struct amdxdna_dev_hdl *ndev, u32 val)
 {
 	int ret;
@@ -80,16 +83,19 @@ int aie2_pm_start(struct amdxdna_dev_hdl *ndev)
 	return 0;
 }
 
-int aie2_pm_set_mode(struct amdxdna_dev_hdl *ndev, enum amdxdna_power_mode_type target)
+int aie2_pm_set_mode(struct amdxdna_dev_hdl *ndev, enum amdxdna_power_mode_type target,
+		     u32 *settle_ms)
 {
 	struct amdxdna_dev *xdna = ndev->aie.xdna;
-	u32 clk_gating, dpm_level;
+	u32 clk_gating, dpm_level, prev_dpm_level;
 	int ret;
 
 	drm_WARN_ON(&xdna->ddev, !mutex_is_locked(&xdna->dev_lock));
 
 	if (ndev->pw_mode == target)
 		return 0;
+
+	prev_dpm_level = ndev->dpm_level;
 
 	switch (target) {
 	case POWER_MODE_TURBO:
@@ -125,6 +131,16 @@ int aie2_pm_set_mode(struct amdxdna_dev_hdl *ndev, enum amdxdna_power_mode_type 
 		return ret;
 
 	ndev->pw_mode = target;
+
+	/*
+	 * Setting a DPM level only defines the allowed clock range; the NPU
+	 * clock then ramps to it over time. When a mode change raises the DPM
+	 * level, report how long the clock needs to settle so the caller can
+	 * wait after releasing dev_lock, instead of running the next workload
+	 * during the ramp. Downclocking has nothing to settle, so it is skipped.
+	 */
+	if (dpm_level > prev_dpm_level)
+		*settle_ms = AIE2_DPM_SETTLE_DELAY_MS;
 
 	return 0;
 }

--- a/drivers/accel/amdxdna/aie4_pci.c
+++ b/drivers/accel/amdxdna/aie4_pci.c
@@ -1166,7 +1166,7 @@ static void aie4_classic_fini(struct amdxdna_dev *xdna)
 }
 
 static int aie4_set_state(struct amdxdna_client *client,
-			  struct amdxdna_drm_set_state *args)
+			  struct amdxdna_drm_set_state *args, u32 *settle_ms)
 {
 	struct amdxdna_dev_hdl *ndev = client->xdna->dev_handle;
 	struct amdxdna_dev *xdna = client->xdna;

--- a/drivers/accel/amdxdna/amdxdna_pci_drv.c
+++ b/drivers/accel/amdxdna/amdxdna_pci_drv.c
@@ -11,6 +11,7 @@
 #include <drm/drm_ioctl.h>
 #include <drm/drm_managed.h>
 #include <drm/gpu_scheduler.h>
+#include <linux/delay.h>
 #include <linux/iommu.h>
 #include <linux/pci.h>
 
@@ -296,6 +297,7 @@ static int amdxdna_drm_set_state_ioctl(struct drm_device *dev, void *data, struc
 	struct amdxdna_client *client = filp->driver_priv;
 	struct amdxdna_dev *xdna = to_xdna_dev(dev);
 	struct amdxdna_drm_set_state *args = data;
+	u32 settle_ms = 0;
 	int ret;
 
 	if (!xdna->dev_info->ops->set_aie_state)
@@ -303,8 +305,16 @@ static int amdxdna_drm_set_state_ioctl(struct drm_device *dev, void *data, struc
 
 	XDNA_DBG(xdna, "Request parameter %u", args->param);
 	mutex_lock(&xdna->dev_lock);
-	ret = xdna->dev_info->ops->set_aie_state(client, args);
+	ret = xdna->dev_info->ops->set_aie_state(client, args, &settle_ms);
 	mutex_unlock(&xdna->dev_lock);
+
+	/*
+	 * Some state changes (e.g. a power-mode override that raises the DPM
+	 * level) need time for the NPU clock to ramp. Wait here, after dev_lock
+	 * is released, so the settle does not stall other dev_lock operations.
+	 */
+	if (!ret && settle_ms)
+		msleep(settle_ms);
 
 	return ret;
 }

--- a/drivers/accel/amdxdna/amdxdna_pci_drv.h
+++ b/drivers/accel/amdxdna/amdxdna_pci_drv.h
@@ -73,7 +73,8 @@ struct amdxdna_dev_ops {
 	int (*cmd_submit)(struct amdxdna_hwctx *hwctx, struct amdxdna_sched_job *job, u64 *seq);
 	int (*cmd_wait)(struct amdxdna_hwctx *hwctx, u64 seq, u32 timeout);
 	int (*get_aie_info)(struct amdxdna_client *client, struct amdxdna_drm_get_info *args);
-	int (*set_aie_state)(struct amdxdna_client *client, struct amdxdna_drm_set_state *args);
+	int (*set_aie_state)(struct amdxdna_client *client, struct amdxdna_drm_set_state *args,
+			     u32 *settle_ms);
 	int (*get_array)(struct amdxdna_client *client, struct amdxdna_drm_get_array *args);
 	int (*get_dev_revision)(struct amdxdna_dev *xdna, u32 *rev);
 };


### PR DESCRIPTION
The power-override clock settle polled PMF telemetry until the NPU clock reached the target. That path only works on kernels with amd-pmf, and it logged a warning on every override because the idle clock plateaus below the table value (which is the under-load clock).

Replace it with a simple fixed delay. This behaves the same with or without PMF and needs no telemetry. Measured on Strix, the NPU clock reaches ~98% of max in ~3.5s after a DPM change, which restores full GEMM throughput, so the delay is sized accordingly.

The delay is only applied when a mode change raises the DPM level; downclocking has nothing to settle and is skipped. The full power mode (DPM level, clock gating and pw_mode) is applied before the delay so the device is never left in a partially updated state, and dev_lock is dropped around the delay so it does not stall other operations on it.