### PR TITLE
accel/amdxdna: Support get/set preemption for AIE4 

### DIFF
--- a/drivers/accel/amdxdna/aie.c
+++ b/drivers/accel/amdxdna/aie.c
@@ -524,6 +524,39 @@ int amdxdna_query_ctx_status_by_id(struct aie_device *aie,
 	return 0;
 }
 
+int amdxdna_get_force_preempt_state(struct aie_device *aie, struct amdxdna_drm_get_info *args)
+{
+	struct amdxdna_drm_attribute_state state = {};
+	u32 buf_sz;
+
+	state.state = aie->force_preempt_enabled;
+
+	buf_sz = min(args->buffer_size, sizeof(state));
+	if (copy_to_user(u64_to_user_ptr(args->buffer), &state, buf_sz))
+		return -EFAULT;
+
+	return 0;
+}
+
+int amdxdna_set_force_preempt_state(struct aie_device *aie, struct amdxdna_client *client,
+				    struct amdxdna_drm_set_state *args)
+{
+	struct amdxdna_drm_attribute_state state;
+
+	if (copy_from_user(&state, u64_to_user_ptr(args->buffer), sizeof(state)))
+		return -EFAULT;
+
+	if (state.state > 1)
+		return -EINVAL;
+
+	if (XDNA_MBZ_DBG(client->xdna, state.pad, sizeof(state.pad)))
+		return -EINVAL;
+
+	aie->force_preempt_enabled = state.state;
+
+	return 0;
+}
+
 void amdxdna_hmm_invalidate(struct amdxdna_gem_obj *abo,
 			    unsigned long cur_seq)
 {

--- a/drivers/accel/amdxdna/aie.h
+++ b/drivers/accel/amdxdna/aie.h
@@ -60,6 +60,7 @@ struct aie_device {
 	struct amdxdna_drm_query_aie_version version;
 	struct amdxdna_drm_query_aie_metadata metadata;
 	struct aie_msg_ops msg_ops;
+	u32	force_preempt_enabled;
 
 	/* FW hwctx slot count for the telemetry map; 0 if arch has no map. */
 	u32 hwctx_limit;
@@ -172,6 +173,9 @@ int amdxdna_query_ctx_status_array(struct aie_device *aie, struct amdxdna_client
 				   struct amdxdna_drm_get_array *args);
 int amdxdna_query_ctx_status_by_id(struct aie_device *aie, struct amdxdna_client *client,
 				   struct amdxdna_drm_get_array *args);
+int amdxdna_get_force_preempt_state(struct aie_device *aie, struct amdxdna_drm_get_info *args);
+int amdxdna_set_force_preempt_state(struct aie_device *aie, struct amdxdna_client *client,
+				    struct amdxdna_drm_set_state *args);
 void amdxdna_hmm_invalidate(struct amdxdna_gem_obj *abo, unsigned long cur_seq);
 
 struct amdxdna_msg_buf_hdl {

--- a/drivers/accel/amdxdna/aie2_message.c
+++ b/drivers/accel/amdxdna/aie2_message.c
@@ -336,7 +336,7 @@ int aie2_create_context(struct amdxdna_dev_hdl *ndev, struct amdxdna_hwctx *hwct
 	if (WARN_ON_ONCE(hwctx->fw_ctx_id == -1))
 		return -EINVAL;
 
-	if (ndev->force_preempt_enabled) {
+	if (ndev->aie.force_preempt_enabled) {
 		ret = aie2_runtime_cfg(ndev, AIE2_RT_CFG_FORCE_PREEMPT, &hwctx->fw_ctx_id);
 		if (ret) {
 			XDNA_ERR(xdna, "failed to enable force preempt %d", ret);

--- a/drivers/accel/amdxdna/aie2_pci.c
+++ b/drivers/accel/amdxdna/aie2_pci.c
@@ -809,19 +809,14 @@ int aie2_fill_hwctx_map(struct aie_device *aie, u32 *map)
 	return 0;
 }
 
-static int aie2_get_preempt_state(struct amdxdna_client *client,
-				  struct amdxdna_drm_get_info *args)
+static int aie2_get_frame_boundary_preempt_state(struct amdxdna_client *client,
+						 struct amdxdna_drm_get_info *args)
 {
 	struct amdxdna_drm_attribute_state state = {};
-	struct amdxdna_dev *xdna = client->xdna;
-	struct amdxdna_dev_hdl *ndev;
+	struct amdxdna_dev_hdl *ndev = client->xdna->dev_handle;
 	u32 buf_sz;
 
-	ndev = xdna->dev_handle;
-	if (args->param == DRM_AMDXDNA_GET_FORCE_PREEMPT_STATE)
-		state.state = ndev->force_preempt_enabled;
-	else if (args->param == DRM_AMDXDNA_GET_FRAME_BOUNDARY_PREEMPT_STATE)
-		state.state = ndev->frame_boundary_preempt;
+	state.state = ndev->frame_boundary_preempt;
 
 	buf_sz = min(args->buffer_size, sizeof(state));
 	if (copy_to_user(u64_to_user_ptr(args->buffer), &state, buf_sz))
@@ -875,8 +870,10 @@ static int aie2_get_info(struct amdxdna_client *client, struct amdxdna_drm_get_i
 		ret = aie2_query_resource_info(client, args);
 		break;
 	case DRM_AMDXDNA_GET_FORCE_PREEMPT_STATE:
+		ret = amdxdna_get_force_preempt_state(&ndev->aie, args);
+		break;
 	case DRM_AMDXDNA_GET_FRAME_BOUNDARY_PREEMPT_STATE:
-		ret = aie2_get_preempt_state(client, args);
+		ret = aie2_get_frame_boundary_preempt_state(client, args);
 		break;
 	default:
 		XDNA_ERR(xdna, "Not supported request parameter %u", args->param);
@@ -998,8 +995,8 @@ static int aie2_set_power_mode(struct amdxdna_client *client,
 	return aie2_pm_set_mode(xdna->dev_handle, power_mode, settle_ms);
 }
 
-static int aie2_set_preempt_state(struct amdxdna_client *client,
-				  struct amdxdna_drm_set_state *args)
+static int aie2_set_frame_boundary_preempt(struct amdxdna_client *client,
+					   struct amdxdna_drm_set_state *args)
 {
 	struct amdxdna_dev_hdl *ndev = client->xdna->dev_handle;
 	struct amdxdna_drm_attribute_state state;
@@ -1015,17 +1012,12 @@ static int aie2_set_preempt_state(struct amdxdna_client *client,
 	if (XDNA_MBZ_DBG(client->xdna, state.pad, sizeof(state.pad)))
 		return -EINVAL;
 
-	if (args->param == DRM_AMDXDNA_SET_FORCE_PREEMPT) {
-		ndev->force_preempt_enabled = state.state;
-	} else if (args->param == DRM_AMDXDNA_SET_FRAME_BOUNDARY_PREEMPT) {
-		val = state.state;
-		ret = aie2_runtime_cfg(ndev, AIE2_RT_CFG_FRAME_BOUNDARY_PREEMPT,
-				       &val);
-		if (ret)
-			return ret;
+	val = state.state;
+	ret = aie2_runtime_cfg(ndev, AIE2_RT_CFG_FRAME_BOUNDARY_PREEMPT, &val);
+	if (ret)
+		return ret;
 
-		ndev->frame_boundary_preempt = state.state;
-	}
+	ndev->frame_boundary_preempt = state.state;
 
 	return 0;
 }
@@ -1049,8 +1041,10 @@ static int aie2_set_state(struct amdxdna_client *client,
 		ret = aie2_set_power_mode(client, args, settle_ms);
 		break;
 	case DRM_AMDXDNA_SET_FORCE_PREEMPT:
+		ret = amdxdna_set_force_preempt_state(&ndev->aie, client, args);
+		break;
 	case DRM_AMDXDNA_SET_FRAME_BOUNDARY_PREEMPT:
-		ret = aie2_set_preempt_state(client, args);
+		ret = aie2_set_frame_boundary_preempt(client, args);
 		break;
 	case DRM_AMDXDNA_AIE_TILE_WRITE:
 		ret = amdxdna_aie_tile_write(&ndev->aie, client, args);

--- a/drivers/accel/amdxdna/aie2_pci.h
+++ b/drivers/accel/amdxdna/aie2_pci.h
@@ -141,7 +141,6 @@ struct amdxdna_dev_hdl {
 	u32				dpm_level;
 	u32				dft_dpm_level;
 	u32				max_dpm_level;
-	u32				force_preempt_enabled;
 	u32				frame_boundary_preempt;
 
 	/* Mailbox and the management channel */

--- a/drivers/accel/amdxdna/aie4_ctx.c
+++ b/drivers/accel/amdxdna/aie4_ctx.c
@@ -201,6 +201,15 @@ int aie4_hwctx_create(struct amdxdna_hwctx *hwctx)
 		 resp.job_complete_msix_idx, resp.hw_context_id,
 		 resp.doorbell_offset);
 
+	if (ndev->aie.force_preempt_enabled) {
+		ret = aie4_force_preemption(ndev);
+		if (ret) {
+			XDNA_ERR(xdna, "failed to enable force preempt: %d", ret);
+			aie4_msg_destroy_context(ndev, resp.hw_context_id);
+			return ret;
+		}
+	}
+
 	/* setup interrupt completion per msix index */
 	ret = aie4_link_cert_comp(hwctx, resp.job_complete_msix_idx);
 	if (ret) {

--- a/drivers/accel/amdxdna/aie4_message.c
+++ b/drivers/accel/amdxdna/aie4_message.c
@@ -196,6 +196,28 @@ int aie4_msg_set_power_mode(struct amdxdna_dev_hdl *ndev, u8 power_mode)
 	return 0;
 }
 
+int aie4_force_preemption(struct amdxdna_dev_hdl *ndev)
+{
+	DECLARE_AIE_MSG(aie4_msg_set_runtime_cfg, AIE4_MSG_OP_SET_RUNTIME_CONFIG);
+	struct aie4_msg_runtime_config_force_preemption *force_preempt;
+	u32 type = AIE4_RUNTIME_CONFIG_FORCE_PREEMPTION;
+	int ret;
+
+	req.type = type;
+	force_preempt = (struct aie4_msg_runtime_config_force_preemption *)req.data;
+	force_preempt->enabled = 1;
+
+	msg.send_size = sizeof(req);
+
+	ret = aie_send_mgmt_msg_wait(&ndev->aie, &msg);
+	if (ret) {
+		XDNA_ERR(ndev->aie.xdna, "Failed to set runtime config, ret %d", ret);
+		return ret;
+	}
+
+	return 0;
+}
+
 int aie4_configure_hw_context_cert_log(struct amdxdna_dev_hdl *ndev,
 				       u32 hw_context_id, u32 property,
 				       const struct aie4_msg_context_config_cert_logging *cl)

--- a/drivers/accel/amdxdna/aie4_msg_priv.h
+++ b/drivers/accel/amdxdna/aie4_msg_priv.h
@@ -15,6 +15,7 @@ enum aie4_msg_opcode {
 	AIE4_MSG_OP_IDENTIFY                         = 0x10002,
 	AIE4_MSG_OP_SUSPEND                          = 0x10003,
 	AIE4_MSG_OP_GET_TELEMETRY                    = 0x10006,
+	AIE4_MSG_OP_SET_RUNTIME_CONFIG               = 0x10007,
 	AIE4_MSG_OP_QUERY_CERT_FIRMWARE_VERSION      = 0x1000F,
 
 	/* PF only */
@@ -75,6 +76,25 @@ struct aie4_msg_suspend_resp {
 
 struct aie4_msg_create_vfs_req {
 	__u32 vf_cnt;
+} __packed;
+
+struct aie4_msg_runtime_config_force_preemption {
+	__u8 enabled;
+	__u8 padding[3];
+} __packed;
+
+enum aie4_msg_runtime_config_type {
+	AIE4_RUNTIME_CONFIG_FORCE_PREEMPTION = 1,
+	AIE4_MAX_RUNTIME_CONFIG
+};
+
+struct aie4_msg_set_runtime_cfg_req {
+	__u32 type;
+	__u8 data[4];
+} __packed;
+
+struct aie4_msg_set_runtime_cfg_resp {
+	enum aie4_msg_status status;
 } __packed;
 
 struct aie4_msg_create_vfs_resp {

--- a/drivers/accel/amdxdna/aie4_pci.c
+++ b/drivers/accel/amdxdna/aie4_pci.c
@@ -778,6 +778,9 @@ static int aie4_get_info(struct amdxdna_client *client, struct amdxdna_drm_get_i
 	case DRM_AMDXDNA_QUERY_TELEMETRY:
 		ret = amdxdna_get_telemetry(&ndev->aie, client, args);
 		break;
+	case DRM_AMDXDNA_GET_FORCE_PREEMPT_STATE:
+		ret = amdxdna_get_force_preempt_state(&ndev->aie, args);
+		break;
 	default:
 		XDNA_ERR(xdna, "Not supported request parameter %u", args->param);
 		ret = -EOPNOTSUPP;
@@ -1202,6 +1205,9 @@ static int aie4_set_state(struct amdxdna_client *client,
 	switch (args->param) {
 	case DRM_AMDXDNA_SET_POWER_MODE:
 		ret = aie4_set_power_mode(client, args);
+		break;
+	case DRM_AMDXDNA_SET_FORCE_PREEMPT:
+		ret = amdxdna_set_force_preempt_state(&ndev->aie, client, args);
 		break;
 	case DRM_AMDXDNA_AIE_TILE_WRITE:
 		ret = amdxdna_aie_tile_write(&ndev->aie, client, args);

--- a/drivers/accel/amdxdna/aie4_pci.h
+++ b/drivers/accel/amdxdna/aie4_pci.h
@@ -102,6 +102,7 @@ int aie4_query_cert_firmware_version(struct amdxdna_dev_hdl *ndev,
 int aie4_suspend_fw(struct amdxdna_dev_hdl *ndev);
 int aie4_attach_work_buffer(struct amdxdna_dev_hdl *ndev, dma_addr_t addr, u32 size);
 int aie4_msg_set_power_mode(struct amdxdna_dev_hdl *ndev, u8 power_mode);
+int aie4_force_preemption(struct amdxdna_dev_hdl *ndev);
 int aie4_configure_hw_context_cert_log(struct amdxdna_dev_hdl *ndev,
 				       u32 hw_context_id, u32 property,
 				       const struct aie4_msg_context_config_cert_logging *cl);

--- a/test/shim_test/shim_test.cpp
+++ b/test/shim_test/shim_test.cpp
@@ -1478,7 +1478,7 @@ std::vector<test_case> test_list {
     TEST_POSITIVE, dev_filter_is_aie2_and_amdxdna_drv, TEST_io_with_ubuf_bo, {}
   },
    test_case{ "multi-command preempt full ELF io test real kernel good run", {},
-    TEST_POSITIVE, dev_filter_is_npu4, TEST_preempt_full_elf_io, { IO_TEST_FORCE_PREEMPTION, 8 }
+    TEST_POSITIVE, dev_filter_is_aie4_or_npu4, TEST_preempt_full_elf_io, { IO_TEST_FORCE_PREEMPTION, 8 }
   },
   test_case{ "Real kernel delay run for auto-suspend/resume", {},
     TEST_POSITIVE, dev_filter_is_aie2, TEST_io_suspend_resume, {}


### PR DESCRIPTION
+ enable shim test for preemption. Labeled as "do not merge" as we should wait for PR#1397 to be merged first because it will need conflict resolution and shim test for preemption needs to query telemetry to get preemption count.