### PR TITLE
accel/amdxdna: fix PF removal with live VF situation

### DIFF
--- a/drivers/accel/amdxdna/aie4_pci.c
+++ b/drivers/accel/amdxdna/aie4_pci.c
@@ -1149,7 +1149,20 @@ free_work_buf:
 
 static void aie4_pf_fini(struct amdxdna_dev *xdna)
 {
-	aie4_sriov_stop(xdna->dev_handle);
+	int ret;
+
+	/* Block new traffic from amdxdna-managed VFs */
+	aie4_unplug_vfs(xdna->dev_handle);
+
+	ret = aie4_sriov_stop(xdna->dev_handle);
+	if (ret == -EPERM) {
+		/*
+		 * The -EPERM indicates that there are VFs set to passthrough via VFIO driver.
+		 * The firmware teardown will disrupt those VMs.
+		 */
+		XDNA_WARN(xdna, "Removing PF with VFs in passthrough - VM disruption expected");
+	}
+
 	aie4_pf_hw_stop(xdna->dev_handle);
 	aie4_free_work_buffer(xdna->dev_handle);
 }

--- a/drivers/accel/amdxdna/aie4_pci.h
+++ b/drivers/accel/amdxdna/aie4_pci.h
@@ -84,12 +84,11 @@ void aie4_hwctx_destroy(struct amdxdna_hwctx *hwctx);
 int aie4_sriov_configure(struct amdxdna_dev *xdna, int num_vfs);
 int aie4_create_vfs(struct amdxdna_dev_hdl *ndev, int num_vfs);
 int aie4_sriov_stop(struct amdxdna_dev_hdl *ndev);
+void aie4_unplug_vfs(struct amdxdna_dev_hdl *ndev);
 #else
 #define aie4_sriov_configure NULL
-static inline int aie4_sriov_stop(struct amdxdna_dev_hdl *ndev)
-{
-	return 0;
-}
+static inline int aie4_sriov_stop(struct amdxdna_dev_hdl *ndev) { return 0; }
+static inline void aie4_unplug_vfs(struct amdxdna_dev_hdl *ndev) {}
 #endif
 
 /* aie4_message.c */

--- a/drivers/accel/amdxdna/aie4_sriov.c
+++ b/drivers/accel/amdxdna/aie4_sriov.c
@@ -4,6 +4,7 @@
  */
 
 #include "drm/amdxdna_accel.h"
+#include <drm/drm_drv.h>
 #include <drm/drm_print.h>
 #include <linux/pci.h>
 
@@ -50,23 +51,33 @@ int aie4_sriov_stop(struct amdxdna_dev_hdl *ndev)
 
 	ret = pci_vfs_assigned(pdev);
 	if (ret) {
+		/*
+		 * VFs are assigned to VMs (passthrough).
+		 * The pci_disable_sriov cannot be called safely.
+		 * thus, return early.
+		 */
 		XDNA_ERR(xdna, "VFs are still assigned to VMs");
 		return -EPERM;
 	}
 
-	pci_disable_sriov(pdev);
+	/*
+	 * Notify firmware that VFs are being torn down.
+	 * this is requested by privileged PF driver, thus continue
+	 * to tear down VF config space. It is up to the admin if any
+	 * error reported in this stage. They should either reload the
+	 * firmware or even reset the device.
+	 */
 	ret = aie4_destroy_vfs(ndev);
-	if (ret)
-		return ret;
-
 	ndev->num_vfs = 0;
-	return 0;
+	pci_disable_sriov(pdev);
+
+	return ret;
 }
 
-static void aie4_link_vfs(struct amdxdna_dev *xdna)
+static void aie4_for_each_vf(struct amdxdna_dev *xdna,
+			     void (*fn)(struct pci_dev *pf, struct pci_dev *vf))
 {
 	struct pci_dev *pdev_pf = to_pci_dev(xdna->ddev.dev);
-	struct device_link *link;
 	struct pci_dev *pdev_vf;
 	int pos;
 	u16 vf_did;
@@ -74,22 +85,73 @@ static void aie4_link_vfs(struct amdxdna_dev *xdna)
 	pos = pci_find_ext_capability(pdev_pf, PCI_EXT_CAP_ID_SRIOV);
 	if (!pos)
 		return;
-	pci_read_config_word(pdev_pf, pos + PCI_SRIOV_VF_DID, &vf_did);
-	pdev_vf = pci_get_device(pdev_pf->vendor, vf_did, NULL);
-	XDNA_DBG(xdna, "Linking VFs to PF %s", pci_name(pdev_pf));
 
-	for (; pdev_vf; pdev_vf = pci_get_device(pdev_pf->vendor, vf_did, pdev_vf)) {
+	if (pci_read_config_word(pdev_pf, pos + PCI_SRIOV_VF_DID, &vf_did)) {
+		XDNA_WARN(xdna, "Failed to read VF device ID");
+		return;
+	}
+
+	for (pdev_vf = pci_get_device(pdev_pf->vendor, vf_did, NULL);
+	     pdev_vf;
+	     pdev_vf = pci_get_device(pdev_pf->vendor, vf_did, pdev_vf)) {
 		if (!pdev_vf->is_virtfn || pdev_vf->physfn != pdev_pf)
 			continue;
-
-		link = device_link_add(&pdev_vf->dev,   /* child = VF */
-				       &pdev_pf->dev,   /* parent = PF */
-				       DL_FLAG_PM_RUNTIME | DL_FLAG_AUTOREMOVE_CONSUMER);
-		if (!link)
-			XDNA_WARN(xdna, "Failed to link VF %s", pci_name(pdev_vf));
-		else
-			XDNA_DBG(xdna, "Linked VF %s", pci_name(pdev_vf));
+		fn(pdev_pf, pdev_vf);
 	}
+}
+
+static void aie4_link_one_vf(struct pci_dev *pf, struct pci_dev *vf)
+{
+	struct amdxdna_dev *xdna = pci_get_drvdata(pf);
+	struct device_link *link;
+
+	/*
+	 * Link VF (consumer) to PF (supplier) for PM runtime ordering.
+	 * DL_FLAG_AUTOREMOVE_SUPPLIER drops the link object when the PF is
+	 * removed; it does not itself enforce VF-before-PF teardown ordering.
+	 * That ordering is enforced explicitly by aie4_unplug_vfs() and
+	 * pci_disable_sriov() in the removal path.
+	 */
+	link = device_link_add(&vf->dev,   /* consumer = VF */
+			       &pf->dev,   /* supplier = PF */
+			       DL_FLAG_PM_RUNTIME | DL_FLAG_AUTOREMOVE_SUPPLIER);
+
+	if (!link)
+		XDNA_WARN(xdna, "Failed to link VF %s", pci_name(vf));
+	else
+		XDNA_DBG(xdna, "Linked VF %s", pci_name(vf));
+}
+
+static void aie4_unplug_one_vf(struct pci_dev *pf, struct pci_dev *vf)
+{
+	struct amdxdna_dev *vf_xdna;
+
+	/*
+	 * Only unplug VFs bound to the same driver. VFs set to passthrough are
+	 * owned by different driver, the vfio-pci driver.
+	 */
+	if (pf->driver != vf->driver)
+		return;
+
+	vf_xdna = pci_get_drvdata(vf);
+	if (!vf_xdna)
+		return;
+
+	drm_dev_unplug(&vf_xdna->ddev);
+}
+
+static void aie4_link_vfs(struct amdxdna_dev *xdna)
+{
+	XDNA_DBG(xdna, "Linking VFs to PF %s", pci_name(to_pci_dev(xdna->ddev.dev)));
+	aie4_for_each_vf(xdna, aie4_link_one_vf);
+}
+
+void aie4_unplug_vfs(struct amdxdna_dev_hdl *ndev)
+{
+	struct amdxdna_dev *xdna = ndev->aie.xdna;
+
+	XDNA_DBG(xdna, "Unplugging VFs from PF %s", pci_name(to_pci_dev(xdna->ddev.dev)));
+	aie4_for_each_vf(xdna, aie4_unplug_one_vf);
 }
 
 static int aie4_sriov_start(struct amdxdna_dev_hdl *ndev, int num_vfs)
@@ -121,5 +183,10 @@ int aie4_sriov_configure(struct amdxdna_dev *xdna, int num_vfs)
 
 	drm_WARN_ON(&xdna->ddev, !mutex_is_locked(&xdna->dev_lock));
 
-	return (num_vfs) ? aie4_sriov_start(ndev, num_vfs) : aie4_sriov_stop(ndev);
+	if (num_vfs)
+		return aie4_sriov_start(ndev, num_vfs);
+
+	/* Block new traffic from amdxdna-managed VFs */
+	aie4_unplug_vfs(ndev);
+	return aie4_sriov_stop(ndev);
 }


### PR DESCRIPTION
add PF as supplier so that linked VF is the consumer, the PF removal will trigger VF removal first and using drm_dev_unplug to block all incoming traffic.