### PR TITLE
accel: amdxdna: ve2: add AMDXDNA_SET_STATE ioctl support

### DIFF
--- a/drivers/accel/amdxdna/amdxdna_solver.c
+++ b/drivers/accel/amdxdna/amdxdna_solver.c
@@ -15,42 +15,6 @@
 #include "amdxdna_drv.h"
 #include "amdxdna_solver.h"
 
-struct partition_node {
-	struct list_head	list;
-	u32			nshared;	/* # shared requests */
-	u32			start_col;	/* start column */
-	u32			ncols;		/* # columns */
-	bool			exclusive;	/* can not be shared if set */
-};
-
-struct solver_node {
-	struct list_head	list;
-	u64			rid;		/* Request ID from consumer */
-
-	struct partition_node	*pt_node;
-	void			*cb_arg;
-	u32			dpm_level;
-	u32			cols_len;
-	u32			start_cols[] __counted_by(cols_len);
-};
-
-struct solver_rgroup {
-	u32				rgid;
-	u32				nnode;
-	u32				npartition_node;
-
-	unsigned long			*resbit;	/* dynamic bitmap, size = total_col */
-	struct list_head		node_list;
-	struct list_head		pt_node_list;
-};
-
-struct solver_state {
-	struct solver_rgroup		rgp;
-	struct init_config		cfg;
-	struct xrs_action_ops		*actions;
-	struct mutex			xrs_lock;	/* serialise alloc/release */
-};
-
 static u32 calculate_gops(struct aie_qos *rqos)
 {
 	u32 service_rate = 0;
@@ -207,19 +171,26 @@ static int get_free_partition(struct solver_state *xrs,
 			      struct solver_node *snode,
 			      struct alloc_requests *req)
 {
+	u32 user_col = req->rqos.user_start_col;
 	u32 total_col = xrs->cfg.total_col;
 	struct partition_node *pt_node;
 	u32 ncols = req->cdo.ncols;
 	u32 col, i;
 
-	for (i = 0; i < snode->cols_len; i++) {
-		col = snode->start_cols[i];
-		if (find_next_bit(xrs->rgp.resbit, total_col, col) >= col + ncols)
-			break;
+	if (user_col != USER_START_COL_NOT_REQUESTED) {
+		/* User pinned a specific start column — validate and use it directly. */
+		col = user_col;
+		if (find_next_bit(xrs->rgp.resbit, total_col, col) < col + ncols)
+			return -ENODEV;
+	} else {
+		for (i = 0; i < snode->cols_len; i++) {
+			col = snode->start_cols[i];
+			if (find_next_bit(xrs->rgp.resbit, total_col, col) >= col + ncols)
+				break;
+		}
+		if (i == snode->cols_len)
+			return -ENODEV;
 	}
-
-	if (i == snode->cols_len)
-		return -ENODEV;
 
 	pt_node = kzalloc_obj(*pt_node);
 	if (!pt_node)
@@ -448,6 +419,7 @@ int amdxdna_alloc_resource(struct amdxdna_hwctx *hwctx)
 	xrs_req->rqos.exec_time = hwctx->qos.frame_exec_time;
 	xrs_req->rqos.priority = hwctx->qos.priority;
 	xrs_req->rqos.exclusive = (hwctx->qos.priority == AMDXDNA_QOS_REALTIME_PRIORITY);
+	xrs_req->rqos.user_start_col = hwctx->qos.user_start_col;
 
 	xrs_req->rid = (uintptr_t)hwctx;
 

--- a/drivers/accel/amdxdna/amdxdna_solver.h
+++ b/drivers/accel/amdxdna/amdxdna_solver.h
@@ -32,6 +32,8 @@ struct aie_qos_cap {
 /*
  * QoS requirement of a resource allocation.
  */
+#define USER_START_COL_NOT_REQUESTED	0xFF
+
 struct aie_qos {
 	u32	gops;		/* Giga operations */
 	u32	fps;		/* Frames per second */
@@ -40,6 +42,7 @@ struct aie_qos {
 	u32	exec_time;	/* Frame execution time */
 	u32	priority;	/* Request priority */
 	u32	exclusive;	/* Exclusive partition */
+	u32	user_start_col;	/* Preferred start column, or USER_START_COL_NOT_REQUESTED */
 };
 
 /*
@@ -119,6 +122,42 @@ struct init_config {
 	struct clk_list_info	clk_list;       /* List of frequencies available in system */
 	struct drm_device	*ddev;
 	struct xrs_action_ops	*actions;
+};
+
+struct partition_node {
+	struct list_head	list;
+	u32			nshared;	/* # shared requests */
+	u32			start_col;	/* start column */
+	u32			ncols;		/* # columns */
+	bool			exclusive;	/* can not be shared if set */
+};
+
+struct solver_node {
+	struct list_head	list;
+	u64			rid;		/* Request ID from consumer */
+
+	struct partition_node	*pt_node;
+	void			*cb_arg;
+	u32			dpm_level;
+	u32			cols_len;
+	u32			start_cols[] __counted_by(cols_len);
+};
+
+struct solver_rgroup {
+	u32				rgid;
+	u32				nnode;
+	u32				npartition_node;
+
+	unsigned long			*resbit;	/* dynamic bitmap, size = total_col */
+	struct list_head		node_list;
+	struct list_head		pt_node_list;
+};
+
+struct solver_state {
+	struct solver_rgroup		rgp;
+	struct init_config		cfg;
+	struct xrs_action_ops		*actions;
+	struct mutex			xrs_lock;	/* serialise alloc/release */
 };
 
 /*

--- a/drivers/accel/amdxdna/ve2_aux.c
+++ b/drivers/accel/amdxdna/ve2_aux.c
@@ -237,4 +237,5 @@ const struct amdxdna_dev_ops ve2_ops = {
 	.cmd_submit		= ve2_cmd_submit,
 	.cmd_wait		= ve2_cmd_wait,
 	.get_array		= ve2_debug_get_array,
+	.set_aie_state		= ve2_set_aie_state,
 };

--- a/drivers/accel/amdxdna/ve2_debug.c
+++ b/drivers/accel/amdxdna/ve2_debug.c
@@ -18,6 +18,7 @@
 
 #include "amdxdna_ctx.h"
 #include "amdxdna_drv.h"
+#include "ve2_aux.h"
 #include "ve2_debug.h"
 #include "ve2_hwctx.h"
 #include "ve2_mgmt.h"
@@ -128,6 +129,118 @@ static int ve2_get_hwctx_mem_bitmap(struct amdxdna_client *client,
 		return -EFAULT;
 
 	args->num_element = 1;
+	return 0;
+}
+
+static int ve2_aie_tile_read(struct amdxdna_client *client, struct amdxdna_drm_get_array *args)
+{
+	struct amdxdna_drm_aie_tile_access footer = {};
+	struct amdxdna_dev *xdna = client->xdna;
+	struct amdxdna_hwctx *hwctx = NULL;
+	struct amdxdna_mgmtctx *mgmtctx;
+	struct amdxdna_ctx_priv *vp;
+	struct amdxdna_client *tmp;
+	struct aie_location loc;
+	void *local_buf = NULL;
+	u32 buf_size, offset;
+	unsigned long hx_id;
+	int ret;
+
+	buf_size = (u32)args->num_element * args->element_size;
+	if (buf_size < sizeof(footer) + 1) {
+		XDNA_ERR(xdna, "buffer_size %u too small", buf_size);
+		return -EINVAL;
+	}
+
+	/* Footer is at the tail of the buffer; data area precedes it */
+	offset = buf_size - sizeof(footer);
+	if (copy_from_user(&footer, u64_to_user_ptr(args->buffer) + offset, sizeof(footer))) {
+		XDNA_ERR(xdna, "Failed to copy tile_access footer from user");
+		return -EFAULT;
+	}
+
+	drm_WARN_ON(&xdna->ddev, !mutex_is_locked(&xdna->dev_lock));
+
+	/* Find the hwctx matching context_id + pid */
+
+	list_for_each_entry(tmp, &xdna->client_list, node) {
+		struct amdxdna_hwctx *hx;
+		int sidx;
+
+		sidx = srcu_read_lock(&tmp->hwctx_srcu);
+		xa_for_each(&tmp->hwctx_xa, hx_id, hx) {
+			if (hx->id == footer.context_id &&
+			    (u64)hx->client->pid == footer.pid) {
+				hwctx = hx;
+				break;
+			}
+		}
+		srcu_read_unlock(&tmp->hwctx_srcu, sidx);
+		if (hwctx)
+			break;
+	}
+
+	if (!hwctx) {
+		XDNA_ERR(xdna, "hwctx %u pid %llu not found",
+			 footer.context_id, footer.pid);
+		return -EINVAL;
+	}
+
+	if (footer.col >= hwctx->num_col) {
+		XDNA_ERR(xdna, "col %u out of partition range [0, %u)",
+			 footer.col, hwctx->num_col);
+		return -EINVAL;
+	}
+
+	if (footer.row >= xdna->dev_handle->aie_dev_info.rows) {
+		XDNA_ERR(xdna, "row %u out of range [0, %u)",
+			 footer.row, xdna->dev_handle->aie_dev_info.rows);
+		return -EINVAL;
+	}
+
+	vp = ve2_hw_priv(hwctx);
+	if (!vp || !vp->mgmtctx) {
+		XDNA_ERR(xdna, "hwctx %u has no AIE partition", hwctx->id);
+		return -EINVAL;
+	}
+	mgmtctx = vp->mgmtctx;
+
+	local_buf = kzalloc(footer.size, GFP_KERNEL);
+	if (!local_buf)
+		return -ENOMEM;
+
+	/* Drop dev_lock — aie_partition_read can block on hardware I/O */
+	mutex_unlock(&xdna->dev_lock);
+	mutex_lock(&mgmtctx->ctx_lock);
+
+	if (mgmtctx->active_ctx != hwctx) {
+		XDNA_ERR(xdna, "hwctx %u is not the active context", hwctx->id);
+		mutex_unlock(&mgmtctx->ctx_lock);
+		mutex_lock(&xdna->dev_lock);
+		kfree(local_buf);
+		return -EPERM;
+	}
+
+	loc.col = footer.col;
+	loc.row = footer.row;
+	ret = aie_partition_read(mgmtctx->aie_dev, loc, footer.addr, footer.size, local_buf);
+	mutex_unlock(&mgmtctx->ctx_lock);
+	mutex_lock(&xdna->dev_lock);
+
+	if (ret < 0) {
+		XDNA_ERR(xdna, "aie_partition_read failed: %d", ret);
+		kfree(local_buf);
+		return ret;
+	}
+
+	if (copy_to_user(u64_to_user_ptr(args->buffer), local_buf, footer.size)) {
+		XDNA_ERR(xdna, "Failed to copy read data to user");
+		kfree(local_buf);
+		return -EFAULT;
+	}
+
+	kfree(local_buf);
+
 	return 0;
 }
 
@@ -253,6 +366,9 @@ int ve2_debug_get_array(struct amdxdna_client *client, struct amdxdna_drm_get_ar
 	case DRM_AMDXDNA_AIE_COREDUMP:
 		ret = ve2_coredump_read(client, args);
 		break;
+	case DRM_AMDXDNA_AIE_TILE_READ:
+		ret = ve2_aie_tile_read(client, args);
+		break;
 	default:
 		XDNA_ERR(xdna, "Not supported GET_ARRAY param %u", args->param);
 		ret = -EOPNOTSUPP;
@@ -260,4 +376,138 @@ int ve2_debug_get_array(struct amdxdna_client *client, struct amdxdna_drm_get_ar
 
 	drm_dev_exit(idx);
 	return ret;
+}
+
+static int ve2_aie_tile_write(struct amdxdna_client *client, struct amdxdna_drm_set_state *args)
+{
+	struct amdxdna_drm_aie_tile_access footer = {};
+	struct amdxdna_dev *xdna = client->xdna;
+	struct amdxdna_hwctx *hwctx = NULL;
+	struct amdxdna_mgmtctx *mgmtctx;
+	struct amdxdna_ctx_priv *vp;
+	struct amdxdna_client *tmp;
+	struct aie_location loc;
+	void *local_buf = NULL;
+	unsigned long hx_id;
+	u32 offset;
+	int ret;
+
+	if (args->buffer_size < sizeof(footer)) {
+		XDNA_ERR(xdna, "buffer_size %u too small (need %zu)",
+			 args->buffer_size, sizeof(footer));
+		return -EINVAL;
+	}
+
+	/* Footer is at the tail of the buffer */
+	offset = args->buffer_size - sizeof(footer);
+	if (copy_from_user(&footer, u64_to_user_ptr(args->buffer) + offset, sizeof(footer))) {
+		XDNA_ERR(xdna, "Failed to copy tile_access footer from user");
+		return -EFAULT;
+	}
+
+	/* Find the hwctx matching context_id + pid */
+	drm_WARN_ON(&xdna->ddev, !mutex_is_locked(&xdna->dev_lock));
+
+	list_for_each_entry(tmp, &xdna->client_list, node) {
+		struct amdxdna_hwctx *hx;
+		int sidx;
+
+		sidx = srcu_read_lock(&tmp->hwctx_srcu);
+		xa_for_each(&tmp->hwctx_xa, hx_id, hx) {
+			if (hx->id == footer.context_id &&
+			    (u64)hx->client->pid == footer.pid) {
+				hwctx = hx;
+				break;
+			}
+		}
+		srcu_read_unlock(&tmp->hwctx_srcu, sidx);
+		if (hwctx)
+			break;
+	}
+
+	if (!hwctx) {
+		XDNA_ERR(xdna, "hwctx %u pid %llu not found", footer.context_id, footer.pid);
+		return -EINVAL;
+	}
+
+	if (footer.col >= hwctx->num_col) {
+		XDNA_ERR(xdna, "col %u out of partition range [0, %u)",
+			 footer.col, hwctx->num_col);
+		return -EINVAL;
+	}
+
+	if (footer.row >= xdna->dev_handle->aie_dev_info.rows) {
+		XDNA_ERR(xdna, "row %u out of range [0, %u)",
+			 footer.row, xdna->dev_handle->aie_dev_info.rows);
+		return -EINVAL;
+	}
+
+	vp = ve2_hw_priv(hwctx);
+	if (!vp || !vp->mgmtctx) {
+		XDNA_ERR(xdna, "hwctx %u has no AIE partition", hwctx->id);
+		return -EINVAL;
+	}
+	mgmtctx = vp->mgmtctx;
+
+	local_buf = kzalloc(footer.size, GFP_KERNEL);
+	if (!local_buf)
+		return -ENOMEM;
+
+	if (copy_from_user(local_buf, u64_to_user_ptr(args->buffer), footer.size)) {
+		XDNA_ERR(xdna, "Failed to copy write data from user");
+		kfree(local_buf);
+		return -EFAULT;
+	}
+
+	/*
+	 * aie_partition_write can block on hardware I/O. Release dev_lock
+	 * before calling it to avoid stalling all other IOCTLs. Use
+	 * mgmtctx->ctx_lock to serialize against context switches.
+	 */
+	mutex_unlock(&xdna->dev_lock);
+	mutex_lock(&mgmtctx->ctx_lock);
+
+	if (mgmtctx->active_ctx != hwctx) {
+		XDNA_ERR(xdna, "hwctx %u is not the active context", hwctx->id);
+		mutex_unlock(&mgmtctx->ctx_lock);
+		mutex_lock(&xdna->dev_lock);
+		kfree(local_buf);
+		return -EPERM;
+	}
+
+	loc.col = footer.col;
+	loc.row = footer.row;
+	ret = aie_partition_write(mgmtctx->aie_dev, loc, footer.addr, footer.size, local_buf, 0);
+	mutex_unlock(&mgmtctx->ctx_lock);
+	mutex_lock(&xdna->dev_lock);
+
+	if (ret < 0)
+		XDNA_ERR(xdna, "aie_partition_write failed: %d", ret);
+	else
+		ret = 0;
+
+	kfree(local_buf);
+	return ret;
+}
+
+int ve2_set_aie_state(struct amdxdna_client *client, struct amdxdna_drm_set_state *args)
+{
+	struct amdxdna_dev *xdna = client->xdna;
+
+	/*
+	 * dev_lock is already held by amdxdna_drm_set_state_ioctl().
+	 * Taking it again here would deadlock (non-recursive mutex).
+	 */
+	drm_WARN_ON(&xdna->ddev, !mutex_is_locked(&xdna->dev_lock));
+
+	XDNA_DBG(xdna, "Set AIE state: param=%u buffer_size=%u",
+		 args->param, args->buffer_size);
+
+	switch (args->param) {
+	case DRM_AMDXDNA_AIE_TILE_WRITE:
+		return ve2_aie_tile_write(client, args);
+	default:
+		XDNA_ERR(xdna, "Unsupported set_state param %u", args->param);
+		return -EOPNOTSUPP;
+	}
 }

--- a/drivers/accel/amdxdna/ve2_debug.h
+++ b/drivers/accel/amdxdna/ve2_debug.h
@@ -6,7 +6,9 @@
 
 struct amdxdna_client;
 struct amdxdna_drm_get_array;
+struct amdxdna_drm_set_state;
 
 int ve2_debug_get_array(struct amdxdna_client *client, struct amdxdna_drm_get_array *args);
+int ve2_set_aie_state(struct amdxdna_client *client, struct amdxdna_drm_set_state *args);
 
 #endif

--- a/drivers/accel/amdxdna/ve2_mgmt.c
+++ b/drivers/accel/amdxdna/ve2_mgmt.c
@@ -21,7 +21,7 @@
 #include "ve2_mgmt.h"
 
 static int ve2_create_mgmt_partition(struct amdxdna_dev *xdna, struct amdxdna_hwctx *hwctx,
-				     u32 start_col, u32 num_col, u32 *partition_id);
+				     u32 part_start_col, u32 num_col, u32 *partition_id);
 
 static void cert_setup_partition(struct amdxdna_mgmtctx *mgmtctx,
 				 struct amdxdna_hwctx *hwctx, u32 col,
@@ -111,22 +111,37 @@ ve2_prepare_hs_data(struct amdxdna_mgmtctx *mgmtctx, struct amdxdna_hwctx *hwctx
 static int ve2_xrs_col_list(struct amdxdna_hwctx *hwctx, u32 total_col)
 {
 	struct amdxdna_dev *xdna = hwctx->client->xdna;
+	u32 user_col = hwctx->qos.user_start_col;
 	u32 num_col = hwctx->num_tiles;
+	u32 first_col = 0;
 	u32 entries = 0;
-	u32 start;
-	u32 i;
+	u32 s, i;
 
 	if (!num_col || num_col > total_col) {
 		XDNA_ERR(xdna, "Invalid num_col %u (total_col %u)", num_col, total_col);
 		return -EINVAL;
 	}
 
-	for (start = 0; start + num_col <= total_col; start += VE2_MIN_COL_SUPPORT)
+	if (user_col != USER_START_COL_NOT_REQUESTED) {
+		if (user_col % VE2_MIN_COL_SUPPORT != 0) {
+			XDNA_ERR(xdna, "user_start_col %u not aligned to %u", user_col,
+				 VE2_MIN_COL_SUPPORT);
+			return -EINVAL;
+		}
+		if (user_col + num_col > total_col) {
+			XDNA_ERR(xdna, "user_start_col %u + num_col %u exceeds total_col %u",
+				 user_col, num_col, total_col);
+			return -ERANGE;
+		}
+		first_col = user_col;
+	}
+
+	for (s = first_col; s + num_col <= total_col; s += VE2_MIN_COL_SUPPORT)
 		entries++;
 
 	if (!entries) {
-		XDNA_ERR(xdna, "No valid start col for num_col %u in total_col %u",
-			 num_col, total_col);
+		XDNA_ERR(xdna, "No valid start col for num_col %u (first_col %u total_col %u)",
+			 num_col, first_col, total_col);
 		return -EINVAL;
 	}
 
@@ -135,8 +150,8 @@ static int ve2_xrs_col_list(struct amdxdna_hwctx *hwctx, u32 total_col)
 		return -ENOMEM;
 
 	hwctx->col_list_len = entries;
-	for (i = 0, start = 0; i < entries; i++, start += VE2_MIN_COL_SUPPORT)
-		hwctx->col_list[i] = start;
+	for (i = 0, s = first_col; i < entries; i++, s += VE2_MIN_COL_SUPPORT)
+		hwctx->col_list[i] = s;
 
 	print_hex_dump_debug("col_list: ", DUMP_PREFIX_OFFSET, 16, 4, hwctx->col_list,
 			     entries * sizeof(*hwctx->col_list), false);
@@ -324,8 +339,7 @@ static bool ve2_check_idle_or_queue_not_empty(struct amdxdna_mgmtctx *mgmtctx)
 
 static bool ve2_check_misc_interrupt(struct amdxdna_mgmtctx *mgmtctx)
 {
-	u32 off = CERT_HANDSHAKE_OFF(mgmtctx->start_col) +
-		  offsetof(struct handshake, misc_status);
+	u32 off = CERT_HANDSHAKE_OFF(0) + offsetof(struct handshake, misc_status);
 	u32 misc_status = 0;
 	struct amdxdna_ctx_priv *vp;
 	int ret;
@@ -426,7 +440,7 @@ static void ve2_irq_handler(u32 partition_id, void *priv)
 }
 
 static int ve2_create_mgmt_partition(struct amdxdna_dev *xdna, struct amdxdna_hwctx *hwctx,
-				     u32 start_col, u32 num_col, u32 *partition_id)
+				     u32 part_start_col, u32 num_col, u32 *partition_id)
 {
 	struct amdxdna_dev_hdl *xdna_hdl = xdna->dev_handle;
 	struct amdxdna_ctx_priv *vp = ve2_hw_priv(hwctx);
@@ -435,7 +449,7 @@ static int ve2_create_mgmt_partition(struct amdxdna_dev *xdna, struct amdxdna_hw
 	struct device *aie_dev;
 	int ret;
 
-	if (!vp || start_col >= xdna_hdl->aie_dev_info.cols)
+	if (!vp || part_start_col >= xdna_hdl->aie_dev_info.cols)
 		return -EINVAL;
 
 	if (vp->mgmtctx)
@@ -446,7 +460,7 @@ static int ve2_create_mgmt_partition(struct amdxdna_dev *xdna, struct amdxdna_hw
 		return -ENOMEM;
 
 	mgmtctx->xdna = xdna;
-	mgmtctx->start_col = start_col;
+	mgmtctx->start_col = part_start_col;
 	mgmtctx->num_col = num_col;
 	mgmtctx->num_rows = xdna_hdl->aie_dev_info.rows;
 	mgmtctx->active_ctx = NULL;
@@ -461,7 +475,7 @@ static int ve2_create_mgmt_partition(struct amdxdna_dev *xdna, struct amdxdna_hw
 
 	INIT_WORK(&mgmtctx->scheduler_work, ve2_scheduler_work);
 
-	req.partition_id = (start_col << AIE_PART_ID_START_COL_SHIFT) |
+	req.partition_id = (part_start_col << AIE_PART_ID_START_COL_SHIFT) |
 			   (num_col << AIE_PART_ID_NUM_COLS_SHIFT);
 	req.user_event1_complete = ve2_irq_handler;
 	req.user_event1_priv = mgmtctx;

--- a/drivers/accel/amdxdna/ve2_mgmt.h
+++ b/drivers/accel/amdxdna/ve2_mgmt.h
@@ -54,7 +54,7 @@ struct amdxdna_mgmtctx {
 static inline int ve2_partition_read_privileged_mem(struct amdxdna_mgmtctx *mgmtctx,
 						    size_t field_off, size_t size, void *buf)
 {
-	u32 offset = CERT_HANDSHAKE_OFF(mgmtctx->start_col) + field_off;
+	u32 offset = CERT_HANDSHAKE_OFF(0) + field_off;
 
 	return aie_partition_read_privileged_mem(mgmtctx->aie_dev, offset, size, buf);
 }

--- a/include/uapi/drm/amdxdna_accel.h
+++ b/include/uapi/drm/amdxdna_accel.h
@@ -60,6 +60,7 @@ enum amdxdna_drm_ioctl_id {
  * @latency: Frame response latency.
  * @frame_exec_time: Frame execution time.
  * @priority: Request priority.
+ * @user_start_col: User preferred start column, or USER_START_COL_NOT_REQUESTED if not specified.
  *
  * User program can provide QoS hints to driver.
  */
@@ -70,6 +71,7 @@ struct amdxdna_qos_info {
 	__u32 latency;
 	__u32 frame_exec_time;
 	__u32 priority;
+	__u32 user_start_col;
 };
 
 /**
@@ -721,6 +723,7 @@ struct amdxdna_drm_aie_coredump {
 #define DRM_AMDXDNA_HW_LAST_ASYNC_ERR	2
 #define DRM_AMDXDNA_AIE_COREDUMP	5
 #define DRM_AMDXDNA_BO_USAGE		6
+#define DRM_AMDXDNA_AIE_TILE_READ	9
 #define DRM_AMDXDNA_HWCTX_MEM_BITMAP	11
 
 /**
@@ -776,6 +779,34 @@ enum amdxdna_drm_set_param {
 	DRM_AMDXDNA_WRITE_AIE_REG,
 	DRM_AMDXDNA_SET_FORCE_PREEMPT,
 	DRM_AMDXDNA_SET_FRAME_BOUNDARY_PREEMPT,
+	DRM_AMDXDNA_SET_FW_LOG_STATE,
+	DRM_AMDXDNA_SET_FW_TRACE_STATE,
+	DRM_AMDXDNA_AIE_TILE_WRITE,
+};
+
+/**
+ * struct amdxdna_drm_aie_tile_access - Data for an AIE tile read/write.
+ * @pid:        PID of the process that owns the context.
+ * @context_id: Hardware context ID.
+ * @col:        AIE column index (partition-relative, 0-based).
+ * @row:        AIE row index.
+ * @addr:       Tile-local register or memory address to access.
+ * @size:       Number of bytes to write.
+ * @type:       Access path — one of enum amdxdna_aie_tile_access_type.
+ * @pad:        MBZ.
+ *
+ * Used as the footer at the end of the buffer for %DRM_AMDXDNA_AIE_TILE_WRITE.
+ * The data to write occupies the first @size bytes of the buffer.
+ */
+struct amdxdna_drm_aie_tile_access {
+	__u64 pid;
+	__u32 context_id;
+	__u32 col;
+	__u32 row;
+	__u32 addr;
+	__u32 size;
+	__u8  type;
+	__u8  pad[3];
 };
 
 /**


### PR DESCRIPTION
-Implement DRM_IOCTL_AMDXDNA_SET_STATE for the VE2 AUX driver.
-aie_partition_read_privileged_mem() expects a partition-relative offset.
-Fix compile time errors by moving structure declaration to header file.
Tests passed:
1) start_col_support
2) write_read_reg_mem