### PR TITLE
shim_ve2: adding explicit sync post buffer allocation

### DIFF
--- a/src/shim_ve2/xdna_bo.cpp
+++ b/src/shim_ve2/xdna_bo.cpp
@@ -136,6 +136,14 @@ xdna_bo(const device_xdna& device, xrt_core::hwctx_handle::slot_id ctx_id,
       xflags.use == XRT_BO_USE_LOG || xflags.use == XRT_BO_USE_UC_DEBUG)
     attach_to_ctx(xflags.use);
 
+  // Freshly allocated pages may carry stale dirty cache lines. If this BO is
+  // used as an output, those lines could later write back over the device's
+  // DMA results and corrupt them. Flush once right after allocation so the
+  // BO starts clean; subsequent coherency is the app's responsibility via
+  // explicit sync().
+  if (m_type == AMDXDNA_BO_SHARE)
+    sync(direction::host2device, m_aligned_size, 0);
+
   shim_debug("Allocated DRM BO (userptr=0x%lx, size=%ld, flags=0x%llx, type=%d, drm_bo=%d)",
 	     m_ptr, m_aligned_size, m_flags, m_type, get_drm_bo_handle());
 }


### PR DESCRIPTION
- Freshly allocated pages may carry stale dirty cache lines. If this BO is used as an output, those lines could later write back over the device's DMA results and corrupt them. Flush once right after allocation so the BO starts clean.
- This explicit sync is required for cacheable buffers. Observed on ve2, on tests based on cacheable buffers 
- On ve2: xrt-smi latency ~25us to ~28us and throughput 104.7k to 105.1k op/s