### PR TITLE
ve2: cacheable hsa queue and explicit sync post buf alloc

### DIFF
--- a/src/driver/amdxdna/ve2_hwctx.c
+++ b/src/driver/amdxdna/ve2_hwctx.c
@@ -401,10 +401,11 @@ static inline void hsa_queue_pkt_set_invalid(struct host_queue_packet *pkt)
 static void ve2_free_hsa_queue(struct amdxdna_dev *xdna, struct ve2_hsa_queue *queue)
 {
 	if (queue->hsa_queue_p) {
-		dma_free_coherent(queue->alloc_dev,
-				  sizeof(struct hsa_queue) + sizeof(u64) * HOST_QUEUE_ENTRY,
-				  queue->hsa_queue_p,
-				  queue->hsa_queue_mem.dma_addr);
+		dma_free_noncoherent(queue->alloc_dev,
+				     sizeof(struct hsa_queue) + sizeof(u64) * HOST_QUEUE_ENTRY,
+				     queue->hsa_queue_p,
+				     queue->hsa_queue_mem.dma_addr,
+				     DMA_BIDIRECTIONAL);
 		queue->hsa_queue_p = NULL;
 		queue->hsa_queue_mem.dma_addr = 0;
 		queue->alloc_dev = NULL;
@@ -515,8 +516,9 @@ static int ve2_create_host_queue(struct amdxdna_dev *xdna, struct amdxdna_ctx *h
 	for (r = 0; r < MAX_MEM_REGIONS; r++) {
 		alloc_dev = xdna->cma_region_devs[r];
 		if ((hwctx->priv->mem_bitmap & (1U << r)) && alloc_dev) {
-			queue->hsa_queue_p = dma_alloc_coherent(alloc_dev, alloc_size,
-								&dma_handle, GFP_KERNEL);
+			queue->hsa_queue_p = dma_alloc_noncoherent(alloc_dev, alloc_size,
+								   &dma_handle, DMA_BIDIRECTIONAL,
+								   GFP_KERNEL);
 			if (!queue->hsa_queue_p)
 				continue;
 			queue->alloc_dev = alloc_dev;
@@ -526,10 +528,11 @@ static int ve2_create_host_queue(struct amdxdna_dev *xdna, struct amdxdna_ctx *h
 
 	/* If no allocation succeeded, use the default device */
 	if (!queue->hsa_queue_p) {
-		queue->hsa_queue_p = dma_alloc_coherent(xdna->ddev.dev,
-							alloc_size,
-							&dma_handle,
-							GFP_KERNEL);
+		queue->hsa_queue_p = dma_alloc_noncoherent(xdna->ddev.dev,
+							   alloc_size,
+							   &dma_handle,
+							   DMA_BIDIRECTIONAL,
+							   GFP_KERNEL);
 		if (!queue->hsa_queue_p) {
 			XDNA_ERR(xdna, "Failed to allocate host queue memory, size=%zu",
 				 alloc_size);

--- a/src/shim_ve2/xdna_bo.cpp
+++ b/src/shim_ve2/xdna_bo.cpp
@@ -136,6 +136,14 @@ xdna_bo(const device_xdna& device, xrt_core::hwctx_handle::slot_id ctx_id,
       xflags.use == XRT_BO_USE_LOG || xflags.use == XRT_BO_USE_UC_DEBUG)
     attach_to_ctx(xflags.use);
 
+  // Freshly allocated pages may carry stale dirty cache lines. If this BO is
+  // used as an output, those lines could later write back over the device's
+  // DMA results and corrupt them. Flush once right after allocation so the
+  // BO starts clean; subsequent coherency is the app's responsibility via
+  // explicit sync().
+  if (m_type == AMDXDNA_BO_SHARE)
+    sync(direction::host2device, m_aligned_size, 0);
+
   shim_debug("Allocated DRM BO (userptr=0x%lx, size=%ld, flags=0x%llx, type=%d, drm_bo=%d)",
 	     m_ptr, m_aligned_size, m_flags, m_type, get_drm_bo_handle());
 }


### PR DESCRIPTION
- using cacheable memory for hsa queue
- added explicit sync post buffer allocation to avoid getting polluted buffers. The issue was observed with ve2 tests based on cacheable buffers.
- ~14.8% to ~15% Throughput increased when all the buffers (hsa queue + ifm, ofm, wts, etc) are cacheable
- ~3.8% to ~4% Throughput increased when only hsa queue is cacheable

```
amd-edf:/mnt# xrt-smi validate -d 0
Validate Device           : [0000:00:00.0]
    Platform              : AMD Versal Prime Gen2
    Power Mode            : default
-------------------------------------------------------------------------------
Test 1 [0000:00:00.0]     : latency
    Details               : Average latency: 25.0 us
    Test Status           : [PASSED]
-------------------------------------------------------------------------------
Test 2 [0000:00:00.0]     : throughput
    Details               : Average throughput: 119655.0 op/s
    Test Status           : [PASSED]
-------------------------------------------------------------------------------
Validation completed
amd-edf:/mnt#
```