### PR TITLE
accel/amdxdna: skip PASID tag in non-SVA mode

### DIFF
--- a/drivers/accel/amdxdna/aie4_ctx.c
+++ b/drivers/accel/amdxdna/aie4_ctx.c
@@ -169,7 +169,7 @@ int aie4_hwctx_create(struct amdxdna_hwctx *hwctx)
 	DECLARE_AIE_MSG(aie4_msg_create_hw_context, AIE4_MSG_OP_CREATE_HW_CONTEXT);
 	struct amdxdna_client *client = hwctx->client;
 	struct amdxdna_hwctx_priv *priv = hwctx->priv;
-	struct amdxdna_dev *xdna = hwctx->client->xdna;
+	struct amdxdna_dev *xdna = client->xdna;
 	struct amdxdna_dev_hdl *ndev = xdna->dev_handle;
 	int ret;
 
@@ -183,10 +183,8 @@ int aie4_hwctx_create(struct amdxdna_hwctx *hwctx)
 
 	req.partition_id = ndev->partition_id;
 	req.request_num_tiles = hwctx->num_tiles;
-	req.pasid = FIELD_PREP(AIE4_MSG_PASID, client->pasid) |
-		FIELD_PREP(AIE4_MSG_PASID_VLD, 1);
+	req.pasid = aie4_msg_pasid(client);
 	req.priority_band = aie4_parse_priority_to_dev(hwctx->qos.priority);
-
 	req.hsa_addr_high = upper_32_bits(amdxdna_gem_dev_addr(priv->umq_bo));
 	req.hsa_addr_low = lower_32_bits(amdxdna_gem_dev_addr(priv->umq_bo));
 
@@ -200,8 +198,7 @@ int aie4_hwctx_create(struct amdxdna_hwctx *hwctx)
 	}
 
 	XDNA_DBG(xdna, "resp msix: %d, ctx id: %d, doorbell: %d",
-		 resp.job_complete_msix_idx,
-		 resp.hw_context_id,
+		 resp.job_complete_msix_idx, resp.hw_context_id,
 		 resp.doorbell_offset);
 
 	/* setup interrupt completion per msix index */

--- a/drivers/accel/amdxdna/aie4_message.c
+++ b/drivers/accel/amdxdna/aie4_message.c
@@ -19,6 +19,15 @@
 #include "amdxdna_mailbox_helper.h"
 #include "amdxdna_pci_drv.h"
 
+u32 aie4_msg_pasid(struct amdxdna_client *client)
+{
+	if (!amdxdna_pasid_on(client))
+		return 0;
+
+	return FIELD_PREP(AIE4_MSG_PASID, client->pasid) |
+	       FIELD_PREP(AIE4_MSG_PASID_VLD, 1);
+}
+
 int aie4_suspend_fw(struct amdxdna_dev_hdl *ndev)
 {
 	DECLARE_AIE_MSG(aie4_msg_suspend, AIE4_MSG_OP_SUSPEND);
@@ -217,8 +226,7 @@ int aie4_get_aie_coredump(struct amdxdna_hwctx *hwctx,
 	int ret;
 
 	req.context_id = hwctx->fw_ctx_id;
-	req.pasid = FIELD_PREP(AIE4_MSG_PASID, hwctx->client->pasid) |
-		    FIELD_PREP(AIE4_MSG_PASID_VLD, 1);
+	req.pasid = aie4_msg_pasid(hwctx->client);
 	req.num_buffers = num_bufs;
 	req.buffer_list_addr = to_dma_addr(list_hdl, 0);
 
@@ -281,8 +289,7 @@ int aie4_rw_aie_mem(struct amdxdna_hwctx *hwctx, bool is_read,
 	req.mem_access.buffer_size = size;
 	req.mem_access.mem_addr = aie_addr;
 	req.mem_access.mem_size = size;
-	req.mem_access.pasid = FIELD_PREP(AIE4_MSG_PASID, hwctx->client->pasid) |
-			       FIELD_PREP(AIE4_MSG_PASID_VLD, 1);
+	req.mem_access.pasid = aie4_msg_pasid(hwctx->client);
 
 	ret = aie_send_mgmt_msg_wait(&ndev->aie, &msg);
 	if (ret) {

--- a/drivers/accel/amdxdna/aie4_pci.h
+++ b/drivers/accel/amdxdna/aie4_pci.h
@@ -107,6 +107,7 @@ int aie4_configure_hw_context_cert_log(struct amdxdna_dev_hdl *ndev,
 				       const struct aie4_msg_context_config_cert_logging *cl);
 int aie4_calibrate_clock(struct amdxdna_dev_hdl *ndev);
 void aie4_msg_init(struct amdxdna_dev_hdl *ndev);
+u32 aie4_msg_pasid(struct amdxdna_client *client);
 
 enum aie4_fw_feature {
 	AIE4_GET_COREDUMP,


### PR DESCRIPTION
In carveout / physical-address mode (e.g. VFIO passthrough into a VM with no IOMMU SVA) the client has no PASID, yet the AIE4 hwctx and mem-access mailbox requests still set PASID_VLD with an invalid PASID. The NPU then issues PASID-tagged DMA that the host IOMMU rejects with INVALID_DEVICE_REQUEST, stalling the device. Add aie4_msg_pasid() to set the field only when the client actually has a PASID.