### PR TITLE
docs: clarify Ryzen AI support discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ On a machine with XDNA device, with both XRT and XRT plugin packages installed, 
 To run AI applications, your system needs
 * Processor:
   - To run AI applications (test machine): RyzenAI processor
+    - To check whether a specific Ryzen AI platform is supported, compare its PCI device ID with the IDs handled by the driver and firmware metadata shipped in this repository.
   - To build this repository (build machine): Any x86 processors, but recommend AMD processor :wink:
 * Operating System:
   - Ubuntu >= 22.04


### PR DESCRIPTION
## Summary

Adds one user-facing sentence to the System Requirements section explaining how to check whether a specific Ryzen AI platform is expected to be supported, without listing XDNA generations or PCI IDs in the README.

## Why

This follows up on #1438 and the compatibility question in #1418. I understand the maintainer concern from #1438: enumerating XDNA generations or PCI IDs in the README would create a stale list and unnecessary maintenance burden. This revision avoids that.

The remaining documentation gap is discoverability for users who are not starting from the PCI driver model. Users usually arrive with a product name like "Ryzen 5 7640HS", "Phoenix", "Hawk Point", or "Ryzen AI", and the current wording does not give them a concrete way to determine whether their platform is expected to work.

The proposed sentence documents the support-discovery rule rather than a device matrix:

> To check whether a specific Ryzen AI platform is supported, compare its PCI device ID with the IDs handled by the driver and firmware metadata shipped in this repository.

That avoids a stale platform list, avoids calling out XDNA1, and gives users a way to self-answer compatibility questions without opening repeat issues. The distinction matters: what is obvious to driver maintainers is often exactly the missing bridge for users trying to decide whether the project supports their hardware.

If the project still prefers not to mention this in the README, I understand. My goal is only to reduce repeated support questions like #1418 without adding maintenance burden.

## Testing

- git diff --check