### PR TITLE
docs: bring-up troubleshooting Q&A (firmware mismatch, unsupported ioctls on old in-tree driver)

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,23 @@ EOF
 ulimit -l
 ```
 
+### Q: `xrt-smi` enumerates the NPU, but commands abort (`ERT_CMD_STATE_ABORT`) or the mailbox times out right after load. What's wrong?
+
+A: This is almost always a **firmware/driver version mismatch** — a stale NPU firmware
+(`npu.sbin`) left over from a previous or distro install does not match the loaded `amdxdna.ko`.
+The plugin package ships the matching firmware to `/usr/lib/firmware/amdnpu/<device>/`; make sure
+that copy is the one in use (re-install the plugin package, or remove a stale firmware you placed
+by hand), then reload the driver. Mixing a firmware version from one source with a driver from
+another is the common cause of post-load command aborts.
+
+### Q: The device enumerates, but telemetry/array queries fail with "Operation not supported" or `EINVAL` (e.g. `GET_ARRAY`, `QUERY_TELEMETRY`). Why?
+
+A: Your XRT/plugin is newer than the loaded kernel driver. A distro **in-tree** `amdxdna` can
+predate ioctls that the current XRT SHIM issues, so those calls return `EOPNOTSUPP`/`EINVAL` while
+basic BO/exec paths still work. Use the driver built and shipped from this repo (the staging
+`amdxdna.ko` — see [Default driver in the plugin package](#default-driver-in-the-plugin-package)),
+which implements the matching ioctls, rather than an older in-tree module.
+
 ## Contributor Guidelines
 1. Read [Getting Started](#getting-started)
 2. Read [System Requirements](#system-requirements)


### PR DESCRIPTION
Adds two troubleshooting entries to the README Q&A, from a first-gen XDNA1 (Phoenix) Linux bring-up:

1. **`ERT_CMD_STATE_ABORT` / mailbox timeout right after load** — a stale `npu.sbin` from a prior/distro install not matching the loaded `amdxdna.ko`. Documents that the plugin ships the matching firmware and that mixing sources is the common cause.
2. **Telemetry/array ioctls return "Operation not supported" / `EINVAL`** while basic exec works — a distro in-tree `amdxdna` predating ioctls the current XRT SHIM issues; points to the repo's staging `amdxdna.ko`. (Related: #1447.)

Both are real bring-up papercuts where the error message doesn't surface the version-mismatch cause. Docs-only; fits the existing Q&A format.