### PR TITLE
shim: gracefully skip optional telemetry queries when the ioctl is unsupported (#1447 follow-up)

### DIFF
--- a/src/shim/device.cpp
+++ b/src/shim/device.cpp
@@ -18,10 +18,14 @@
 #include <sys/syscall.h>
 
 #include <algorithm>
+#include <cerrno>
 #include <climits>
 #include <cstdio>
+#include <cstdlib>
+#include <mutex>
 #include <sstream>
 #include <string>
+#include <system_error>
 
 namespace {
 
@@ -1049,6 +1053,32 @@ struct telemetry
   public:
     virtual ~telemetry_handler() = default;
 
+    // Telemetry is an OPTIONAL diagnostic query. An older in-tree amdxdna driver may not
+    // implement DRM_AMDXDNA_QUERY_TELEMETRY and returns EOPNOTSUPP/EINVAL. In that case
+    // degrade gracefully (skip + warn once) instead of throwing and aborting the whole
+    // xrt-smi report, so basic device use still works on older drivers. See amd/xdna-driver#1447.
+    // Returns true if the query succeeded; false if telemetry is unsupported (caller returns
+    // an empty result). Any other (real) error is rethrown.
+    static bool
+    telemetry_query(const shim_xdna::pdev& pci_dev, amdxdna_drm_get_info& query)
+    {
+      try {
+        pci_dev.drv_ioctl(shim_xdna::drv_ioctl_cmd::get_info, &query);
+        return true;
+      } catch (const std::system_error& e) {
+        const int code = std::abs(e.code().value());
+        if (code == EOPNOTSUPP || code == ENOTSUP || code == EINVAL || code == ENOTTY) {
+          static std::once_flag warned;
+          std::call_once(warned, [] {
+            shim_debug("telemetry not supported by this driver version; skipping "
+                       "(update amdxdna; see amd/xdna-driver#1447)");
+          });
+          return false;
+        }
+        throw;
+      }
+    }
+
     virtual xrt_core::query::aie_telemetry::result_type
     query_aie_telemetry(const shim_xdna::pdev& pci_dev) const {
 
@@ -1061,7 +1091,8 @@ struct telemetry
         .buffer = reinterpret_cast<uintptr_t>(&telemetry)
       };
 
-      pci_dev.drv_ioctl(shim_xdna::drv_ioctl_cmd::get_info, &query_telemetry);
+      if (!telemetry_query(pci_dev, query_telemetry))
+        return output;
 
       for (uint32_t i = 0; i < NPU_MAX_SLEEP_COUNT; i++) {
         xrt_core::query::aie_telemetry::data task;
@@ -1073,7 +1104,7 @@ struct telemetry
 
     virtual xrt_core::query::misc_telemetry::result_type
     query_misc_telemetry(const shim_xdna::pdev& pci_dev) const {
-      xrt_core::query::misc_telemetry::result_type output;
+      xrt_core::query::misc_telemetry::result_type output{};
       amdxdna_drm_query_telemetry telemetry{};
 
       amdxdna_drm_get_info query_telemetry = {
@@ -1082,7 +1113,8 @@ struct telemetry
         .buffer = reinterpret_cast<uintptr_t>(&telemetry)
       };
 
-      pci_dev.drv_ioctl(shim_xdna::drv_ioctl_cmd::get_info, &query_telemetry);
+      if (!telemetry_query(pci_dev, query_telemetry))
+        return output;
       output.l1_interrupts = telemetry.l1_interrupts;
       return output;
     }
@@ -1098,7 +1130,8 @@ struct telemetry
         .buffer = reinterpret_cast<uintptr_t>(&telemetry)
       };
 
-      pci_dev.drv_ioctl(shim_xdna::drv_ioctl_cmd::get_info, &query_telemetry);
+      if (!telemetry_query(pci_dev, query_telemetry))
+        return output;
 
       for (uint32_t i = 0; i < NPU_MAX_OPCODE_COUNT; i++) {
         xrt_core::query::opcode_telemetry::data task;
@@ -1119,7 +1152,8 @@ struct telemetry
         .buffer = reinterpret_cast<uintptr_t>(&telemetry)
       };
 
-      pci_dev.drv_ioctl(shim_xdna::drv_ioctl_cmd::get_info, &query_telemetry);
+      if (!telemetry_query(pci_dev, query_telemetry))
+        return output;
 
       for (uint32_t i = 0; i < telemetry.ctx_map_num_elements; i++) {
         xrt_core::query::rtos_telemetry::data task;
@@ -1158,7 +1192,8 @@ struct telemetry
         .buffer = reinterpret_cast<uintptr_t>(&telemetry)
       };
 
-      pci_dev.drv_ioctl(shim_xdna::drv_ioctl_cmd::get_info, &query_telemetry);
+      if (!telemetry_query(pci_dev, query_telemetry))
+        return output;
 
       for (uint32_t i = 0; i < NPU_MAX_STREAM_BUFFER_COUNT; i++) {
         xrt_core::query::stream_buffer_telemetry::data task;
@@ -1192,7 +1227,8 @@ struct telemetry
         .buffer = reinterpret_cast<uintptr_t>(telemetry_buffer.data())
       };
 
-      pci_dev.drv_ioctl(shim_xdna::drv_ioctl_cmd::get_info, &query_telemetry);
+      if (!telemetry_query(pci_dev, query_telemetry))
+        return output;
 
       auto* fw_telemetry = reinterpret_cast<aie4_fw_telemetry*>(telemetry_buffer.data());
 
@@ -1215,7 +1251,7 @@ struct telemetry
 
     xrt_core::query::misc_telemetry::result_type
     query_misc_telemetry(const shim_xdna::pdev& pci_dev) const override {
-      xrt_core::query::misc_telemetry::result_type output;
+      xrt_core::query::misc_telemetry::result_type output{};
       std::vector<uint8_t> telemetry_buffer(AIE4_TELEMETRY_BUFFER_SIZE, 0);
 
       amdxdna_drm_get_info query_telemetry = {
@@ -1224,7 +1260,8 @@ struct telemetry
         .buffer = reinterpret_cast<uintptr_t>(telemetry_buffer.data())
       };
 
-      pci_dev.drv_ioctl(shim_xdna::drv_ioctl_cmd::get_info, &query_telemetry);
+      if (!telemetry_query(pci_dev, query_telemetry))
+        return output;
 
       auto* fw_telemetry = reinterpret_cast<aie4_fw_telemetry*>(telemetry_buffer.data());
       output.l1_interrupts = fw_telemetry->l1_interrupt;
@@ -1242,7 +1279,8 @@ struct telemetry
         .buffer = reinterpret_cast<uintptr_t>(telemetry_buffer.data())
       };
 
-      pci_dev.drv_ioctl(shim_xdna::drv_ioctl_cmd::get_info, &query_telemetry);
+      if (!telemetry_query(pci_dev, query_telemetry))
+        return output;
 
       auto* fw_telemetry = reinterpret_cast<aie4_fw_telemetry*>(telemetry_buffer.data());
 
@@ -1275,7 +1313,8 @@ struct telemetry
         .buffer = reinterpret_cast<uintptr_t>(telemetry_buffer.data())
       };
 
-      pci_dev.drv_ioctl(shim_xdna::drv_ioctl_cmd::get_info, &query_telemetry);
+      if (!telemetry_query(pci_dev, query_telemetry))
+        return output;
 
       auto* fw_telemetry = reinterpret_cast<aie4_fw_telemetry*>(telemetry_buffer.data());
 


### PR DESCRIPTION
Follow-up to #1447 (in-tree `amdxdna` ≤6.17 missing `GET_ARRAY`/AIE2 telemetry ioctls).

**Problem.** When the loaded kernel driver predates `DRM_AMDXDNA_QUERY_TELEMETRY`, the ioctl returns `EOPNOTSUPP`/`EINVAL`. The SHIM's telemetry query handlers call it unconditionally, so `shim_err` throws and the **entire** `xrt-smi` report aborts — even though basic BO/exec paths work fine on that driver.

**Fix.** A small helper (`telemetry_handler::telemetry_query`) wraps the optional telemetry ioctl: on `EOPNOTSUPP`/`ENOTSUP`/`EINVAL`/`ENOTTY` it logs a one-time warning and returns `false`, so the caller returns an empty result and the rest of the report continues. Any other (real) error is rethrown. Applied to all 9 optional telemetry query handlers (aie/misc/opcode/rtos/stream_buffer, incl. the aie4 overrides). Required paths are untouched.

This turns #1447 from "this ioctl is missing" into "the SHIM handles it safely on older drivers."

**Testing.**
- Compiles cleanly under the repo's `-Werror` release build (`cmake --build ... --target xrt_driver_xdna`). The `-Werror=maybe-uninitialized` check caught that `misc_telemetry`'s scalar result needed value-initialization on the new early-return path — fixed (`result_type output{}`).
- Surgical/no-regression by construction: on a telemetry-capable driver the `try` succeeds and behavior is unchanged.
- **Disclosure:** I could not live-reproduce the unsupported-ioctl path on my test box — the in-tree 6.17 driver had been replaced by the DKMS staging build, and the other installed in-tree modules are for different kernels (vermagic mismatch). The runtime degradation is straightforward (standard errno catch) but is best confirmed against an older in-tree driver / in CI. Happy to iterate.

Surfaced during an open-source XDNA1 (Phoenix) Linux bring-up.