### PR TITLE
xrt: bump submodule to 0026185de

### DIFF
--- a/tools/info.json
+++ b/tools/info.json
@@ -1,7 +1,7 @@
 {
 	"copyright": "Copyright (C) 2023-2026 Advanced Micro Devices, Inc. All rights reserved.",
 	"xrt" : {
-		"version": "202620.2.25.23",
+		"version": "202620.2.25.37",
 		"os_rel": ["22.04", "24.04"]
 	},
 	"firmwares": [


### PR DESCRIPTION
Update the xrt submodule pointer to 0026185de81a179dc7d886197d3e35f9a179b4e8.