### PR TITLE
accel/amdxdna: Increase max ctx id for aie4/umq

### DIFF
--- a/drivers/accel/amdxdna/amdxdna_ctx.c
+++ b/drivers/accel/amdxdna/amdxdna_ctx.c
@@ -19,7 +19,7 @@
 #include "amdxdna_pci_drv.h"
 #include "amdxdna_pm.h"
 
-#define MAX_HWCTX_ID		255
+#define MAX_HWCTX_ID		1024
 #define MAX_ARG_COUNT		4095
 
 struct amdxdna_fence {


### PR DESCRIPTION
@NishadSaraf fw for umq supports > 255 ctxs, I am assuming we want to keep 255 as max for kmq? Let me know.