### PR TITLE
accel/amdxdna: npu9/npu11: set cert_feature_tbl so the HSA queue vers…

### DIFF
--- a/drivers/accel/amdxdna/npu3_regs.c
+++ b/drivers/accel/amdxdna/npu3_regs.c
@@ -201,6 +201,7 @@ const struct amdxdna_dev_info dev_npu9_pf_info = {
 	.device_type		= AMDXDNA_DEV_TYPE_PF,
 	.dev_priv		= &npu3_dev_priv,
 	.fw_feature_tbl		= npu3_fw_feature_table,
+	.cert_feature_tbl	= npu3_cert_feature_table,
 	.ops			= &aie4_pf_ops,
 };
 
@@ -212,6 +213,7 @@ const struct amdxdna_dev_info dev_npu9_vf_info = {
 	.device_type		= AMDXDNA_DEV_TYPE_UMQ,
 	.dev_priv		= &npu3_dev_vf_priv,
 	.fw_feature_tbl		= npu3_fw_feature_table,
+	.cert_feature_tbl	= npu3_cert_feature_table,
 	.ops			= &aie4_vf_ops,
 };
 
@@ -225,6 +227,7 @@ const struct amdxdna_dev_info dev_npu9_classic_info = {
 	.device_type		= AMDXDNA_DEV_TYPE_UMQ,
 	.dev_priv		= &npu3_dev_priv,
 	.fw_feature_tbl		= npu3_fw_feature_table,
+	.cert_feature_tbl	= npu3_cert_feature_table,
 	.ops			= &aie4_classic_ops,
 };
 
@@ -237,6 +240,7 @@ const struct amdxdna_dev_info dev_npu11_pf_info = {
 	.device_type		= AMDXDNA_DEV_TYPE_PF,
 	.dev_priv		= &npu3_dev_priv,
 	.fw_feature_tbl		= npu3_fw_feature_table,
+	.cert_feature_tbl	= npu3_cert_feature_table,
 	.ops			= &aie4_pf_ops,
 };
 
@@ -248,6 +252,7 @@ const struct amdxdna_dev_info dev_npu11_vf_info = {
 	.device_type		= AMDXDNA_DEV_TYPE_UMQ,
 	.dev_priv		= &npu3_dev_vf_priv,
 	.fw_feature_tbl		= npu3_fw_feature_table,
+	.cert_feature_tbl	= npu3_cert_feature_table,
 	.ops			= &aie4_vf_ops,
 };
 
@@ -261,5 +266,6 @@ const struct amdxdna_dev_info dev_npu11_classic_info = {
 	.device_type		= AMDXDNA_DEV_TYPE_UMQ,
 	.dev_priv		= &npu3_dev_priv,
 	.fw_feature_tbl		= npu3_fw_feature_table,
+	.cert_feature_tbl	= npu3_cert_feature_table,
 	.ops			= &aie4_classic_ops,
 };

--- a/src/shim/device.cpp
+++ b/src/shim/device.cpp
@@ -917,9 +917,15 @@ struct archive_path
         return std::string("amdxdna/bins/xrt_smi_strx.a");
       case xrt_core::smi::smi_hardware_config::hardware_type::phx:
         return std::string("amdxdna/bins/xrt_smi_phx.a");
+      case xrt_core::smi::smi_hardware_config::hardware_type::npu3_f0:
       case xrt_core::smi::smi_hardware_config::hardware_type::npu3_f1:
       case xrt_core::smi::smi_hardware_config::hardware_type::npu3_f2:
       case xrt_core::smi::smi_hardware_config::hardware_type::npu3_f3:
+      case xrt_core::smi::smi_hardware_config::hardware_type::npu3_f4:
+      case xrt_core::smi::smi_hardware_config::hardware_type::npu3_f5:
+      case xrt_core::smi::smi_hardware_config::hardware_type::npu3_f6:
+      case xrt_core::smi::smi_hardware_config::hardware_type::npu3_f7:
+      case xrt_core::smi::smi_hardware_config::hardware_type::npu3_f10:
       case xrt_core::smi::smi_hardware_config::hardware_type::npu3_B01:
       case xrt_core::smi::smi_hardware_config::hardware_type::npu3_B02:
       case xrt_core::smi::smi_hardware_config::hardware_type::npu3_B03:


### PR DESCRIPTION
…ion is accepted

The npu9 and npu11 device-info entries (pf/vf/classic) were missing .cert_feature_tbl. With a NULL table, aie_check_protocol_impl() matches no entry and returns -EOPNOTSUPP, so aie4_query_cert_firmware_version() rejects every CERT host queue version ("host queue 1.0 is not supported") and probe fails with -95 (seen on a 17f1 rev 0x13 npu9 part).

npu9/npu11 share npu3_dev_priv/npu3_fw_feature_table and the aie4 ops, and their CERT firmware reports host queue 1.0, so point them at npu3_cert_feature_table (which accepts major 1) like the npu3 entries do.