### PR TITLE
accel/amdxdna: Fix UAF after calling vma->vm_ops->close()

### DIFF
--- a/drivers/accel/amdxdna/amdxdna_gem.c
+++ b/drivers/accel/amdxdna/amdxdna_gem.c
@@ -464,6 +464,7 @@ static int amdxdna_insert_pages(struct amdxdna_gem_obj *abo,
 				      &num_pages);
 		if (ret) {
 			XDNA_ERR(xdna, "Failed insert pages %d", ret);
+			drm_gem_object_get(to_gobj(abo));
 			vma->vm_ops->close(vma);
 			return ret;
 		}
@@ -552,6 +553,7 @@ static int amdxdna_gem_dmabuf_mmap(struct dma_buf *dma_buf, struct vm_area_struc
 
 close_vma:
 	vma->vm_ops->close(vma);
+	return ret;
 put_obj:
 	drm_gem_object_put(gobj);
 	return ret;


### PR DESCRIPTION
close() could internally call drm_gem_object_put(). Calling drm_gem_object_put() again after close() may cause UAF.

In amdxdna_gem_dmabuf_mmap() skip the second drm_gem_object_put() after calling close(). And in amdxdna_insert_pages(), hold buffer reference before calling close().