### PR TITLE
Backport query telemetry, hwctx status, get/set preemption & null ptr fix for cd_submit

### DIFF
--- a/drivers/accel/amdxdna/aie.c
+++ b/drivers/accel/amdxdna/aie.c
@@ -524,6 +524,39 @@ int amdxdna_query_ctx_status_by_id(struct aie_device *aie,
 	return 0;
 }
 
+int amdxdna_get_force_preempt_state(struct aie_device *aie, struct amdxdna_drm_get_info *args)
+{
+	struct amdxdna_drm_attribute_state state = {};
+	u32 buf_sz;
+
+	state.state = aie->force_preempt_enabled;
+
+	buf_sz = min(args->buffer_size, sizeof(state));
+	if (copy_to_user(u64_to_user_ptr(args->buffer), &state, buf_sz))
+		return -EFAULT;
+
+	return 0;
+}
+
+int amdxdna_set_force_preempt_state(struct aie_device *aie, struct amdxdna_client *client,
+				    struct amdxdna_drm_set_state *args)
+{
+	struct amdxdna_drm_attribute_state state;
+
+	if (copy_from_user(&state, u64_to_user_ptr(args->buffer), sizeof(state)))
+		return -EFAULT;
+
+	if (state.state > 1)
+		return -EINVAL;
+
+	if (XDNA_MBZ_DBG(client->xdna, state.pad, sizeof(state.pad)))
+		return -EINVAL;
+
+	aie->force_preempt_enabled = state.state;
+
+	return 0;
+}
+
 void amdxdna_hmm_invalidate(struct amdxdna_gem_obj *abo,
 			    unsigned long cur_seq)
 {

--- a/drivers/accel/amdxdna/aie.c
+++ b/drivers/accel/amdxdna/aie.c
@@ -223,6 +223,307 @@ int amdxdna_get_metadata(struct aie_device *aie,
 	return ret;
 }
 
+int amdxdna_get_telemetry(struct aie_device *aie,
+			  struct amdxdna_client *client,
+			  struct amdxdna_drm_get_info *args)
+{
+	struct amdxdna_drm_query_telemetry_header *header __free(kfree) = NULL;
+	u32 telemetry_data_sz, header_sz, elem_num;
+	struct amdxdna_dev *xdna = client->xdna;
+	u64 payload;
+	int ret;
+
+	if (!aie->msg_ops.query_telemetry)
+		return -EOPNOTSUPP;
+
+	/* Device-wide telemetry: admin or matching EUID only (see uAPI). */
+	if (!amdxdna_client_visible(client))
+		return -EPERM;
+
+	drm_WARN_ON(&xdna->ddev, !mutex_is_locked(&xdna->dev_lock));
+
+	elem_num = aie->hwctx_limit;
+	header_sz = struct_size(header, map, elem_num);
+	if (args->buffer_size <= header_sz) {
+		XDNA_DBG(xdna, "Invalid buffer size");
+		return -EINVAL;
+	}
+	telemetry_data_sz = args->buffer_size - header_sz;
+
+	header = kzalloc(header_sz, GFP_KERNEL);
+	if (!header)
+		return -ENOMEM;
+
+	if (copy_from_user(header, u64_to_user_ptr(args->buffer), sizeof(*header))) {
+		XDNA_ERR(xdna, "Failed to copy telemetry header from user");
+		return -EFAULT;
+	}
+
+	header->map_num_elements = elem_num;
+	if (elem_num && aie->msg_ops.fill_hwctx_map) {
+		ret = aie->msg_ops.fill_hwctx_map(aie, header->map);
+		if (ret)
+			return ret;
+	}
+
+	if (check_add_overflow(args->buffer, (u64)header_sz, &payload))
+		return -EINVAL;
+
+	ret = aie->msg_ops.query_telemetry(aie, u64_to_user_ptr(payload),
+					   telemetry_data_sz, header);
+	if (ret) {
+		XDNA_ERR(xdna, "Query telemetry failed ret %d", ret);
+		return ret;
+	}
+
+	if (copy_to_user(u64_to_user_ptr(args->buffer), header, header_sz)) {
+		XDNA_ERR(xdna, "Copy telemetry header to user failed");
+		return -EFAULT;
+	}
+
+	return 0;
+}
+
+struct amdxdna_hwctx_status_ctx {
+	struct amdxdna_hwctx_key	key;
+
+	struct aie_device		*aie;
+	struct amdxdna_drm_get_array	*array_args;
+};
+
+/* amdxdna_hwctx_match() casts the walk arg to struct amdxdna_hwctx_key. */
+static_assert(offsetof(struct amdxdna_hwctx_status_ctx, key) == 0,
+	      "key must be the first member for amdxdna_hwctx_match()");
+
+static int amdxdna_fill_hwctx_status_entry(struct aie_device *aie,
+					   struct amdxdna_hwctx *hwctx,
+					   struct amdxdna_drm_get_array *array_args)
+{
+	struct amdxdna_drm_hwctx_entry *tmp __free(kfree) = NULL;
+	struct amdxdna_drm_hwctx_entry __user *buf;
+	u32 size;
+
+	/*
+	 * Out of output slots. This is a benign "buffer full" condition (the
+	 * caller reports the entries that fit), distinct from a real failure
+	 * like -EFAULT below, so the walk caller can tell them apart.
+	 */
+	if (!array_args->num_element)
+		return -ENOSPC;
+
+	tmp = kzalloc_obj(*tmp);
+	if (!tmp)
+		return -ENOMEM;
+
+	tmp->pid = hwctx->client->pid;
+	tmp->context_id = hwctx->id;
+	tmp->start_col = hwctx->start_col;
+	tmp->num_col = hwctx->num_col;
+	tmp->command_submissions = atomic64_read(&hwctx->job_submit_cnt);
+	tmp->command_completions = atomic64_read(&hwctx->job_free_cnt);
+	tmp->pasid = hwctx->client->pasid;
+	tmp->heap_usage = hwctx->client->heap_usage;
+	tmp->priority = hwctx->qos.priority;
+	tmp->gops = hwctx->qos.gops;
+	tmp->fps = hwctx->qos.fps;
+	tmp->dma_bandwidth = hwctx->qos.dma_bandwidth;
+	tmp->latency = hwctx->qos.latency;
+	tmp->frame_exec_time = hwctx->qos.frame_exec_time;
+	tmp->state = AMDXDNA_HWCTX_STATE_ACTIVE;
+
+	/* Optional FW health is best-effort; ignore errors. */
+	if (aie->msg_ops.fill_hwctx_health)
+		aie->msg_ops.fill_hwctx_health(aie, hwctx, tmp);
+
+	buf = u64_to_user_ptr(array_args->buffer);
+	size = min(sizeof(*tmp), array_args->element_size);
+
+	if (copy_to_user(buf, tmp, size))
+		return -EFAULT;
+
+	array_args->buffer += size;
+	array_args->num_element--;
+
+	return 0;
+}
+
+/*
+ * Visibility-gated emitter shared by the HW_CONTEXTS / HW_CONTEXT_ALL /
+ * HW_CONTEXT_BY_ID walks: a context the caller may not see (different Linux
+ * user without CAP_SYS_ADMIN) is silently skipped so its existence is not
+ * disclosed.
+ */
+static int amdxdna_hwctx_status_cb(struct amdxdna_hwctx *hwctx, void *arg)
+{
+	struct amdxdna_hwctx_status_ctx *ctx = arg;
+
+	if (!amdxdna_client_visible(hwctx->client))
+		return 0;
+
+	return amdxdna_fill_hwctx_status_entry(ctx->aie, hwctx, ctx->array_args);
+}
+
+int amdxdna_get_hwctx_status(struct aie_device *aie,
+			     struct amdxdna_client *client,
+			     struct amdxdna_drm_get_info *args)
+{
+	struct amdxdna_drm_get_array array_args = {};
+	struct amdxdna_hwctx_status_ctx ctx = { .aie = aie };
+	struct amdxdna_dev *xdna = client->xdna;
+	struct amdxdna_client *tmp_client;
+	int ret = 0;
+
+	drm_WARN_ON(&xdna->ddev, !mutex_is_locked(&xdna->dev_lock));
+
+	array_args.element_size = sizeof(struct amdxdna_drm_query_hwctx);
+	array_args.buffer = args->buffer;
+	array_args.num_element = args->buffer_size / array_args.element_size;
+	ctx.array_args = &array_args;
+	amdxdna_for_each_client(xdna, tmp_client) {
+		ret = amdxdna_hwctx_walk(tmp_client, &ctx, NULL,
+					 amdxdna_hwctx_status_cb);
+		if (ret)
+			break;
+	}
+
+	/*
+	 * -ENOSPC means the output buffer filled up; report the entries
+	 * that fit. Any other error (e.g. -EFAULT from copy_to_user) is a real
+	 * failure and must be propagated instead of a partial success.
+	 */
+	if (ret && ret != -ENOSPC)
+		return ret;
+
+	args->buffer_size -= (u32)(array_args.buffer - args->buffer);
+	return 0;
+}
+
+int amdxdna_query_ctx_status_array(struct aie_device *aie,
+				   struct amdxdna_client *client,
+				   struct amdxdna_drm_get_array *args)
+{
+	struct amdxdna_drm_get_array array_args = {};
+	struct amdxdna_hwctx_status_ctx ctx = { .aie = aie };
+	struct amdxdna_dev *xdna = client->xdna;
+	struct amdxdna_client *tmp_client;
+	int ret = 0;
+
+	drm_WARN_ON(&xdna->ddev, !mutex_is_locked(&xdna->dev_lock));
+
+	if (!args->element_size || args->element_size > SZ_4K ||
+	    args->num_element > SZ_1K) {
+		XDNA_DBG(xdna, "Invalid element size %u or number of element %u",
+			 args->element_size, args->num_element);
+		return -EINVAL;
+	}
+
+	array_args.element_size = min(args->element_size,
+				      sizeof(struct amdxdna_drm_hwctx_entry));
+	array_args.buffer = args->buffer;
+	array_args.num_element = args->num_element * args->element_size /
+				 array_args.element_size;
+	ctx.array_args = &array_args;
+	amdxdna_for_each_client(xdna, tmp_client) {
+		ret = amdxdna_hwctx_walk(tmp_client, &ctx, NULL,
+					 amdxdna_hwctx_status_cb);
+		if (ret)
+			break;
+	}
+
+	/*
+	 * -ENOSPC just means the output buffer filled up; report the entries
+	 * that fit. Any other error (e.g. -EFAULT from copy_to_user) is a real
+	 * failure and must be propagated instead of a partial success.
+	 */
+	if (ret && ret != -ENOSPC)
+		return ret;
+
+	args->element_size = array_args.element_size;
+	args->num_element = (u32)((array_args.buffer - args->buffer) /
+				  args->element_size);
+
+	return 0;
+}
+
+int amdxdna_query_ctx_status_by_id(struct aie_device *aie,
+				   struct amdxdna_client *client,
+				   struct amdxdna_drm_get_array *args)
+{
+	struct amdxdna_drm_hwctx_entry input = {};
+	struct amdxdna_drm_get_array array_args = {};
+	struct amdxdna_hwctx_status_ctx ctx = { .aie = aie };
+	struct amdxdna_dev *xdna = client->xdna;
+	struct amdxdna_client *tmp_client;
+	int ret = -ENOENT;
+	size_t buf_size;
+
+	drm_WARN_ON(&xdna->ddev, !mutex_is_locked(&xdna->dev_lock));
+
+	if (args->num_element != 1) {
+		XDNA_ERR(xdna, "Invalid num_element %u, expected 1",
+			 args->num_element);
+		return -EINVAL;
+	}
+
+	if (args->element_size > SZ_4K) {
+		XDNA_DBG(xdna, "Invalid element size %u", args->element_size);
+		return -EINVAL;
+	}
+
+	buf_size = (size_t)args->num_element * args->element_size;
+	if (buf_size < sizeof(input)) {
+		XDNA_ERR(xdna, "Insufficient buffer size: 0x%zx", buf_size);
+		return -EINVAL;
+	}
+
+	if (copy_from_user(&input, u64_to_user_ptr(args->buffer), sizeof(input))) {
+		XDNA_ERR(xdna, "Failed to copy hwctx entry from user");
+		return -EFAULT;
+	}
+
+	if (!input.context_id || !input.pid) {
+		XDNA_ERR(xdna, "Invalid context ID %u or PID %lld",
+			 input.context_id, input.pid);
+		return -EINVAL;
+	}
+
+	array_args.element_size = min_t(size_t, args->element_size,
+					sizeof(struct amdxdna_drm_hwctx_entry));
+	array_args.buffer = args->buffer;
+	array_args.num_element = 1;
+
+	ctx.array_args = &array_args;
+	ctx.key.ctx_id = input.context_id;
+	ctx.key.pid = input.pid;
+
+	amdxdna_for_each_client(xdna, tmp_client) {
+		ret = amdxdna_hwctx_walk(tmp_client, &ctx,
+					 amdxdna_hwctx_match,
+					 amdxdna_hwctx_status_cb);
+		if (ret != -ENOENT)
+			break;
+	}
+
+	/*
+	 * A matched context that the caller may not see is skipped by the gated
+	 * emitter (nothing emitted, num_element stays 1). Do not disclose its
+	 * existence: report it as not found, same as a genuinely missing context.
+	 */
+	if (!ret && array_args.num_element)
+		ret = -ENOENT;
+
+	if (ret == -ENOENT)
+		XDNA_DBG(xdna, "Context %u for pid %lld not found",
+			 input.context_id, input.pid);
+	if (ret)
+		return ret;
+
+	args->element_size = array_args.element_size;
+	args->num_element = 1;
+
+	return 0;
+}
+
 void amdxdna_hmm_invalidate(struct amdxdna_gem_obj *abo,
 			    unsigned long cur_seq)
 {

--- a/drivers/accel/amdxdna/aie.h
+++ b/drivers/accel/amdxdna/aie.h
@@ -27,6 +27,14 @@ struct aie_msg_ops {
 		      u8 row, u8 col, u32 aie_addr,
 		      dma_addr_t dram_addr, u32 size);
 
+	int (*query_telemetry)(struct aie_device *aie, char __user *buf, u32 size,
+			       struct amdxdna_drm_query_telemetry_header *header);
+	/* Optional per-arch FW health/map hooks; leave NULL when unsupported. */
+	int (*fill_hwctx_health)(struct aie_device *aie,
+				 struct amdxdna_hwctx *hwctx,
+				 struct amdxdna_drm_hwctx_entry *entry);
+	int (*fill_hwctx_map)(struct aie_device *aie, u32 *map);
+
 	int  (*fw_log_init)(struct amdxdna_dev *xdna, size_t size, u32 level);
 	int  (*fw_log_config)(struct amdxdna_dev *xdna, u32 level);
 	int  (*fw_log_fini)(struct amdxdna_dev *xdna);
@@ -52,6 +60,9 @@ struct aie_device {
 	struct amdxdna_drm_query_aie_version version;
 	struct amdxdna_drm_query_aie_metadata metadata;
 	struct aie_msg_ops msg_ops;
+
+	/* FW hwctx slot count for the telemetry map; 0 if arch has no map. */
+	u32 hwctx_limit;
 
 	u32 clk_gating;
 	u32 npuclk_freq;
@@ -152,6 +163,14 @@ int amdxdna_get_aie_version(struct amdxdna_client *client,
 int amdxdna_get_firmware_version(struct amdxdna_client *client,
 				 struct amdxdna_drm_get_info *args,
 				 struct amdxdna_drm_query_firmware_version *version);
+int amdxdna_get_telemetry(struct aie_device *aie, struct amdxdna_client *client,
+			  struct amdxdna_drm_get_info *args);
+int amdxdna_get_hwctx_status(struct aie_device *aie, struct amdxdna_client *client,
+			     struct amdxdna_drm_get_info *args);
+int amdxdna_query_ctx_status_array(struct aie_device *aie, struct amdxdna_client *client,
+				   struct amdxdna_drm_get_array *args);
+int amdxdna_query_ctx_status_by_id(struct aie_device *aie, struct amdxdna_client *client,
+				   struct amdxdna_drm_get_array *args);
 void amdxdna_hmm_invalidate(struct amdxdna_gem_obj *abo, unsigned long cur_seq);
 
 struct amdxdna_msg_buf_hdl {

--- a/drivers/accel/amdxdna/aie.h
+++ b/drivers/accel/amdxdna/aie.h
@@ -60,6 +60,7 @@ struct aie_device {
 	struct amdxdna_drm_query_aie_version version;
 	struct amdxdna_drm_query_aie_metadata metadata;
 	struct aie_msg_ops msg_ops;
+	u32	force_preempt_enabled;
 
 	/* FW hwctx slot count for the telemetry map; 0 if arch has no map. */
 	u32 hwctx_limit;
@@ -171,6 +172,9 @@ int amdxdna_query_ctx_status_array(struct aie_device *aie, struct amdxdna_client
 				   struct amdxdna_drm_get_array *args);
 int amdxdna_query_ctx_status_by_id(struct aie_device *aie, struct amdxdna_client *client,
 				   struct amdxdna_drm_get_array *args);
+int amdxdna_get_force_preempt_state(struct aie_device *aie, struct amdxdna_drm_get_info *args);
+int amdxdna_set_force_preempt_state(struct aie_device *aie, struct amdxdna_client *client,
+				    struct amdxdna_drm_set_state *args);
 void amdxdna_hmm_invalidate(struct amdxdna_gem_obj *abo, unsigned long cur_seq);
 
 struct amdxdna_msg_buf_hdl {

--- a/drivers/accel/amdxdna/aie2_message.c
+++ b/drivers/accel/amdxdna/aie2_message.c
@@ -336,7 +336,7 @@ int aie2_create_context(struct amdxdna_dev_hdl *ndev, struct amdxdna_hwctx *hwct
 	if (WARN_ON_ONCE(hwctx->fw_ctx_id == -1))
 		return -EINVAL;
 
-	if (ndev->force_preempt_enabled) {
+	if (ndev->aie.force_preempt_enabled) {
 		ret = aie2_runtime_cfg(ndev, AIE2_RT_CFG_FORCE_PREEMPT, &hwctx->fw_ctx_id);
 		if (ret) {
 			XDNA_ERR(xdna, "failed to enable force preempt %d", ret);

--- a/drivers/accel/amdxdna/aie2_message.c
+++ b/drivers/accel/amdxdna/aie2_message.c
@@ -1017,12 +1017,24 @@ aie2_cmdlist_fill_slot(void *slot, struct amdxdna_gem_obj *cmd_abo,
 	return ret;
 }
 
+static int aie2_query_telemetry_cb(struct aie_device *aie, char __user *buf, u32 size,
+				   struct amdxdna_drm_query_telemetry_header *header)
+{
+	return aie2_query_telemetry(container_of(aie, struct amdxdna_dev_hdl, aie),
+				    buf, size, header);
+}
+
 void aie2_msg_init(struct amdxdna_dev_hdl *ndev)
 {
 	if (AIE_FEATURE_ON(&ndev->aie, AIE2_NPU_COMMAND))
 		ndev->exec_msg_ops = &npu_exec_message_ops;
 	else
 		ndev->exec_msg_ops = &legacy_exec_message_ops;
+
+	ndev->aie.hwctx_limit = ndev->priv->hwctx_limit;
+	ndev->aie.msg_ops.query_telemetry = aie2_query_telemetry_cb;
+	ndev->aie.msg_ops.fill_hwctx_map = aie2_fill_hwctx_map;
+	ndev->aie.msg_ops.fill_hwctx_health = aie2_fill_hwctx_health;
 
 	if (AIE_FEATURE_ON(&ndev->aie, AIE2_GET_COREDUMP))
 		ndev->aie.msg_ops.get_coredump = aie2_get_aie_coredump;

--- a/drivers/accel/amdxdna/aie2_pci.c
+++ b/drivers/accel/amdxdna/aie2_pci.c
@@ -727,101 +727,24 @@ static int aie2_get_clock_metadata(struct amdxdna_client *client,
 	return ret;
 }
 
-static int aie2_fill_hwctx_status_entry(struct amdxdna_hwctx *hwctx, void *arg)
+int aie2_fill_hwctx_health(struct aie_device *aie, struct amdxdna_hwctx *hwctx,
+			   struct amdxdna_drm_hwctx_entry *entry)
 {
-	struct amdxdna_drm_hwctx_entry *tmp __free(kfree) = NULL;
-	struct amdxdna_drm_get_array *array_args = arg;
-	struct amdxdna_drm_hwctx_entry __user *buf;
+	struct amdxdna_dev_hdl *ndev = container_of(aie, struct amdxdna_dev_hdl, aie);
 	struct app_health_report report;
-	struct amdxdna_dev_hdl *ndev;
-	u32 size;
 	int ret;
 
-	/*
-	 * Out of output slots. This is a benign "buffer full" condition (the
-	 * caller reports the entries that fit), distinct from a real failure
-	 * like -EFAULT below, so the walk caller can tell them apart.
-	 */
-	if (!array_args->num_element)
-		return -ENOSPC;
-
-	tmp = kzalloc_obj(*tmp);
-	if (!tmp)
-		return -ENOMEM;
-
-	tmp->pid = hwctx->client->pid;
-	tmp->context_id = hwctx->id;
-	tmp->start_col = hwctx->start_col;
-	tmp->num_col = hwctx->num_col;
-	tmp->command_submissions = hwctx->priv->seq;
-	tmp->command_completions = hwctx->priv->completed;
-	tmp->pasid = hwctx->client->pasid;
-	tmp->heap_usage = hwctx->client->heap_usage;
-	tmp->priority = hwctx->qos.priority;
-	tmp->gops = hwctx->qos.gops;
-	tmp->fps = hwctx->qos.fps;
-	tmp->dma_bandwidth = hwctx->qos.dma_bandwidth;
-	tmp->latency = hwctx->qos.latency;
-	tmp->frame_exec_time = hwctx->qos.frame_exec_time;
-	tmp->state = AMDXDNA_HWCTX_STATE_ACTIVE;
-	ndev = hwctx->client->xdna->dev_handle;
 	ret = aie2_query_app_health(ndev, hwctx->fw_ctx_id, &report);
-	if (!ret) {
-		/* Fill in app health report fields */
-		tmp->txn_op_idx = report.txn_op_id;
-		tmp->ctx_pc = report.ctx_pc;
-		tmp->fatal_error_type = report.fatal_info.fatal_type;
-		tmp->fatal_error_exception_type = report.fatal_info.exception_type;
-		tmp->fatal_error_exception_pc = report.fatal_info.exception_pc;
-		tmp->fatal_error_app_module = report.fatal_info.app_module;
-	}
+	if (ret)
+		return ret;
 
-	buf = u64_to_user_ptr(array_args->buffer);
-	size = min(sizeof(*tmp), array_args->element_size);
+	entry->txn_op_idx = report.txn_op_id;
+	entry->ctx_pc = report.ctx_pc;
+	entry->fatal_error_type = report.fatal_info.fatal_type;
+	entry->fatal_error_exception_type = report.fatal_info.exception_type;
+	entry->fatal_error_exception_pc = report.fatal_info.exception_pc;
+	entry->fatal_error_app_module = report.fatal_info.app_module;
 
-	if (copy_to_user(buf, tmp, size))
-		return -EFAULT;
-
-	array_args->buffer += size;
-	array_args->num_element--;
-
-	return 0;
-}
-
-/*
- * Visibility-gated emitter shared by the HW_CONTEXT_ALL and HW_CONTEXT_BY_ID
- * walks: a context the caller may not see (different Linux user without
- * CAP_SYS_ADMIN) is silently skipped so its existence is not disclosed.
- */
-static int aie2_hwctx_status_cb(struct amdxdna_hwctx *hwctx, void *arg)
-{
-	if (!amdxdna_client_visible(hwctx->client))
-		return 0;
-
-	return aie2_fill_hwctx_status_entry(hwctx, arg);
-}
-
-static int aie2_get_hwctx_status(struct amdxdna_client *client,
-				 struct amdxdna_drm_get_info *args)
-{
-	struct amdxdna_drm_get_array array_args;
-	struct amdxdna_dev *xdna = client->xdna;
-	struct amdxdna_client *tmp_client;
-	int ret;
-
-	drm_WARN_ON(&xdna->ddev, !mutex_is_locked(&xdna->dev_lock));
-
-	array_args.element_size = sizeof(struct amdxdna_drm_query_hwctx);
-	array_args.buffer = args->buffer;
-	array_args.num_element = args->buffer_size / array_args.element_size;
-	amdxdna_for_each_client(xdna, tmp_client) {
-		ret = amdxdna_hwctx_walk(tmp_client, &array_args, NULL,
-					 aie2_hwctx_status_cb);
-		if (ret)
-			break;
-	}
-
-	args->buffer_size -= (u32)(array_args.buffer - args->buffer);
 	return 0;
 }
 
@@ -852,7 +775,7 @@ static int aie2_query_resource_info(struct amdxdna_client *client,
 	return 0;
 }
 
-static int aie2_fill_hwctx_map(struct amdxdna_hwctx *hwctx, void *arg)
+static int aie2_fill_hwctx_map_cb(struct amdxdna_hwctx *hwctx, void *arg)
 {
 	struct amdxdna_dev *xdna = hwctx->client->xdna;
 	u32 *map = arg;
@@ -867,53 +790,19 @@ static int aie2_fill_hwctx_map(struct amdxdna_hwctx *hwctx, void *arg)
 	return 0;
 }
 
-static int aie2_get_telemetry(struct amdxdna_client *client,
-			      struct amdxdna_drm_get_info *args)
+int aie2_fill_hwctx_map(struct aie_device *aie, u32 *map)
 {
-	struct amdxdna_drm_query_telemetry_header *header __free(kfree) = NULL;
-	u32 telemetry_data_sz, header_sz, elem_num;
-	struct amdxdna_dev *xdna = client->xdna;
+	struct amdxdna_dev *xdna = aie->xdna;
 	struct amdxdna_client *tmp_client;
 	int ret;
 
-	elem_num = xdna->dev_handle->priv->hwctx_limit;
-	header_sz = struct_size(header, map, elem_num);
-	if (args->buffer_size <= header_sz) {
-		XDNA_ERR(xdna, "Invalid buffer size");
-		return -EINVAL;
-	}
-	telemetry_data_sz = args->buffer_size - header_sz;
-
-	header = kzalloc(header_sz, GFP_KERNEL);
-	if (!header)
-		return -ENOMEM;
-
-	if (copy_from_user(header, u64_to_user_ptr(args->buffer), sizeof(*header))) {
-		XDNA_ERR(xdna, "Failed to copy telemetry header from user");
-		return -EFAULT;
-	}
-
-	header->map_num_elements = elem_num;
 	amdxdna_for_each_client(xdna, tmp_client) {
 		if (!amdxdna_client_visible(tmp_client))
 			continue;
-		ret = amdxdna_hwctx_walk(tmp_client, &header->map, NULL,
-					 aie2_fill_hwctx_map);
+		ret = amdxdna_hwctx_walk(tmp_client, map, NULL,
+					 aie2_fill_hwctx_map_cb);
 		if (ret)
 			return ret;
-	}
-
-	ret = aie2_query_telemetry(xdna->dev_handle,
-				   u64_to_user_ptr(args->buffer + header_sz),
-				   telemetry_data_sz, header);
-	if (ret) {
-		XDNA_ERR(xdna, "Query telemetry failed ret %d", ret);
-		return ret;
-	}
-
-	if (copy_to_user(u64_to_user_ptr(args->buffer), header, header_sz)) {
-		XDNA_ERR(xdna, "Copy header failed");
-		return -EFAULT;
 	}
 
 	return 0;
@@ -970,7 +859,7 @@ static int aie2_get_info(struct amdxdna_client *client, struct amdxdna_drm_get_i
 		ret = amdxdna_query_sensors(args, ndev->total_col);
 		break;
 	case DRM_AMDXDNA_QUERY_HW_CONTEXTS:
-		ret = aie2_get_hwctx_status(client, args);
+		ret = amdxdna_get_hwctx_status(&ndev->aie, client, args);
 		break;
 	case DRM_AMDXDNA_QUERY_FIRMWARE_VERSION:
 		ret = amdxdna_get_firmware_version(client, args, &xdna->fw_ver);
@@ -979,7 +868,7 @@ static int aie2_get_info(struct amdxdna_client *client, struct amdxdna_drm_get_i
 		ret = aie2_get_power_mode(client, args);
 		break;
 	case DRM_AMDXDNA_QUERY_TELEMETRY:
-		ret = aie2_get_telemetry(client, args);
+		ret = amdxdna_get_telemetry(&ndev->aie, client, args);
 		break;
 	case DRM_AMDXDNA_QUERY_RESOURCE_INFO:
 		ret = aie2_query_resource_info(client, args);
@@ -999,148 +888,6 @@ static int aie2_get_info(struct amdxdna_client *client, struct amdxdna_drm_get_i
 dev_exit:
 	drm_dev_exit(idx);
 	return ret;
-}
-
-static int aie2_query_ctx_status_array(struct amdxdna_client *client,
-				       struct amdxdna_drm_get_array *args)
-{
-	struct amdxdna_drm_get_array array_args;
-	struct amdxdna_dev *xdna = client->xdna;
-	struct amdxdna_client *tmp_client;
-	int ret = 0;
-
-	drm_WARN_ON(&xdna->ddev, !mutex_is_locked(&xdna->dev_lock));
-
-	if (args->element_size > SZ_4K || args->num_element > SZ_1K) {
-		XDNA_DBG(xdna, "Invalid element size %d or number of element %d",
-			 args->element_size, args->num_element);
-		return -EINVAL;
-	}
-
-	array_args.element_size = min(args->element_size,
-				      sizeof(struct amdxdna_drm_hwctx_entry));
-	array_args.buffer = args->buffer;
-	array_args.num_element = args->num_element * args->element_size /
-				array_args.element_size;
-	amdxdna_for_each_client(xdna, tmp_client) {
-		ret = amdxdna_hwctx_walk(tmp_client, &array_args, NULL,
-					 aie2_hwctx_status_cb);
-		if (ret)
-			break;
-	}
-
-	/*
-	 * -ENOSPC just means the output buffer filled up; report the entries
-	 * that fit. Any other error (e.g. -EFAULT from copy_to_user) is a real
-	 * failure and must be propagated instead of a partial success.
-	 */
-	if (ret && ret != -ENOSPC)
-		return ret;
-
-	args->element_size = array_args.element_size;
-	args->num_element = (u32)((array_args.buffer - args->buffer) /
-				  args->element_size);
-
-	return 0;
-}
-
-struct aie2_hwctx_status_walk_arg {
-	struct amdxdna_hwctx_key	key;
-	struct amdxdna_drm_get_array	*array_args;
-};
-
-/* amdxdna_hwctx_match() casts the walk arg to struct amdxdna_hwctx_key. */
-static_assert(offsetof(struct aie2_hwctx_status_walk_arg, key) == 0,
-	      "key must be the first member for amdxdna_hwctx_match()");
-
-/*
- * BY_ID adapter: amdxdna_hwctx_match() has already selected the (pid, ctx_id)
- * target, so just forward to the shared gated emitter, which skips the entry
- * when the caller may not see it.
- */
-static int aie2_hwctx_by_id_cb(struct amdxdna_hwctx *hwctx, void *arg)
-{
-	struct aie2_hwctx_status_walk_arg *wa = arg;
-
-	return aie2_hwctx_status_cb(hwctx, wa->array_args);
-}
-
-static int aie2_query_ctx_status_by_id(struct amdxdna_client *client,
-				       struct amdxdna_drm_get_array *args)
-{
-	struct amdxdna_drm_hwctx_entry input = {};
-	struct amdxdna_dev *xdna = client->xdna;
-	struct amdxdna_drm_get_array array_args;
-	struct aie2_hwctx_status_walk_arg wa;
-	struct amdxdna_client *tmp_client;
-	int ret = -ENOENT;
-	size_t buf_size;
-
-	drm_WARN_ON(&xdna->ddev, !mutex_is_locked(&xdna->dev_lock));
-
-	if (args->num_element != 1) {
-		XDNA_ERR(xdna, "Invalid num_element %u, expected 1",
-			 args->num_element);
-		return -EINVAL;
-	}
-
-	if (args->element_size > SZ_4K) {
-		XDNA_DBG(xdna, "Invalid element size %u", args->element_size);
-		return -EINVAL;
-	}
-
-	buf_size = (size_t)args->num_element * args->element_size;
-	if (buf_size < sizeof(input)) {
-		XDNA_ERR(xdna, "Insufficient buffer size: 0x%zx", buf_size);
-		return -EINVAL;
-	}
-
-	if (copy_from_user(&input, u64_to_user_ptr(args->buffer), sizeof(input))) {
-		XDNA_ERR(xdna, "Failed to copy hwctx entry from user");
-		return -EFAULT;
-	}
-
-	if (!input.context_id || !input.pid) {
-		XDNA_ERR(xdna, "Invalid context ID %u or PID %lld",
-			 input.context_id, input.pid);
-		return -EINVAL;
-	}
-
-	array_args.element_size = min_t(size_t, args->element_size,
-					sizeof(struct amdxdna_drm_hwctx_entry));
-	array_args.buffer = args->buffer;
-	array_args.num_element = 1;
-
-	wa.array_args = &array_args;
-	wa.key.ctx_id = input.context_id;
-	wa.key.pid = input.pid;
-
-	amdxdna_for_each_client(xdna, tmp_client) {
-		ret = amdxdna_hwctx_walk(tmp_client, &wa,
-					 amdxdna_hwctx_match,
-					 aie2_hwctx_by_id_cb);
-		if (ret != -ENOENT)
-			break;
-	}
-
-	/*
-	 * A matched context that the caller may not see is skipped by the gated
-	 * emitter (nothing emitted, num_element stays 1). Do not disclose its
-	 * existence: report it as not found, same as a genuinely missing context.
-	 */
-	if (!ret && array_args.num_element)
-		ret = -ENOENT;
-
-	if (ret == -ENOENT)
-		XDNA_DBG(xdna, "Context %u for pid %lld not found",
-			 input.context_id, input.pid);
-	if (ret)
-		return ret;
-
-	args->element_size = array_args.element_size;
-	args->num_element = 1;
-
-	return 0;
 }
 
 static int aie2_get_array(struct amdxdna_client *client,
@@ -1180,10 +927,10 @@ static int aie2_get_array(struct amdxdna_client *client,
 
 	switch (args->param) {
 	case DRM_AMDXDNA_HW_CONTEXT_ALL:
-		ret = aie2_query_ctx_status_array(client, args);
+		ret = amdxdna_query_ctx_status_array(&ndev->aie, client, args);
 		break;
 	case DRM_AMDXDNA_HW_CONTEXT_BY_ID:
-		ret = aie2_query_ctx_status_by_id(client, args);
+		ret = amdxdna_query_ctx_status_by_id(&ndev->aie, client, args);
 		break;
 	case DRM_AMDXDNA_HW_LAST_ASYNC_ERR:
 		ret = aie2_get_array_async_error(xdna->dev_handle, args);

--- a/drivers/accel/amdxdna/aie2_pci.c
+++ b/drivers/accel/amdxdna/aie2_pci.c
@@ -808,19 +808,14 @@ int aie2_fill_hwctx_map(struct aie_device *aie, u32 *map)
 	return 0;
 }
 
-static int aie2_get_preempt_state(struct amdxdna_client *client,
-				  struct amdxdna_drm_get_info *args)
+static int aie2_get_frame_boundary_preempt_state(struct amdxdna_client *client,
+						 struct amdxdna_drm_get_info *args)
 {
 	struct amdxdna_drm_attribute_state state = {};
-	struct amdxdna_dev *xdna = client->xdna;
-	struct amdxdna_dev_hdl *ndev;
+	struct amdxdna_dev_hdl *ndev = client->xdna->dev_handle;
 	u32 buf_sz;
 
-	ndev = xdna->dev_handle;
-	if (args->param == DRM_AMDXDNA_GET_FORCE_PREEMPT_STATE)
-		state.state = ndev->force_preempt_enabled;
-	else if (args->param == DRM_AMDXDNA_GET_FRAME_BOUNDARY_PREEMPT_STATE)
-		state.state = ndev->frame_boundary_preempt;
+	state.state = ndev->frame_boundary_preempt;
 
 	buf_sz = min(args->buffer_size, sizeof(state));
 	if (copy_to_user(u64_to_user_ptr(args->buffer), &state, buf_sz))
@@ -874,8 +869,10 @@ static int aie2_get_info(struct amdxdna_client *client, struct amdxdna_drm_get_i
 		ret = aie2_query_resource_info(client, args);
 		break;
 	case DRM_AMDXDNA_GET_FORCE_PREEMPT_STATE:
+		ret = amdxdna_get_force_preempt_state(&ndev->aie, args);
+		break;
 	case DRM_AMDXDNA_GET_FRAME_BOUNDARY_PREEMPT_STATE:
-		ret = aie2_get_preempt_state(client, args);
+		ret = aie2_get_frame_boundary_preempt_state(client, args);
 		break;
 	default:
 		XDNA_ERR(xdna, "Not supported request parameter %u", args->param);
@@ -997,8 +994,8 @@ static int aie2_set_power_mode(struct amdxdna_client *client,
 	return aie2_pm_set_mode(xdna->dev_handle, power_mode, settle_ms);
 }
 
-static int aie2_set_preempt_state(struct amdxdna_client *client,
-				  struct amdxdna_drm_set_state *args)
+static int aie2_set_frame_boundary_preempt(struct amdxdna_client *client,
+					   struct amdxdna_drm_set_state *args)
 {
 	struct amdxdna_dev_hdl *ndev = client->xdna->dev_handle;
 	struct amdxdna_drm_attribute_state state;
@@ -1014,17 +1011,12 @@ static int aie2_set_preempt_state(struct amdxdna_client *client,
 	if (XDNA_MBZ_DBG(client->xdna, state.pad, sizeof(state.pad)))
 		return -EINVAL;
 
-	if (args->param == DRM_AMDXDNA_SET_FORCE_PREEMPT) {
-		ndev->force_preempt_enabled = state.state;
-	} else if (args->param == DRM_AMDXDNA_SET_FRAME_BOUNDARY_PREEMPT) {
-		val = state.state;
-		ret = aie2_runtime_cfg(ndev, AIE2_RT_CFG_FRAME_BOUNDARY_PREEMPT,
-				       &val);
-		if (ret)
-			return ret;
+	val = state.state;
+	ret = aie2_runtime_cfg(ndev, AIE2_RT_CFG_FRAME_BOUNDARY_PREEMPT, &val);
+	if (ret)
+		return ret;
 
-		ndev->frame_boundary_preempt = state.state;
-	}
+	ndev->frame_boundary_preempt = state.state;
 
 	return 0;
 }
@@ -1048,8 +1040,10 @@ static int aie2_set_state(struct amdxdna_client *client,
 		ret = aie2_set_power_mode(client, args, settle_ms);
 		break;
 	case DRM_AMDXDNA_SET_FORCE_PREEMPT:
+		ret = amdxdna_set_force_preempt_state(&ndev->aie, client, args);
+		break;
 	case DRM_AMDXDNA_SET_FRAME_BOUNDARY_PREEMPT:
-		ret = aie2_set_preempt_state(client, args);
+		ret = aie2_set_frame_boundary_preempt(client, args);
 		break;
 	case DRM_AMDXDNA_AIE_TILE_WRITE:
 		ret = amdxdna_aie_tile_write(&ndev->aie, client, args);

--- a/drivers/accel/amdxdna/aie2_pci.h
+++ b/drivers/accel/amdxdna/aie2_pci.h
@@ -141,7 +141,6 @@ struct amdxdna_dev_hdl {
 	u32				dpm_level;
 	u32				dft_dpm_level;
 	u32				max_dpm_level;
-	u32				force_preempt_enabled;
 	u32				frame_boundary_preempt;
 
 	/* Mailbox and the management channel */

--- a/drivers/accel/amdxdna/aie2_pci.h
+++ b/drivers/accel/amdxdna/aie2_pci.h
@@ -278,6 +278,9 @@ int aie2_query_status(struct amdxdna_dev_hdl *ndev, char __user *buf, u32 size, 
 int aie2_query_telemetry(struct amdxdna_dev_hdl *ndev,
 			 char __user *buf, u32 size,
 			 struct amdxdna_drm_query_telemetry_header *header);
+int aie2_fill_hwctx_health(struct aie_device *aie, struct amdxdna_hwctx *hwctx,
+			   struct amdxdna_drm_hwctx_entry *entry);
+int aie2_fill_hwctx_map(struct aie_device *aie, u32 *map);
 int aie2_register_asyn_event_msg(struct amdxdna_dev_hdl *ndev, dma_addr_t addr, u32 size,
 				 void *handle, int (*cb)(void*, void __iomem *, size_t));
 int aie2_config_cu(struct amdxdna_hwctx *hwctx,

--- a/drivers/accel/amdxdna/aie4_ctx.c
+++ b/drivers/accel/amdxdna/aie4_ctx.c
@@ -201,6 +201,15 @@ int aie4_hwctx_create(struct amdxdna_hwctx *hwctx)
 		 resp.job_complete_msix_idx, resp.hw_context_id,
 		 resp.doorbell_offset);
 
+	if (ndev->aie.force_preempt_enabled) {
+		ret = aie4_force_preemption(ndev);
+		if (ret) {
+			XDNA_ERR(xdna, "failed to enable force preempt: %d", ret);
+			aie4_msg_destroy_context(ndev, resp.hw_context_id);
+			return ret;
+		}
+	}
+
 	/* setup interrupt completion per msix index */
 	ret = aie4_link_cert_comp(hwctx, resp.job_complete_msix_idx);
 	if (ret) {

--- a/drivers/accel/amdxdna/aie4_message.c
+++ b/drivers/accel/amdxdna/aie4_message.c
@@ -4,6 +4,7 @@
  */
 
 #include "drm/amdxdna_accel.h"
+#include <drm/drm_cache.h>
 #include <drm/drm_print.h>
 #include <drm/gpu_scheduler.h>
 #include <linux/bitfield.h>
@@ -300,6 +301,56 @@ int aie4_rw_aie_mem(struct amdxdna_hwctx *hwctx, bool is_read,
 	return 0;
 }
 
+static int aie4_query_telemetry(struct aie_device *aie, char __user *buf, u32 size,
+				struct amdxdna_drm_query_telemetry_header *header)
+{
+	DECLARE_AIE_MSG(aie4_msg_get_telemetry, AIE4_MSG_OP_GET_TELEMETRY);
+	struct amdxdna_dev *xdna = aie->xdna;
+	struct amdxdna_msg_buf_hdl *buf_hdl;
+	int ret;
+
+	if (header->type >= AIE4_TELEMETRY_TYPE_MAX)
+		return -EINVAL;
+
+	buf_hdl = amdxdna_alloc_msg_buff(xdna,
+					 clamp_t(u32, size,
+						 AIE4_MIN_TELEMETRY_BUFF_SIZE, SZ_4M));
+	if (IS_ERR(buf_hdl))
+		return PTR_ERR(buf_hdl);
+
+	req.type = header->type;
+	req.buf_addr = to_dma_addr(buf_hdl, 0);
+	req.buf_size = to_buf_size(buf_hdl);
+	/* Kernel DMA buffer in the default domain: leave the PASID valid bit clear. */
+	req.pasid = 0;
+	req.hw_context_id = 0;
+
+	memset(to_cpu_addr(buf_hdl, 0), 0, to_buf_size(buf_hdl));
+	drm_clflush_virt_range(to_cpu_addr(buf_hdl, 0), to_buf_size(buf_hdl));
+
+	ret = aie_send_mgmt_msg_wait(aie, &msg);
+	if (ret) {
+		XDNA_ERR(xdna, "Get telemetry failed, ret %d", ret);
+		goto free_buf;
+	}
+
+	drm_clflush_virt_range(to_cpu_addr(buf_hdl, 0), to_buf_size(buf_hdl));
+
+	size = min(size, to_buf_size(buf_hdl));
+	if (copy_to_user(buf, to_cpu_addr(buf_hdl, 0), size)) {
+		XDNA_ERR(xdna, "Failed to copy telemetry to user space");
+		ret = -EFAULT;
+		goto free_buf;
+	}
+
+	header->major = 0;
+	header->minor = 0;
+
+free_buf:
+	amdxdna_free_msg_buff(buf_hdl);
+	return ret;
+}
+
 void aie4_msg_init(struct amdxdna_dev_hdl *ndev)
 {
 	if (AIE_FEATURE_ON(&ndev->aie, AIE4_GET_COREDUMP))
@@ -309,4 +360,8 @@ void aie4_msg_init(struct amdxdna_dev_hdl *ndev)
 		ndev->aie.msg_ops.rw_reg = aie4_rw_aie_reg;
 		ndev->aie.msg_ops.rw_mem = aie4_rw_aie_mem;
 	}
+
+	ndev->aie.msg_ops.query_telemetry = aie4_query_telemetry;
+	/* aie4 has no fw_ctx_id <-> hwctx_id map and no per-ctx FW health. */
+	ndev->aie.hwctx_limit = 0;
 }

--- a/drivers/accel/amdxdna/aie4_message.c
+++ b/drivers/accel/amdxdna/aie4_message.c
@@ -196,6 +196,28 @@ int aie4_msg_set_power_mode(struct amdxdna_dev_hdl *ndev, u8 power_mode)
 	return 0;
 }
 
+int aie4_force_preemption(struct amdxdna_dev_hdl *ndev)
+{
+	DECLARE_AIE_MSG(aie4_msg_set_runtime_cfg, AIE4_MSG_OP_SET_RUNTIME_CONFIG);
+	struct aie4_msg_runtime_config_force_preemption *force_preempt;
+	u32 type = AIE4_RUNTIME_CONFIG_FORCE_PREEMPTION;
+	int ret;
+
+	req.type = type;
+	force_preempt = (struct aie4_msg_runtime_config_force_preemption *)req.data;
+	force_preempt->enabled = 1;
+
+	msg.send_size = sizeof(req);
+
+	ret = aie_send_mgmt_msg_wait(&ndev->aie, &msg);
+	if (ret) {
+		XDNA_ERR(ndev->aie.xdna, "Failed to set runtime config, ret %d", ret);
+		return ret;
+	}
+
+	return 0;
+}
+
 int aie4_configure_hw_context_cert_log(struct amdxdna_dev_hdl *ndev,
 				       u32 hw_context_id, u32 property,
 				       const struct aie4_msg_context_config_cert_logging *cl)

--- a/drivers/accel/amdxdna/aie4_msg_priv.h
+++ b/drivers/accel/amdxdna/aie4_msg_priv.h
@@ -14,6 +14,7 @@ enum aie4_msg_opcode {
 	/* Classic/PF/VF common */
 	AIE4_MSG_OP_IDENTIFY                         = 0x10002,
 	AIE4_MSG_OP_SUSPEND                          = 0x10003,
+	AIE4_MSG_OP_GET_TELEMETRY                    = 0x10006,
 	AIE4_MSG_OP_QUERY_CERT_FIRMWARE_VERSION      = 0x1000F,
 
 	/* PF only */
@@ -240,6 +241,28 @@ struct aie4_msg_power_override_resp {
 } __packed;
 
 #define AIE4_WORK_BUFFER_MIN_SIZE      SZ_4M
+
+/* Telemetry type for AIE4_MSG_OP_GET_TELEMETRY. */
+enum aie4_msg_telemetry_type {
+	AIE4_TELEMETRY_TYPE_DISABLED = 0,
+	AIE4_TELEMETRY_TYPE_PERF_COUNTER,
+	AIE4_TELEMETRY_TYPE_MAX,
+};
+
+#define AIE4_MIN_TELEMETRY_BUFF_SIZE	SZ_128K
+
+/* AIE4_MSG_OP_GET_TELEMETRY */
+struct aie4_msg_get_telemetry_req {
+	__u32 type;
+	__u64 buf_addr;
+	__u32 pasid;
+	__u32 buf_size;
+	__u32 hw_context_id;
+} __packed;
+
+struct aie4_msg_get_telemetry_resp {
+	enum aie4_msg_status status;
+} __packed;
 
 struct aie4_msg_attach_work_buffer_req {
 	__u64 buff_addr;

--- a/drivers/accel/amdxdna/aie4_msg_priv.h
+++ b/drivers/accel/amdxdna/aie4_msg_priv.h
@@ -15,6 +15,7 @@ enum aie4_msg_opcode {
 	AIE4_MSG_OP_IDENTIFY                         = 0x10002,
 	AIE4_MSG_OP_SUSPEND                          = 0x10003,
 	AIE4_MSG_OP_GET_TELEMETRY                    = 0x10006,
+	AIE4_MSG_OP_SET_RUNTIME_CONFIG               = 0x10007,
 	AIE4_MSG_OP_QUERY_CERT_FIRMWARE_VERSION      = 0x1000F,
 
 	/* PF only */
@@ -75,6 +76,25 @@ struct aie4_msg_suspend_resp {
 
 struct aie4_msg_create_vfs_req {
 	__u32 vf_cnt;
+} __packed;
+
+struct aie4_msg_runtime_config_force_preemption {
+	__u8 enabled;
+	__u8 padding[3];
+} __packed;
+
+enum aie4_msg_runtime_config_type {
+	AIE4_RUNTIME_CONFIG_FORCE_PREEMPTION = 1,
+	AIE4_MAX_RUNTIME_CONFIG
+};
+
+struct aie4_msg_set_runtime_cfg_req {
+	__u32 type;
+	__u8 data[4];
+} __packed;
+
+struct aie4_msg_set_runtime_cfg_resp {
+	enum aie4_msg_status status;
 } __packed;
 
 struct aie4_msg_create_vfs_resp {

--- a/drivers/accel/amdxdna/aie4_pci.c
+++ b/drivers/accel/amdxdna/aie4_pci.c
@@ -778,6 +778,9 @@ static int aie4_get_info(struct amdxdna_client *client, struct amdxdna_drm_get_i
 	case DRM_AMDXDNA_QUERY_TELEMETRY:
 		ret = amdxdna_get_telemetry(&ndev->aie, client, args);
 		break;
+	case DRM_AMDXDNA_GET_FORCE_PREEMPT_STATE:
+		ret = amdxdna_get_force_preempt_state(&ndev->aie, args);
+		break;
 	default:
 		XDNA_ERR(xdna, "Not supported request parameter %u", args->param);
 		ret = -EOPNOTSUPP;
@@ -1195,6 +1198,9 @@ static int aie4_set_state(struct amdxdna_client *client,
 	switch (args->param) {
 	case DRM_AMDXDNA_SET_POWER_MODE:
 		ret = aie4_set_power_mode(client, args);
+		break;
+	case DRM_AMDXDNA_SET_FORCE_PREEMPT:
+		ret = amdxdna_set_force_preempt_state(&ndev->aie, client, args);
 		break;
 	case DRM_AMDXDNA_AIE_TILE_WRITE:
 		ret = amdxdna_aie_tile_write(&ndev->aie, client, args);

--- a/drivers/accel/amdxdna/aie4_pci.c
+++ b/drivers/accel/amdxdna/aie4_pci.c
@@ -772,6 +772,12 @@ static int aie4_get_info(struct amdxdna_client *client, struct amdxdna_drm_get_i
 	case DRM_AMDXDNA_QUERY_RESOURCE_INFO:
 		ret = aie4_query_resource_info(client, args);
 		break;
+	case DRM_AMDXDNA_QUERY_HW_CONTEXTS:
+		ret = amdxdna_get_hwctx_status(&ndev->aie, client, args);
+		break;
+	case DRM_AMDXDNA_QUERY_TELEMETRY:
+		ret = amdxdna_get_telemetry(&ndev->aie, client, args);
+		break;
 	default:
 		XDNA_ERR(xdna, "Not supported request parameter %u", args->param);
 		ret = -EOPNOTSUPP;
@@ -831,6 +837,12 @@ static int aie4_get_array(struct amdxdna_client *client,
 	mutex_lock(&xdna->dev_lock);
 
 	switch (args->param) {
+	case DRM_AMDXDNA_HW_CONTEXT_ALL:
+		ret = amdxdna_query_ctx_status_array(&ndev->aie, client, args);
+		break;
+	case DRM_AMDXDNA_HW_CONTEXT_BY_ID:
+		ret = amdxdna_query_ctx_status_by_id(&ndev->aie, client, args);
+		break;
 	case DRM_AMDXDNA_AIE_COREDUMP:
 		ret = amdxdna_get_coredump(&ndev->aie, client, args);
 		break;
@@ -1140,6 +1152,7 @@ static int aie4_classic_init(struct amdxdna_dev *xdna)
 	if (ret)
 		goto free_work_buf;
 
+	aie4_msg_init(xdna->dev_handle);
 	return 0;
 
 free_work_buf:

--- a/drivers/accel/amdxdna/aie4_pci.h
+++ b/drivers/accel/amdxdna/aie4_pci.h
@@ -104,6 +104,7 @@ int aie4_query_cert_firmware_version(struct amdxdna_dev_hdl *ndev,
 int aie4_suspend_fw(struct amdxdna_dev_hdl *ndev);
 int aie4_attach_work_buffer(struct amdxdna_dev_hdl *ndev, dma_addr_t addr, u32 size);
 int aie4_msg_set_power_mode(struct amdxdna_dev_hdl *ndev, u8 power_mode);
+int aie4_force_preemption(struct amdxdna_dev_hdl *ndev);
 int aie4_configure_hw_context_cert_log(struct amdxdna_dev_hdl *ndev,
 				       u32 hw_context_id, u32 property,
 				       const struct aie4_msg_context_config_cert_logging *cl);

--- a/drivers/accel/amdxdna/amdxdna_ctx.c
+++ b/drivers/accel/amdxdna/amdxdna_ctx.c
@@ -576,6 +576,9 @@ int amdxdna_cmd_submit(struct amdxdna_client *client,
 	struct amdxdna_hwctx *hwctx;
 	int ret, idx;
 
+	if (!xdna->dev_info->ops->cmd_submit)
+		return -EOPNOTSUPP;
+
 	XDNA_DBG(xdna, "Command BO hdl %d, Arg BO count %d", cmd_bo_hdl, arg_bo_cnt);
 	job = kzalloc_flex(*job, bos, arg_bo_cnt);
 	if (!job)

--- a/test/shim_test/shim_test.cpp
+++ b/test/shim_test/shim_test.cpp
@@ -82,6 +82,10 @@ void TEST_preempt_elf_io(device::id_type, std::shared_ptr<device>&, arg_type&);
 void TEST_cmd_fence_host(device::id_type, std::shared_ptr<device>&, arg_type&);
 void TEST_cmd_fence_device(device::id_type, std::shared_ptr<device>&, arg_type&);
 void TEST_preempt_full_elf_io(device::id_type, std::shared_ptr<device>&, arg_type&);
+void TEST_query_hw_contexts(device::id_type, std::shared_ptr<device>&, arg_type&);
+void TEST_hw_context_all(device::id_type, std::shared_ptr<device>&, arg_type&);
+void TEST_query_telemetry(device::id_type, std::shared_ptr<device>&, arg_type&);
+void TEST_query_telemetry_short_buf(device::id_type, std::shared_ptr<device>&, arg_type&);
 void TEST_io_coredump(device::id_type, std::shared_ptr<device>&, arg_type&);
 void TEST_io_aie_mem(device::id_type, std::shared_ptr<device>&, arg_type&);
 void TEST_io_aie_reg(device::id_type, std::shared_ptr<device>&, arg_type&);
@@ -935,6 +939,178 @@ TEST_create_destroy_hw_queue(device::id_type id, std::shared_ptr<device>& sdev, 
   auto hwq2 = hwctx.get()->get_hw_queue();
 }
 
+constexpr uint32_t HWCTX_QUERY_CAPACITY = 64;
+
+struct hwctx_info_probe {
+  int ret;
+  int err;
+  uint32_t bytes_written;
+  bool found_self;
+};
+
+struct hwctx_array_probe {
+  int ret;
+  int err;
+  uint32_t num_element;
+  uint32_t element_size;
+  bool found_self;
+};
+
+void
+TEST_query_hw_contexts(device::id_type id, std::shared_ptr<device>& sdev, arg_type& arg)
+{
+  // Create a context so the query returns an entry to validate.
+  hw_ctx hwctx{sdev.get()};
+
+  auto probe = fork_query<hwctx_info_probe>(sdev.get(), [](int fd) {
+    std::array<amdxdna_drm_query_hwctx, HWCTX_QUERY_CAPACITY> entries{};
+    const uint32_t in_size = entries.size() * sizeof(entries[0]);
+    amdxdna_drm_get_info info = {
+      .param = DRM_AMDXDNA_QUERY_HW_CONTEXTS,
+      .buffer_size = in_size,
+      .buffer = reinterpret_cast<uintptr_t>(entries.data()),
+    };
+
+    hwctx_info_probe r{};
+    r.ret = ::ioctl(fd, DRM_IOCTL_AMDXDNA_GET_INFO, &info);
+    r.err = errno;
+    if (r.ret == 0) {
+      // QUERY_HW_CONTEXTS reports the leftover capacity in buffer_size.
+      r.bytes_written = in_size - info.buffer_size;
+      const uint32_t n = r.bytes_written / sizeof(entries[0]);
+      const __s64 self_pid = getppid();
+      for (uint32_t i = 0; i < n && i < entries.size(); i++) {
+        if (entries[i].pid == self_pid) {
+          r.found_self = true;
+          break;
+        }
+      }
+    }
+    return r;
+  });
+
+  if (probe.ret == -1)
+    throw std::runtime_error(
+      "ioctl(QUERY_HW_CONTEXTS) failed: " + std::string(std::strerror(probe.err)));
+  if (probe.bytes_written > HWCTX_QUERY_CAPACITY * sizeof(amdxdna_drm_query_hwctx))
+    throw std::runtime_error("QUERY_HW_CONTEXTS wrote more than the input buffer");
+  if (probe.bytes_written % sizeof(amdxdna_drm_query_hwctx))
+    throw std::runtime_error("QUERY_HW_CONTEXTS byte count not element-aligned");
+  if (!probe.found_self)
+    throw std::runtime_error("QUERY_HW_CONTEXTS did not report the created context");
+}
+
+void
+TEST_hw_context_all(device::id_type id, std::shared_ptr<device>& sdev, arg_type& arg)
+{
+  // Create a context so the query returns an entry to validate.
+  hw_ctx hwctx{sdev.get()};
+
+  auto probe = fork_query<hwctx_array_probe>(sdev.get(), [](int fd) {
+    std::array<amdxdna_drm_hwctx_entry, HWCTX_QUERY_CAPACITY> entries{};
+    amdxdna_drm_get_array array = {
+      .param = DRM_AMDXDNA_HW_CONTEXT_ALL,
+      .element_size = sizeof(entries[0]),
+      .num_element = static_cast<uint32_t>(entries.size()),
+      .buffer = reinterpret_cast<uintptr_t>(entries.data()),
+    };
+
+    hwctx_array_probe r{};
+    r.ret = ::ioctl(fd, DRM_IOCTL_AMDXDNA_GET_ARRAY, &array);
+    r.err = errno;
+    if (r.ret == 0) {
+      r.num_element = array.num_element;
+      r.element_size = array.element_size;
+      const __s64 self_pid = getppid();
+      for (uint32_t i = 0; i < array.num_element && i < entries.size(); i++) {
+        if (entries[i].pid == self_pid) {
+          r.found_self = true;
+          break;
+        }
+      }
+    }
+    return r;
+  });
+
+  if (probe.ret == -1)
+    throw std::runtime_error(
+      "ioctl(HW_CONTEXT_ALL) failed: " + std::string(std::strerror(probe.err)));
+  if (probe.num_element > HWCTX_QUERY_CAPACITY)
+    throw std::runtime_error("HW_CONTEXT_ALL num_element exceeds input");
+  if (probe.element_size == 0 || probe.element_size > sizeof(amdxdna_drm_hwctx_entry))
+    throw std::runtime_error("HW_CONTEXT_ALL element_size out of range");
+  if (!probe.found_self)
+    throw std::runtime_error("HW_CONTEXT_ALL did not report the created context");
+}
+
+constexpr uint32_t TELEMETRY_DATA_SIZE = 256 * 1024;
+constexpr uint32_t TELEMETRY_MAP_CAPACITY = 256;
+// aie4 selects a telemetry category via the type field; older NPUs require 0.
+constexpr uint32_t AIE4_TELEMETRY_PERF_COUNTER = 1;
+
+struct telemetry_probe {
+  int ret;
+  int err;
+  uint32_t map_num_elements;
+};
+
+void
+TEST_query_telemetry(device::id_type id, std::shared_ptr<device>& sdev, arg_type& arg)
+{
+  uint32_t type = dev_filter_is_aie4(id, sdev.get()) ? AIE4_TELEMETRY_PERF_COUNTER : 0;
+
+  auto probe = fork_query<telemetry_probe>(sdev.get(), [type](int fd) {
+    const uint32_t buf_sz = sizeof(amdxdna_drm_query_telemetry_header) +
+                            TELEMETRY_MAP_CAPACITY * sizeof(uint32_t) +
+                            TELEMETRY_DATA_SIZE;
+    // uint32_t storage guarantees alignment for the telemetry header.
+    std::vector<uint32_t> buf(buf_sz / sizeof(uint32_t), 0);
+    auto *hdr = reinterpret_cast<amdxdna_drm_query_telemetry_header *>(buf.data());
+    hdr->type = type;
+
+    amdxdna_drm_get_info info = {
+      .param = DRM_AMDXDNA_QUERY_TELEMETRY,
+      .buffer_size = buf_sz,
+      .buffer = reinterpret_cast<uintptr_t>(buf.data()),
+    };
+
+    telemetry_probe r{};
+    r.ret = ::ioctl(fd, DRM_IOCTL_AMDXDNA_GET_INFO, &info);
+    r.err = errno;
+    r.map_num_elements = hdr->map_num_elements;
+    return r;
+  });
+
+  if (probe.ret == -1)
+    throw std::runtime_error(
+      "ioctl(QUERY_TELEMETRY) failed: " + std::string(std::strerror(probe.err)));
+
+  if (probe.map_num_elements > TELEMETRY_MAP_CAPACITY)
+    throw std::runtime_error("QUERY_TELEMETRY: map_num_elements > capacity");
+}
+
+void
+TEST_query_telemetry_short_buf(device::id_type id, std::shared_ptr<device>& sdev, arg_type& arg)
+{
+  // Negative case: a header-only buffer must fail EINVAL.
+  int err = fork_query<int>(sdev.get(), [](int fd) {
+    amdxdna_drm_query_telemetry_header hdr{};
+    amdxdna_drm_get_info info = {
+      .param = DRM_AMDXDNA_QUERY_TELEMETRY,
+      .buffer_size = sizeof(hdr),
+      .buffer = reinterpret_cast<uintptr_t>(&hdr),
+    };
+    if (::ioctl(fd, DRM_IOCTL_AMDXDNA_GET_INFO, &info) == -1)
+      return errno;
+    return 0;
+  });
+
+  if (err != EINVAL)
+    throw std::runtime_error(
+      "QUERY_TELEMETRY with header-only buffer should fail EINVAL, got "
+      + std::to_string(err));
+}
+
 // List of all test cases
 std::vector<test_case> test_list {
   test_case{ "get_xrt_info", {},
@@ -1137,6 +1313,18 @@ std::vector<test_case> test_list {
   },
   test_case{ "io test timeout run for context health report", {},
     TEST_POSITIVE, dev_filter_is_npu4, TEST_io_timeout, {}
+  },
+  test_case{ "query hw_contexts (get_info)", {},
+    TEST_POSITIVE, dev_filter_is_aie, TEST_query_hw_contexts, {}
+  },
+  test_case{ "hw_context_all (get_array)", {},
+    TEST_POSITIVE, dev_filter_is_aie, TEST_hw_context_all, {}
+  },
+  test_case{ "query telemetry", {},
+    TEST_POSITIVE, dev_filter_is_aie, TEST_query_telemetry, {}
+  },
+  test_case{ "query telemetry header-only buffer fails", {},
+    TEST_POSITIVE, dev_filter_is_aie, TEST_query_telemetry_short_buf, {}
   },
   //test_case{ "io test no-op kernel good run", {},
   //  TEST_POSITIVE, dev_filter_is_aie2, TEST_io, { IO_TEST_NOOP_RUN, 1 }

--- a/test/shim_test/shim_test.cpp
+++ b/test/shim_test/shim_test.cpp
@@ -1306,7 +1306,7 @@ std::vector<test_case> test_list {
     TEST_POSITIVE, dev_filter_is_aie2_and_amdxdna_drv, TEST_io_with_ubuf_bo, {}
   },
    test_case{ "multi-command preempt full ELF io test real kernel good run", {},
-    TEST_POSITIVE, dev_filter_is_npu4, TEST_preempt_full_elf_io, { IO_TEST_FORCE_PREEMPTION, 8 }
+    TEST_POSITIVE, dev_filter_is_aie4_or_npu4, TEST_preempt_full_elf_io, { IO_TEST_FORCE_PREEMPTION, 8 }
   },
   test_case{ "Real kernel delay run for auto-suspend/resume", {},
     TEST_POSITIVE, dev_filter_is_aie2, TEST_io_suspend_resume, {}


### PR DESCRIPTION
Backporting below commits from main to 1.8 branch for xrt-smi validate advance.


PR 1 - add aie4 Telemetry and HW-context status queries -
Commit1 - 66545bd831d10cdb4593abd73b1ba3a5b33fe47d
PR 2 - fix null pointer dereference for cmd_submit on aie4
Commit 2-  fe2f8be538578b8dbc5b0eeb6daebcc82e1bb73d
PR 3 - Support get/set preemption for AIE4
Commit 3- 
3.a> 8d1712d92005d0ebfd48cea10f5e8731a8263751
3.b> 39c1abadbd15f01bceee8b085b9f5edf3ed9db8a