### PR TITLE
fix: reorder NPU init — PSP before SMU on Strix Halo

### DIFF
--- a/drivers/accel/amdxdna/aie2_pci.c
+++ b/drivers/accel/amdxdna/aie2_pci.c
@@ -372,16 +372,16 @@ static int aie2_hw_start(struct amdxdna_dev *xdna)
 		goto disable_dev;
 	}
 
-	ret = aie_smu_init(ndev->aie.smu_hdl);
-	if (ret) {
-		XDNA_ERR(xdna, "failed to init smu, ret %d", ret);
-		goto free_channel;
-	}
-
 	ret = aie_psp_start(ndev->aie.psp_hdl);
 	if (ret) {
 		XDNA_ERR(xdna, "failed to start psp, ret %d", ret);
-		goto fini_smu;
+		goto free_channel;
+	}
+
+	ret = aie_smu_init(ndev->aie.smu_hdl);
+	if (ret) {
+		XDNA_ERR(xdna, "failed to init smu, ret %d", ret);
+		goto stop_psp_no_smu;
 	}
 
 	ret = aie2_get_mgmt_chann_info(ndev);
@@ -442,6 +442,11 @@ stop_fw:
 	xdna_mailbox_stop_channel(ndev->aie.mgmt_chann);
 stop_psp:
 	aie_psp_stop(ndev->aie.psp_hdl);
+	goto fini_smu;
+stop_psp_no_smu:
+	/* SMU not initialized yet -- skip SMU fini; still stop PSP */
+	aie_psp_stop(ndev->aie.psp_hdl);
+	goto free_channel;
 fini_smu:
 	aie2_smu_fini(ndev);
 free_channel:


### PR DESCRIPTION
On Strix Point/Halo (NPU4, PCI \`0x17f0\` rev \`0x10\`), the NPU SMU is embedded in the firmware package loaded by PSP. The current init order (SMU → PSP) always fails because SMU firmware hasn't been loaded yet.

Swap to PSP → SMU. Also adds a \`stop_psp_no_smu\` cleanup label that skips SMU fini when SMU was never initialized.

The community confirmed this bug affects all Strix Halo Linux users — existing workaround bypasses SMU entirely, leaving the NPU without power management. See: https://github.com/Peterc3-dev/amdxdna-strix-fix

Compile-tested on kernel 7.0.0.