### PR TITLE
amdxdna/ve2 : Fixed partition Initialization issue.

### DIFF
--- a/src/driver/amdxdna/ve2_mgmt.c
+++ b/src/driver/amdxdna/ve2_mgmt.c
@@ -439,14 +439,13 @@ ve2_response_ctx_switch_req(struct amdxdna_mgmtctx *mgmtctx)
 			hwctx = c_ctx->ctx;
 			XDNA_DBG(xdna, "NEW context to be schedule next: %p\n", hwctx);
 			mgmtctx->is_partition_idle = 0;
+			mgmtctx->is_idle_due_to_context = 0;
 			ve2_mgmt_handshake_init(mgmtctx->xdna, hwctx);
-			if (mgmtctx->active_ctx == hwctx)
-				break;
-
 			mgmtctx->active_ctx = hwctx;
+			break;
 		}
 
-		if (t_ctx && c_ctx->ctx != t_ctx->ctx)
+		if (c_ctx->ctx != mgmtctx->active_ctx)
 			ve2_request_context_switch(mgmtctx->xdna, mgmtctx);
 
 		break;
@@ -522,8 +521,17 @@ static bool ve2_check_context_req(struct amdxdna_mgmtctx  *mgmtctx)
 {
 	if (mgmtctx->is_context_req == 1) {
 		mgmtctx->is_context_req = 0;
-		mgmtctx->is_idle_due_to_context = 1;
-		return true;
+		/*
+		 * Only promote to is_idle_due_to_context if the FIFO head is
+		 * actually a different context.
+		 */
+		struct amdxdna_ctx_command_fifo *head =
+			list_first_entry_or_null(&mgmtctx->ctx_command_fifo_head,
+						 struct amdxdna_ctx_command_fifo, list);
+		if (head && head->ctx != mgmtctx->active_ctx) {
+			mgmtctx->is_idle_due_to_context = 1;
+			return true;
+		}
 	}
 
 	return false;


### PR DESCRIPTION
Issue :

The driver was calling ve2_partition_initialize (partition init) unnecessarily, even when the same hardware context was already running on the partition.
Root Cause 1:

In ve2_response_ctx_switch_req, the condition to detect a context switch compared two adjacent FIFO entries (c_ctx vs t_ctx) instead of the FIFO head against the currently running context (active_ctx). Since t_ctx in a kernel linked list is never NULL, this comparison always evaluated incorrectly, triggering a context switch request even when no real switch was needed.
Root Cause 2:

In ve2_check_context_req, when the scheduler ran, it blindly promoted is_context_req → is_idle_due_to_context without verifying whether a different context was still waiting in the FIFO. By the time the scheduler ran, the FIFO may have already drained back to the same context, making the switch request stale.
Fix 1:

Corrected the comparison in ve2_response_ctx_switch_req from c_ctx->ctx != t_ctx->ctx to c_ctx->ctx != mgmtctx->active_ctx — so a context switch is only requested when the FIFO head is genuinely a different context from the one currently running.
Fix 2:

Added a FIFO head check in ve2_check_context_req before promoting the flag — is_idle_due_to_context is now only set when the FIFO head is actually a different context at the moment the scheduler runs, preventing stale promotions from triggering unnecessary partition re-inits.