### PR TITLE
ve2: bump BO size to 8K minimum and revert d7e71f7

### DIFF
--- a/src/driver/amdxdna/ve2_hwctx.c
+++ b/src/driver/amdxdna/ve2_hwctx.c
@@ -401,11 +401,10 @@ static inline void hsa_queue_pkt_set_invalid(struct host_queue_packet *pkt)
 static void ve2_free_hsa_queue(struct amdxdna_dev *xdna, struct ve2_hsa_queue *queue)
 {
 	if (queue->hsa_queue_p) {
-		dma_free_noncoherent(queue->alloc_dev,
-				     sizeof(struct hsa_queue) + sizeof(u64) * HOST_QUEUE_ENTRY,
-				     queue->hsa_queue_p,
-				     queue->hsa_queue_mem.dma_addr,
-				     DMA_BIDIRECTIONAL);
+		dma_free_coherent(queue->alloc_dev,
+				  sizeof(struct hsa_queue) + sizeof(u64) * HOST_QUEUE_ENTRY,
+				  queue->hsa_queue_p,
+				  queue->hsa_queue_mem.dma_addr);
 		queue->hsa_queue_p = NULL;
 		queue->hsa_queue_mem.dma_addr = 0;
 		queue->alloc_dev = NULL;
@@ -516,9 +515,8 @@ static int ve2_create_host_queue(struct amdxdna_dev *xdna, struct amdxdna_ctx *h
 	for (r = 0; r < MAX_MEM_REGIONS; r++) {
 		alloc_dev = xdna->cma_region_devs[r];
 		if ((hwctx->priv->mem_bitmap & (1U << r)) && alloc_dev) {
-			queue->hsa_queue_p = dma_alloc_noncoherent(alloc_dev, alloc_size,
-								   &dma_handle, DMA_BIDIRECTIONAL,
-								   GFP_KERNEL);
+			queue->hsa_queue_p = dma_alloc_coherent(alloc_dev, alloc_size,
+								&dma_handle, GFP_KERNEL);
 			if (!queue->hsa_queue_p)
 				continue;
 			queue->alloc_dev = alloc_dev;
@@ -528,11 +526,10 @@ static int ve2_create_host_queue(struct amdxdna_dev *xdna, struct amdxdna_ctx *h
 
 	/* If no allocation succeeded, use the default device */
 	if (!queue->hsa_queue_p) {
-		queue->hsa_queue_p = dma_alloc_noncoherent(xdna->ddev.dev,
-							   alloc_size,
-							   &dma_handle,
-							   DMA_BIDIRECTIONAL,
-							   GFP_KERNEL);
+		queue->hsa_queue_p = dma_alloc_coherent(xdna->ddev.dev,
+							alloc_size,
+							&dma_handle,
+							GFP_KERNEL);
 		if (!queue->hsa_queue_p) {
 			XDNA_ERR(xdna, "Failed to allocate host queue memory, size=%zu",
 				 alloc_size);

--- a/src/shim_ve2/xdna_bo.cpp
+++ b/src/shim_ve2/xdna_bo.cpp
@@ -8,6 +8,12 @@
 #include "xdna_bo.h"
 
 namespace shim_xdna_edge {
+
+// Minimum size (8K) for BO allocations. Small buffers can fail to be allocated
+// on the requested CMA region on custom VE2 platforms where the AIE has
+// restricted DDR access, so round small sizes up to this.
+static constexpr size_t MIN_BO_SIZE = 8 * 1024;
+
 static void
 init_metadata_buffer(xdna_bo& mdata_base_bo,
 		     uint32_t boh,
@@ -270,6 +276,15 @@ alloc_bo(uint32_t mem_bitmap)
      if (bank_index < 32)
        xflags.bank = (1U << bank_index);
    }
+ 
+  // On some custom VE2 platforms the AIE does not have access to all DDR
+  // regions. Very small buffers (< 8K) can fail to be allocated on the
+  // requested (default or specified) CMA region because the size is too
+  // small to back from that region. Round the BO size up to a minimum of
+  // 8K so the allocation lands on the requested CMA region.
+  // This intentionally trades some wasted memory for correctness.
+  if (m_aligned_size < MIN_BO_SIZE)
+    m_aligned_size = MIN_BO_SIZE;
 
   amdxdna_drm_create_bo cbo = {
     .flags = xflags.all,

--- a/src/shim_ve2/xdna_bo.cpp
+++ b/src/shim_ve2/xdna_bo.cpp
@@ -142,14 +142,6 @@ xdna_bo(const device_xdna& device, xrt_core::hwctx_handle::slot_id ctx_id,
       xflags.use == XRT_BO_USE_LOG || xflags.use == XRT_BO_USE_UC_DEBUG)
     attach_to_ctx(xflags.use);
 
-  // Freshly allocated pages may carry stale dirty cache lines. If this BO is
-  // used as an output, those lines could later write back over the device's
-  // DMA results and corrupt them. Flush once right after allocation so the
-  // BO starts clean; subsequent coherency is the app's responsibility via
-  // explicit sync().
-  if (m_type == AMDXDNA_BO_SHARE)
-    sync(direction::host2device, m_aligned_size, 0);
-
   shim_debug("Allocated DRM BO (userptr=0x%lx, size=%ld, flags=0x%llx, type=%d, drm_bo=%d)",
 	     m_ptr, m_aligned_size, m_flags, m_type, get_drm_bo_handle());
 }


### PR DESCRIPTION
Small buffers (< 8K) can fail to allocate on the requested CMA region on custom VE2 platforms causing certain usecases to fail. Round smaller (< 8K) BO sizes to 8K to address the issue.
- This is intentional as it trades some wasted memory for correctness.
- This fixes AIESW-35227
- It also reverts d7e71f7af3552746b15336fc4be9f213a34ead74