### PR TITLE
accel/amdxdna: AIE4 HSA queue submission from Linux kernel

### DIFF
--- a/drivers/accel/amdxdna/aie4_ctx.c
+++ b/drivers/accel/amdxdna/aie4_ctx.c
@@ -10,6 +10,7 @@
 #include <drm/drm_print.h>
 #include <drm/gpu_scheduler.h>
 #include <linux/overflow.h>
+#include <linux/sched/mm.h>
 #include <linux/types.h>
 
 #include "aie.h"
@@ -21,6 +22,13 @@
 #include "amdxdna_mailbox.h"
 #include "amdxdna_mailbox_helper.h"
 #include "amdxdna_pci_drv.h"
+#include "trace/events/amdxdna.h"
+
+#define CTX_INVALID_ID			(~0U)
+#define CTX_INVALID_DOORBELL		AMDXDNA_INVALID_DOORBELL_OFFSET
+
+static void job_worker(struct work_struct *work);
+static void aie4_hwctx_cleanup_running_jobs(struct amdxdna_hwctx *hwctx);
 
 static irqreturn_t cert_comp_isr(int irq, void *p)
 {
@@ -201,6 +209,25 @@ int aie4_hwctx_create(struct amdxdna_hwctx *hwctx)
 		 resp.job_complete_msix_idx, resp.hw_context_id,
 		 resp.doorbell_offset);
 
+	if (priv->kernel_submit) {
+		struct pci_dev *pdev = to_pci_dev(xdna->ddev.dev);
+		u64 db_off = (u64)ndev->priv->doorbell_off + resp.doorbell_offset;
+
+		/*
+		 * doorbell_base is a pcim_iomap() of the whole doorbell BAR.  The
+		 * doorbell offset comes from firmware (or, on a VF, the PF/hypervisor);
+		 * reject one that would place the u32 doorbell write past the mapped
+		 * BAR before ring_doorbell() ever dereferences priv->doorbell_addr.
+		 * Mirrors the bounds check on the user mmap path (aie4_doorbell_mmap).
+		 */
+		if (db_off + sizeof(u32) >
+		    pci_resource_len(pdev, xdna->dev_info->doorbell_bar)) {
+			XDNA_ERR(xdna, "doorbell offset 0x%llx out of BAR", db_off);
+			aie4_msg_destroy_context(ndev, resp.hw_context_id);
+			return -EINVAL;
+		}
+	}
+
 	if (ndev->aie.force_preempt_enabled) {
 		ret = aie4_force_preemption(ndev);
 		if (ret) {
@@ -218,7 +245,23 @@ int aie4_hwctx_create(struct amdxdna_hwctx *hwctx)
 	}
 
 	priv->hw_ctx_id = resp.hw_context_id;
-	hwctx->doorbell_offset = resp.doorbell_offset;
+
+	if (priv->kernel_submit) {
+		/*
+		 * Kernel-mode submission: point at this context's doorbell within
+		 * the device-level doorbell BAR mapping (fixed for the device's
+		 * lifetime) so the driver can ring it, and keep it out of user
+		 * space (hand back an invalid offset so the doorbell cannot be
+		 * mmap'd/rung by the user).
+		 */
+		priv->doorbell_addr = ndev->doorbell_base +
+				      ndev->priv->doorbell_off + resp.doorbell_offset;
+		hwctx->doorbell_offset = CTX_INVALID_DOORBELL;
+	} else {
+		/* User-mode submission: hand the doorbell to user space to ring. */
+		hwctx->doorbell_offset = resp.doorbell_offset;
+	}
+	WRITE_ONCE(priv->status, CTX_STATE_CONNECTED);
 
 	return 0;
 }
@@ -233,14 +276,20 @@ void aie4_hwctx_destroy(struct amdxdna_hwctx *hwctx)
 
 	drm_WARN_ON(&xdna->ddev, !mutex_is_locked(&xdna->dev_lock));
 
+	/*
+	 * Mark disconnected before waking waiters in aie4_unlink_cert_comp() so
+	 * the job worker observes the teardown and stops waiting on read_index.
+	 */
+	WRITE_ONCE(priv->status, CTX_STATE_DISCONNECTED);
+
 	ret = aie4_msg_destroy_context(ndev, priv->hw_ctx_id);
 	if (ret)
 		XDNA_WARN(xdna, "destroy ctx id %d failed %d", priv->hw_ctx_id, ret);
 
-#define CTX_INVALID_ID			(~0U)
-#define CTX_INVALID_DOORBELL		(~0U)
 	priv->hw_ctx_id = CTX_INVALID_ID;
 	hwctx->doorbell_offset = CTX_INVALID_DOORBELL;
+	/* doorbell_base is a device-level managed mapping; just drop the pointer. */
+	priv->doorbell_addr = NULL;
 	aie4_unlink_cert_comp(hwctx);
 }
 
@@ -252,33 +301,102 @@ static void aie4_hwctx_umq_fini(struct amdxdna_hwctx *hwctx)
 
 static int aie4_hwctx_umq_init(struct amdxdna_hwctx *hwctx)
 {
+	const size_t indir_pkts_sz = CTX_MAX_CMDS * HSA_MAX_LEVEL1_INDIRECT_ENTRIES *
+				     sizeof(struct host_indirect_packet_data);
+	const size_t pkts_sz = CTX_MAX_CMDS * sizeof(struct host_queue_packet);
 	struct amdxdna_hwctx_priv *priv = hwctx->priv;
 	struct amdxdna_dev *xdna = hwctx->client->xdna;
 	struct amdxdna_gem_obj *umq_bo;
 	struct host_queue_header *qhdr;
+	u64 data_dev_addr;
+	void *umq_va;
+	int ret;
+	int i;
 
+	/*
+	 * The HSA queue lives in a user-allocated BO (umq_bo_hdl) in both user- and
+	 * kernel-mode submission; the driver does not allocate it privately.  Under
+	 * PASID/SVA the device reaches the queue through the submitting process's
+	 * own page tables, so it must have a user virtual address - a kernel-private
+	 * buffer would be unreachable by the device.  This is also safe: a forged
+	 * read_index in this shared BO can only make the owning process complete its
+	 * own command early and harm itself, never another context (NO_PASID/IOVA is
+	 * a single-trust bring-up mode with no inter-process isolation).
+	 */
 	umq_bo = amdxdna_gem_get_obj(hwctx->client, hwctx->umq_bo_hdl, AMDXDNA_BO_SHARE);
 	if (!umq_bo) {
 		XDNA_ERR(xdna, "cannot find umq_bo handle %d", hwctx->umq_bo_hdl);
 		return -ENOENT;
 	}
-	if (umq_bo->mem.size < sizeof(*qhdr)) {
-		XDNA_ERR(xdna, "umq_bo size is too small");
-		return -EINVAL;
+	priv->umq_bo = umq_bo;
+
+	/*
+	 * Kernel-mode submission: the driver fills the host queue and rings the
+	 * doorbell, so the user umq_bo must hold the header plus the direct and
+	 * level-1 indirect packet arrays.  User-mode submission only needs the
+	 * header (the user owns the queue content).
+	 */
+	if (umq_bo->mem.size < sizeof(*qhdr) ||
+	    (priv->kernel_submit &&
+	     umq_bo->mem.size < sizeof(*qhdr) + pkts_sz + indir_pkts_sz)) {
+		XDNA_ERR(xdna, "umq_bo size %zu is too small",
+			 (size_t)umq_bo->mem.size);
+		ret = -EINVAL;
+		goto err_fini;
 	}
 
-	priv->umq_bo = umq_bo;
-	/* get kva address for host queue read index and write index */
-	qhdr = amdxdna_gem_vmap(umq_bo);
-	if (!qhdr) {
-		aie4_hwctx_umq_fini(hwctx);
-		return -ENOMEM;
+	umq_va = amdxdna_gem_vmap(umq_bo);
+	if (!umq_va) {
+		ret = -ENOMEM;
+		goto err_fini;
 	}
+	qhdr = umq_va;
 
 	priv->umq_read_index = &qhdr->read_index;
 	priv->umq_write_index = &qhdr->write_index;
 
+	/* User-mode submission: user owns the queue content and the doorbell. */
+	if (!priv->kernel_submit)
+		return 0;
+
+	/*
+	 * The queue content is driver-owned and never trusted from user space
+	 * (only read_index is read back to detect completion).  Lay out the
+	 * direct packets right after the header and the indirect packets after
+	 * them, and publish the same base via data_address for CERT.
+	 */
+	data_dev_addr = amdxdna_gem_dev_addr(umq_bo) + sizeof(*qhdr);
+	priv->umq_pkts = umq_va + sizeof(*qhdr);
+	priv->umq_indirect_pkts = umq_va + sizeof(*qhdr) + pkts_sz;
+	priv->umq_indirect_pkts_dev_addr = data_dev_addr + pkts_sz;
+
+	/*
+	 * Only the header + direct/indirect packet regions are driver-owned and
+	 * used for kernel submission; the size check above guarantees they fit.
+	 * Clear just that range, not the whole user-sized BO, so an oversized
+	 * umq_bo cannot force a huge memset (and page faults) under dev_lock.
+	 */
+	memset(umq_va, 0, sizeof(*qhdr) + pkts_sz + indir_pkts_sz);
+	priv->write_index = QUEUE_INDEX_START;
+	qhdr->read_index = QUEUE_INDEX_START;
+	qhdr->write_index = QUEUE_INDEX_START;
+	qhdr->version.major = HOST_QUEUE_MAJOR_VERSION;
+	qhdr->version.minor = HOST_QUEUE_MINOR_VERSION;
+	qhdr->capacity = CTX_MAX_CMDS;
+	qhdr->data_address = data_dev_addr;
+	for (i = 0; i < CTX_MAX_CMDS; i++)
+		priv->umq_pkts[i].pkt_header.common_header.opcode = OPCODE_EXEC_BUF;
+	for (i = 0; i < CTX_MAX_CMDS * HSA_MAX_LEVEL1_INDIRECT_ENTRIES; i++) {
+		priv->umq_indirect_pkts[i].header.opcode = OPCODE_EXEC_BUF;
+		priv->umq_indirect_pkts[i].header.count = sizeof(struct exec_buf);
+		priv->umq_indirect_pkts[i].header.distribute = 1;
+	}
+
 	return 0;
+
+err_fini:
+	aie4_hwctx_umq_fini(hwctx);
+	return ret;
 }
 
 int aie4_hwctx_init(struct amdxdna_hwctx *hwctx)
@@ -296,21 +414,52 @@ int aie4_hwctx_init(struct amdxdna_hwctx *hwctx)
 	if (!priv)
 		return -ENOMEM;
 	hwctx->priv = priv;
+	priv->hwctx = hwctx;
+	/*
+	 * Snapshot the device's kernel-mode submission setting (debugfs-tunable)
+	 * so it is stable for this ctx's lifetime.
+	 */
+	priv->kernel_submit = ndev->kernel_submit;
+
+	/*
+	 * Kernel-mode submission: the driver fills the queue and rings the
+	 * doorbell, so it needs the job machinery.  User-mode submission leaves
+	 * the queue and doorbell to user space (no job machinery here).
+	 */
+	if (priv->kernel_submit) {
+		mutex_init(&priv->io_lock);
+		INIT_LIST_HEAD(&priv->pending_job_list);
+		INIT_LIST_HEAD(&priv->running_job_list);
+		init_waitqueue_head(&priv->job_list_wq);
+		INIT_WORK(&priv->job_work, job_worker);
+		priv->job_work_q = alloc_ordered_workqueue("%s", 0, hwctx->name);
+		if (!priv->job_work_q) {
+			XDNA_ERR(xdna, "Create job_work_q failed");
+			ret = -ENOMEM;
+			goto destroy_lock;
+		}
+	}
 
 	ret = aie4_hwctx_umq_init(hwctx);
 	if (ret)
-		goto free_priv;
+		goto destroy_wq;
 
 	ret = aie4_hwctx_create(hwctx);
 	if (ret)
 		goto umq_fini;
 
-	XDNA_DBG(xdna, "hwctx %s init completed", hwctx->name);
+	XDNA_DBG(xdna, "hwctx %s init completed (%s submission)", hwctx->name,
+		 priv->kernel_submit ? "kernel" : "user");
 	return 0;
 
 umq_fini:
 	aie4_hwctx_umq_fini(hwctx);
-free_priv:
+destroy_wq:
+	if (priv->kernel_submit)
+		destroy_workqueue(priv->job_work_q);
+destroy_lock:
+	if (priv->kernel_submit)
+		mutex_destroy(&priv->io_lock);
 	kfree(priv);
 	hwctx->priv = NULL;
 	return ret;
@@ -318,9 +467,19 @@ free_priv:
 
 void aie4_hwctx_fini(struct amdxdna_hwctx *hwctx)
 {
+	struct amdxdna_hwctx_priv *priv = hwctx->priv;
+
+	/* Disconnects the ctx and wakes the job worker (status DISCONNECTED). */
 	aie4_hwctx_destroy(hwctx);
+	if (priv->kernel_submit) {
+		/* Drain/abort any in-flight jobs before tearing down the queue. */
+		aie4_hwctx_cleanup_running_jobs(hwctx);
+		destroy_workqueue(priv->job_work_q);
+	}
 	aie4_hwctx_umq_fini(hwctx);
-	kfree(hwctx->priv);
+	if (priv->kernel_submit)
+		mutex_destroy(&priv->io_lock);
+	kfree(priv);
 }
 
 static inline bool valid_queue_index(u64 read, u64 write, u32 capacity)
@@ -330,49 +489,76 @@ static inline bool valid_queue_index(u64 read, u64 write, u32 capacity)
 
 static u64 get_read_index(struct amdxdna_hwctx *hwctx)
 {
-	u64 wi = READ_ONCE(*hwctx->priv->umq_write_index);
-	u64 ri = READ_ONCE(*hwctx->priv->umq_read_index);
+	struct amdxdna_hwctx_priv *priv = hwctx->priv;
 	struct amdxdna_dev *xdna = hwctx->client->xdna;
+	u64 ri, wi;
+
+	/*
+	 * Sample read_index (written by CERT) before write_index. CERT can
+	 * never complete more than has been published, so a write_index sampled
+	 * after read_index always satisfies wi >= ri; sampling write_index
+	 * first races the submit path / CERT and yields a bogus ri > wi.
+	 *
+	 * In kernel-mode submission write_index is the driver's host-owned copy
+	 * in coherent kernel memory (always >= the value mirrored into the UMQ,
+	 * and the device never writes it).  In user-mode submission the user
+	 * owns the queue, so fall back to the shared UMQ copy.
+	 *
+	 * Security: read_index lives in the umq_bo, which the owning process can
+	 * map.  Under PASID/SVA the device reaches the queue through that process's
+	 * own page tables, so a forged read_index only completes the process's own
+	 * command early and corrupts or hangs itself - it cannot reach another
+	 * context.
+	 */
+	ri = READ_ONCE(*priv->umq_read_index);
+	/* Order the read_index sample before the write_index sample. */
+	smp_rmb();
+	wi = priv->kernel_submit ? READ_ONCE(priv->write_index)
+				 : READ_ONCE(*priv->umq_write_index);
 
 	/*
 	 * CERT cannot update read index as uint64 atomically. Driver may read
-	 * half-updated read index when it has bits in high 32bit. In case read
-	 * index is not valid, wait for some time and retry once. It should
-	 * allow CERT to complete the read index update.
+	 * a half-updated read index when it has bits in the high 32 bits. If it
+	 * looks invalid, re-sample once -- WITHOUT sleeping, since this can run as
+	 * a wait_event() condition. If still invalid, report not-advanced; the
+	 * waiter re-checks on the next completion wake or timeout.
 	 */
 	if (!valid_queue_index(ri, wi, CTX_MAX_CMDS)) {
-		XDNA_WARN(xdna, "Invalid index, ri %llu, wi %llu", ri, wi);
-		usleep_range(100, 200);
-		ri = READ_ONCE(*hwctx->priv->umq_read_index);
+		ri = READ_ONCE(*priv->umq_read_index);
+		/* Order the read_index sample before the write_index sample. */
+		smp_rmb();
+		wi = priv->kernel_submit ? READ_ONCE(priv->write_index)
+					 : READ_ONCE(*priv->umq_write_index);
 		if (!valid_queue_index(ri, wi, CTX_MAX_CMDS)) {
-			XDNA_ERR(xdna, "Invalid index after retry, ri %llu, wi %llu", ri, wi);
-			ri = 0;
+			/*
+			 * Still invalid (torn 64-bit read, or a transient
+			 * accounting skew).  Return the last valid read_index
+			 * instead of 0: read_index only advances, so the cached
+			 * value is a safe lower bound -- it never reports a
+			 * command complete that isn't, and never regresses the
+			 * worker into falsely timing out a finished job.
+			 */
+			XDNA_DBG(xdna, "Invalid index, ri %llu, wi %llu", ri, wi);
+			return READ_ONCE(priv->last_read_index);
 		}
 	}
 
+	WRITE_ONCE(priv->last_read_index, ri);
 	return ri;
 }
 
-static int check_cert_comp_linked(struct amdxdna_hwctx *hwctx, struct cert_comp *comp)
+static bool check_cmd_done(struct amdxdna_hwctx *hwctx, u64 seq)
 {
-	struct amdxdna_dev_hdl *ndev = hwctx->client->xdna->dev_handle;
-
-	guard(mutex)(&ndev->cert_comp_lock);
-
-	/* any changed comp indicates that EAGAIN is needed */
-	return comp == hwctx->priv->cert_comp;
-}
-
-static bool check_cmd_done(struct amdxdna_hwctx *hwctx, u64 seq, struct cert_comp *comp)
-{
-	u64 read_idx;
-
-	if (!check_cert_comp_linked(hwctx, comp))
+	/*
+	 * Runs as a wait_event() condition, so it must not sleep: use only
+	 * lockless reads.  A disconnect (teardown/reset) also breaks the wait via
+	 * the status check; the caller then confirms real completion by re-reading
+	 * read_index, so a disconnect wake is not mistaken for success.
+	 */
+	if (READ_ONCE(hwctx->priv->status) != CTX_STATE_CONNECTED)
 		return true;
 
-	read_idx = get_read_index(hwctx);
-	XDNA_DBG(hwctx->client->xdna, "check read idx %lld > seq %lld", read_idx, seq);
-	return read_idx > seq;
+	return get_read_index(hwctx) > seq;
 }
 
 int aie4_cmd_wait(struct amdxdna_hwctx *hwctx, u64 seq, u32 timeout)
@@ -388,12 +574,13 @@ int aie4_cmd_wait(struct amdxdna_hwctx *hwctx, u64 seq, u32 timeout)
 		wait_jifs = msecs_to_jiffies(timeout);
 
 	ret = wait_event_interruptible_timeout(cert_comp->waitq,
-					       (check_cmd_done(hwctx, seq, cert_comp)),
+					       check_cmd_done(hwctx, seq),
 					       wait_jifs);
 
 	if (!ret)
 		ret = -ETIME;
-	else if (ret > 0 && !check_cert_comp_linked(hwctx, cert_comp))
+	else if (ret > 0 && get_read_index(hwctx) <= seq)
+		/* Woke on disconnect/reset, not on real completion. */
 		ret = -EAGAIN;
 
 	aie4_put_cert_comp(cert_comp);
@@ -401,24 +588,375 @@ int aie4_cmd_wait(struct amdxdna_hwctx *hwctx, u64 seq, u32 timeout)
 	return ret <= 0 ? ret : 0;
 }
 
-int aie4_hwctx_valid_doorbell(struct amdxdna_client *client, u32 vm_pgoff)
+/* ---- kernel-mode submission (driver fills the queue and rings doorbell) ---- */
+
+static inline void ring_doorbell(struct amdxdna_hwctx *hwctx)
 {
-	struct amdxdna_dev *xdna = client->xdna;
-	struct amdxdna_hwctx *hwctx;
-	unsigned long hwctx_id;
-	int idx;
+	writel(0, hwctx->priv->doorbell_addr);
+}
 
-	guard(mutex)(&xdna->dev_lock);
+/* Publish a command to CERT and return the assigned command sequence (slot). */
+static u64 publish_cmd(struct amdxdna_hwctx *hwctx)
+{
+	struct amdxdna_hwctx_priv *priv = hwctx->priv;
+	u64 wi = priv->write_index;
 
-	idx = srcu_read_lock(&client->hwctx_srcu);
-	amdxdna_for_each_hwctx(client, hwctx_id, hwctx) {
-		if (vm_pgoff == (hwctx->doorbell_offset >> PAGE_SHIFT)) {
-			srcu_read_unlock(&client->hwctx_srcu, idx);
-			return 1;
+	/* Paired with the lockless READ_ONCE() readers of write_index. */
+	WRITE_ONCE(priv->write_index, wi + 1);
+	/* Order the packet-slot writes before CERT sees the new write_index. */
+	wmb();
+	WRITE_ONCE(*priv->umq_write_index, wi + 1);
+	return wi;
+}
+
+static int wait_till_seq_completed(struct amdxdna_hwctx *hwctx, u64 seq)
+{
+	struct cert_comp *cert_comp = aie4_get_cert_comp(hwctx);
+	int ret;
+
+	if (!cert_comp)
+		return -EAGAIN;
+
+	/*
+	 * Killable: the submit path (wait_till_hsa_not_full) reaches here while
+	 * holding hwctx_srcu, and ctx teardown blocks on synchronize_srcu(), so a
+	 * fatal signal (e.g. the app being killed) must be able to unwind the wait
+	 * - otherwise a full queue with a silent CERT would hang the submitter in
+	 * D state and stall teardown forever.  Harmless for the job worker kthread
+	 * (a kthread never has a fatal signal pending).
+	 */
+	ret = wait_event_killable(cert_comp->waitq, check_cmd_done(hwctx, seq));
+	aie4_put_cert_comp(cert_comp);
+
+	if (ret)
+		return ret;	/* -ERESTARTSYS: fatal signal on the submit path */
+	return (hwctx->priv->status != CTX_STATE_CONNECTED) ? -EAGAIN : 0;
+}
+
+static int wait_till_hsa_not_full(struct amdxdna_hwctx *hwctx)
+{
+	u64 wi = READ_ONCE(hwctx->priv->write_index);
+
+	if (wi < CTX_MAX_CMDS)
+		return 0;
+
+	return wait_till_seq_completed(hwctx, wi - CTX_MAX_CMDS);
+}
+
+static int fill_indirect_pkt(struct amdxdna_hwctx_priv *priv, u64 slot_idx,
+			     u32 total_slots, struct amdxdna_cmd_start_dpu *dpu,
+			     u16 entries)
+{
+	struct host_queue_packet *pkt = &priv->umq_pkts[slot_idx];
+	struct host_indirect_packet_entry *hipe =
+		(struct host_indirect_packet_entry *)(pkt->data);
+	u16 i;
+
+	for (i = 0; i < entries; i++, dpu++, hipe++) {
+		struct host_indirect_packet_data *hipd;
+		u64 indirect_pkt_dev_addr;
+		u32 uci = dpu->uc_index;
+		u32 idx;
+
+		/*
+		 * dpu is the user-shared cmd_abo payload, so uc_index is read at
+		 * use time here and indexes priv->umq_indirect_pkts[].  Reject an
+		 * out-of-range value: the slot is reused, so skipping the entry
+		 * would leave a stale one that count still advertises to CERT.
+		 * Abort before the packet is published.
+		 */
+		if (uci >= HSA_MAX_LEVEL1_INDIRECT_ENTRIES) {
+			XDNA_ERR(priv->hwctx->client->xdna, "Invalid uc index %d", uci);
+			return -EINVAL;
 		}
-	}
-	srcu_read_unlock(&client->hwctx_srcu, idx);
+		idx = uci * total_slots + slot_idx;
+		hipd = &priv->umq_indirect_pkts[idx];
+		indirect_pkt_dev_addr = priv->umq_indirect_pkts_dev_addr +
+			sizeof(struct host_indirect_packet_data) * idx;
 
+		/* Point the indirect entry at the indirect packet. */
+		hipe->host_addr_low = lower_32_bits(indirect_pkt_dev_addr);
+		hipe_set_host_addr_high(&hipe->host_addr_high_uc_index,
+					upper_32_bits(indirect_pkt_dev_addr));
+		hipe_set_uc_index(&hipe->host_addr_high_uc_index, uci);
+
+		/* Fill in the indirect packet. */
+		hipd->payload.dpu_control_code_host_addr_low =
+			lower_32_bits(dpu->instruction_buffer);
+		hipd->payload.dpu_control_code_host_addr_high =
+			upper_32_bits(dpu->instruction_buffer);
+		hipd->payload.dtrace_buf_host_addr_low =
+			lower_32_bits(dpu->dtrace_buffer);
+		hipd->payload.dtrace_buf_host_addr_high =
+			lower_16_bits(upper_32_bits(dpu->dtrace_buffer));
+	}
+	pkt->pkt_header.common_header.distribute = 1;
+	pkt->pkt_header.common_header.indirect = 1;
+	pkt->pkt_header.common_header.count = entries * sizeof(*hipe);
+	return 0;
+}
+
+static void fill_direct_pkt(struct amdxdna_hwctx_priv *priv, u64 slot_idx,
+			    struct amdxdna_cmd_start_dpu *dpu)
+{
+	struct host_queue_packet *pkt = &priv->umq_pkts[slot_idx];
+	struct exec_buf *ebuf = (struct exec_buf *)(pkt->data);
+
+	memset(pkt->data, 0, sizeof(pkt->data));
+	ebuf->dpu_control_code_host_addr_low = lower_32_bits(dpu->instruction_buffer);
+	ebuf->dpu_control_code_host_addr_high = upper_32_bits(dpu->instruction_buffer);
+	ebuf->dtrace_buf_host_addr_low = lower_32_bits(dpu->dtrace_buffer);
+	ebuf->dtrace_buf_host_addr_high = lower_16_bits(upper_32_bits(dpu->dtrace_buffer));
+	pkt->pkt_header.common_header.distribute = 0;
+	pkt->pkt_header.common_header.indirect = 0;
+	pkt->pkt_header.common_header.count = sizeof(*ebuf);
+}
+
+/*
+ * Build and submit one HSA command for @cmd_abo into the user host queue and
+ * ring the doorbell.  Called with io_lock held.
+ *
+ * Security: cmd_abo is shared with user space; cache and validate its fields
+ * before use and never trust the queue content (only read_index is read back).
+ */
+static int submit_one_cmd(struct amdxdna_hwctx *hwctx,
+			  struct amdxdna_gem_obj *cmd_abo, u64 *seq)
+{
+	struct amdxdna_hwctx_priv *priv = hwctx->priv;
+	struct amdxdna_dev *xdna = hwctx->client->xdna;
+	struct amdxdna_cmd_start_dpu *dpu;
+	struct host_queue_packet *pkt;
+	u32 payload_size;
+	u64 slot_idx;
+	u16 chained;
+	int ret;
+	u32 op;
+
+	op = amdxdna_cmd_get_op(cmd_abo);
+	if (op != ERT_START_DPU) {
+		XDNA_ERR(xdna, "Invalid exec buf op, %d", op);
+		return -EINVAL;
+	}
+
+	dpu = amdxdna_cmd_get_payload(cmd_abo, &payload_size);
+	if (!dpu) {
+		XDNA_ERR(xdna, "Invalid DPU payload");
+		return -EINVAL;
+	}
+	/*
+	 * cmd_abo is shared with user space; validate the cached chained count
+	 * against the actual payload size before dereferencing chained+1 DPU
+	 * entries, so a bogus count cannot drive an out-of-bounds read.
+	 */
+	chained = dpu->chained;
+	if (chained >= HSA_MAX_LEVEL1_INDIRECT_ENTRIES) {
+		XDNA_ERR(xdna, "Invalid DPU data");
+		return -EINVAL;
+	}
+	if (payload_size < (u32)(chained + 1) * sizeof(*dpu)) {
+		XDNA_ERR(xdna, "DPU payload %u too small for %u entries",
+			 payload_size, chained + 1);
+		return -EINVAL;
+	}
+
+	/*
+	 * The queue may be full; the wait sleeps until CERT drains it.  Drop
+	 * io_lock across the sleep so the job worker (and other submitters) can
+	 * make progress, then re-acquire and re-check the ctx is still live.
+	 */
+	mutex_unlock(&priv->io_lock);
+	ret = wait_till_hsa_not_full(hwctx);
+	mutex_lock(&priv->io_lock);
+	if (ret)
+		return ret;
+	if (priv->status != CTX_STATE_CONNECTED)
+		return -EIO;
+
+	slot_idx = priv->write_index & (CTX_MAX_CMDS - 1);
+	if (chained) {
+		ret = fill_indirect_pkt(priv, slot_idx, CTX_MAX_CMDS, dpu, chained + 1);
+		if (ret)
+			return ret;
+	} else {
+		fill_direct_pkt(priv, slot_idx, dpu);
+	}
+
+	pkt = &priv->umq_pkts[slot_idx];
+	pkt->pkt_header.common_header.opcode = OPCODE_EXEC_BUF;
+	pkt->pkt_header.common_header.chain_flag = CHAIN_FLG_LAST_CMD;
+	pkt->pkt_header.common_header.reserved = 0x0;
+	pkt->pkt_header.completion_signal = amdxdna_gem_dev_addr(cmd_abo) +
+					    offsetof(struct amdxdna_cmd, header);
+	*seq = publish_cmd(hwctx);
+	ring_doorbell(hwctx);
+	XDNA_DBG(xdna, "Submitted one cmd, %s seq %lld", hwctx->name, *seq);
+	return 0;
+}
+
+static struct amdxdna_sched_job *next_running_job(struct amdxdna_hwctx *hwctx)
+{
+	struct amdxdna_hwctx_priv *priv = hwctx->priv;
+	struct amdxdna_sched_job *job;
+
+	mutex_lock(&priv->io_lock);
+	job = list_first_entry_or_null(&priv->running_job_list,
+				       struct amdxdna_sched_job, aie4_job_list);
+	if (job)
+		list_del(&job->aie4_job_list);
+	mutex_unlock(&priv->io_lock);
+	return job;
+}
+
+static void aie4_job_release(struct kref *ref)
+{
+	struct amdxdna_sched_job *job =
+		container_of(ref, struct amdxdna_sched_job, refcnt);
+
+	amdxdna_sched_job_cleanup(job);
+	atomic64_inc(&job->hwctx->job_free_cnt);
+	if (job->out_fence)
+		dma_fence_put(job->out_fence);
+	kfree(job);
+}
+
+static void job_done(struct amdxdna_sched_job *job)
+{
+	job->aie4_job_state = AIE4_JOB_STATE_DONE;
+	dma_fence_signal(job->fence);
+	/*
+	 * Release the address-space reference taken at submit.  On SVA/IOMMU
+	 * platforms the device walks the submitter's page tables while the job
+	 * runs, so its mm must stay alive until completion.
+	 */
+	mmput_async(job->mm);
+	kref_put(&job->refcnt, aie4_job_release);
+}
+
+static void job_complete(struct amdxdna_sched_job *job)
+{
+	job_done(job);
+}
+
+/*
+ * When CERT cannot complete a command (context teardown), the driver advances
+ * read_index so any waiter observes the command as finished.  Only valid while
+ * the context is disconnected -- never race CERT's own read_index updates.
+ */
+static void update_read_index(struct amdxdna_hwctx *hwctx, u64 idx)
+{
+	struct amdxdna_hwctx_priv *priv = hwctx->priv;
+
+	drm_WARN_ON(&hwctx->client->xdna->ddev, priv->status == CTX_STATE_CONNECTED);
+
+	/* Order cmd-bo state write before the waiter observes completion. */
+	wmb();
+	WRITE_ONCE(*priv->umq_read_index, idx);
+}
+
+static void job_abort(struct amdxdna_sched_job *job)
+{
+	struct amdxdna_hwctx *hwctx = job->hwctx;
+
+	XDNA_ERR(hwctx->client->xdna, "aborting %s job %lld", hwctx->name, job->seq);
+	amdxdna_cmd_set_state(job->cmd_bo, ERT_CMD_STATE_ABORT);
+	update_read_index(hwctx, job->seq + 1);
+	job_done(job);
+}
+
+static void job_worker(struct work_struct *work)
+{
+	struct amdxdna_hwctx_priv *priv =
+		container_of(work, struct amdxdna_hwctx_priv, job_work);
+	struct amdxdna_hwctx *hwctx = priv->hwctx;
+	struct amdxdna_sched_job *job;
+
+	while ((job = next_running_job(hwctx))) {
+		wait_till_seq_completed(hwctx, job->seq);
+		trace_amdxdna_debug_point(hwctx->name, job->seq, "job complete");
+
+		if (get_read_index(hwctx) > job->seq)
+			job_complete(job);
+		else
+			job_abort(job);
+	}
+}
+
+static void aie4_hwctx_cleanup_running_jobs(struct amdxdna_hwctx *hwctx)
+{
+	struct amdxdna_hwctx_priv *priv = hwctx->priv;
+
+	/* Must be disconnected so CERT can no longer complete jobs. */
+	drm_WARN_ON(&hwctx->client->xdna->ddev, priv->status == CTX_STATE_CONNECTED);
+	queue_work(priv->job_work_q, &priv->job_work);
+	flush_work(&priv->job_work);
+}
+
+int aie4_cmd_submit(struct amdxdna_hwctx *hwctx, struct amdxdna_sched_job *job, u64 *seq)
+{
+	struct amdxdna_hwctx_priv *priv = hwctx->priv;
+	struct amdxdna_dev *xdna = hwctx->client->xdna;
+	u32 op;
+	int ret;
+
+	XDNA_DBG(xdna, "ctx %s job 0x%llx received", hwctx->name, (u64)job);
+
+	if (!priv->kernel_submit) {
+		/* User-mode submission rings its own doorbell; no kernel submit. */
+		XDNA_ERR(xdna, "cmd submit ioctl not supported in user-mode submission");
+		return -EOPNOTSUPP;
+	}
+
+	if (!job->cmd_bo) {
+		XDNA_ERR(xdna, "No command BO in job");
+		return -EINVAL;
+	}
+
+	op = amdxdna_cmd_get_op(job->cmd_bo);
+	if (op == ERT_CMD_CHAIN) {
+		/* Command chains are not supported on the aie4 kernel path yet. */
+		XDNA_ERR(xdna, "Command chain not supported");
+		return -EOPNOTSUPP;
+	}
+	if (op != ERT_START_DPU) {
+		XDNA_ERR(xdna, "Invalid cmd opcode %d", op);
+		return -EINVAL;
+	}
+
+	INIT_LIST_HEAD(&job->aie4_job_list);
+	job->aie4_job_state = AIE4_JOB_STATE_PENDING;
+
+	/*
+	 * Hold a reference on the submitter's address space until the job
+	 * completes (job_done): on SVA/IOMMU platforms the device walks the
+	 * submitter's page tables while the command runs.  Balanced with the
+	 * mmput_async() in job_done() and the mmput() on the failure paths below.
+	 */
+	if (!mmget_not_zero(job->mm)) {
+		XDNA_ERR(xdna, "Failed to get mm reference");
+		return -ESRCH;
+	}
+
+	mutex_lock(&priv->io_lock);
+	if (priv->status != CTX_STATE_CONNECTED) {
+		mutex_unlock(&priv->io_lock);
+		mmput(job->mm);
+		return -EIO;
+	}
+
+	ret = submit_one_cmd(hwctx, job->cmd_bo, &job->seq);
+	if (ret) {
+		mutex_unlock(&priv->io_lock);
+		mmput(job->mm);
+		return ret;
+	}
+
+	job->aie4_job_state = AIE4_JOB_STATE_SUBMITTED;
+	list_add_tail(&job->aie4_job_list, &priv->running_job_list);
+	*seq = job->seq;
+	mutex_unlock(&priv->io_lock);
+
+	atomic64_inc(&hwctx->job_submit_cnt);
+	queue_work(priv->job_work_q, &priv->job_work);
 	return 0;
 }
 

--- a/drivers/accel/amdxdna/aie4_ctx.c
+++ b/drivers/accel/amdxdna/aie4_ctx.c
@@ -27,6 +27,9 @@
 #define CTX_INVALID_ID			(~0U)
 #define CTX_INVALID_DOORBELL		AMDXDNA_INVALID_DOORBELL_OFFSET
 
+/* Max sub-commands in one ERT_CMD_CHAIN, matching the user-mode shim cap. */
+#define MAX_CHAINED_SUB_CMD		64
+
 static void job_worker(struct work_struct *work);
 static void aie4_hwctx_cleanup_running_jobs(struct amdxdna_hwctx *hwctx);
 
@@ -720,7 +723,8 @@ static void fill_direct_pkt(struct amdxdna_hwctx_priv *priv, u64 slot_idx,
  * before use and never trust the queue content (only read_index is read back).
  */
 static int submit_one_cmd(struct amdxdna_hwctx *hwctx,
-			  struct amdxdna_gem_obj *cmd_abo, u64 *seq)
+			  struct amdxdna_gem_obj *cmd_abo, bool last_of_chain,
+			  u64 *seq)
 {
 	struct amdxdna_hwctx_priv *priv = hwctx->priv;
 	struct amdxdna_dev *xdna = hwctx->client->xdna;
@@ -783,7 +787,8 @@ static int submit_one_cmd(struct amdxdna_hwctx *hwctx,
 
 	pkt = &priv->umq_pkts[slot_idx];
 	pkt->pkt_header.common_header.opcode = OPCODE_EXEC_BUF;
-	pkt->pkt_header.common_header.chain_flag = CHAIN_FLG_LAST_CMD;
+	pkt->pkt_header.common_header.chain_flag =
+		last_of_chain ? CHAIN_FLG_LAST_CMD : CHAIN_FLG_NOT_LAST_CMD;
 	pkt->pkt_header.common_header.reserved = 0x0;
 	pkt->pkt_header.completion_signal = amdxdna_gem_dev_addr(cmd_abo) +
 					    offsetof(struct amdxdna_cmd, header);
@@ -874,10 +879,19 @@ static void job_worker(struct work_struct *work)
 		wait_till_seq_completed(hwctx, job->seq);
 		trace_amdxdna_debug_point(hwctx->name, job->seq, "job complete");
 
-		if (get_read_index(hwctx) > job->seq)
+		if (get_read_index(hwctx) > job->seq) {
+			/*
+			 * The published commands drained.  A chain that was only
+			 * partially published (a later sub-command failed to
+			 * enqueue) still drains its prefix here, but must be
+			 * reported as failed rather than mistaken for success.
+			 */
+			if (job->aie4_job_state != AIE4_JOB_STATE_SUBMITTED)
+				amdxdna_cmd_set_state(job->cmd_bo, ERT_CMD_STATE_ABORT);
 			job_complete(job);
-		else
+		} else {
 			job_abort(job);
+		}
 	}
 }
 
@@ -889,6 +903,119 @@ static void aie4_hwctx_cleanup_running_jobs(struct amdxdna_hwctx *hwctx)
 	drm_WARN_ON(&hwctx->client->xdna->ddev, priv->status == CTX_STATE_CONNECTED);
 	queue_work(priv->job_work_q, &priv->job_work);
 	flush_work(&priv->job_work);
+}
+
+/*
+ * Submit the command(s) carried by @job into the host queue.  Called with
+ * io_lock held.  A single ERT_START_DPU maps to one queue entry; an
+ * ERT_CMD_CHAIN expands to one entry per sub-command, only the last of which
+ * carries CHAIN_FLG_LAST_CMD so CERT runs the whole chain back to back.
+ *
+ * job->seq tracks the last published sequence; the worker waits on it to reap
+ * the entire chain.  job->aie4_job_state advances past PENDING as soon as any
+ * sub-command is published, so the caller knows whether in-flight commands must
+ * still be reaped even when a later sub-command fails to enqueue.
+ *
+ * Security: the chain payload and its BO handles come from user space; cache
+ * command_count and validate it against the payload size before walking the
+ * handle array so a bogus count cannot drive an out-of-bounds read.
+ */
+static int submit_job_cmds(struct amdxdna_hwctx *hwctx, struct amdxdna_sched_job *job)
+{
+	struct amdxdna_gem_obj *cmd_abo = job->cmd_bo;
+	struct amdxdna_dev *xdna = hwctx->client->xdna;
+	struct amdxdna_cmd_chain *payload;
+	u32 op = amdxdna_cmd_get_op(cmd_abo);
+	u32 payload_len, ccnt;
+	int ret;
+	u32 i;
+
+	/* Single cmd. */
+	if (op == ERT_START_DPU) {
+		ret = submit_one_cmd(hwctx, cmd_abo, true, &job->seq);
+		if (!ret)
+			job->aie4_job_state = AIE4_JOB_STATE_SUBMITTED;
+		return ret;
+	}
+
+	/* Cmd chain. */
+	payload = amdxdna_cmd_get_payload(cmd_abo, &payload_len);
+	if (!payload) {
+		XDNA_ERR(xdna, "Invalid cmd payload for chained cmd");
+		return -EINVAL;
+	}
+	ccnt = payload->command_count;
+	if (!ccnt || ccnt > MAX_CHAINED_SUB_CMD ||
+	    payload_len < struct_size(payload, data, ccnt)) {
+		XDNA_ERR(xdna, "Invalid command count %u", ccnt);
+		return -EINVAL;
+	}
+
+	for (i = 0; i < ccnt; i++) {
+		u32 boh = (u32)(payload->data[i]);
+		struct amdxdna_gem_obj *abo;
+
+		abo = amdxdna_gem_get_obj(hwctx->client, boh, AMDXDNA_BO_SHARE);
+		if (!abo) {
+			XDNA_ERR(xdna, "Failed to find cmd BO %u", boh);
+			ret = -ENOENT;
+			break;
+		}
+		ret = submit_one_cmd(hwctx, abo, i + 1 == ccnt, &job->seq);
+		amdxdna_gem_put_obj(abo);
+		if (ret)
+			break;
+		job->aie4_job_state = AIE4_JOB_STATE_SUBMITTING;
+	}
+	if (i == ccnt)
+		job->aie4_job_state = AIE4_JOB_STATE_SUBMITTED;
+
+	return ret;
+}
+
+/*
+ * Whole-job submission is serialized across submitters that share a ctx via the
+ * pending list: a job is appended on entry and only the head of the list is
+ * allowed to publish its command(s).  Because the head stays on the list for the
+ * entire duration of submit_job_cmds() -- which may drop io_lock to wait for
+ * free queue slots -- no other submitter can interleave its commands into the
+ * middle of the head job's command chain.  io_lock protects the lists; the
+ * job_list_wq waitqueue notifies parked submitters when the head changes.
+ */
+/* Publish the current pending-list head for the lockless submit wait condition.
+ * Caller holds io_lock.
+ */
+static void update_pending_head(struct amdxdna_hwctx_priv *priv)
+{
+	WRITE_ONCE(priv->pending_head,
+		   list_first_entry_or_null(&priv->pending_job_list,
+					    struct amdxdna_sched_job, aie4_job_list));
+}
+
+static void enqueue_pending_job(struct amdxdna_hwctx *hwctx,
+				struct amdxdna_sched_job *job)
+{
+	struct amdxdna_hwctx_priv *priv = hwctx->priv;
+
+	mutex_lock(&priv->io_lock);
+	list_add_tail(&job->aie4_job_list, &priv->pending_job_list);
+	job->aie4_job_state = AIE4_JOB_STATE_PENDING;
+	update_pending_head(priv);
+	mutex_unlock(&priv->io_lock);
+}
+
+static void cancel_pending_job(struct amdxdna_hwctx *hwctx,
+			       struct amdxdna_sched_job *job)
+{
+	struct amdxdna_hwctx_priv *priv = hwctx->priv;
+
+	mutex_lock(&priv->io_lock);
+	list_del(&job->aie4_job_list);
+	job->aie4_job_state = AIE4_JOB_STATE_INIT;
+	update_pending_head(priv);
+	mutex_unlock(&priv->io_lock);
+	/* Let the next pending submitter re-check whether it is now first. */
+	wake_up_all(&priv->job_list_wq);
 }
 
 int aie4_cmd_submit(struct amdxdna_hwctx *hwctx, struct amdxdna_sched_job *job, u64 *seq)
@@ -912,18 +1039,12 @@ int aie4_cmd_submit(struct amdxdna_hwctx *hwctx, struct amdxdna_sched_job *job, 
 	}
 
 	op = amdxdna_cmd_get_op(job->cmd_bo);
-	if (op == ERT_CMD_CHAIN) {
-		/* Command chains are not supported on the aie4 kernel path yet. */
-		XDNA_ERR(xdna, "Command chain not supported");
-		return -EOPNOTSUPP;
-	}
-	if (op != ERT_START_DPU) {
+	if (op != ERT_START_DPU && op != ERT_CMD_CHAIN) {
 		XDNA_ERR(xdna, "Invalid cmd opcode %d", op);
 		return -EINVAL;
 	}
 
 	INIT_LIST_HEAD(&job->aie4_job_list);
-	job->aie4_job_state = AIE4_JOB_STATE_PENDING;
 
 	/*
 	 * Hold a reference on the submitter's address space until the job
@@ -936,25 +1057,56 @@ int aie4_cmd_submit(struct amdxdna_hwctx *hwctx, struct amdxdna_sched_job *job, 
 		return -ESRCH;
 	}
 
-	mutex_lock(&priv->io_lock);
-	if (priv->status != CTX_STATE_CONNECTED) {
-		mutex_unlock(&priv->io_lock);
-		mmput(job->mm);
-		return -EIO;
-	}
-
-	ret = submit_one_cmd(hwctx, job->cmd_bo, &job->seq);
+	/*
+	 * Wait until this job is at the head of the pending list before touching
+	 * the queue (see enqueue_pending_job).  The wait is killable so a parked
+	 * submitter cannot keep ctx teardown (synchronize_srcu) blocked forever;
+	 * it also breaks out if the ctx is being disconnected.
+	 */
+	enqueue_pending_job(hwctx, job);
+	ret = wait_event_killable(priv->job_list_wq,
+				  READ_ONCE(priv->status) != CTX_STATE_CONNECTED ||
+				  READ_ONCE(priv->pending_head) == job);
 	if (ret) {
-		mutex_unlock(&priv->io_lock);
+		cancel_pending_job(hwctx, job);
 		mmput(job->mm);
 		return ret;
 	}
 
-	job->aie4_job_state = AIE4_JOB_STATE_SUBMITTED;
-	list_add_tail(&job->aie4_job_list, &priv->running_job_list);
+	mutex_lock(&priv->io_lock);
+	if (priv->status != CTX_STATE_CONNECTED) {
+		mutex_unlock(&priv->io_lock);
+		cancel_pending_job(hwctx, job);
+		mmput(job->mm);
+		return -EIO;
+	}
+
+	ret = submit_job_cmds(hwctx, job);
+	if (job->aie4_job_state == AIE4_JOB_STATE_PENDING) {
+		/* No command was published; nothing for the worker to reap. */
+		list_del(&job->aie4_job_list);
+		update_pending_head(priv);
+		mutex_unlock(&priv->io_lock);
+		/* Release the next pending submitter. */
+		wake_up_all(&priv->job_list_wq);
+		mmput(job->mm);
+		return ret;
+	}
+
+	/*
+	 * At least one command is in flight (a chain may have published some
+	 * before failing); move the job to the running list so the worker waits
+	 * on the last published seq and reaps it.  A partially-submitted chain
+	 * stays at AIE4_JOB_STATE_SUBMITTING so the worker reports it as failed
+	 * after draining its published prefix.
+	 */
+	list_move_tail(&job->aie4_job_list, &priv->running_job_list);
+	update_pending_head(priv);
 	*seq = job->seq;
 	mutex_unlock(&priv->io_lock);
 
+	/* Release the next pending submitter and kick the reaper. */
+	wake_up_all(&priv->job_list_wq);
 	atomic64_inc(&hwctx->job_submit_cnt);
 	queue_work(priv->job_work_q, &priv->job_work);
 	return 0;

--- a/drivers/accel/amdxdna/aie4_ctx.c
+++ b/drivers/accel/amdxdna/aie4_ctx.c
@@ -31,7 +31,6 @@
 #define MAX_CHAINED_SUB_CMD		64
 
 static void job_worker(struct work_struct *work);
-static void aie4_hwctx_cleanup_running_jobs(struct amdxdna_hwctx *hwctx);
 
 static irqreturn_t cert_comp_isr(int irq, void *p)
 {
@@ -294,6 +293,19 @@ void aie4_hwctx_destroy(struct amdxdna_hwctx *hwctx)
 	/* doorbell_base is a device-level managed mapping; just drop the pointer. */
 	priv->doorbell_addr = NULL;
 	aie4_unlink_cert_comp(hwctx);
+
+	/*
+	 * Quiesce the job worker now that the ctx is disconnected and the waitq
+	 * has been woken.  The worker observes the disconnect, re-parks its
+	 * in-flight job at the head of running_job_list, and returns, so
+	 * cancel_work_sync() completes rather than blocking.  This is required on
+	 * the suspend path (which does not call aie4_hwctx_cleanup_running_jobs):
+	 * it makes running_job_list stable before aie4_hwctx_resume_jobs() samples
+	 * it, and guarantees the worker is never left sleeping on this (now
+	 * unlinked) cert_comp waitq while resume allocates a fresh one.
+	 */
+	if (priv->kernel_submit)
+		cancel_work_sync(&priv->job_work);
 }
 
 static void aie4_hwctx_umq_fini(struct amdxdna_hwctx *hwctx)
@@ -621,18 +633,20 @@ static int wait_till_seq_completed(struct amdxdna_hwctx *hwctx, u64 seq)
 		return -EAGAIN;
 
 	/*
-	 * Killable: the submit path (wait_till_hsa_not_full) reaches here while
-	 * holding hwctx_srcu, and ctx teardown blocks on synchronize_srcu(), so a
-	 * fatal signal (e.g. the app being killed) must be able to unwind the wait
-	 * - otherwise a full queue with a silent CERT would hang the submitter in
-	 * D state and stall teardown forever.  Harmless for the job worker kthread
-	 * (a kthread never has a fatal signal pending).
+	 * Freezable + interruptible: the submit path (wait_till_hsa_not_full)
+	 * reaches here while holding hwctx_srcu, and ctx teardown blocks on
+	 * synchronize_srcu(), so a signal (e.g. the app being killed) must be
+	 * able to unwind the wait - otherwise a full queue with a silent CERT
+	 * would hang the submitter in D state and stall teardown forever.
+	 * TASK_FREEZABLE lets the freezer suspend this wait in place during
+	 * S3/S4 instead of aborting the suspend.  Harmless for the job worker
+	 * kthread (never gets a signal; simply freezes/thaws around it).
 	 */
-	ret = wait_event_killable(cert_comp->waitq, check_cmd_done(hwctx, seq));
+	ret = wait_event_freezable(cert_comp->waitq, check_cmd_done(hwctx, seq));
 	aie4_put_cert_comp(cert_comp);
 
 	if (ret)
-		return ret;	/* -ERESTARTSYS: fatal signal on the submit path */
+		return ret;	/* -ERESTARTSYS: signal on the submit path */
 	return (hwctx->priv->status != CTX_STATE_CONNECTED) ? -EAGAIN : 0;
 }
 
@@ -812,6 +826,34 @@ static struct amdxdna_sched_job *next_running_job(struct amdxdna_hwctx *hwctx)
 	return job;
 }
 
+/*
+ * Return the head running job without removing it.  The job worker keeps the
+ * in-flight job on the list while it waits so that a disconnect (suspend) can
+ * just leave it there for resume - no dequeue/requeue - and running_job_list is
+ * never transiently empty while a job is in flight.
+ */
+static struct amdxdna_sched_job *peek_running_job(struct amdxdna_hwctx *hwctx)
+{
+	struct amdxdna_hwctx_priv *priv = hwctx->priv;
+	struct amdxdna_sched_job *job;
+
+	mutex_lock(&priv->io_lock);
+	job = list_first_entry_or_null(&priv->running_job_list,
+				       struct amdxdna_sched_job, aie4_job_list);
+	mutex_unlock(&priv->io_lock);
+	return job;
+}
+
+/* Remove a job from the running list once it is completed or reaped. */
+static void dequeue_running_job(struct amdxdna_hwctx *hwctx, struct amdxdna_sched_job *job)
+{
+	struct amdxdna_hwctx_priv *priv = hwctx->priv;
+
+	mutex_lock(&priv->io_lock);
+	list_del(&job->aie4_job_list);
+	mutex_unlock(&priv->io_lock);
+}
+
 static void aie4_job_release(struct kref *ref)
 {
 	struct amdxdna_sched_job *job =
@@ -875,7 +917,7 @@ static void job_worker(struct work_struct *work)
 	struct amdxdna_hwctx *hwctx = priv->hwctx;
 	struct amdxdna_sched_job *job;
 
-	while ((job = next_running_job(hwctx))) {
+	while ((job = peek_running_job(hwctx))) {
 		wait_till_seq_completed(hwctx, job->seq);
 		trace_amdxdna_debug_point(hwctx->name, job->seq, "job complete");
 
@@ -885,24 +927,65 @@ static void job_worker(struct work_struct *work)
 			 * partially published (a later sub-command failed to
 			 * enqueue) still drains its prefix here, but must be
 			 * reported as failed rather than mistaken for success.
+			 * Remove from the running list before job_complete() frees it.
 			 */
+			dequeue_running_job(hwctx, job);
 			if (job->aie4_job_state != AIE4_JOB_STATE_SUBMITTED)
 				amdxdna_cmd_set_state(job->cmd_bo, ERT_CMD_STATE_ABORT);
 			job_complete(job);
 		} else {
-			job_abort(job);
+			/*
+			 * Ctx disconnected before completion (suspend): leave the job
+			 * on the running list and stop.  It stays at the head (submission
+			 * order preserved) so resume re-drives it; ctx teardown and TDR
+			 * reset reap it via aie4_hwctx_cleanup_running_jobs().
+			 */
+			break;
 		}
 	}
 }
 
-static void aie4_hwctx_cleanup_running_jobs(struct amdxdna_hwctx *hwctx)
+void aie4_hwctx_cleanup_running_jobs(struct amdxdna_hwctx *hwctx)
 {
 	struct amdxdna_hwctx_priv *priv = hwctx->priv;
+	struct amdxdna_sched_job *job;
 
 	/* Must be disconnected so CERT can no longer complete jobs. */
 	drm_WARN_ON(&hwctx->client->xdna->ddev, priv->status == CTX_STATE_CONNECTED);
+
+	/*
+	 * The worker parks (preserves) in-flight jobs on disconnect instead of
+	 * reaping them, so on teardown/reset stop it and abort the preserved jobs
+	 * here.  cancel_work_sync() ensures the worker is not touching the list.
+	 */
+	cancel_work_sync(&priv->job_work);
+	while ((job = next_running_job(hwctx)))
+		job_abort(job);
+}
+
+/*
+ * Resume kernel-mode submission after the ctx was recreated (S3/S4 resume).  Any
+ * jobs the worker preserved on suspend are still queued on running_job_list, and
+ * the HSA queue (a host-resident BO) kept its packets and write/read indices
+ * across suspend.  Ring the doorbell so the fresh firmware ctx re-consumes the
+ * un-drained packets, then restart the worker to reap them as they complete.
+ */
+void aie4_hwctx_resume_jobs(struct amdxdna_hwctx *hwctx)
+{
+	struct amdxdna_hwctx_priv *priv = hwctx->priv;
+
+	if (!priv->kernel_submit)
+		return;
+
+	mutex_lock(&priv->io_lock);
+	if (list_empty(&priv->running_job_list)) {
+		mutex_unlock(&priv->io_lock);
+		return;
+	}
+	ring_doorbell(hwctx);
+	mutex_unlock(&priv->io_lock);
+
 	queue_work(priv->job_work_q, &priv->job_work);
-	flush_work(&priv->job_work);
 }
 
 /*
@@ -1059,14 +1142,16 @@ int aie4_cmd_submit(struct amdxdna_hwctx *hwctx, struct amdxdna_sched_job *job, 
 
 	/*
 	 * Wait until this job is at the head of the pending list before touching
-	 * the queue (see enqueue_pending_job).  The wait is killable so a parked
-	 * submitter cannot keep ctx teardown (synchronize_srcu) blocked forever;
-	 * it also breaks out if the ctx is being disconnected.
+	 * the queue (see enqueue_pending_job).  Freezable so the freezer can
+	 * suspend a parked submitter in place across S3/S4 rather than aborting
+	 * the suspend; still interruptible so it cannot keep ctx teardown
+	 * (synchronize_srcu) blocked forever, and it breaks out if the ctx is
+	 * being disconnected.
 	 */
 	enqueue_pending_job(hwctx, job);
-	ret = wait_event_killable(priv->job_list_wq,
-				  READ_ONCE(priv->status) != CTX_STATE_CONNECTED ||
-				  READ_ONCE(priv->pending_head) == job);
+	ret = wait_event_freezable(priv->job_list_wq,
+				   READ_ONCE(priv->status) != CTX_STATE_CONNECTED ||
+				   READ_ONCE(priv->pending_head) == job);
 	if (ret) {
 		cancel_pending_job(hwctx, job);
 		mmput(job->mm);

--- a/drivers/accel/amdxdna/aie4_host_queue.h
+++ b/drivers/accel/amdxdna/aie4_host_queue.h
@@ -6,9 +6,14 @@
 #ifndef _AIE4_HOST_QUEUE_H_
 #define _AIE4_HOST_QUEUE_H_
 
+#include <linux/bits.h>
 #include <linux/types.h>
 
 #define CTX_MAX_CMDS                    32
+#define HSA_MAX_LEVEL1_INDIRECT_ENTRIES	6
+#define QUEUE_INDEX_START		0
+#define HOST_QUEUE_MAJOR_VERSION	1
+#define HOST_QUEUE_MINOR_VERSION	0
 
 struct host_queue_header {
 	__u64 read_index;
@@ -21,6 +26,66 @@ struct host_queue_header {
 	__u64 write_index;
 	__u64 padding1[6];
 	__u64 data_address; /* The xdna dev addr for payload. */
+};
+
+/* Payload for an OPCODE_EXEC_BUF host-queue packet (single command). */
+struct exec_buf {
+	u32 dtrace_buf_host_addr_low;
+	u32 dpu_control_code_host_addr_low;
+	u32 dpu_control_code_host_addr_high;
+	u16 args_len;
+	u16 dtrace_buf_host_addr_high;
+	u32 args_host_addr_low;
+	u32 args_host_addr_high;
+};
+
+#define OPCODE_EXEC_BUF		1
+#define CHAIN_FLG_LAST_CMD	0
+#define CHAIN_FLG_NOT_LAST_CMD	1
+struct common_header {
+	u16 reserved; /* MBZ. */
+	u8 opcode;
+	u8 chain_flag;
+	u16 count;
+	u8 distribute;
+	u8 indirect;
+};
+
+struct host_queue_packet_header {
+	struct common_header common_header;
+	u64 completion_signal;
+};
+
+struct host_queue_packet {
+	struct host_queue_packet_header pkt_header;
+	u32 data[12]; /* total 64-byte packet */
+};
+
+struct host_indirect_packet_entry {
+	u32 host_addr_low;
+	u32 host_addr_high_uc_index;
+};
+
+#define HIPE_HOST_ADDR_HIGH_SHIFT	0
+#define HIPE_HOST_ADDR_HIGH_MASK	GENMASK(24, 0)
+#define HIPE_UC_INDEX_SHIFT		25
+#define HIPE_UC_INDEX_MASK		GENMASK(31, 25)
+
+static inline void hipe_set_host_addr_high(u32 *val, u32 addr_hi)
+{
+	*val &= ~HIPE_HOST_ADDR_HIGH_MASK;
+	*val |= (addr_hi << HIPE_HOST_ADDR_HIGH_SHIFT) & HIPE_HOST_ADDR_HIGH_MASK;
+}
+
+static inline void hipe_set_uc_index(u32 *val, u32 uc_idx)
+{
+	*val &= ~HIPE_UC_INDEX_MASK;
+	*val |= (uc_idx << HIPE_UC_INDEX_SHIFT) & HIPE_UC_INDEX_MASK;
+}
+
+struct host_indirect_packet_data {
+	struct common_header header;
+	struct exec_buf payload;
 };
 
 #endif /* _AIE4_HOST_QUEUE_H_ */

--- a/drivers/accel/amdxdna/aie4_pci.c
+++ b/drivers/accel/amdxdna/aie4_pci.c
@@ -959,6 +959,32 @@ static void aie4_hwctx_suspend_all(struct amdxdna_dev_hdl *ndev)
 	XDNA_DBG(xdna, "Finished hwctx suspend");
 }
 
+/*
+ * Abort and reap the jobs that aie4_hwctx_destroy() preserved on the running
+ * list.  Used on the resume-failure fallback: after aie4_hwctx_suspend_all()
+ * has disconnected every context, the preserved kernel-mode jobs would
+ * otherwise sit unreaped (fences unsignaled, mm/BO refs held) until context
+ * teardown.  Reap them here so fences are signaled and refs released promptly.
+ * All contexts must already be disconnected.
+ */
+static void aie4_hwctx_cleanup_all(struct amdxdna_dev_hdl *ndev)
+{
+	struct amdxdna_dev *xdna = ndev->aie.xdna;
+	struct amdxdna_client *client;
+	struct amdxdna_hwctx *hwctx;
+	unsigned long hwctx_id;
+	int idx;
+
+	amdxdna_for_each_client(xdna, client) {
+		idx = srcu_read_lock(&client->hwctx_srcu);
+		amdxdna_for_each_hwctx(client, hwctx_id, hwctx) {
+			if (hwctx->priv->kernel_submit)
+				aie4_hwctx_cleanup_running_jobs(hwctx);
+		}
+		srcu_read_unlock(&client->hwctx_srcu, idx);
+	}
+}
+
 static int aie4_hwctx_resume_all(struct amdxdna_dev_hdl *ndev)
 {
 	struct amdxdna_dev *xdna = ndev->aie.xdna;
@@ -973,6 +999,7 @@ static int aie4_hwctx_resume_all(struct amdxdna_dev_hdl *ndev)
 			ret = aie4_hwctx_create(hwctx);
 			if (ret)
 				goto error;
+			aie4_hwctx_resume_jobs(hwctx);
 		}
 		srcu_read_unlock(&client->hwctx_srcu, idx);
 	}
@@ -1099,6 +1126,7 @@ static int aie4_vf_resume(struct amdxdna_dev *xdna)
 
 hw_clear:
 	aie4_hwctx_suspend_all(ndev);
+	aie4_hwctx_cleanup_all(ndev);
 	aie4_vf_hw_stop(ndev);
 pci_disable:
 	pci_disable_device(pdev);
@@ -1136,6 +1164,7 @@ static int aie4_classic_resume(struct amdxdna_dev *xdna)
 	return 0;
 hw_clear:
 	aie4_hwctx_suspend_all(ndev);
+	aie4_hwctx_cleanup_all(ndev);
 	aie4_classic_hw_stop(ndev);
 pci_disable:
 	pci_disable_device(pdev);

--- a/drivers/accel/amdxdna/aie4_pci.c
+++ b/drivers/accel/amdxdna/aie4_pci.c
@@ -7,6 +7,7 @@
 #include <drm/drm_drv.h>
 #include <drm/drm_managed.h>
 #include <drm/drm_print.h>
+#include <linux/debugfs.h>
 #include <linux/firmware.h>
 #include <linux/sizes.h>
 #include <linux/pm_runtime.h>
@@ -14,6 +15,7 @@
 #include "aie.h"
 #include "aie4_pci.h"
 #include "aie4_msg_priv.h"
+#include "amdxdna_ctx.h"
 #include "amdxdna_mailbox.h"
 #include "amdxdna_mailbox_helper.h"
 #include "amdxdna_pci_drv.h"
@@ -566,6 +568,7 @@ static int aie4m_pcidev_init(struct amdxdna_dev *xdna)
 
 	ndev->priv = xdna->dev_info->dev_priv;
 	ndev->aie.xdna = xdna;
+	ndev->kernel_submit = true;
 	xdna->dev_handle = ndev;
 
 	xa_init_flags(&ndev->cert_comp_xa, XA_FLAGS_ALLOC);
@@ -590,6 +593,7 @@ static int aie4m_pcidev_init(struct amdxdna_dev *xdna)
 		set_bit(SMU_REG_BAR(ndev, i), &bars);
 	set_bit(xdna->dev_info->mbox_bar, &bars);
 	set_bit(xdna->dev_info->sram_bar, &bars);
+	set_bit(xdna->dev_info->doorbell_bar, &bars);
 
 	for (i = 0; i < PCI_NUM_RESOURCES; i++) {
 		if (!test_bit(i, &bars))
@@ -603,6 +607,7 @@ static int aie4m_pcidev_init(struct amdxdna_dev *xdna)
 
 	ndev->mbox_base = tbl[xdna->dev_info->mbox_bar];
 	ndev->rbuf_base = tbl[xdna->dev_info->sram_bar];
+	ndev->doorbell_base = tbl[xdna->dev_info->doorbell_bar];
 
 	pci_set_master(pdev);
 
@@ -630,33 +635,71 @@ static int aie4m_pcidev_init(struct amdxdna_dev *xdna)
 	return 0;
 }
 
-static int aie4_doorbell_mmap(struct amdxdna_client *client, struct vm_area_struct *vma)
+/*
+ * Validate a doorbell mmap request and return the pfn to map.  The page offset
+ * must belong to one of the caller's own user-mode contexts (kernel-mode
+ * contexts carry the AMDXDNA_INVALID_DOORBELL_OFFSET sentinel and are never
+ * mappable), and the resulting page must lie fully within the doorbell BAR - a
+ * BAR whose length is not page-aligned must not leak the MMIO that follows it
+ * into the last mapped page.
+ */
+static int aie4_doorbell_mmap_pfn(struct amdxdna_client *client,
+				  unsigned long vm_pgoff, unsigned long *pfnp)
 {
 	struct amdxdna_dev *xdna = client->xdna;
 	struct pci_dev *pdev = to_pci_dev(xdna->ddev.dev);
 	const struct amdxdna_dev_priv *npriv = xdna->dev_info->dev_priv;
-	phys_addr_t res_start;
+	phys_addr_t res_start, res_end;
+	struct amdxdna_hwctx *hwctx;
+	unsigned long hwctx_id, pfn;
+	bool owned = false;
+	int idx;
+
+	mutex_lock(&xdna->dev_lock);
+	idx = srcu_read_lock(&client->hwctx_srcu);
+	amdxdna_for_each_hwctx(client, hwctx_id, hwctx) {
+		if (hwctx->doorbell_offset == AMDXDNA_INVALID_DOORBELL_OFFSET)
+			continue;
+		if (vm_pgoff == (hwctx->doorbell_offset >> PAGE_SHIFT)) {
+			owned = true;
+			break;
+		}
+	}
+	srcu_read_unlock(&client->hwctx_srcu, idx);
+	mutex_unlock(&xdna->dev_lock);
+	if (!owned)
+		return -EINVAL;
+
+	res_start = pci_resource_start(pdev, xdna->dev_info->doorbell_bar) + npriv->doorbell_off;
+	res_end = pci_resource_end(pdev, xdna->dev_info->doorbell_bar);
+	pfn = PHYS_PFN(res_start) + vm_pgoff;
+	if (((phys_addr_t)pfn << PAGE_SHIFT) + PAGE_SIZE - 1 > res_end)
+		return -EINVAL;
+
+	*pfnp = pfn;
+	return 0;
+}
+
+static int aie4_doorbell_mmap(struct amdxdna_client *client, struct vm_area_struct *vma)
+{
+	struct amdxdna_dev *xdna = client->xdna;
 	unsigned long pfn;
 	int ret;
-
-	if (!aie4_hwctx_valid_doorbell(client, vma->vm_pgoff)) {
-		XDNA_ERR(xdna, "Invalid doorbell page offset 0x%lx", vma->vm_pgoff);
-		return -EINVAL;
-	}
 
 	if (vma_pages(vma) != 1) {
 		XDNA_ERR(xdna, "can only map one page, got %ld", vma_pages(vma));
 		return -EINVAL;
 	}
 
-	res_start = pci_resource_start(pdev, xdna->dev_info->doorbell_bar) + npriv->doorbell_off;
-	pfn = PHYS_PFN(res_start) + vma->vm_pgoff;
+	ret = aie4_doorbell_mmap_pfn(client, vma->vm_pgoff, &pfn);
+	if (ret) {
+		XDNA_ERR(xdna, "Invalid doorbell page offset 0x%lx", vma->vm_pgoff);
+		return ret;
+	}
+
 	vma->vm_page_prot = pgprot_noncached(vma->vm_page_prot);
 	vm_flags_set(vma, VM_IO | VM_DONTEXPAND | VM_DONTDUMP);
-	ret = io_remap_pfn_range(vma, vma->vm_start,
-				 pfn,
-				 PAGE_SIZE,
-				 vma->vm_page_prot);
+	ret = io_remap_pfn_range(vma, vma->vm_start, pfn, PAGE_SIZE, vma->vm_page_prot);
 
 	XDNA_DBG(xdna, "doorbell ret %d", ret);
 	return ret;
@@ -1225,6 +1268,15 @@ dev_exit:
 	return ret;
 }
 
+static void aie4_debugfs_init(struct amdxdna_dev *xdna)
+{
+	struct amdxdna_dev_hdl *ndev = xdna->dev_handle;
+
+	/* 0 - submit by user space, 1 - submit by driver (default). */
+	debugfs_create_bool("kernel_mode_submission", 0600,
+			    xdna->ddev.accel->debugfs_root, &ndev->kernel_submit);
+}
+
 const struct amdxdna_dev_ops aie4_pf_ops = {
 	.init			= aie4_pf_init,
 	.fini			= aie4_pf_fini,
@@ -1236,10 +1288,12 @@ const struct amdxdna_dev_ops aie4_pf_ops = {
 const struct amdxdna_dev_ops aie4_vf_ops = {
 	.init			= aie4_vf_init,
 	.fini			= aie4_vf_fini,
+	.debugfs_init		= aie4_debugfs_init,
 	.hwctx_init		= aie4_hwctx_init,
 	.hwctx_fini		= aie4_hwctx_fini,
 	.hwctx_config		= aie4_hwctx_config,
 	.mmap			= aie4_doorbell_mmap,
+	.cmd_submit		= aie4_cmd_submit,
 	.cmd_wait		= aie4_cmd_wait,
 	.get_aie_info		= aie4_get_info,
 	.set_aie_state		= aie4_set_state,
@@ -1251,10 +1305,12 @@ const struct amdxdna_dev_ops aie4_vf_ops = {
 const struct amdxdna_dev_ops aie4_classic_ops = {
 	.init			= aie4_classic_init,
 	.fini			= aie4_classic_fini,
+	.debugfs_init		= aie4_debugfs_init,
 	.hwctx_init		= aie4_hwctx_init,
 	.hwctx_fini		= aie4_hwctx_fini,
 	.hwctx_config		= aie4_hwctx_config,
 	.mmap			= aie4_doorbell_mmap,
+	.cmd_submit		= aie4_cmd_submit,
 	.cmd_wait		= aie4_cmd_wait,
 	.get_aie_info		= aie4_get_info,
 	.set_aie_state		= aie4_set_state,

--- a/drivers/accel/amdxdna/aie4_pci.h
+++ b/drivers/accel/amdxdna/aie4_pci.h
@@ -8,10 +8,17 @@
 
 #include <linux/device.h>
 #include <linux/iopoll.h>
+#include <linux/list.h>
 #include <linux/pci.h>
+#include <linux/wait.h>
+#include <linux/workqueue.h>
 
 #include "aie.h"
 #include "amdxdna_mailbox.h"
+
+struct host_queue_packet;
+struct host_indirect_packet_data;
+struct amdxdna_hwctx;
 
 struct cert_comp {
 	struct amdxdna_dev_hdl          *ndev;
@@ -21,13 +28,53 @@ struct cert_comp {
 	wait_queue_head_t               waitq;
 };
 
+/* aie4 hwctx connection state (kernel-submission lifecycle). */
+#define CTX_STATE_DISCONNECTED		0x0
+#define CTX_STATE_CONNECTED		0x1
+
+/*
+ * aie4 kernel-submission job states (stored in amdxdna_sched_job priv.aie4.state).
+ * Anonymous enum - the aie4_job_state identifier is already a field-access macro.
+ */
+enum {
+	AIE4_JOB_STATE_INIT,
+	AIE4_JOB_STATE_PENDING,
+	AIE4_JOB_STATE_SUBMITTING,
+	AIE4_JOB_STATE_SUBMITTED,
+	AIE4_JOB_STATE_DONE,
+};
+
 struct amdxdna_hwctx_priv {
+	struct amdxdna_hwctx            *hwctx;
 	struct amdxdna_gem_obj          *umq_bo;
 	u64                             *umq_read_index;
 	u64                             *umq_write_index;
+	/* Last valid read_index, returned when a sampled index looks invalid. */
+	u64                             last_read_index;
 
 	struct cert_comp                *cert_comp;
 	u32                             hw_ctx_id;
+	u32                             status;
+	/* Snapshot of kernel_mode_submission for this ctx's lifetime. */
+	bool                            kernel_submit;
+
+	/* Kernel-mode submission: driver fills the user HSA queue and rings
+	 * the doorbell.  umq_pkts/umq_indirect_pkts alias the user umq_bo;
+	 * their content is driver-owned, only read_index is trusted from the
+	 * shared queue.
+	 */
+	u64                             write_index;
+	struct host_queue_packet        *umq_pkts;
+	struct host_indirect_packet_data *umq_indirect_pkts;
+	u64                             umq_indirect_pkts_dev_addr;
+	void                    __iomem *doorbell_addr;
+
+	struct mutex                    io_lock; /* serialize submit, protect job lists */
+	struct list_head                pending_job_list;
+	struct list_head                running_job_list;
+	wait_queue_head_t               job_list_wq;
+	struct work_struct              job_work;
+	struct workqueue_struct         *job_work_q;
 };
 
 struct amdxdna_dev_priv {
@@ -50,6 +97,7 @@ struct amdxdna_dev_hdl {
 	const struct amdxdna_dev_priv	*priv;
 	void			__iomem *mbox_base;
 	void			__iomem *rbuf_base;
+	void			__iomem *doorbell_base;
 
 	struct mailbox			*mbox;
 	u32				partition_id;
@@ -64,6 +112,9 @@ struct amdxdna_dev_hdl {
 
 	u8				pw_mode;
 
+	/* aie4 kernel-mode submission default; tunable via debugfs. */
+	bool				kernel_submit;
+
 	struct amdxdna_drm_query_firmware_version cert_version;
 };
 
@@ -75,7 +126,7 @@ void aie4_hwctx_fini(struct amdxdna_hwctx *hwctx);
 int aie4_hwctx_config(struct amdxdna_hwctx *hwctx, u32 type, u64 value,
 		      void *buf, u32 size);
 int aie4_cmd_wait(struct amdxdna_hwctx *hwctx, u64 seq, u32 timeout);
-int aie4_hwctx_valid_doorbell(struct amdxdna_client *client, u32 vm_pgoff);
+int aie4_cmd_submit(struct amdxdna_hwctx *hwctx, struct amdxdna_sched_job *job, u64 *seq);
 int aie4_hwctx_create(struct amdxdna_hwctx *hwctx);
 void aie4_hwctx_destroy(struct amdxdna_hwctx *hwctx);
 

--- a/drivers/accel/amdxdna/aie4_pci.h
+++ b/drivers/accel/amdxdna/aie4_pci.h
@@ -71,6 +71,10 @@ struct amdxdna_hwctx_priv {
 
 	struct mutex                    io_lock; /* serialize submit, protect job lists */
 	struct list_head                pending_job_list;
+	/* Head of pending_job_list, updated under io_lock; read locklessly by the
+	 * submit wait condition so it never takes a lock inside wait_event().
+	 */
+	struct amdxdna_sched_job        *pending_head;
 	struct list_head                running_job_list;
 	wait_queue_head_t               job_list_wq;
 	struct work_struct              job_work;

--- a/drivers/accel/amdxdna/aie4_pci.h
+++ b/drivers/accel/amdxdna/aie4_pci.h
@@ -133,6 +133,8 @@ int aie4_cmd_wait(struct amdxdna_hwctx *hwctx, u64 seq, u32 timeout);
 int aie4_cmd_submit(struct amdxdna_hwctx *hwctx, struct amdxdna_sched_job *job, u64 *seq);
 int aie4_hwctx_create(struct amdxdna_hwctx *hwctx);
 void aie4_hwctx_destroy(struct amdxdna_hwctx *hwctx);
+void aie4_hwctx_resume_jobs(struct amdxdna_hwctx *hwctx);
+void aie4_hwctx_cleanup_running_jobs(struct amdxdna_hwctx *hwctx);
 
 /* aie4_sriov.c */
 #if IS_ENABLED(CONFIG_PCI_IOV)

--- a/drivers/accel/amdxdna/amdxdna_ctx.h
+++ b/drivers/accel/amdxdna/amdxdna_ctx.h
@@ -48,6 +48,18 @@ struct amdxdna_cmd_start_npu {
 };
 
 /*
+ * struct amdxdna_cmd_start_dpu - interpretation of data payload for
+ * ERT_START_DPU in amdxdna_cmd.
+ */
+struct amdxdna_cmd_start_dpu {
+	u64 dtrace_buffer;		/* dtrace buffer address 2 words */
+	u64 instruction_buffer;		/* buffer address 2 words */
+	u32 instruction_buffer_size;	/* size of buffer in bytes */
+	u16 uc_index;			/* microblaze controller index */
+	u16 chained;			/* number of following amdxdna_cmd_start_dpu elements */
+};
+
+/*
  * Interpretation of the beginning of data payload for ERT_CMD_CHAIN in
  * amdxdna_cmd. The rest of the payload in amdxdna_cmd is cmd BO handles.
  */
@@ -137,8 +149,14 @@ struct amdxdna_drv_cmd {
 };
 
 struct app_health_report;
+
 union amdxdna_job_priv {
 	struct app_health_report *aie2_health;
+	/* aie4 kernel submission: queue linkage + job state */
+	struct {
+		struct list_head	list;
+		u32			state;
+	} aie4;
 };
 
 struct amdxdna_sched_job {
@@ -161,6 +179,8 @@ struct amdxdna_sched_job {
 };
 
 #define aie2_job_health priv.aie2_health
+#define aie4_job_list	priv.aie4.list
+#define aie4_job_state	priv.aie4.state
 
 static inline u32
 amdxdna_cmd_get_op(struct amdxdna_gem_obj *abo)

--- a/drivers/accel/amdxdna/amdxdna_debugfs.c
+++ b/drivers/accel/amdxdna/amdxdna_debugfs.c
@@ -126,4 +126,7 @@ void amdxdna_debugfs_init(struct amdxdna_dev *xdna)
 				    xdna,
 				    amdxdna_dbgfs_files[i].fops);
 	}
+
+	if (xdna->dev_info->ops->debugfs_init)
+		xdna->dev_info->ops->debugfs_init(xdna);
 }

--- a/drivers/accel/amdxdna/amdxdna_pci_drv.h
+++ b/drivers/accel/amdxdna/amdxdna_pci_drv.h
@@ -60,6 +60,7 @@ struct amdxdna_msg_buf_hdl;
 struct amdxdna_dev_ops {
 	int (*init)(struct amdxdna_dev *xdna);
 	void (*fini)(struct amdxdna_dev *xdna);
+	void (*debugfs_init)(struct amdxdna_dev *xdna);
 	int (*resume)(struct amdxdna_dev *xdna);
 	int (*suspend)(struct amdxdna_dev *xdna);
 	int (*sriov_configure)(struct amdxdna_dev *xdna, int num_vfs);


### PR DESCRIPTION
 Adds aie4 (NPU3) kernel-mode queue (KMQ) command submission to the
  drivers/accel/amdxdna tree: the driver submits I/O commands to the device's HSA
  queue itself, instead of relying on user-mode submission. This PR contains three
  commits:

  - **accel/amdxdna: aie4: add kernel-mode queue command submission** — driver
    pushes a single ERT_START_DPU into the HSA queue, rings the doorbell, and
    completes the job by reading read_index back from the queue header. The HSA
    queue stays a user-allocated BO in all addressing modes (under PASID/SVA the
    device must reach the queue via the submitting process's page tables; a forged
    read_index is self-harm only). Per-entry uc_index and doorbell-BAR bounds are
    validated; write_index/status lockless accesses are annotated. The completion
    wait is unbounded but **killable**: a signalled/killed submitter unwinds the
    ioctl and drops hwctx_srcu so context teardown and module unload proceed.
    There is no driver-side per-job timer — the per-context deadline and recovery
    are provided by firmware TDR (consumed by the follow-up TDR commit).

  - **accel/amdxdna: aie4: serialize KMQ submission and report partial-chain
    failure** — serializes submitters through a pending list so concurrent
    contexts cannot interleave runlist packets, and enables the ERT_CMD_CHAIN path.

  - **accel/amdxdna: aie4: preserve kernel-mode jobs across suspend/resume** —
    instead of aborting in-flight KMQ jobs whenever the context disconnects, the
    job worker preserves them (re-parks them on the running list) so they survive
    suspend, and re-drives them on resume (re-ring doorbell + restart worker);
    context teardown and TDR reset reap directly. The worker is quiesced
    (cancel_work_sync) on the suspend/destroy path so the running list is stable
    before resume samples it and the worker is never left on a stale cert_comp
    waitq. Relies on firmware not resetting the HSA queue read/write indices on
    context create — it adopts the host-resident indices, so a recreated context
    continues consuming from the preserved read_index.

  This PR is the submission path plus suspend/resume preservation. It deliberately
  excludes the error-reporting and recovery work. Without those follow-up commits,
  the KMQ path has the following gaps:

  - **No firmware async-error reporting.** AIE-tile and context-fatal errors raised
    by firmware are not surfaced, and no health/diagnostic data is attached to a
    failed command BO. Userspace cannot tell why a job failed. (Closed by the
    async-error commit.)
  - **No in-driver timeout-driven recovery (TDR).** A context that faults or wedges
    cannot be recovered in-driver yet: there is no health-data timeout handling and
    no context reset/recreate. The completion wait being killable (plus per-context
    workqueue and per-client srcu isolation) means an unresponsive CERT cannot hang
    the kernel or block teardown/suspend, but a wedged context stays wedged until
    the client tears it down and recreates it. (Closed by the TDR commit, which
    consumes the firmware per-context timeout/health report and resets the context.)

  In short: this PR can submit and complete healthy work, preserve in-flight work
  across suspend/resume, and survive an unresponsive CERT without hanging the
  kernel, but cannot yet report or recover from a faulting context in-driver. The
  async-error and TDR commits turn "doesn't hang" into "reports and recovers."


TDR patch can be found in: https://github.com/wendyliang25/xdna-driver/commits/umq-ksubmit-tdr/
They build on top of this PR's two commits and will be sent as a follow-up series once this base lands.
 
Tested with shim-test and xrt-smi validation.
* shim test:
```
28      test(s) skipped: 7 22 24 26 36 49 52 53 54 56 57 58 60 61 62 67 68 69 70 72 73 74 75 76 77 78 79 80
58      test(s) executed
ALL 58 executed test(s) PASSED!
```
