### PR TITLE
ve2: cacheable buffer allocation support

### DIFF
--- a/src/driver/amdxdna/amdxdna_cma_buf.c
+++ b/src/driver/amdxdna/amdxdna_cma_buf.c
@@ -5,6 +5,8 @@
 
 #include <linux/kernel.h>
 #include <linux/dma-buf.h>
+#include <linux/dma-mapping.h>
+#include <linux/mm.h>
 #include "amdxdna_cma_buf.h"
 
 struct amdxdna_cmabuf_priv {
@@ -75,7 +77,8 @@ static void amdxdna_cmabuf_free(struct device *dev, void *cpu_addr,
 				bool cacheable)
 {
 	if (cacheable)
-		dma_free_wc(dev, size, cpu_addr, dma_addr);
+		dma_free_noncoherent(dev, size, cpu_addr, dma_addr,
+				     DMA_BIDIRECTIONAL);
 	else
 		dma_free_coherent(dev, size, cpu_addr, dma_addr);
 }
@@ -108,16 +111,17 @@ static int amdxdna_cmabuf_mmap(struct dma_buf *dbuf, struct vm_area_struct *vma)
 
 	vm_flags_set(vma, VM_IO | VM_DONTEXPAND | VM_DONTDUMP);
 
-	if (cmabuf->cacheable)
-		ret = dma_mmap_wc(cmabuf->dev, vma,
-				  cmabuf->cpu_addr,
-				  cmabuf->dma_addr,
-				  cmabuf->size);
-	else
+	if (cmabuf->cacheable) {
+		unsigned long pfn = page_to_pfn(virt_to_page(cmabuf->cpu_addr));
+
+		ret = remap_pfn_range(vma, vma->vm_start, pfn,
+				      size, vma->vm_page_prot);
+	} else {
 		ret = dma_mmap_coherent(cmabuf->dev, vma,
 					cmabuf->cpu_addr,
 					cmabuf->dma_addr,
 					cmabuf->size);
+	}
 
 	vma->vm_pgoff = vm_pgoff;
 
@@ -158,7 +162,8 @@ static struct dma_buf *amdxdna_get_cma_buf(struct device *dev,
 	size = PAGE_ALIGN(size);
 
 	if (cacheable)
-		cpu_addr = dma_alloc_wc(dev, size, &dma_addr, GFP_KERNEL);
+		cpu_addr = dma_alloc_noncoherent(dev, size, &dma_addr,
+						 DMA_BIDIRECTIONAL, GFP_KERNEL);
 	else
 		cpu_addr = dma_alloc_coherent(dev, size, &dma_addr, GFP_KERNEL);
 	if (!cpu_addr) {

--- a/src/shim_ve2/xdna_bo.cpp
+++ b/src/shim_ve2/xdna_bo.cpp
@@ -124,6 +124,13 @@ xdna_bo(const device_xdna& device, xrt_core::hwctx_handle::slot_id ctx_id,
       xflags.use == XRT_BO_USE_LOG || xflags.use == XRT_BO_USE_UC_DEBUG)
     attach_to_ctx(xflags.use);
 
+  // Cacheable buffers are not zero-initialized and a freshly allocated page
+  // may hold dirty cachelines. If used as an output buffer, those lines can
+  // later be evicted to memory and pollute the device's output. Flush right
+  // after allocation to avoid this.
+  if ((static_cast<uint32_t>(xflags.boflags) << 24) == XCL_BO_FLAGS_CACHEABLE)
+    sync(xrt_core::buffer_handle::direction::host2device, m_aligned_size, 0);
+
   shim_debug("Allocated DRM BO (userptr=0x%lx, size=%ld, flags=0x%llx, type=%d, drm_bo=%d)",
 	     m_ptr, m_aligned_size, m_flags, m_type, get_drm_bo_handle());
 }


### PR DESCRIPTION
This PR adds support to allocate cacheable buffers if xrt::bo:;flags::cacheable flags is set for user buffers. 

- Testes all the supported tests based on ve2. All are passing
- Tested some tests by having cacheable buffers instead of non-cacheable and test passes as expected.

Note to users: If any buffer becomes dirty in host application that has to be flushed by calling explicit sync before using it.