### PR TITLE
xrt: track XRT-2.25 branch for submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "xrt"]
 	path = xrt
 	url = https://github.com/Xilinx/XRT.git
+	branch = XRT-2.25


### PR DESCRIPTION
Set submodule.xrt.branch to XRT-2.25 so the xrt submodule is explicitly associated with the XRT-2.25 branch. The pinned commit (0026185de81a179dc7d886197d3e35f9a179b4e8) is unchanged.