### PR TITLE
ve2: Moving HSA queue to cacheable buffer & removed hq_mem ownership to firmware

### DIFF
--- a/src/driver/amdxdna/ve2_host_queue.h
+++ b/src/driver/amdxdna/ve2_host_queue.h
@@ -121,6 +121,8 @@ struct ve2_hsa_queue {
 	u64				reserved_write_index;
 	/* Device used for host queue allocation */
 	struct device			*alloc_dev;
+	/* Driver-local slot readiness tracking; avoids writing to hqc_mem (cert-owned) */
+	DECLARE_BITMAP(slot_ready, HOST_QUEUE_ENTRY);
 };
 
 /*

--- a/src/driver/amdxdna/ve2_hwctx.c
+++ b/src/driver/amdxdna/ve2_hwctx.c
@@ -240,6 +240,7 @@ static void hsa_queue_commit_slot(struct amdxdna_dev *xdna, struct amdxdna_ctx *
 		if (!test_bit(next_idx, queue->slot_ready))
 			break;
 
+		clear_bit(next_idx, queue->slot_ready);
 		header->write_index++;
 	}
 	/* Sync write_index after writing (device will read) */
@@ -574,10 +575,19 @@ static int ve2_create_host_queue(struct amdxdna_dev *xdna, struct amdxdna_ctx *h
 		}
 	}
 
+	/* Zero hqc_mem so physical memory starts clean for cert's completion writes */
+	memset(queue->hq_complete.hqc_mem, 0, sizeof(u64) * HOST_QUEUE_ENTRY);
+
 	/* Sync entire queue structure after initialization (device will read) */
 	dma_sync_single_for_device(queue->alloc_dev,
 				   queue->hsa_queue_mem.dma_addr,
 				   sizeof(struct hsa_queue),
+				   DMA_TO_DEVICE);
+
+	/* Sync hqc_mem to device so physical memory is clean before cert writes */
+	dma_sync_single_for_device(queue->alloc_dev,
+				   queue->hq_complete.hqc_dma_addr,
+				   sizeof(u64) * HOST_QUEUE_ENTRY,
 				   DMA_TO_DEVICE);
 
 	XDNA_DBG(xdna, "Created host queue: dma_addr=0x%llx, capacity=%d, data_addr=0x%llx",

--- a/src/driver/amdxdna/ve2_hwctx.c
+++ b/src/driver/amdxdna/ve2_hwctx.c
@@ -203,9 +203,7 @@ hsa_queue_reserve_slot(struct amdxdna_dev *xdna, struct amdxdna_ctx_priv *priv, 
 
 	/* Reserve this slot by incrementing reserved_write_index. */
 	*slot = queue->reserved_write_index++;
-	queue->hq_complete.hqc_mem[slot_idx] = ERT_CMD_STATE_NEW;
-	/* Sync completion memory after writing (device will read) */
-	hsa_queue_sync_completion_for_write(queue, slot_idx);
+	clear_bit(slot_idx, queue->slot_ready);
 
 	mutex_unlock(&queue->hq_lock);
 
@@ -232,19 +230,14 @@ static void hsa_queue_commit_slot(struct amdxdna_dev *xdna, struct amdxdna_ctx *
 	/* Sync packet after writing (device will read) */
 	hsa_queue_sync_packet_for_write(queue, slot_idx);
 
-	/* Mark this seq as ready in driver tracking */
-	queue->hq_complete.hqc_mem[slot_idx] = ERT_CMD_STATE_SUBMITTED;
-	/* Sync completion memory after writing (device will read) */
-	hsa_queue_sync_completion_for_write(queue, slot_idx);
+	/* Mark slot ready in driver-local tracking (cert owns hqc_mem) */
+	set_bit(slot_idx, queue->slot_ready);
 
 	/* Advance write_index as far as possible through all ready slots. */
 	while (header->write_index < queue->reserved_write_index) {
 		u32 next_idx = header->write_index % capacity;
-		/* Sync completion memory before reading (device may have written) */
-		hsa_queue_sync_completion_for_read(queue, next_idx);
-		enum ert_cmd_state state = queue->hq_complete.hqc_mem[next_idx];
 
-		if (state != ERT_CMD_STATE_SUBMITTED)
+		if (!test_bit(next_idx, queue->slot_ready))
 			break;
 
 		header->write_index++;
@@ -515,8 +508,9 @@ static int ve2_create_host_queue(struct amdxdna_dev *xdna, struct amdxdna_ctx *h
 	for (r = 0; r < MAX_MEM_REGIONS; r++) {
 		alloc_dev = xdna->cma_region_devs[r];
 		if ((hwctx->priv->mem_bitmap & (1U << r)) && alloc_dev) {
-			queue->hsa_queue_p = dma_alloc_coherent(alloc_dev, alloc_size,
-								&dma_handle, GFP_KERNEL);
+			queue->hsa_queue_p = dma_alloc_noncoherent(alloc_dev, alloc_size,
+								   &dma_handle, DMA_BIDIRECTIONAL,
+								   GFP_KERNEL);
 			if (!queue->hsa_queue_p)
 				continue;
 			queue->alloc_dev = alloc_dev;
@@ -526,10 +520,11 @@ static int ve2_create_host_queue(struct amdxdna_dev *xdna, struct amdxdna_ctx *h
 
 	/* If no allocation succeeded, use the default device */
 	if (!queue->hsa_queue_p) {
-		queue->hsa_queue_p = dma_alloc_coherent(xdna->ddev.dev,
-							alloc_size,
-							&dma_handle,
-							GFP_KERNEL);
+		queue->hsa_queue_p = dma_alloc_noncoherent(xdna->ddev.dev,
+							   alloc_size,
+							   &dma_handle,
+							   DMA_BIDIRECTIONAL,
+							   GFP_KERNEL);
 		if (!queue->hsa_queue_p) {
 			XDNA_ERR(xdna, "Failed to allocate host queue memory, size=%zu",
 				 alloc_size);

--- a/src/driver/amdxdna/ve2_hwctx.c
+++ b/src/driver/amdxdna/ve2_hwctx.c
@@ -240,7 +240,6 @@ static void hsa_queue_commit_slot(struct amdxdna_dev *xdna, struct amdxdna_ctx *
 		if (!test_bit(next_idx, queue->slot_ready))
 			break;
 
-		clear_bit(next_idx, queue->slot_ready);
 		header->write_index++;
 	}
 	/* Sync write_index after writing (device will read) */

--- a/src/driver/amdxdna/ve2_hwctx.c
+++ b/src/driver/amdxdna/ve2_hwctx.c
@@ -394,10 +394,11 @@ static inline void hsa_queue_pkt_set_invalid(struct host_queue_packet *pkt)
 static void ve2_free_hsa_queue(struct amdxdna_dev *xdna, struct ve2_hsa_queue *queue)
 {
 	if (queue->hsa_queue_p) {
-		dma_free_coherent(queue->alloc_dev,
-				  sizeof(struct hsa_queue) + sizeof(u64) * HOST_QUEUE_ENTRY,
-				  queue->hsa_queue_p,
-				  queue->hsa_queue_mem.dma_addr);
+		dma_free_noncoherent(queue->alloc_dev,
+				     sizeof(struct hsa_queue) + sizeof(u64) * HOST_QUEUE_ENTRY,
+				     queue->hsa_queue_p,
+				     queue->hsa_queue_mem.dma_addr,
+				     DMA_BIDIRECTIONAL);
 		queue->hsa_queue_p = NULL;
 		queue->hsa_queue_mem.dma_addr = 0;
 		queue->alloc_dev = NULL;

--- a/src/shim_ve2/xdna_bo.cpp
+++ b/src/shim_ve2/xdna_bo.cpp
@@ -142,6 +142,14 @@ xdna_bo(const device_xdna& device, xrt_core::hwctx_handle::slot_id ctx_id,
       xflags.use == XRT_BO_USE_LOG || xflags.use == XRT_BO_USE_UC_DEBUG)
     attach_to_ctx(xflags.use);
 
+  // Freshly allocated pages may carry stale dirty cache lines. If this BO is
+  // used as an output, those lines could later write back over the device's
+  // DMA results and corrupt them. Flush once right after allocation so the
+  // BO starts clean; subsequent coherency is the app's responsibility via
+  // explicit sync().
+  if (m_type == AMDXDNA_BO_SHARE)
+    sync(direction::host2device, m_aligned_size, 0);
+
   shim_debug("Allocated DRM BO (userptr=0x%lx, size=%ld, flags=0x%llx, type=%d, drm_bo=%d)",
 	     m_ptr, m_aligned_size, m_flags, m_type, get_drm_bo_handle());
 }


### PR DESCRIPTION
ve2: Moving HSA queue to cacheable buffer & removed hq_mem ownership to firmware