### PR TITLE
accel/amdxdna: use last-progress timestamp for TDR no-hang

### DIFF
--- a/drivers/accel/amdxdna/aie2_ctx.c
+++ b/drivers/accel/amdxdna/aie2_ctx.c
@@ -44,21 +44,33 @@ struct aie2_ctx_health {
 
 static inline void aie2_tdr_signal(struct amdxdna_dev *xdna)
 {
-	WRITE_ONCE(xdna->dev_handle->tdr_status, AIE2_TDR_SIGNALED);
+	struct amdxdna_dev_hdl *ndev = xdna->dev_handle;
+
+#ifdef HAVE_6_17_drm_gpu_sched_stat_no_hang
+	WRITE_ONCE(ndev->tdr.last_signal, jiffies);
+#else
+	WRITE_ONCE(ndev->tdr_status, AIE2_TDR_SIGNALED);
+#endif
 }
 
 #ifdef HAVE_6_17_drm_gpu_sched_stat_no_hang
 static bool aie2_tdr_detect(struct amdxdna_dev *xdna)
 {
 	struct amdxdna_dev_hdl *ndev = xdna->dev_handle;
+	unsigned long last = READ_ONCE(ndev->tdr.last_signal);
 
-	if (READ_ONCE(ndev->tdr_status) == AIE2_TDR_WAIT) {
-		XDNA_ERR(xdna, "TDR timeout detected");
-		return true;
-	}
+	/*
+	 * The scheduler fires this tdr_timeout_ms after the job started. If
+	 * we observed progress (a job completed or a new submission) within
+	 * the last tdr_timeout_ms, the context is not hung - the job was
+	 * merely preempted or starved - so keep waiting instead of
+	 * resetting the context.
+	 */
+	if (time_before(jiffies, last + msecs_to_jiffies(tdr_timeout_ms)))
+		return false;
 
-	WRITE_ONCE(ndev->tdr_status, AIE2_TDR_WAIT);
-	return false;
+	XDNA_ERR(xdna, "TDR timeout detected");
+	return true;
 }
 #endif
 

--- a/drivers/accel/amdxdna/aie2_pci.h
+++ b/drivers/accel/amdxdna/aie2_pci.h
@@ -124,6 +124,9 @@ struct aie2_tdr {
 	enum aie2_tdr_status progress;
 #ifndef HAVE_6_17_drm_gpu_sched_stat_no_hang
 	struct delayed_work work;
+#else
+	/* jiffies of the last progress signal (job completion or submission) */
+	unsigned long last_signal;
 #endif
 };
 


### PR DESCRIPTION
On 6.17+ kernels the DRM scheduler drives the per-job timeout and calls aie2_sched_job_timedout() tdr_timeout_ms after a job starts. The previous detect used a coarse WAIT/SIGNALED toggle that granted up to two timeout intervals of grace and could not tell a genuinely hung device from a job that was merely preempted or starved while the device kept making progress.

Record the jiffies of the last progress signal (job completion or submission) and, in the timeout callback, return no-hang when that signal occurred within tdr_timeout_ms. A context is only reset when no progress was made for the full window. The timestamp is a single word-sized field accessed with WRITE_ONCE/READ_ONCE, which is safe locklessly.