### PR TITLE
accel/amdxdna: aie4 async error support

### DIFF
--- a/drivers/accel/amdxdna/Kbuild
+++ b/drivers/accel/amdxdna/Kbuild
@@ -49,6 +49,7 @@ amdxdna-$(OFT_CONFIG_AMDXDNA_PCI) += \
 	aie2_solver.o \
 	aie2_tdr.o \
 	aie4_ctx.o \
+	aie4_error.o \
 	aie4_message.o \
 	aie4_pci.o \
 	amdxdna_dpt.o \

--- a/drivers/accel/amdxdna/Kbuild
+++ b/drivers/accel/amdxdna/Kbuild
@@ -52,6 +52,7 @@ amdxdna-$(OFT_CONFIG_AMDXDNA_PCI) += \
 	aie4_message.o \
 	aie4_pci.o \
 	amdxdna_dpt.o \
+	amdxdna_error.o \
 	npu1_regs.o \
 	npu3_regs.o \
 	npu4_regs.o \

--- a/drivers/accel/amdxdna/aie.h
+++ b/drivers/accel/amdxdna/aie.h
@@ -16,6 +16,7 @@ struct psp_device;
 struct smu_device;
 struct amdxdna_hwctx;
 struct amdxdna_msg_buf_hdl;
+struct amdxdna_async_events;
 
 struct aie_msg_ops {
 	int (*get_coredump)(struct amdxdna_hwctx *hwctx,
@@ -70,6 +71,10 @@ struct aie_device {
 	u32 hclk_freq;
 	u32 max_tops;
 	u32 curr_tops;
+
+	/* Async error reporting state, shared by aie2 and aie4. */
+	struct amdxdna_async_events	*async_events;
+	struct amdxdna_async_error	last_async_err;
 };
 
 struct aie_hw_ops {

--- a/drivers/accel/amdxdna/aie2_error.c
+++ b/drivers/accel/amdxdna/aie2_error.c
@@ -1,416 +1,116 @@
 // SPDX-License-Identifier: GPL-2.0
 /*
- * Copyright (C) 2023-2024, Advanced Micro Devices, Inc.
+ * Copyright (C) 2023-2026, Advanced Micro Devices, Inc.
  */
 
-#include <drm/drm_cache.h>
 #include <drm/drm_device.h>
 #include <drm/drm_print.h>
-#include <drm/gpu_scheduler.h>
-#include <linux/dma-mapping.h>
-#include <linux/kthread.h>
 #include <linux/kernel.h>
+#include <linux/mutex.h>
 
 #include "aie.h"
 #include "aie2_msg_priv.h"
 #include "aie2_pci.h"
 #include "amdxdna_error.h"
-#include "amdxdna_mailbox.h"
 #include "amdxdna_pci_drv.h"
 
-struct async_event {
-	struct amdxdna_dev_hdl		*ndev;
-	struct async_event_msg_resp	resp;
-	struct workqueue_struct		*wq;
-	struct work_struct		work;
-	u8				*buf;
-	dma_addr_t			addr;
-	u32				size;
-};
-
-struct async_events {
-	struct workqueue_struct		*wq;
-	struct amdxdna_msg_buf_hdl	*hdl;
-	u32				event_cnt;
-	struct async_event		event[] __counted_by(event_cnt);
-};
-
 /*
- * Below enum, struct and lookup tables are porting from XAIE util header file.
+ * The async event scaffolding, worker, mailbox callback, GET_ARRAY query and
+ * the generic category / module to driver-error mapping and stringify are
+ * shared with aie4 and live in amdxdna_error.c. This file provides the aie2
+ * specific pieces: the mailbox register call and the aie2 event_id to category
+ * tables. The async status sentinel value (MAX_AIE2_STATUS_CODE) is wired into
+ * dev_info.async_max_status_code by the npu*_regs.c device tables.
  *
- * Below data is defined by AIE device and it is used for decode error message
- * from the device.
+ * Map an AIE tile error event id to an error category for the aie2
+ * generation. These are the enabled fatal error events per module;
+ * correctable and non-fatal events are omitted. The category assignment is
+ * the driver's choice.
  */
-
-enum aie_module_type {
-	AIE_MEM_MOD = 0,
-	AIE_CORE_MOD,
-	AIE_PL_MOD,
-	AIE_UNKNOWN_MOD,
+static const struct aie_error_event aie2_mem_error_events[] = {
+	AIE_ERROR_EVENT(88U,  AIE_ERROR_ECC, "DM ECC error scrub 2bit"),
+	AIE_ERROR_EVENT(90U,  AIE_ERROR_ECC, "DM ECC error 2bit"),
+	AIE_ERROR_EVENT(91U,  AIE_ERROR_MEM_PARITY, "DM parity error bank 2"),
+	AIE_ERROR_EVENT(92U,  AIE_ERROR_MEM_PARITY, "DM parity error bank 3"),
+	AIE_ERROR_EVENT(93U,  AIE_ERROR_MEM_PARITY, "DM parity error bank 4"),
+	AIE_ERROR_EVENT(94U,  AIE_ERROR_MEM_PARITY, "DM parity error bank 5"),
+	AIE_ERROR_EVENT(95U,  AIE_ERROR_MEM_PARITY, "DM parity error bank 6"),
+	AIE_ERROR_EVENT(96U,  AIE_ERROR_MEM_PARITY, "DM parity error bank 7"),
+	AIE_ERROR_EVENT(97U,  AIE_ERROR_DMA, "DMA S2MM 0 error"),
+	AIE_ERROR_EVENT(98U,  AIE_ERROR_DMA, "DMA S2MM 1 error"),
+	AIE_ERROR_EVENT(99U,  AIE_ERROR_DMA, "DMA MM2S 0 error"),
+	AIE_ERROR_EVENT(100U, AIE_ERROR_DMA, "DMA MM2S 1 error"),
+	AIE_ERROR_EVENT(101U, AIE_ERROR_LOCK, "Lock error"),
+	{ }
 };
 
-enum aie_error_category {
-	AIE_ERROR_SATURATION = 0,
-	AIE_ERROR_FP,
-	AIE_ERROR_STREAM,
-	AIE_ERROR_ACCESS,
-	AIE_ERROR_BUS,
-	AIE_ERROR_INSTRUCTION,
-	AIE_ERROR_ECC,
-	AIE_ERROR_LOCK,
-	AIE_ERROR_DMA,
-	AIE_ERROR_MEM_PARITY,
-	/* Unknown is not from XAIE, added for better category */
-	AIE_ERROR_UNKNOWN,
+static const struct aie_error_event aie2_core_error_events[] = {
+	AIE_ERROR_EVENT(55U, AIE_ERROR_ACCESS, "PM reg access failure"),
+	AIE_ERROR_EVENT(56U, AIE_ERROR_STREAM, "Stream packet parity error"),
+	AIE_ERROR_EVENT(57U, AIE_ERROR_STREAM, "Control packet error"),
+	AIE_ERROR_EVENT(58U, AIE_ERROR_BUS, "AXI-MM slave error"),
+	AIE_ERROR_EVENT(59U, AIE_ERROR_INSTRUCTION, "Instruction decompression error"),
+	AIE_ERROR_EVENT(60U, AIE_ERROR_ACCESS, "DM address out of range"),
+	AIE_ERROR_EVENT(62U, AIE_ERROR_ECC, "PM ECC error scrub 2bit"),
+	AIE_ERROR_EVENT(64U, AIE_ERROR_ECC, "PM ECC error 2bit"),
+	AIE_ERROR_EVENT(65U, AIE_ERROR_ACCESS, "PM address out of range"),
+	AIE_ERROR_EVENT(66U, AIE_ERROR_ACCESS, "DM access to unavailable"),
+	AIE_ERROR_EVENT(67U, AIE_ERROR_LOCK, "Lock access to unavailable"),
+	AIE_ERROR_EVENT(70U, AIE_ERROR_INSTRUCTION, "Sparsity overflow"),
+	AIE_ERROR_EVENT(71U, AIE_ERROR_STREAM, "Stream switch port parity error"),
+	AIE_ERROR_EVENT(72U, AIE_ERROR_BUS, "Processor bus error"),
+	{ }
 };
 
-/* Don't pack, unless XAIE side changed */
-struct aie_error {
-	__u8			row;
-	__u8			col;
-	__u32			mod_type;
-	__u8			event_id;
+static const struct aie_error_event aie2_mem_tile_error_events[] = {
+	AIE_ERROR_EVENT(130U, AIE_ERROR_ECC, "DM ECC error scrub 2bit"),
+	AIE_ERROR_EVENT(132U, AIE_ERROR_ECC, "DM ECC error 2bit"),
+	AIE_ERROR_EVENT(133U, AIE_ERROR_DMA, "DMA S2MM error"),
+	AIE_ERROR_EVENT(134U, AIE_ERROR_DMA, "DMA MM2S error"),
+	AIE_ERROR_EVENT(135U, AIE_ERROR_STREAM, "Stream switch port parity error"),
+	AIE_ERROR_EVENT(136U, AIE_ERROR_STREAM, "Stream packet parity error"),
+	AIE_ERROR_EVENT(137U, AIE_ERROR_STREAM, "Control packet error"),
+	AIE_ERROR_EVENT(138U, AIE_ERROR_BUS, "AXI-MM slave error"),
+	AIE_ERROR_EVENT(139U, AIE_ERROR_LOCK, "Lock error"),
+	{ }
 };
 
-struct aie_err_info {
-	u32			err_cnt;
-	u32			ret_code;
-	u32			rsvd;
-	struct aie_error	payload[] __counted_by(err_cnt);
+static const struct aie_error_event aie2_shim_tile_error_events[] = {
+	AIE_ERROR_EVENT(64U, AIE_ERROR_BUS, "AXI-MM slave tile error"),
+	AIE_ERROR_EVENT(65U, AIE_ERROR_STREAM, "Control packet error"),
+	AIE_ERROR_EVENT(66U, AIE_ERROR_STREAM, "Stream switch port parity error"),
+	AIE_ERROR_EVENT(67U, AIE_ERROR_BUS, "AXI-MM decode NSU error"),
+	AIE_ERROR_EVENT(68U, AIE_ERROR_BUS, "AXI-MM slave NSU error"),
+	AIE_ERROR_EVENT(69U, AIE_ERROR_BUS, "AXI-MM unsupported traffic"),
+	AIE_ERROR_EVENT(70U, AIE_ERROR_BUS, "AXI-MM unsecure access in secure mode"),
+	AIE_ERROR_EVENT(71U, AIE_ERROR_BUS, "AXI-MM byte strobe error"),
+	AIE_ERROR_EVENT(72U, AIE_ERROR_DMA, "DMA S2MM error"),
+	AIE_ERROR_EVENT(73U, AIE_ERROR_DMA, "DMA MM2S error"),
+	AIE_ERROR_EVENT(74U, AIE_ERROR_LOCK, "Lock error"),
+	{ }
 };
 
-struct aie_event_category {
-	u8			event_id;
-	enum aie_error_category category;
+const struct aie_error_lut_set aie2_error_luts = {
+	.shim		= aie2_shim_tile_error_events,
+	.core		= aie2_core_error_events,
+	.mem_tile	= aie2_mem_tile_error_events,
+	.mem		= aie2_mem_error_events,
 };
 
-#define EVENT_CATEGORY(id, cat) { id, cat }
-static const struct aie_event_category aie_ml_mem_event_cat[] = {
-	EVENT_CATEGORY(88U,  AIE_ERROR_ECC),
-	EVENT_CATEGORY(90U,  AIE_ERROR_ECC),
-	EVENT_CATEGORY(91U,  AIE_ERROR_MEM_PARITY),
-	EVENT_CATEGORY(92U,  AIE_ERROR_MEM_PARITY),
-	EVENT_CATEGORY(93U,  AIE_ERROR_MEM_PARITY),
-	EVENT_CATEGORY(94U,  AIE_ERROR_MEM_PARITY),
-	EVENT_CATEGORY(95U,  AIE_ERROR_MEM_PARITY),
-	EVENT_CATEGORY(96U,  AIE_ERROR_MEM_PARITY),
-	EVENT_CATEGORY(97U,  AIE_ERROR_DMA),
-	EVENT_CATEGORY(98U,  AIE_ERROR_DMA),
-	EVENT_CATEGORY(99U,  AIE_ERROR_DMA),
-	EVENT_CATEGORY(100U, AIE_ERROR_DMA),
-	EVENT_CATEGORY(101U, AIE_ERROR_LOCK),
-};
-
-static const struct aie_event_category aie_ml_core_event_cat[] = {
-	EVENT_CATEGORY(55U, AIE_ERROR_ACCESS),
-	EVENT_CATEGORY(56U, AIE_ERROR_STREAM),
-	EVENT_CATEGORY(57U, AIE_ERROR_STREAM),
-	EVENT_CATEGORY(58U, AIE_ERROR_BUS),
-	EVENT_CATEGORY(59U, AIE_ERROR_INSTRUCTION),
-	EVENT_CATEGORY(60U, AIE_ERROR_ACCESS),
-	EVENT_CATEGORY(62U, AIE_ERROR_ECC),
-	EVENT_CATEGORY(64U, AIE_ERROR_ECC),
-	EVENT_CATEGORY(65U, AIE_ERROR_ACCESS),
-	EVENT_CATEGORY(66U, AIE_ERROR_ACCESS),
-	EVENT_CATEGORY(67U, AIE_ERROR_LOCK),
-	EVENT_CATEGORY(70U, AIE_ERROR_INSTRUCTION),
-	EVENT_CATEGORY(71U, AIE_ERROR_STREAM),
-	EVENT_CATEGORY(72U, AIE_ERROR_BUS),
-};
-
-static const struct aie_event_category aie_ml_mem_tile_event_cat[] = {
-	EVENT_CATEGORY(130U, AIE_ERROR_ECC),
-	EVENT_CATEGORY(132U, AIE_ERROR_ECC),
-	EVENT_CATEGORY(133U, AIE_ERROR_DMA),
-	EVENT_CATEGORY(134U, AIE_ERROR_DMA),
-	EVENT_CATEGORY(135U, AIE_ERROR_STREAM),
-	EVENT_CATEGORY(136U, AIE_ERROR_STREAM),
-	EVENT_CATEGORY(137U, AIE_ERROR_STREAM),
-	EVENT_CATEGORY(138U, AIE_ERROR_BUS),
-	EVENT_CATEGORY(139U, AIE_ERROR_LOCK),
-};
-
-static const struct aie_event_category aie_ml_shim_tile_event_cat[] = {
-	EVENT_CATEGORY(64U, AIE_ERROR_BUS),
-	EVENT_CATEGORY(65U, AIE_ERROR_STREAM),
-	EVENT_CATEGORY(66U, AIE_ERROR_STREAM),
-	EVENT_CATEGORY(67U, AIE_ERROR_BUS),
-	EVENT_CATEGORY(68U, AIE_ERROR_BUS),
-	EVENT_CATEGORY(69U, AIE_ERROR_BUS),
-	EVENT_CATEGORY(70U, AIE_ERROR_BUS),
-	EVENT_CATEGORY(71U, AIE_ERROR_BUS),
-	EVENT_CATEGORY(72U, AIE_ERROR_DMA),
-	EVENT_CATEGORY(73U, AIE_ERROR_DMA),
-	EVENT_CATEGORY(74U, AIE_ERROR_LOCK),
-};
-
-static const enum amdxdna_error_num aie_cat_err_num_map[] = {
-	[AIE_ERROR_SATURATION] = AMDXDNA_ERROR_NUM_AIE_SATURATION,
-	[AIE_ERROR_FP] = AMDXDNA_ERROR_NUM_AIE_FP,
-	[AIE_ERROR_STREAM] = AMDXDNA_ERROR_NUM_AIE_STREAM,
-	[AIE_ERROR_ACCESS] = AMDXDNA_ERROR_NUM_AIE_ACCESS,
-	[AIE_ERROR_BUS] = AMDXDNA_ERROR_NUM_AIE_BUS,
-	[AIE_ERROR_INSTRUCTION] = AMDXDNA_ERROR_NUM_AIE_INSTRUCTION,
-	[AIE_ERROR_ECC] = AMDXDNA_ERROR_NUM_AIE_ECC,
-	[AIE_ERROR_LOCK] = AMDXDNA_ERROR_NUM_AIE_LOCK,
-	[AIE_ERROR_DMA] = AMDXDNA_ERROR_NUM_AIE_DMA,
-	[AIE_ERROR_MEM_PARITY] = AMDXDNA_ERROR_NUM_AIE_MEM_PARITY,
-	[AIE_ERROR_UNKNOWN] = AMDXDNA_ERROR_NUM_UNKNOWN,
-};
-
-static_assert(ARRAY_SIZE(aie_cat_err_num_map) == AIE_ERROR_UNKNOWN + 1);
-
-static const enum amdxdna_error_module aie_err_mod_map[] = {
-	[AIE_MEM_MOD] = AMDXDNA_ERROR_MODULE_AIE_MEMORY,
-	[AIE_CORE_MOD] = AMDXDNA_ERROR_MODULE_AIE_CORE,
-	[AIE_PL_MOD] = AMDXDNA_ERROR_MODULE_AIE_PL,
-	[AIE_UNKNOWN_MOD] = AMDXDNA_ERROR_MODULE_UNKNOWN,
-};
-
-static_assert(ARRAY_SIZE(aie_err_mod_map) == AIE_UNKNOWN_MOD + 1);
-
-static enum aie_error_category
-aie_get_error_category(u8 row, u8 event_id, enum aie_module_type mod_type)
+int aie2_async_event_register(struct aie_device *aie, dma_addr_t addr, u32 size,
+			      void *handle, int (*cb)(void *, void __iomem *, size_t))
 {
-	const struct aie_event_category *lut;
-	int num_entry;
-	int i;
+	struct amdxdna_dev_hdl *ndev = aie->xdna->dev_handle;
 
-	switch (mod_type) {
-	case AIE_PL_MOD:
-		lut = aie_ml_shim_tile_event_cat;
-		num_entry = ARRAY_SIZE(aie_ml_shim_tile_event_cat);
-		break;
-	case AIE_CORE_MOD:
-		lut = aie_ml_core_event_cat;
-		num_entry = ARRAY_SIZE(aie_ml_core_event_cat);
-		break;
-	case AIE_MEM_MOD:
-		if (row == 1) {
-			lut = aie_ml_mem_tile_event_cat;
-			num_entry = ARRAY_SIZE(aie_ml_mem_tile_event_cat);
-		} else {
-			lut = aie_ml_mem_event_cat;
-			num_entry = ARRAY_SIZE(aie_ml_mem_event_cat);
-		}
-		break;
-	default:
-		return AIE_ERROR_UNKNOWN;
-	}
-
-	for (i = 0; i < num_entry; i++) {
-		if (event_id != lut[i].event_id)
-			continue;
-
-		if (lut[i].category > AIE_ERROR_UNKNOWN)
-			return AIE_ERROR_UNKNOWN;
-
-		return lut[i].category;
-	}
-
-	return AIE_ERROR_UNKNOWN;
+	return aie2_register_asyn_event_msg(ndev, addr, size, handle, cb);
 }
 
-static void aie2_update_last_async_error(struct amdxdna_dev_hdl *ndev, void *err_info, u32 num_err)
-{
-	struct aie_error *errs = err_info;
-	enum amdxdna_error_module err_mod;
-	enum aie_error_category aie_err;
-	enum amdxdna_error_num err_num;
-	struct aie_error *last_err;
-
-	last_err = &errs[num_err - 1];
-	if (last_err->mod_type >= AIE_UNKNOWN_MOD) {
-		err_num = aie_cat_err_num_map[AIE_ERROR_UNKNOWN];
-		err_mod = aie_err_mod_map[AIE_UNKNOWN_MOD];
-	} else {
-		aie_err = aie_get_error_category(last_err->row,
-						 last_err->event_id,
-						 last_err->mod_type);
-		err_num = aie_cat_err_num_map[aie_err];
-		err_mod = aie_err_mod_map[last_err->mod_type];
-	}
-
-	ndev->last_async_err.err_code = AMDXDNA_ERROR_ENCODE(err_num, err_mod);
-	ndev->last_async_err.ts_us = ktime_to_us(ktime_get_real());
-	ndev->last_async_err.ex_err_code = AMDXDNA_EXTRA_ERR_ENCODE(last_err->row, last_err->col);
-}
-
-static u32 aie2_error_backtrack(struct amdxdna_dev_hdl *ndev, void *err_info, u32 num_err)
-{
-	struct aie_error *errs = err_info;
-	u32 err_col = 0; /* assume that AIE has less than 32 columns */
-	int i;
-
-	/* Get err column bitmap */
-	for (i = 0; i < num_err; i++) {
-		struct aie_error *err = &errs[i];
-		enum aie_error_category cat;
-
-		cat = aie_get_error_category(err->row, err->event_id, err->mod_type);
-		XDNA_ERR(ndev->aie.xdna, "Row: %d, Col: %d, module %d, event ID %d, category %d",
-			 err->row, err->col, err->mod_type,
-			 err->event_id, cat);
-
-		if (err->col >= 32) {
-			XDNA_WARN(ndev->aie.xdna, "Invalid column number");
-			break;
-		}
-
-		err_col |= (1 << err->col);
-	}
-
-	return err_col;
-}
-
-static int aie2_error_async_cb(void *handle, void __iomem *data, size_t size)
-{
-	struct async_event *e = handle;
-
-	if (data) {
-		e->resp.type = readl(data + offsetof(struct async_event_msg_resp, type));
-		wmb(); /* Update status in the end, so that no lock for here */
-		e->resp.status = readl(data + offsetof(struct async_event_msg_resp, status));
-	}
-	queue_work(e->wq, &e->work);
-	return 0;
-}
-
-static int aie2_error_event_send(struct async_event *e)
-{
-	drm_clflush_virt_range(e->buf, e->size); /* device can access */
-	return aie2_register_asyn_event_msg(e->ndev, e->addr, e->size, e,
-					    aie2_error_async_cb);
-}
-
-static void aie2_error_worker(struct work_struct *err_work)
-{
-	struct aie_err_info *info;
-	struct amdxdna_dev *xdna;
-	struct async_event *e;
-	u32 max_err;
-	u32 err_col;
-
-	e = container_of(err_work, struct async_event, work);
-
-	xdna = e->ndev->aie.xdna;
-
-	if (e->resp.status == MAX_AIE2_STATUS_CODE)
-		return;
-
-	e->resp.status = MAX_AIE2_STATUS_CODE;
-
-	print_hex_dump_debug("AIE error: ", DUMP_PREFIX_OFFSET, 16, 4,
-			     e->buf, 0x100, false);
-
-	info = (struct aie_err_info *)e->buf;
-	XDNA_DBG(xdna, "Error count %d return code %d", info->err_cnt, info->ret_code);
-
-	max_err = (e->size - sizeof(*info)) / sizeof(struct aie_error);
-	if (unlikely(info->err_cnt > max_err)) {
-		WARN_ONCE(1, "Error count too large %d\n", info->err_cnt);
-		return;
-	}
-	err_col = aie2_error_backtrack(e->ndev, info->payload, info->err_cnt);
-	if (!err_col) {
-		XDNA_WARN(xdna, "Did not get error column");
-		return;
-	}
-
-	mutex_lock(&xdna->dev_lock);
-	aie2_update_last_async_error(e->ndev, info->payload, info->err_cnt);
-
-	/* Re-sent this event to firmware */
-	if (aie2_error_event_send(e))
-		XDNA_WARN(xdna, "Unable to register async event");
-	mutex_unlock(&xdna->dev_lock);
-}
-
-void aie2_error_async_events_free(struct amdxdna_dev_hdl *ndev)
-{
-	struct amdxdna_dev *xdna = ndev->aie.xdna;
-	struct async_events *events;
-
-	events = ndev->async_events;
-
-	mutex_unlock(&xdna->dev_lock);
-	destroy_workqueue(events->wq);
-	mutex_lock(&xdna->dev_lock);
-
-	amdxdna_free_msg_buff(events->hdl);
-	kfree(events);
-}
-
-int aie2_error_async_events_alloc(struct amdxdna_dev_hdl *ndev)
-{
-	struct amdxdna_dev *xdna = ndev->aie.xdna;
-	u32 total_col = ndev->total_col;
-	struct async_events *events;
-	int i, ret;
-
-	events = kzalloc_flex(*events, event, total_col);
-	if (!events)
-		return -ENOMEM;
-
-	events->hdl = amdxdna_alloc_msg_buff(xdna, ASYNC_BUF_SIZE * total_col);
-	if (IS_ERR(events->hdl)) {
-		ret = PTR_ERR(events->hdl);
-		goto free_events;
-	}
-	events->event_cnt = total_col;
-
-	events->wq = alloc_ordered_workqueue("async_wq", 0);
-	if (!events->wq) {
-		ret = -ENOMEM;
-		goto free_buf;
-	}
-
-	for (i = 0; i < events->event_cnt; i++) {
-		struct async_event *e = &events->event[i];
-		u32 offset = i * ASYNC_BUF_SIZE;
-
-		e->ndev = ndev;
-		e->wq = events->wq;
-		e->buf = to_cpu_addr(events->hdl, offset);
-		e->addr = to_dma_addr(events->hdl, offset);
-		e->size = ASYNC_BUF_SIZE;
-		e->resp.status = MAX_AIE2_STATUS_CODE;
-		INIT_WORK(&e->work, aie2_error_worker);
-
-		ret = aie2_error_event_send(e);
-		if (ret)
-			goto free_wq;
-	}
-
-	ndev->async_events = events;
-
-	XDNA_DBG(xdna, "Async event count %d, buf total size 0x%x",
-		 events->event_cnt, to_buf_size(events->hdl));
-	return 0;
-
-free_wq:
-	destroy_workqueue(events->wq);
-free_buf:
-	amdxdna_free_msg_buff(events->hdl);
-free_events:
-	kfree(events);
-	return ret;
-}
-
-int aie2_get_array_async_error(struct amdxdna_dev_hdl *ndev, struct amdxdna_drm_get_array *args)
+int aie2_get_array_async_error(struct amdxdna_dev_hdl *ndev,
+			       struct amdxdna_drm_get_array *args)
 {
 	struct amdxdna_dev *xdna = ndev->aie.xdna;
 
 	drm_WARN_ON(&xdna->ddev, !mutex_is_locked(&xdna->dev_lock));
 
-	if (!args->num_element)
-		return -EINVAL;
-
-	args->num_element = 1;
-	args->element_size = min(args->element_size, sizeof(ndev->last_async_err));
-	if (copy_to_user(u64_to_user_ptr(args->buffer),
-			 &ndev->last_async_err, args->element_size))
-		return -EFAULT;
-
-	return 0;
+	return amdxdna_get_array_last_async_error(&ndev->aie, args);
 }

--- a/drivers/accel/amdxdna/aie2_msg_priv.h
+++ b/drivers/accel/amdxdna/aie2_msg_priv.h
@@ -363,7 +363,6 @@ enum async_event_type {
 	MAX_ASYNC_EVENT_TYPE
 };
 
-#define ASYNC_BUF_SIZE SZ_8K
 struct async_event_msg_req {
 	__u64 buf_addr;
 	__u32 buf_size;

--- a/drivers/accel/amdxdna/aie2_pci.c
+++ b/drivers/accel/amdxdna/aie2_pci.c
@@ -327,7 +327,7 @@ static void aie2_hw_stop(struct amdxdna_dev *xdna)
 	ndev->mbox = NULL;
 	aie_psp_stop(ndev->aie.psp_hdl);
 	aie2_smu_fini(ndev);
-	aie2_error_async_events_free(ndev);
+	amdxdna_async_events_free(&ndev->aie);
 	pci_disable_device(pdev);
 
 	ndev->dev_status = AIE2_DEV_INIT;
@@ -427,7 +427,7 @@ static int aie2_hw_start(struct amdxdna_dev *xdna)
 		goto stop_fw;
 	}
 
-	ret = aie2_error_async_events_alloc(ndev);
+	ret = amdxdna_async_events_alloc(&ndev->aie, ndev->total_col);
 	if (ret) {
 		XDNA_ERR(xdna, "Allocate async events failed, ret %d", ret);
 		goto stop_fw;
@@ -440,6 +440,8 @@ static int aie2_hw_start(struct amdxdna_dev *xdna)
 stop_fw:
 	aie2_suspend_fw(ndev);
 	xdna_mailbox_stop_channel(ndev->aie.mgmt_chann);
+	/* Reclaim a partially-armed async pool now that the channel is stopped. */
+	amdxdna_async_events_free(&ndev->aie);
 stop_psp:
 	aie_psp_stop(ndev->aie.psp_hdl);
 fini_smu:
@@ -1248,4 +1250,5 @@ const struct amdxdna_dev_ops aie2_ops = {
 	.get_array = aie2_get_array,
 	.get_dev_revision = aie2_get_dev_rev,
 	.hwctx_heap_expand = aie2_hwctx_heap_expand,
+	.register_async_event = aie2_async_event_register,
 };

--- a/drivers/accel/amdxdna/aie2_pci.h
+++ b/drivers/accel/amdxdna/aie2_pci.h
@@ -15,6 +15,7 @@
 
 #include "aie.h"
 #include "aie2_msg_priv.h"
+#include "amdxdna_error.h"
 #include "amdxdna_mailbox.h"
 
 /* Firmware determines device memory base address and size */
@@ -148,12 +149,10 @@ struct amdxdna_dev_hdl {
 
 	/* Mailbox and the management channel */
 	struct mailbox			*mbox;
-	struct async_events		*async_events;
 
 	enum aie2_dev_status		dev_status;
 	u32				hwctx_num;
 
-	struct amdxdna_async_error	last_async_err;
 	enum aie2_tdr_status		tdr_status;
 	struct aie2_tdr			tdr; /* TDR for device recovery */
 };
@@ -221,9 +220,9 @@ int aie2_pm_set_mode(struct amdxdna_dev_hdl *ndev, enum amdxdna_power_mode_type 
 int aie2_pm_set_dpm(struct amdxdna_dev_hdl *ndev, u32 dpm_level);
 
 /* aie2_error.c */
-int aie2_error_async_events_alloc(struct amdxdna_dev_hdl *ndev);
-void aie2_error_async_events_free(struct amdxdna_dev_hdl *ndev);
-int aie2_error_async_msg_thread(void *data);
+extern const struct aie_error_lut_set aie2_error_luts;
+int aie2_async_event_register(struct aie_device *aie, dma_addr_t addr, u32 size,
+			      void *handle, int (*cb)(void *, void __iomem *, size_t));
 int aie2_get_array_async_error(struct amdxdna_dev_hdl *ndev,
 			       struct amdxdna_drm_get_array *args);
 

--- a/drivers/accel/amdxdna/aie4_ctx.c
+++ b/drivers/accel/amdxdna/aie4_ctx.c
@@ -9,6 +9,7 @@
 #include <drm/drm_gem_shmem_helper.h>
 #include <drm/drm_print.h>
 #include <drm/gpu_scheduler.h>
+#include <linux/minmax.h>
 #include <linux/overflow.h>
 #include <linux/sched/mm.h>
 #include <linux/types.h>
@@ -299,6 +300,88 @@ void aie4_hwctx_destroy(struct amdxdna_hwctx *hwctx)
 	 */
 	if (priv->kernel_submit)
 		cancel_work_sync(&priv->job_work);
+}
+
+/*
+ * Fill @cmd_abo's data region with the cached aie4 context health report as a
+ * struct amdxdna_ctx_health_data (version 1) so user space can read it after
+ * the command is marked timed out. If no report was cached for this context,
+ * the per-generation fields are zeroed. The cached report is consumed (cleared)
+ * on use. Caller must hold io_lock, which serializes this multi-word read
+ * against the async error worker overwriting the cache concurrently.
+ */
+static void aie4_fill_health_data_locked(struct amdxdna_gem_obj *cmd_abo,
+					 struct amdxdna_hwctx *hwctx)
+{
+	const size_t min_size = offsetof(struct amdxdna_ctx_health_data, aie4.uc_info);
+	struct amdxdna_hwctx_priv *priv = hwctx->priv;
+	struct amdxdna_dev *xdna = hwctx->client->xdna;
+	struct aie4_msg_app_health_report *report;
+	struct amdxdna_ctx_health_data *health;
+	u32 data_total;
+
+	health = amdxdna_cmd_get_data(cmd_abo, &data_total);
+	if (!health || data_total < min_size) {
+		XDNA_WARN(xdna, "Health data buffer too small: %u min %zu",
+			  data_total, min_size);
+		return;
+	}
+
+	health->version = AMDXDNA_CTX_HEALTH_DATA_V1;
+	health->npu_gen = AMDXDNA_NPU_GEN_AIE4;
+	health->aie4.ctx_state = 0;
+	health->aie4.num_uc = 0;
+	health->aie4.ctx_error_type = 0;
+	/*
+	 * Zero the uc_info tail up front so an empty (no cached report) or
+	 * partial (num_uc < capacity) result never exposes stale bytes from the
+	 * caller's command BO. Bounded by both the BO's available room and the
+	 * field size.
+	 */
+	memset(health->aie4.uc_info, 0,
+	       min_t(u32, data_total - min_size, sizeof(health->aie4.uc_info)));
+
+	if (!priv->cached_ctx_error_valid)
+		return;
+
+	report = &priv->cached_ctx_error.app_health_report;
+	health->aie4.ctx_state = FIELD_GET(AIE4_APP_HEALTH_CTX_STATUS, report->ctx_num_uc);
+	health->aie4.ctx_error_type = priv->cached_ctx_error.error_type;
+
+	if (data_total > min_size) {
+		u32 max_uc = (data_total - min_size) / sizeof(struct uc_health_info);
+		u32 num_uc = FIELD_GET(AIE4_APP_HEALTH_NUM_UC, report->ctx_num_uc);
+
+		/*
+		 * Bound by the fixed firmware source array (report->uc_info has
+		 * AIE4_MPNPUFW_MAX_UC_COUNT entries) as well as the user buffer
+		 * capacity, so a firmware-reported count cannot drive an
+		 * out-of-bounds read of the source or write of the destination.
+		 */
+		num_uc = min_t(u32, num_uc, AIE4_MPNPUFW_MAX_UC_COUNT);
+		num_uc = min_t(u32, num_uc, max_uc);
+		if (num_uc)
+			memcpy(health->aie4.uc_info, report->uc_info,
+			       num_uc * sizeof(struct uc_health_info));
+		health->aie4.num_uc = num_uc;
+	}
+
+	/* Consumed; later reads report zeros until a new error is cached. */
+	priv->cached_ctx_error_valid = false;
+}
+
+/*
+ * Fill a command's data region with this context's cached health report. Helper
+ * for the kernel-mode timeout/recovery (TDR) path to call on a failing command;
+ * the TDR detection and recovery mechanism itself is not implemented here.
+ */
+void aie4_fill_health_data(struct amdxdna_gem_obj *cmd_abo, struct amdxdna_hwctx *hwctx)
+{
+	struct amdxdna_hwctx_priv *priv = hwctx->priv;
+
+	mutex_lock(&priv->io_lock);
+	aie4_fill_health_data_locked(cmd_abo, hwctx);
+	mutex_unlock(&priv->io_lock);
 }
 
 static void aie4_hwctx_umq_fini(struct amdxdna_hwctx *hwctx)

--- a/drivers/accel/amdxdna/aie4_ctx.c
+++ b/drivers/accel/amdxdna/aie4_ctx.c
@@ -306,9 +306,12 @@ void aie4_hwctx_destroy(struct amdxdna_hwctx *hwctx)
  * Fill @cmd_abo's data region with the cached aie4 context health report as a
  * struct amdxdna_ctx_health_data (version 1) so user space can read it after
  * the command is marked timed out. If no report was cached for this context,
- * the per-generation fields are zeroed. The cached report is consumed (cleared)
- * on use. Caller must hold io_lock, which serializes this multi-word read
- * against the async error worker overwriting the cache concurrently.
+ * the per-generation fields are zeroed. The cached report is not consumed here:
+ * every job completed by a single context reset must observe the same report,
+ * so the reset cleanup (aie4_hwctx_cleanup_running_jobs) clears it exactly once
+ * after all parked jobs have been served. Caller must hold io_lock, which
+ * serializes this multi-word read against the async error worker overwriting
+ * the cache concurrently.
  */
 static void aie4_fill_health_data_locked(struct amdxdna_gem_obj *cmd_abo,
 					 struct amdxdna_hwctx *hwctx)
@@ -365,9 +368,6 @@ static void aie4_fill_health_data_locked(struct amdxdna_gem_obj *cmd_abo,
 			       num_uc * sizeof(struct uc_health_info));
 		health->aie4.num_uc = num_uc;
 	}
-
-	/* Consumed; later reads report zeros until a new error is cached. */
-	priv->cached_ctx_error_valid = false;
 }
 
 /*
@@ -564,7 +564,7 @@ void aie4_hwctx_fini(struct amdxdna_hwctx *hwctx)
 	aie4_hwctx_destroy(hwctx);
 	if (priv->kernel_submit) {
 		/* Drain/abort any in-flight jobs before tearing down the queue. */
-		aie4_hwctx_cleanup_running_jobs(hwctx);
+		aie4_hwctx_cleanup_running_jobs(hwctx, false);
 		destroy_workqueue(priv->job_work_q);
 	}
 	aie4_hwctx_umq_fini(hwctx);
@@ -1005,6 +1005,71 @@ static void job_abort(struct amdxdna_sched_job *job)
 	job_done(job);
 }
 
+/*
+ * For a timed-out command chain, identify the failing sub-command from the
+ * cached health report's runlist index, record it in the chain's error_index,
+ * and fill that sub-command's data region with the health report. The runlist
+ * index and the report body are read under a single io_lock hold so they cannot
+ * be taken from two different cached reports.
+ */
+static void aie4_fill_chain_health_data(struct amdxdna_hwctx *hwctx,
+					struct amdxdna_gem_obj *cmd_abo)
+{
+	struct amdxdna_hwctx_priv *priv = hwctx->priv;
+	struct amdxdna_dev *xdna = hwctx->client->xdna;
+	struct amdxdna_cmd_chain *payload;
+	struct amdxdna_gem_obj *sub_abo;
+	u32 payload_len, ccnt, i = 0;
+
+	payload = amdxdna_cmd_get_payload(cmd_abo, &payload_len);
+	if (!payload) {
+		XDNA_ERR(xdna, "No chain payload for timed-out command");
+		return;
+	}
+	ccnt = payload->command_count;
+	if (!ccnt || payload_len < struct_size(payload, data, ccnt))
+		return;
+
+	mutex_lock(&priv->io_lock);
+	if (priv->cached_ctx_error_valid)
+		i = priv->cached_ctx_error.app_health_report.runlist_read_idx;
+	if (i >= ccnt)
+		i = 0;
+	payload->error_index = i;
+	sub_abo = amdxdna_gem_get_obj(hwctx->client, (u32)payload->data[i], AMDXDNA_BO_SHARE);
+	if (sub_abo)
+		aie4_fill_health_data_locked(sub_abo, hwctx);
+	mutex_unlock(&priv->io_lock);
+
+	if (sub_abo)
+		amdxdna_gem_put_obj(sub_abo);
+	else
+		XDNA_ERR(xdna, "Failed to find sub cmd BO %u", (u32)payload->data[i]);
+}
+
+/*
+ * Complete an in-flight job that could not finish because the context hit a
+ * critical firmware error and is being reset. Attach the cached health report
+ * (into the failing sub-command for a chain), mark the command TIMEOUT, advance
+ * read_index so waiters observe completion, and signal the fence. Runs with the
+ * context DISCONNECTED (firmware quiesced by aie4_hwctx_destroy).
+ */
+static void job_timeout(struct amdxdna_sched_job *job)
+{
+	struct amdxdna_hwctx *hwctx = job->hwctx;
+
+	XDNA_ERR(hwctx->client->xdna, "timing out %s job %lld", hwctx->name, job->seq);
+
+	if (amdxdna_cmd_get_op(job->cmd_bo) == ERT_CMD_CHAIN)
+		aie4_fill_chain_health_data(hwctx, job->cmd_bo);
+	else
+		aie4_fill_health_data(job->cmd_bo, hwctx);
+
+	amdxdna_cmd_set_state(job->cmd_bo, ERT_CMD_STATE_TIMEOUT);
+	update_read_index(hwctx, job->seq + 1);
+	job_done(job);
+}
+
 static void job_worker(struct work_struct *work)
 {
 	struct amdxdna_hwctx_priv *priv =
@@ -1040,19 +1105,43 @@ static void job_worker(struct work_struct *work)
 	}
 }
 
-void aie4_hwctx_cleanup_running_jobs(struct amdxdna_hwctx *hwctx)
+/*
+ * Reap the in-flight jobs parked by the worker on disconnect. On a plain
+ * teardown (@errored false) they are aborted. On the critical-error reset path
+ * (@errored true) they are completed as TIMEOUT with the cached firmware health
+ * report attached, so waiters observe the timeout (and its per-command health
+ * data) instead of a bare abort.
+ */
+void aie4_hwctx_cleanup_running_jobs(struct amdxdna_hwctx *hwctx, bool errored)
 {
 	struct amdxdna_hwctx_priv *priv = hwctx->priv;
 	struct amdxdna_sched_job *job;
 
 	/*
 	 * The worker parks (preserves) in-flight jobs on disconnect instead of
-	 * reaping them, so on teardown/reset stop it and abort the preserved jobs
-	 * here.  cancel_work_sync() ensures the worker is not touching the list.
+	 * reaping them, so on teardown/reset stop it and complete the preserved
+	 * jobs here.  cancel_work_sync() ensures the worker is not touching the
+	 * list.
 	 */
 	cancel_work_sync(&priv->job_work);
-	while ((job = next_running_job(hwctx)))
-		job_abort(job);
+	while ((job = next_running_job(hwctx))) {
+		if (errored)
+			job_timeout(job);
+		else
+			job_abort(job);
+	}
+
+	if (errored) {
+		/*
+		 * Every job above was filled from the same cached health report;
+		 * consume it exactly once now that all parked jobs for this reset
+		 * have been served, so a later unrelated reset cannot observe a
+		 * stale report.
+		 */
+		mutex_lock(&priv->io_lock);
+		priv->cached_ctx_error_valid = false;
+		mutex_unlock(&priv->io_lock);
+	}
 }
 
 /*

--- a/drivers/accel/amdxdna/aie4_error.c
+++ b/drivers/accel/amdxdna/aie4_error.c
@@ -104,9 +104,11 @@ static void aie4_async_ctx_error_cache(struct aie_device *aie,
 	struct aie4_msg_app_health_report *health = &ctx_err->app_health_report;
 	struct amdxdna_async_error *record = &aie->last_async_err;
 	struct amdxdna_dev *xdna = aie->xdna;
+	struct amdxdna_hwctx *hwctx;
 	struct uc_health_info *uc;
 	u32 ctx_status;
 	u32 num_uc;
+	int idx;
 	int i;
 
 	ctx_status = FIELD_GET(AIE4_APP_HEALTH_CTX_STATUS, health->ctx_num_uc);
@@ -162,6 +164,27 @@ static void aie4_async_ctx_error_cache(struct aie_device *aie,
 	 * encodings are disambiguated by the KDS category in err_code.
 	 */
 	record->ex_err_code = AMDXDNA_EXTRA_ERR_CTX_ENCODE(ctx_status, ctx_err->ctx_id);
+
+	/*
+	 * Cache the full report on the owning kernel-mode context so the
+	 * timeout/recovery path can attach it to the failing command. Only
+	 * kernel-mode contexts consume it and have an initialized io_lock, which
+	 * serializes this multi-word write against that reader. The device-level
+	 * last_async_err above stays unconditional so GET_ARRAY works for all
+	 * contexts.
+	 */
+	hwctx = hw_ctx_id2hwctx(aie, ctx_err->ctx_id, &idx);
+	if (hwctx) {
+		struct amdxdna_hwctx_priv *priv = hwctx->priv;
+
+		if (priv->kernel_submit) {
+			mutex_lock(&priv->io_lock);
+			memcpy(&priv->cached_ctx_error, ctx_err, sizeof(*ctx_err));
+			priv->cached_ctx_error_valid = true;
+			mutex_unlock(&priv->io_lock);
+		}
+		srcu_read_unlock(&hwctx->client->hwctx_srcu, idx);
+	}
 	mutex_unlock(&xdna->dev_lock);
 }
 

--- a/drivers/accel/amdxdna/aie4_error.c
+++ b/drivers/accel/amdxdna/aie4_error.c
@@ -1,0 +1,286 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Copyright (C) 2023-2026, Advanced Micro Devices, Inc.
+ */
+
+#include <drm/drm_device.h>
+#include <drm/drm_print.h>
+#include <linux/bitfield.h>
+#include <linux/bits.h>
+#include <linux/kernel.h>
+#include <linux/ktime.h>
+#include <linux/minmax.h>
+#include <linux/mutex.h>
+#include <linux/srcu.h>
+
+#include "aie.h"
+#include "aie4_msg_priv.h"
+#include "aie4_pci.h"
+#include "amdxdna_ctx.h"
+#include "amdxdna_error.h"
+#include "amdxdna_pci_drv.h"
+
+/*
+ * The async event scaffolding, GET_ARRAY query and the generic category /
+ * module to driver-error mapping are shared with aie2 and live in
+ * amdxdna_error.c. This file adds the aie4 specific pieces: the mailbox register
+ * call, the MAX status code sentinel, the aie4 (AIE4/MDS generation) event_id to
+ * category tables, and the aie4 only context-error handling (app health report
+ * logging plus context reset).
+ */
+
+static enum amdxdna_error_num aie4_ctx_error_num(u32 error_type)
+{
+	switch (error_type) {
+	case AIE4_ASYNC_EVENT_CTX_ERR_HWSCH_FAILURE:
+	case AIE4_ASYNC_EVENT_CTX_ERR_STOP_FAILURE:
+		return AMDXDNA_ERROR_NUM_KDS_CU;
+	case AIE4_ASYNC_EVENT_CTX_ERR_AIE_FAILURE:
+	case AIE4_ASYNC_EVENT_CTX_ERR_PREEMPTION_TIMEOUT:
+	case AIE4_ASYNC_EVENT_CTX_ERR_NEW_PROCESS_FAILURE:
+	case AIE4_ASYNC_EVENT_CTX_ERR_UC_CRITICAL_ERROR:
+	case AIE4_ASYNC_EVENT_CTX_ERR_UC_COMPLETION_TIMEOUT:
+		return AMDXDNA_ERROR_NUM_KDS_EXEC;
+	default:
+		return AMDXDNA_ERROR_NUM_UNKNOWN;
+	}
+}
+
+static struct amdxdna_hwctx *hw_ctx_id2hwctx(struct aie_device *aie, u32 hw_ctx_id,
+					     int *srcu_idx)
+{
+	struct amdxdna_dev *xdna = aie->xdna;
+	struct amdxdna_client *client;
+	struct amdxdna_hwctx *hwctx;
+	unsigned long hwctx_idx;
+	int idx;
+
+	drm_WARN_ON(&xdna->ddev, !mutex_is_locked(&xdna->dev_lock));
+	amdxdna_for_each_client(xdna, client) {
+		idx = srcu_read_lock(&client->hwctx_srcu);
+		amdxdna_for_each_hwctx(client, hwctx_idx, hwctx) {
+			if (hwctx->priv && hwctx->priv->hw_ctx_id == hw_ctx_id) {
+				/* Released by the caller. */
+				*srcu_idx = idx;
+				return hwctx;
+			}
+		}
+		srcu_read_unlock(&client->hwctx_srcu, idx);
+	}
+	XDNA_WARN(xdna, "Could not find context for hw_ctx_id=%u", hw_ctx_id);
+	return NULL;
+}
+
+/*
+ * When a critical context error occurs, find the matching context and reset it
+ * by destroying then recreating it.
+ */
+static void aie4_ctx_reset(struct aie_device *aie, u32 hw_ctx_id)
+{
+	struct amdxdna_dev *xdna = aie->xdna;
+	struct amdxdna_hwctx *hwctx;
+	int ret, idx;
+
+	mutex_lock(&xdna->dev_lock);
+
+	hwctx = hw_ctx_id2hwctx(aie, hw_ctx_id, &idx);
+	if (hwctx) {
+		/* Reset the context by destroy then recreate it. */
+		aie4_hwctx_destroy(hwctx);
+		ret = aie4_hwctx_create(hwctx);
+		if (ret)
+			XDNA_ERR(xdna, "Reset hw_ctx_id=%u ctx failed, ret %d",
+				 hw_ctx_id, ret);
+		srcu_read_unlock(&hwctx->client->hwctx_srcu, idx);
+	}
+
+	mutex_unlock(&xdna->dev_lock);
+}
+
+static void aie4_async_ctx_error_cache(struct aie_device *aie,
+				       struct aie4_async_ctx_error *ctx_err)
+{
+	enum amdxdna_error_num err_num = aie4_ctx_error_num(ctx_err->error_type);
+	struct aie4_msg_app_health_report *health = &ctx_err->app_health_report;
+	struct amdxdna_async_error *record = &aie->last_async_err;
+	struct amdxdna_dev *xdna = aie->xdna;
+	struct uc_health_info *uc;
+	u32 ctx_status;
+	u32 num_uc;
+	int i;
+
+	ctx_status = FIELD_GET(AIE4_APP_HEALTH_CTX_STATUS, health->ctx_num_uc);
+	num_uc = FIELD_GET(AIE4_APP_HEALTH_NUM_UC, health->ctx_num_uc);
+
+	/* Log the health report information to aid debugging. */
+	XDNA_ERR(xdna, "Context health report:");
+	XDNA_ERR(xdna, "\tVersion: %u.%u",
+		 (u32)FIELD_GET(AIE4_APP_HEALTH_MAJOR_VER, health->version),
+		 (u32)FIELD_GET(AIE4_APP_HEALTH_MINOR_VER, health->version));
+	XDNA_ERR(xdna, "\tContext status: %u", ctx_status);
+	XDNA_ERR(xdna, "\tActive uC count: %u", num_uc);
+	XDNA_ERR(xdna, "\tRunlist read index: %u", health->runlist_read_idx);
+
+	for (i = 0; i < min_t(u32, num_uc, AIE4_MPNPUFW_MAX_UC_COUNT); i++) {
+		uc = &health->uc_info[i];
+		XDNA_ERR(xdna, "\tuC[%u]: idx: %u fw_state: %u page: %u offset: 0x%x",
+			 i, uc->uc_idx, uc->fw_state, uc->page_idx, uc->offset);
+		/* Parse idle_status bits */
+		if (uc->uc_idle_status) {
+			XDNA_ERR(xdna, "\t\tIdle status: 0x%x %s%s%s",
+				 uc->uc_idle_status,
+				 (uc->uc_idle_status & BIT(0)) ? "HSA_queue_not_empty " : "",
+				 (uc->uc_idle_status & BIT(1)) ? "preempt_done " : "",
+				 (uc->uc_idle_status & BIT(2)) ? "CERT_idle" : "");
+		}
+		/* Parse misc_status bits */
+		if (uc->misc_status) {
+			XDNA_ERR(xdna, "\t\tMisc status: 0x%x %s%s",
+				 uc->misc_status,
+				 (uc->misc_status & BIT(0)) ? "FW_EXCEPTION " : "",
+				 (uc->misc_status & BIT(1)) ? "CTRL_CODE_HANG" : "");
+		}
+		/* Exception details */
+		if (uc->misc_status & BIT(0)) {
+			XDNA_ERR(xdna, "\t\tException: PC: 0x%x EAR: 0x%x ESR: 0x%x",
+				 uc->uc_pc, uc->uc_ear, uc->uc_esr);
+			/*
+			 * PC  = Program Counter at crash (instruction address)
+			 * EAR = Exception Address Register (faulting memory address)
+			 * ESR = Exception Status Register (arch-specific exception info)
+			 */
+		}
+	}
+
+	mutex_lock(&xdna->dev_lock);
+	record->err_code = AMDXDNA_ERROR_ENCODE(err_num, AMDXDNA_ERROR_MODULE_AIE_CORE);
+	record->ts_us = ktime_to_us(ktime_get_real());
+	/*
+	 * Reuse the __u64 ex_err_code field with a context-error encoding
+	 * distinct from the tile-error row/col encoding: high 32 bits are the
+	 * firmware context status, low 32 bits are the context id. The two
+	 * encodings are disambiguated by the KDS category in err_code.
+	 */
+	record->ex_err_code = AMDXDNA_EXTRA_ERR_CTX_ENCODE(ctx_status, ctx_err->ctx_id);
+	mutex_unlock(&xdna->dev_lock);
+}
+
+/*
+ * Dispatch on the async event type read from the mailbox response. Returns true
+ * when the event was consumed here (the shared AIE tile decode is then skipped),
+ * false to let the caller run the shared tile decode.
+ */
+bool aie4_handle_dev_event(struct aie_device *aie, u32 type, void *vaddr)
+{
+	struct amdxdna_dev *xdna = aie->xdna;
+	struct aie4_async_ctx_error *ctx_err;
+
+	switch (type) {
+	case AIE4_ASYNC_EVENT_TYPE_AIE_ERROR:
+		/* Let the caller run the shared AIE tile error decode. */
+		return false;
+	case AIE4_ASYNC_EVENT_TYPE_EXCEPTION:
+		/* Type-only notification (no payload defined by the firmware). */
+		XDNA_ERR(xdna, "Firmware reported a fatal exception event");
+		return true;
+	case AIE4_ASYNC_EVENT_TYPE_CTX_ERROR:
+		ctx_err = vaddr;
+		XDNA_DBG(xdna, "Context error: ctx_id: %u error_type: %u",
+			 ctx_err->ctx_id, ctx_err->error_type);
+		/* Cache the error/health first, then recover the context. */
+		aie4_async_ctx_error_cache(aie, ctx_err);
+		aie4_ctx_reset(aie, ctx_err->ctx_id);
+		return true;
+	case AIE4_ASYNC_EVENT_TYPE_PWR_ERROR:
+		/*
+		 * PWR_ERROR is a type-only notification (no payload) sent right
+		 * before the firmware halts, so there is nothing to cache.
+		 */
+		XDNA_ERR(xdna, "Firmware reported a power error, device is halting");
+		return true;
+	default:
+		XDNA_WARN(xdna, "Unhandled/unknown async event type %u, skipping", type);
+		return true;
+	}
+}
+
+/* aie4 core and mem module error events (combined table). */
+static const struct aie_error_event aie4_core_mem_error_events[] = {
+	AIE_ERROR_EVENT(95U,  AIE_ERROR_STREAM, "Control packet error"),
+	AIE_ERROR_EVENT(96U,  AIE_ERROR_BUS, "AXI-MM slave error"),
+	AIE_ERROR_EVENT(97U,  AIE_ERROR_ACCESS, "Stream read collision"),
+	AIE_ERROR_EVENT(98U,  AIE_ERROR_ACCESS, "DM address out of range"),
+	AIE_ERROR_EVENT(100U, AIE_ERROR_ECC, "PM ECC error scrub 2bit"),
+	AIE_ERROR_EVENT(102U, AIE_ERROR_ECC, "PM ECC error 2bit"),
+	AIE_ERROR_EVENT(103U, AIE_ERROR_ACCESS, "PM address out of range"),
+	AIE_ERROR_EVENT(104U, AIE_ERROR_ACCESS, "DM access to unavailable"),
+	AIE_ERROR_EVENT(105U, AIE_ERROR_LOCK, "Lock access to unavailable"),
+	AIE_ERROR_EVENT(108U, AIE_ERROR_INSTRUCTION, "Data error"),
+	AIE_ERROR_EVENT(109U, AIE_ERROR_STREAM, "Stream switch port parity error"),
+	AIE_ERROR_EVENT(110U, AIE_ERROR_BUS, "Processor bus error"),
+	AIE_ERROR_EVENT(112U, AIE_ERROR_ECC, "DM ECC error scrub 2bit"),
+	AIE_ERROR_EVENT(114U, AIE_ERROR_ECC, "DM ECC error 2bit"),
+	AIE_ERROR_EVENT(115U, AIE_ERROR_MEM_PARITY, "DM parity error"),
+	AIE_ERROR_EVENT(116U, AIE_ERROR_DMA, "DMA error"),
+	{ }
+};
+
+/* aie4 shim (PL) module error events. */
+static const struct aie_error_event aie4_shim_tile_error_events[] = {
+	AIE_ERROR_EVENT(153U, AIE_ERROR_BUS, "AXI-MM slave tile error"),
+	AIE_ERROR_EVENT(154U, AIE_ERROR_STREAM, "Control packet error"),
+	AIE_ERROR_EVENT(155U, AIE_ERROR_STREAM, "Stream switch port parity error"),
+	AIE_ERROR_EVENT(156U, AIE_ERROR_BUS, "NSU error"),
+	AIE_ERROR_EVENT(157U, AIE_ERROR_DMA, "DMA error"),
+	AIE_ERROR_EVENT(158U, AIE_ERROR_LOCK, "Lock error"),
+	AIE_ERROR_EVENT(160U, AIE_ERROR_DMA, "DMA HW error"),
+	AIE_ERROR_EVENT(161U, AIE_ERROR_DMA, "uC module A error"),
+	AIE_ERROR_EVENT(162U, AIE_ERROR_DMA, "uC module B error"),
+	AIE_ERROR_EVENT(163U, AIE_ERROR_BUS, "uC module A AXI-MM error"),
+	AIE_ERROR_EVENT(164U, AIE_ERROR_BUS, "uC module B AXI-MM error"),
+	AIE_ERROR_EVENT(167U, AIE_ERROR_ECC, "uC module A ECC error 2bit"),
+	AIE_ERROR_EVENT(168U, AIE_ERROR_ECC, "uC module B ECC error 2bit"),
+	{ }
+};
+
+/* aie4 mem tile module error events. */
+static const struct aie_error_event aie4_mem_tile_error_events[] = {
+	AIE_ERROR_EVENT(164U, AIE_ERROR_ECC, "DM ECC error scrub 2bit"),
+	AIE_ERROR_EVENT(166U, AIE_ERROR_ECC, "DM ECC error 2bit"),
+	AIE_ERROR_EVENT(167U, AIE_ERROR_DMA, "DMA S2MM error"),
+	AIE_ERROR_EVENT(168U, AIE_ERROR_DMA, "DMA MM2S error"),
+	AIE_ERROR_EVENT(169U, AIE_ERROR_STREAM, "Stream switch port parity error"),
+	AIE_ERROR_EVENT(170U, AIE_ERROR_STREAM, "Control packet error"),
+	AIE_ERROR_EVENT(171U, AIE_ERROR_BUS, "AXI-MM slave error"),
+	AIE_ERROR_EVENT(172U, AIE_ERROR_LOCK, "Lock error"),
+	{ }
+};
+
+/*
+ * core and mem both point at the combined table because AIE4 merges the
+ * core-tile core and mem module error broadcast switch.
+ */
+const struct aie_error_lut_set aie4_error_luts = {
+	.shim		= aie4_shim_tile_error_events,
+	.core		= aie4_core_mem_error_events,
+	.mem_tile	= aie4_mem_tile_error_events,
+	.mem		= aie4_core_mem_error_events,
+};
+
+int aie4_async_event_register(struct aie_device *aie, dma_addr_t addr, u32 size,
+			      void *handle, int (*cb)(void *, void __iomem *, size_t))
+{
+	struct amdxdna_dev_hdl *ndev = aie->xdna->dev_handle;
+
+	return aie4_register_asyn_event_msg(ndev, addr, size, handle, cb);
+}
+
+int aie4_get_array_async_error(struct amdxdna_dev_hdl *ndev,
+			       struct amdxdna_drm_get_array *args)
+{
+	struct amdxdna_dev *xdna = ndev->aie.xdna;
+
+	drm_WARN_ON(&xdna->ddev, !mutex_is_locked(&xdna->dev_lock));
+
+	return amdxdna_get_array_last_async_error(&ndev->aie, args);
+}

--- a/drivers/accel/amdxdna/aie4_error.c
+++ b/drivers/accel/amdxdna/aie4_error.c
@@ -85,8 +85,18 @@ static void aie4_ctx_reset(struct aie_device *aie, u32 hw_ctx_id)
 
 	hwctx = hw_ctx_id2hwctx(aie, hw_ctx_id, &idx);
 	if (hwctx) {
-		/* Reset the context by destroy then recreate it. */
+		/*
+		 * Reset the context by destroy then recreate it. Destroy marks the
+		 * context DISCONNECTED; complete any parked in-flight jobs (as timed
+		 * out) before recreating so their fences are signaled and the read
+		 * index advances, releasing waiters in aie4_cmd_wait() with an
+		 * error. Otherwise the recreate flips the context back to CONNECTED
+		 * and the waiter can never observe completion, hanging the
+		 * submitter.
+		 */
 		aie4_hwctx_destroy(hwctx);
+		if (hwctx->priv->kernel_submit)
+			aie4_hwctx_cleanup_running_jobs(hwctx, true);
 		ret = aie4_hwctx_create(hwctx);
 		if (ret)
 			XDNA_ERR(xdna, "Reset hw_ctx_id=%u ctx failed, ret %d",

--- a/drivers/accel/amdxdna/aie4_message.c
+++ b/drivers/accel/amdxdna/aie4_message.c
@@ -238,6 +238,27 @@ int aie4_configure_hw_context_cert_log(struct amdxdna_dev_hdl *ndev,
 	return ret;
 }
 
+int aie4_register_asyn_event_msg(struct amdxdna_dev_hdl *ndev, dma_addr_t addr, u32 size,
+				 void *handle, int (*cb)(void *, void __iomem *, size_t))
+{
+	struct aie4_msg_async_event_config_req req = { 0 };
+	struct xdna_mailbox_msg msg = {
+		.send_data = (u8 *)&req,
+		.send_size = sizeof(req),
+		.handle = handle,
+		.opcode = AIE4_MSG_OP_ASYNC_EVENT_MSG,
+		.notify_cb = cb,
+	};
+
+	req.buff_addr = addr;
+	req.buff_size = size;
+	/* Management channel buffer in the default domain: no PASID. */
+	req.pasid = 0;
+
+	XDNA_DBG(ndev->aie.xdna, "Register addr 0x%llx size 0x%x", addr, size);
+	return xdna_mailbox_send_msg(ndev->aie.mgmt_chann, &msg, TX_TIMEOUT);
+}
+
 int aie4_get_aie_coredump(struct amdxdna_hwctx *hwctx,
 			  struct amdxdna_msg_buf_hdl *list_hdl,
 			  u32 num_bufs)

--- a/drivers/accel/amdxdna/aie4_msg_priv.h
+++ b/drivers/accel/amdxdna/aie4_msg_priv.h
@@ -14,6 +14,7 @@ enum aie4_msg_opcode {
 	/* Classic/PF/VF common */
 	AIE4_MSG_OP_IDENTIFY                         = 0x10002,
 	AIE4_MSG_OP_SUSPEND                          = 0x10003,
+	AIE4_MSG_OP_ASYNC_EVENT_MSG                  = 0x10004,
 	AIE4_MSG_OP_GET_TELEMETRY                    = 0x10006,
 	AIE4_MSG_OP_SET_RUNTIME_CONFIG               = 0x10007,
 	AIE4_MSG_OP_QUERY_CERT_FIRMWARE_VERSION      = 0x1000F,
@@ -349,5 +350,115 @@ struct aie4_msg_calibrate_clock_req {
 struct aie4_msg_calibrate_clock_resp {
 	enum aie4_msg_status status;
 } __packed;
+
+/*
+ * Asynchronous error reporting definitions.
+ *
+ * These mirror the documented external mailbox API (see the mpnpu-api
+ * npu_msg_priv.h npu_async_* and npu_msg_app_health_report definitions). They
+ * must stay in sync with that header; do not include npu_msg_priv.h directly.
+ */
+
+/* Maximum number of uCs reported in an app health report. */
+#define AIE4_MPNPUFW_MAX_UC_COUNT	6
+
+/* AIE4_MSG_OP_ASYNC_EVENT_MSG: register one async event report buffer. */
+struct aie4_msg_async_event_config_req {
+	__u64 buff_addr;
+	__u32 pasid;
+	__u32 buff_size;
+} __packed;
+
+/*
+ * Async event report header written by firmware into the mailbox response.
+ * @status: enum aie4_msg_status.
+ * @type: enum aie4_msg_async_event_type.
+ */
+struct aie4_msg_async_event_msg_event {
+	__u32 status;
+	__u32 type;
+} __packed;
+
+/* The async event types returned in each async response message. */
+enum aie4_msg_async_event_type {
+	AIE4_ASYNC_EVENT_TYPE_AIE_ERROR,
+	AIE4_ASYNC_EVENT_TYPE_EXCEPTION,
+	AIE4_ASYNC_EVENT_TYPE_CTX_ERROR,
+	AIE4_ASYNC_EVENT_TYPE_PWR_ERROR,
+	MAX_AIE4_ASYNC_EVENT_TYPE,
+};
+
+/* The async context error types. */
+enum aie4_msg_async_ctx_error_type {
+	AIE4_ASYNC_EVENT_CTX_ERR_HWSCH_FAILURE,
+	AIE4_ASYNC_EVENT_CTX_ERR_STOP_FAILURE,
+	AIE4_ASYNC_EVENT_CTX_ERR_AIE_FAILURE,
+	AIE4_ASYNC_EVENT_CTX_ERR_PREEMPTION_TIMEOUT,
+	AIE4_ASYNC_EVENT_CTX_ERR_NEW_PROCESS_FAILURE,
+	AIE4_ASYNC_EVENT_CTX_ERR_UC_CRITICAL_ERROR,
+	AIE4_ASYNC_EVENT_CTX_ERR_UC_COMPLETION_TIMEOUT,
+};
+
+/*
+ * Per-uC health information included in an app health report.
+ * @uc_idx: uC index in this context, 0 is the lead.
+ * @uc_idle_status: valid when uC is idle, reason the uC is idle.
+ * @misc_status: valid on context error, reason the uC hangs.
+ * @fw_state: current uC firmware state.
+ * @page_idx: page index of the current control code being executed.
+ * @offset: byte offset inside the page for the current control code.
+ * @restore_page: page index to execute on resume after preemption.
+ * @restore_offset: byte offset inside restore_page to execute on resume.
+ * @uc_ear: exception address register on a uC crash.
+ * @uc_esr: exception status register on a uC crash.
+ * @uc_pc: program counter on a uC crash.
+ */
+struct uc_health_info {
+	__u32 uc_idx;
+	__u32 uc_idle_status;
+	__u32 misc_status;
+	__u32 fw_state;
+	__u32 page_idx;
+	__u32 offset;
+	__u32 restore_page;
+	__u32 restore_offset;
+	__u32 uc_ear;
+	__u32 uc_esr;
+	__u32 uc_pc;
+};
+
+/* Field masks for the packed @version and @ctx_num_uc words below. */
+#define AIE4_APP_HEALTH_MAJOR_VER	GENMASK(15, 0)
+#define AIE4_APP_HEALTH_MINOR_VER	GENMASK(31, 16)
+#define AIE4_APP_HEALTH_CTX_STATUS	GENMASK(15, 0)
+#define AIE4_APP_HEALTH_NUM_UC		GENMASK(31, 16)
+
+/*
+ * App health report stored in the async report buffer on a context error.
+ * @version: health report structure version, packed as
+ *           AIE4_APP_HEALTH_MAJOR_VER | AIE4_APP_HEALTH_MINOR_VER.
+ * @context_id: context ID copied from the request.
+ * @ctx_num_uc: context status and uC count, packed as
+ *              AIE4_APP_HEALTH_CTX_STATUS | AIE4_APP_HEALTH_NUM_UC. The status
+ *              is the enum hw_ctx_status tracked by the scheduler.
+ * @runlist_read_idx: index of the most recently executed run list entry.
+ * @uc_info: per-uC health information.
+ */
+struct aie4_msg_app_health_report {
+	__u32 version;
+	__u32 context_id;
+	__u32 ctx_num_uc;
+	__u32 runlist_read_idx;
+	struct uc_health_info uc_info[AIE4_MPNPUFW_MAX_UC_COUNT];
+};
+
+/* The data shared in the async report buffer after a context error. */
+struct aie4_async_ctx_error {
+	__u32 ctx_id;
+	__u32 error_type;
+	union {
+		struct aie4_msg_app_health_report app_health_report;
+	};
+};
 
 #endif /* _AIE4_MSG_PRIV_H_ */

--- a/drivers/accel/amdxdna/aie4_msg_priv.h
+++ b/drivers/accel/amdxdna/aie4_msg_priv.h
@@ -10,6 +10,8 @@
 #include <linux/sizes.h>
 #include <linux/types.h>
 
+#include "amdxdna_ctx.h"	/* struct uc_health_info */
+
 enum aie4_msg_opcode {
 	/* Classic/PF/VF common */
 	AIE4_MSG_OP_IDENTIFY                         = 0x10002,
@@ -399,33 +401,7 @@ enum aie4_msg_async_ctx_error_type {
 	AIE4_ASYNC_EVENT_CTX_ERR_UC_COMPLETION_TIMEOUT,
 };
 
-/*
- * Per-uC health information included in an app health report.
- * @uc_idx: uC index in this context, 0 is the lead.
- * @uc_idle_status: valid when uC is idle, reason the uC is idle.
- * @misc_status: valid on context error, reason the uC hangs.
- * @fw_state: current uC firmware state.
- * @page_idx: page index of the current control code being executed.
- * @offset: byte offset inside the page for the current control code.
- * @restore_page: page index to execute on resume after preemption.
- * @restore_offset: byte offset inside restore_page to execute on resume.
- * @uc_ear: exception address register on a uC crash.
- * @uc_esr: exception status register on a uC crash.
- * @uc_pc: program counter on a uC crash.
- */
-struct uc_health_info {
-	__u32 uc_idx;
-	__u32 uc_idle_status;
-	__u32 misc_status;
-	__u32 fw_state;
-	__u32 page_idx;
-	__u32 offset;
-	__u32 restore_page;
-	__u32 restore_offset;
-	__u32 uc_ear;
-	__u32 uc_esr;
-	__u32 uc_pc;
-};
+/* struct uc_health_info (per-uC health entry) is defined in amdxdna_ctx.h. */
 
 /* Field masks for the packed @version and @ctx_num_uc words below. */
 #define AIE4_APP_HEALTH_MAJOR_VER	GENMASK(15, 0)

--- a/drivers/accel/amdxdna/aie4_pci.c
+++ b/drivers/accel/amdxdna/aie4_pci.c
@@ -1067,7 +1067,7 @@ static void aie4_hwctx_cleanup_all(struct amdxdna_dev_hdl *ndev)
 		idx = srcu_read_lock(&client->hwctx_srcu);
 		amdxdna_for_each_hwctx(client, hwctx_id, hwctx) {
 			if (hwctx->priv->kernel_submit)
-				aie4_hwctx_cleanup_running_jobs(hwctx);
+				aie4_hwctx_cleanup_running_jobs(hwctx, false);
 		}
 		srcu_read_unlock(&client->hwctx_srcu, idx);
 	}

--- a/drivers/accel/amdxdna/aie4_pci.c
+++ b/drivers/accel/amdxdna/aie4_pci.c
@@ -432,10 +432,20 @@ static int aie4_vf_hw_start(struct amdxdna_dev_hdl *ndev)
 	if (ret)
 		goto mailbox_fini;
 
+	ret = amdxdna_async_events_alloc(&ndev->aie, ndev->total_col);
+	if (ret) {
+		XDNA_ERR(ndev->aie.xdna, "Allocate async events failed, ret %d", ret);
+		goto partition_fini;
+	}
+
 	return 0;
 
+partition_fini:
+	aie4_partition_fini(ndev);
 mailbox_fini:
 	aie4_mailbox_fini(ndev);
+	/* Reclaim a partially-armed async pool after the mailbox is stopped. */
+	amdxdna_async_events_free(&ndev->aie);
 	return ret;
 }
 
@@ -447,6 +457,11 @@ static void aie4_vf_hw_stop(struct amdxdna_dev_hdl *ndev)
 
 	aie4_partition_fini(ndev);
 	aie4_mailbox_fini(ndev);
+	/*
+	 * Free the async pool after the mailbox is torn down so channel teardown
+	 * cannot fire the async callback on freed event slots.
+	 */
+	amdxdna_async_events_free(&ndev->aie);
 }
 
 static int aie4_classic_hw_start(struct amdxdna_dev_hdl *ndev)
@@ -492,10 +507,20 @@ static int aie4_classic_hw_start(struct amdxdna_dev_hdl *ndev)
 	if (ret)
 		goto mbox_fini;
 
+	ret = amdxdna_async_events_alloc(&ndev->aie, ndev->total_col);
+	if (ret) {
+		XDNA_ERR(ndev->aie.xdna, "Allocate async events failed, ret %d", ret);
+		goto partition_fini;
+	}
+
 	return 0;
 
+partition_fini:
+	aie4_partition_fini(ndev);
 mbox_fini:
 	aie4_mailbox_fini(ndev);
+	/* Reclaim a partially-armed async pool after the mailbox is stopped. */
+	amdxdna_async_events_free(&ndev->aie);
 fw_unload:
 	aie4_fw_unload(ndev);
 
@@ -511,6 +536,11 @@ static void aie4_classic_hw_stop(struct amdxdna_dev_hdl *ndev)
 	aie4_partition_fini(ndev);
 	aie4_suspend_fw(ndev);
 	aie4_mailbox_fini(ndev);
+	/*
+	 * Free the async pool after the mailbox is torn down so channel teardown
+	 * cannot fire the async callback on freed event slots.
+	 */
+	amdxdna_async_events_free(&ndev->aie);
 	aie4_fw_unload(ndev);
 }
 
@@ -950,6 +980,9 @@ static int aie4_get_array(struct amdxdna_client *client,
 	case DRM_AMDXDNA_AIE_TILE_READ:
 		ret = amdxdna_aie_tile_read(&ndev->aie, client, args);
 		break;
+	case DRM_AMDXDNA_HW_LAST_ASYNC_ERR:
+		ret = aie4_get_array_async_error(ndev, args);
+		break;
 	default:
 		ret = -EOPNOTSUPP;
 		break;
@@ -1087,6 +1120,12 @@ static int aie4_vf_suspend(struct amdxdna_dev *xdna)
 	aie4_hwctx_suspend_all(ndev);
 	/* when PF and VF both present, PF suspend will do cleanup for all VFs */
 	aie4_mailbox_fini(ndev);
+	/*
+	 * Mirror the stop path: free the async pool after the mailbox is torn
+	 * down (resume re-allocates it) to avoid leaking the workqueue and the
+	 * per-column DMA buffers across suspend/resume.
+	 */
+	amdxdna_async_events_free(&ndev->aie);
 
 	XDNA_DBG(xdna, "vf suspend done");
 	return 0;
@@ -1367,6 +1406,8 @@ const struct amdxdna_dev_ops aie4_pf_ops = {
 	.sriov_configure        = aie4_sriov_configure,
 	.resume			= aie4_pf_resume,
 	.suspend		= aie4_pf_suspend,
+	.register_async_event	= aie4_async_event_register,
+	.handle_dev_async_event	= aie4_handle_dev_event,
 };
 
 const struct amdxdna_dev_ops aie4_vf_ops = {
@@ -1384,6 +1425,8 @@ const struct amdxdna_dev_ops aie4_vf_ops = {
 	.get_array		= aie4_get_array,
 	.resume			= aie4_vf_resume,
 	.suspend		= aie4_vf_suspend,
+	.register_async_event	= aie4_async_event_register,
+	.handle_dev_async_event	= aie4_handle_dev_event,
 };
 
 const struct amdxdna_dev_ops aie4_classic_ops = {
@@ -1401,4 +1444,6 @@ const struct amdxdna_dev_ops aie4_classic_ops = {
 	.get_array		= aie4_get_array,
 	.resume			= aie4_classic_resume,
 	.suspend		= aie4_classic_suspend,
+	.register_async_event	= aie4_async_event_register,
+	.handle_dev_async_event	= aie4_handle_dev_event,
 };

--- a/drivers/accel/amdxdna/aie4_pci.h
+++ b/drivers/accel/amdxdna/aie4_pci.h
@@ -14,6 +14,7 @@
 #include <linux/workqueue.h>
 
 #include "aie.h"
+#include "aie4_msg_priv.h"	/* struct aie4_async_ctx_error */
 #include "amdxdna_error.h"
 #include "amdxdna_mailbox.h"
 
@@ -53,6 +54,16 @@ struct amdxdna_hwctx_priv {
 	u32                             hw_ctx_id;
 	/* Snapshot of kernel_mode_submission for this ctx's lifetime. */
 	bool                            kernel_submit;
+
+	/*
+	 * Last CERT async context-error report for this ctx, cached by the async
+	 * error worker and consumed by the kernel-mode timeout/recovery path.
+	 * Both the flag and the multi-word report body are protected by io_lock
+	 * (cached only for kernel-mode contexts); the flag alone is insufficient
+	 * because the worker can overwrite the body while a reader consumes it.
+	 */
+	bool                            cached_ctx_error_valid;
+	struct aie4_async_ctx_error     cached_ctx_error;
 
 	/* Kernel-mode submission: driver fills the user HSA queue and rings
 	 * the doorbell.  umq_pkts/umq_indirect_pkts alias the user umq_bo;
@@ -131,6 +142,7 @@ int aie4_hwctx_create(struct amdxdna_hwctx *hwctx);
 void aie4_hwctx_destroy(struct amdxdna_hwctx *hwctx);
 void aie4_hwctx_resume_jobs(struct amdxdna_hwctx *hwctx);
 void aie4_hwctx_cleanup_running_jobs(struct amdxdna_hwctx *hwctx);
+void aie4_fill_health_data(struct amdxdna_gem_obj *cmd_abo, struct amdxdna_hwctx *hwctx);
 
 /* aie4_sriov.c */
 #if IS_ENABLED(CONFIG_PCI_IOV)

--- a/drivers/accel/amdxdna/aie4_pci.h
+++ b/drivers/accel/amdxdna/aie4_pci.h
@@ -14,6 +14,7 @@
 #include <linux/workqueue.h>
 
 #include "aie.h"
+#include "amdxdna_error.h"
 #include "amdxdna_mailbox.h"
 
 struct host_queue_packet;
@@ -161,6 +162,16 @@ int aie4_configure_hw_context_cert_log(struct amdxdna_dev_hdl *ndev,
 int aie4_calibrate_clock(struct amdxdna_dev_hdl *ndev);
 void aie4_msg_init(struct amdxdna_dev_hdl *ndev);
 u32 aie4_msg_pasid(struct amdxdna_client *client);
+int aie4_register_asyn_event_msg(struct amdxdna_dev_hdl *ndev, dma_addr_t addr, u32 size,
+				 void *handle, int (*cb)(void *, void __iomem *, size_t));
+
+/* aie4_error.c */
+extern const struct aie_error_lut_set aie4_error_luts;
+int aie4_async_event_register(struct aie_device *aie, dma_addr_t addr, u32 size,
+			      void *handle, int (*cb)(void *, void __iomem *, size_t));
+bool aie4_handle_dev_event(struct aie_device *aie, u32 type, void *vaddr);
+int aie4_get_array_async_error(struct amdxdna_dev_hdl *ndev,
+			       struct amdxdna_drm_get_array *args);
 
 enum aie4_fw_feature {
 	AIE4_GET_COREDUMP,

--- a/drivers/accel/amdxdna/aie4_pci.h
+++ b/drivers/accel/amdxdna/aie4_pci.h
@@ -141,7 +141,7 @@ int aie4_cmd_submit(struct amdxdna_hwctx *hwctx, struct amdxdna_sched_job *job, 
 int aie4_hwctx_create(struct amdxdna_hwctx *hwctx);
 void aie4_hwctx_destroy(struct amdxdna_hwctx *hwctx);
 void aie4_hwctx_resume_jobs(struct amdxdna_hwctx *hwctx);
-void aie4_hwctx_cleanup_running_jobs(struct amdxdna_hwctx *hwctx);
+void aie4_hwctx_cleanup_running_jobs(struct amdxdna_hwctx *hwctx, bool errored);
 void aie4_fill_health_data(struct amdxdna_gem_obj *cmd_abo, struct amdxdna_hwctx *hwctx);
 
 /* aie4_sriov.c */

--- a/drivers/accel/amdxdna/amdxdna_ctx.h
+++ b/drivers/accel/amdxdna/amdxdna_ctx.h
@@ -93,6 +93,69 @@ struct amdxdna_ctx_health {
 	u32 npu_gen;
 };
 
+/*
+ * Per-uC health entry. Layout matches the XRT ert_uc_health_info ABI
+ * (drm/detail/ert.h) and the aie4 firmware report; shared by the aie4 firmware
+ * app-health report (struct aie4_msg_app_health_report) and the command-data
+ * health structure below.
+ */
+struct uc_health_info {
+	u32 uc_idx;
+	u32 uc_idle_status;
+	u32 misc_status;
+	u32 fw_state;
+	u32 page_idx;
+	u32 offset;
+	u32 restore_page;
+	u32 restore_offset;
+	u32 uc_ear;
+	u32 uc_esr;
+	u32 uc_pc;
+};
+
+/* Context health data payload for aie2/aie2p (matches XRT ert_ctx_health_data_aie2). */
+struct amdxdna_ctx_health_data_aie2 {
+	u32 txn_op_idx;
+	u32 ctx_pc;
+	u32 fatal_error_type;
+	u32 fatal_error_exception_type;
+	u32 fatal_error_exception_pc;
+	u32 fatal_error_app_module;
+};
+
+/*
+ * Max per-uC health entries in amdxdna_ctx_health_data_aie4. A fixed size (not
+ * a flexible array) is required because this struct is a union member; matches
+ * the firmware AIE4_MPNPUFW_MAX_UC_COUNT.
+ */
+#define AMDXDNA_CTX_HEALTH_MAX_UC	6
+
+/* Context health data payload for aie2ps/aie4 (matches XRT ert_ctx_health_data_aie4). */
+struct amdxdna_ctx_health_data_aie4 {
+	u32 ctx_state;
+	u32 num_uc;
+	u32 ctx_error_type;
+	struct uc_health_info uc_info[AMDXDNA_CTX_HEALTH_MAX_UC];
+};
+
+/*
+ * Interpretation of the amdxdna_cmd payload when a command completes with
+ * ERT_CMD_STATE_TIMEOUT; @npu_gen selects the per-generation union member.
+ * Layout matches the XRT struct ert_ctx_health_data_v1 (drm/detail/ert.h).
+ * Only version 1 is produced/supported by this driver.
+ */
+struct amdxdna_ctx_health_data {
+#define AMDXDNA_CTX_HEALTH_DATA_V1	1
+	u32 version;
+#define AMDXDNA_NPU_GEN_AIE2		0
+#define AMDXDNA_NPU_GEN_AIE4		1
+	u32 npu_gen;
+	union {
+		struct amdxdna_ctx_health_data_aie2 aie2;
+		struct amdxdna_ctx_health_data_aie4 aie4;
+	};
+};
+
 /* Exec buffer command header format */
 #define AMDXDNA_CMD_STATE		GENMASK(3, 0)
 #define AMDXDNA_CMD_EXTRA_CU_MASK	GENMASK(11, 10)
@@ -214,6 +277,27 @@ amdxdna_cmd_get_state(struct amdxdna_gem_obj *abo)
 		return ERT_CMD_STATE_INVALID;
 
 	return FIELD_GET(AMDXDNA_CMD_STATE, cmd->header);
+}
+
+/* Return the whole writable data region of a cmd BO (e.g. for health data). */
+static inline void *
+amdxdna_cmd_get_data(struct amdxdna_gem_obj *abo, u32 *size)
+{
+	struct amdxdna_cmd *cmd = amdxdna_gem_vmap(abo);
+
+	if (size)
+		*size = 0;
+
+	if (!cmd)
+		return NULL;
+
+	/* Guard against a BO too small to hold the command header. */
+	if (abo->mem.size <= offsetof(struct amdxdna_cmd, data))
+		return NULL;
+
+	if (size)
+		*size = abo->mem.size - offsetof(struct amdxdna_cmd, data);
+	return cmd->data;
 }
 
 void *amdxdna_cmd_get_payload(struct amdxdna_gem_obj *abo, u32 *size);

--- a/drivers/accel/amdxdna/amdxdna_error.c
+++ b/drivers/accel/amdxdna/amdxdna_error.c
@@ -1,0 +1,484 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Copyright (C) 2023-2026, Advanced Micro Devices, Inc.
+ */
+
+#include <drm/drm_cache.h>
+#include <drm/drm_device.h>
+#include <drm/drm_print.h>
+#include <linux/bits.h>
+#include <linux/dma-mapping.h>
+#include <linux/io.h>
+#include <linux/kernel.h>
+#include <linux/ktime.h>
+#include <linux/slab.h>
+#include <linux/uaccess.h>
+#include <linux/workqueue.h>
+
+#include "aie.h"
+#include "amdxdna_error.h"
+#include "amdxdna_pci_drv.h"
+
+/* Private workqueue name (also the worker/rescuer thread name). */
+#define AMDXDNA_ASYNC_ERR_WQ_NAME	"amdxdna_async_err"
+
+/*
+ * The AIE tile error report payload layout below is defined by the AIE device
+ * and is common to the aie2 and aie4 firmware. The categorization of an
+ * event_id (which category / driver error number it maps to) is specific to the
+ * AIE generation, so it is NOT here: each back end supplies its own tables via
+ * struct amdxdna_dev_info.luts.
+ */
+
+/* Do not pack, unless the AIE side changes */
+struct aie_error {
+	__u8			row;
+	__u8			col;
+	__u32			mod_type;
+	__u8			event_id;
+};
+
+struct aie_err_info {
+	u32			err_cnt;
+	u32			ret_code;
+	u32			rsvd;
+	struct aie_error	payload[] __counted_by(err_cnt);
+};
+
+/* Mailbox async response header. status and type are at fixed offsets. */
+struct amdxdna_async_event_resp {
+	u32			status;
+	u32			type;
+};
+
+/**
+ * struct amdxdna_async_event - one async error report buffer slot
+ * @aie: back pointer to the shared aie device.
+ * @events: owning event pool.
+ * @work: worker that decodes the report and re-registers the slot.
+ * @hdl: message buffer backing this slot.
+ * @buf: CPU address of the report buffer.
+ * @addr: DMA address of the report buffer.
+ * @size: report buffer size.
+ * @resp: last mailbox response (status and event type) for this slot.
+ */
+struct amdxdna_async_event {
+	struct aie_device		*aie;
+	struct amdxdna_async_events	*events;
+	struct work_struct		work;
+	struct amdxdna_msg_buf_hdl	*hdl;
+	void				*buf;
+	dma_addr_t			addr;
+	u32				size;
+	struct amdxdna_async_event_resp	resp;
+};
+
+/**
+ * struct amdxdna_async_events - pool of async error report buffer slots
+ * @wq: ordered workqueue draining the report workers.
+ * @event_cnt: number of slots (one per column).
+ * @event: per column event slots, each with its own message buffer.
+ */
+struct amdxdna_async_events {
+	struct workqueue_struct		*wq;
+	u32				event_cnt;
+	struct amdxdna_async_event	event[] __counted_by(event_cnt);
+};
+
+/*
+ * The category to driver-error-number and module to driver-error-module maps,
+ * and the human-readable strings, are arch-independent. Only the per-arch event
+ * tables (which produce the category and event name) differ.
+ */
+static const enum amdxdna_error_num aie_cat_err_num_map[] = {
+	[AIE_ERROR_SATURATION] = AMDXDNA_ERROR_NUM_AIE_SATURATION,
+	[AIE_ERROR_FP] = AMDXDNA_ERROR_NUM_AIE_FP,
+	[AIE_ERROR_STREAM] = AMDXDNA_ERROR_NUM_AIE_STREAM,
+	[AIE_ERROR_ACCESS] = AMDXDNA_ERROR_NUM_AIE_ACCESS,
+	[AIE_ERROR_BUS] = AMDXDNA_ERROR_NUM_AIE_BUS,
+	[AIE_ERROR_INSTRUCTION] = AMDXDNA_ERROR_NUM_AIE_INSTRUCTION,
+	[AIE_ERROR_ECC] = AMDXDNA_ERROR_NUM_AIE_ECC,
+	[AIE_ERROR_LOCK] = AMDXDNA_ERROR_NUM_AIE_LOCK,
+	[AIE_ERROR_DMA] = AMDXDNA_ERROR_NUM_AIE_DMA,
+	[AIE_ERROR_MEM_PARITY] = AMDXDNA_ERROR_NUM_AIE_MEM_PARITY,
+	[AIE_ERROR_UNKNOWN] = AMDXDNA_ERROR_NUM_UNKNOWN,
+};
+
+static_assert(ARRAY_SIZE(aie_cat_err_num_map) == AIE_ERROR_UNKNOWN + 1);
+
+static const enum amdxdna_error_module aie_err_mod_map[] = {
+	[AIE_MEM_MOD] = AMDXDNA_ERROR_MODULE_AIE_MEMORY,
+	[AIE_CORE_MOD] = AMDXDNA_ERROR_MODULE_AIE_CORE,
+	[AIE_PL_MOD] = AMDXDNA_ERROR_MODULE_AIE_PL,
+	[AIE_UNKNOWN_MOD] = AMDXDNA_ERROR_MODULE_UNKNOWN,
+};
+
+static_assert(ARRAY_SIZE(aie_err_mod_map) == AIE_UNKNOWN_MOD + 1);
+
+static const char * const aie_module_names[] = {
+	[AIE_MEM_MOD] = "Memory",
+	[AIE_CORE_MOD] = "Core",
+	[AIE_PL_MOD] = "Shim",
+	[AIE_UNKNOWN_MOD] = "Unknown",
+};
+
+static_assert(ARRAY_SIZE(aie_module_names) == AIE_UNKNOWN_MOD + 1);
+
+static const char * const aie_category_names[] = {
+	[AIE_ERROR_SATURATION] = "Saturation",
+	[AIE_ERROR_FP] = "FP",
+	[AIE_ERROR_STREAM] = "Stream",
+	[AIE_ERROR_ACCESS] = "Access",
+	[AIE_ERROR_BUS] = "Bus",
+	[AIE_ERROR_INSTRUCTION] = "Instruction",
+	[AIE_ERROR_ECC] = "ECC",
+	[AIE_ERROR_LOCK] = "Lock",
+	[AIE_ERROR_DMA] = "DMA",
+	[AIE_ERROR_MEM_PARITY] = "Mem parity",
+	[AIE_ERROR_UNKNOWN] = "Unknown",
+};
+
+static_assert(ARRAY_SIZE(aie_category_names) == AIE_ERROR_UNKNOWN + 1);
+
+void amdxdna_aie_fill_decode(enum aie_error_category cat, u32 mod_type,
+			     const char *event_name,
+			     struct amdxdna_aie_err_decode *out)
+{
+	enum aie_module_type mod;
+
+	mod = (mod_type >= AIE_UNKNOWN_MOD) ? AIE_UNKNOWN_MOD : mod_type;
+	if (cat > AIE_ERROR_UNKNOWN)
+		cat = AIE_ERROR_UNKNOWN;
+
+	out->err_num = aie_cat_err_num_map[cat];
+	out->err_mod = aie_err_mod_map[mod];
+	out->mod_str = aie_module_names[mod];
+	out->cat_str = aie_category_names[cat];
+	out->event_str = event_name ? event_name : "unknown";
+}
+
+/*
+ * A row hosts a dedicated mem tile when it falls within the firmware-reported
+ * mem-tile row range [mem.row_start, mem.row_start + mem.row_count). This
+ * replaces the aie2 hard-coded "row == 1" test: on documented aie2 layouts
+ * the single mem tile sits at row 1, so the metadata range is {1, 1} and the
+ * aie2 decode is unchanged, while other generations use their reported range.
+ */
+static bool aie_row_is_mem_tile(const struct aie_device *aie, u8 row)
+{
+	return row >= aie->metadata.mem.row_start &&
+	       row <  aie->metadata.mem.row_start + aie->metadata.mem.row_count;
+}
+
+enum aie_error_category
+aie_lookup_error_category(struct aie_device *aie,
+			  u8 row, u8 event_id, u32 mod_type, const char **name)
+{
+	const struct aie_error_lut_set *set = aie->xdna->dev_info->luts;
+	const struct aie_error_event *tbl;
+	const struct aie_error_event *e;
+
+	*name = "unknown";
+
+	switch (mod_type) {
+	case AIE_PL_MOD:
+		tbl = set->shim;
+		break;
+	case AIE_CORE_MOD:
+		tbl = set->core;
+		break;
+	case AIE_MEM_MOD:
+		tbl = aie_row_is_mem_tile(aie, row) ? set->mem_tile : set->mem;
+		break;
+	default:
+		return AIE_ERROR_UNKNOWN;
+	}
+
+	/* Tables are terminated by a sentinel entry with a NULL name. */
+	for (e = tbl; e->name; e++) {
+		if (e->event_id != event_id)
+			continue;
+
+		*name = e->name;
+		return e->category > AIE_ERROR_UNKNOWN ? AIE_ERROR_UNKNOWN : e->category;
+	}
+
+	return AIE_ERROR_UNKNOWN;
+}
+
+/*
+ * Decode one AIE tile error into @d using the arch's category tables (ops->luts)
+ * for the category and event name, then the shared num/module/string mapping.
+ */
+static void amdxdna_aie_decode_one(struct aie_device *aie,
+				   u8 row, u8 event_id, u32 mod_type,
+				   struct amdxdna_aie_err_decode *d)
+{
+	enum aie_error_category cat = AIE_ERROR_UNKNOWN;
+	const char *name = "unknown";
+
+	if (mod_type < AIE_UNKNOWN_MOD)
+		cat = aie_lookup_error_category(aie, row, event_id, mod_type, &name);
+
+	amdxdna_aie_fill_decode(cat, mod_type, name, d);
+}
+
+/*
+ * Iterate the AIE tile error report payload once: log every error and validate
+ * each error column against the device geometry, then cache the last error into
+ * aie->last_async_err (the field read under dev_lock by the GET_ARRAY query).
+ * Returns true when the report is valid (at least one error and every column in
+ * range). A column outside [0, metadata.cols) makes the whole report invalid so
+ * the cache is not updated from unvalidated data. dev_lock is taken only around
+ * the cache write; the iteration itself runs without the lock.
+ */
+static bool amdxdna_aie_backtrack_and_cache(struct aie_device *aie,
+					    void *err_info, u32 num_err)
+{
+	struct amdxdna_async_error *rec = &aie->last_async_err;
+	struct amdxdna_dev *xdna = aie->xdna;
+	struct aie_error *errs = err_info;
+	struct amdxdna_aie_err_decode d;
+	struct aie_error *last_err;
+	bool saw_valid_col = false;
+	int i;
+
+	for (i = 0; i < num_err; i++) {
+		struct aie_error *err = &errs[i];
+
+		amdxdna_aie_decode_one(aie, err->row, err->event_id, err->mod_type, &d);
+		XDNA_ERR(xdna, "AIE error:");
+		XDNA_ERR(xdna, "\tTile location (Row, Column): (%u, %u)", err->row, err->col);
+		XDNA_ERR(xdna, "\tModule: %s", d.mod_str);
+		XDNA_ERR(xdna, "\tCategory: %s", d.cat_str);
+		XDNA_ERR(xdna, "\tEvent (ID): %s (%u)", d.event_str, err->event_id);
+
+		if (err->col >= aie->metadata.cols) {
+			XDNA_WARN(xdna, "Invalid column number %u", err->col);
+			return false;
+		}
+
+		saw_valid_col = true;
+	}
+
+	if (!saw_valid_col)
+		return false;
+
+	/* Cache the last error for the GET_ARRAY query. */
+	last_err = &errs[num_err - 1];
+	amdxdna_aie_decode_one(aie, last_err->row, last_err->event_id, last_err->mod_type, &d);
+
+	mutex_lock(&xdna->dev_lock);
+	rec->err_code = AMDXDNA_ERROR_ENCODE(d.err_num, d.err_mod);
+	rec->ts_us = ktime_to_us(ktime_get_real());
+	rec->ex_err_code = AMDXDNA_EXTRA_ERR_ENCODE(last_err->row, last_err->col);
+	mutex_unlock(&xdna->dev_lock);
+
+	return true;
+}
+
+/*
+ * Decode an AIE tile error report and cache the last error. Returns true when
+ * the report was valid and the slot should be re-registered, false otherwise.
+ * The last-error caching (and its dev_lock) is handled inside
+ * amdxdna_aie_backtrack_and_cache().
+ */
+static bool amdxdna_aie_decode_tile_error(struct aie_device *aie,
+					  void *vaddr, u32 buf_size)
+{
+	struct amdxdna_dev *xdna = aie->xdna;
+	struct aie_err_info *info = vaddr;
+	u32 max_err;
+
+	XDNA_DBG(xdna, "Error count %d return code %d", info->err_cnt, info->ret_code);
+
+	max_err = (buf_size - sizeof(*info)) / sizeof(struct aie_error);
+	if (unlikely(info->err_cnt > max_err)) {
+		WARN_ONCE(1, "Error count too large %d\n", info->err_cnt);
+		return false;
+	}
+
+	if (!amdxdna_aie_backtrack_and_cache(aie, info->payload, info->err_cnt)) {
+		XDNA_WARN(xdna, "No valid AIE error column found in report");
+		return false;
+	}
+
+	return true;
+}
+
+static int amdxdna_async_error_cb(void *handle, void __iomem *data, size_t size)
+{
+	struct amdxdna_async_event *e = handle;
+
+	if (data) {
+		e->resp.type = readl(data + offsetof(struct amdxdna_async_event_resp, type));
+		wmb(); /* Update status in the end, so that no lock for here */
+		e->resp.status = readl(data + offsetof(struct amdxdna_async_event_resp, status));
+	}
+	queue_work(e->events->wq, &e->work);
+	return 0;
+}
+
+static int amdxdna_async_event_send(struct amdxdna_async_event *e)
+{
+	drm_clflush_virt_range(e->buf, e->size); /* device can access */
+	return e->aie->xdna->dev_info->ops->register_async_event(e->aie, e->addr, e->size,
+								 e, amdxdna_async_error_cb);
+}
+
+static void amdxdna_async_error_worker(struct work_struct *err_work)
+{
+	struct amdxdna_async_event *e = container_of(err_work, struct amdxdna_async_event, work);
+	const struct amdxdna_dev_info *info = e->aie->xdna->dev_info;
+	struct amdxdna_dev *xdna = e->aie->xdna;
+	struct aie_device *aie = e->aie;
+
+	/*
+	 * On mailbox channel teardown the registered-event callback runs with
+	 * data == NULL (see xdna_mailbox_stop_channel), which leaves resp.status
+	 * at the sentinel. Skip decode and re-registration in that case so the
+	 * dying channel is not touched.
+	 */
+	if (e->resp.status == info->async_max_status_code)
+		return;
+
+	e->resp.status = info->async_max_status_code;
+
+	/* Invalidate stale cache lines before reading the device-written report. */
+	drm_clflush_virt_range(e->buf, e->size);
+
+	print_hex_dump_debug("AIE error: ", DUMP_PREFIX_OFFSET, 16, 4, e->buf, 0x100, false);
+
+	/* Call the device handler without dev_lock; it may take dev_lock itself. */
+	if (info->ops->handle_dev_async_event &&
+	    info->ops->handle_dev_async_event(aie, e->resp.type, e->buf))
+		goto reregister;
+
+	if (!amdxdna_aie_decode_tile_error(aie, e->buf, e->size))
+		return; /* invalid report: do not re-register */
+
+reregister:
+	mutex_lock(&xdna->dev_lock);
+	/*
+	 * Skip re-registration if the event pool is being torn down. The free
+	 * path clears async_events under dev_lock before draining this worker,
+	 * so a drained worker cannot re-arm firmware on an already-stopped
+	 * mailbox channel.
+	 */
+	if (aie->async_events && amdxdna_async_event_send(e))
+		XDNA_WARN(xdna, "Unable to register async event");
+	mutex_unlock(&xdna->dev_lock);
+}
+
+int amdxdna_async_events_alloc(struct aie_device *aie,
+			       u32 total_col)
+{
+	struct amdxdna_dev *xdna = aie->xdna;
+	struct amdxdna_async_events *events;
+	int i, ret;
+
+	drm_WARN_ON(&xdna->ddev, !mutex_is_locked(&xdna->dev_lock));
+
+	events = kzalloc_flex(*events, event, total_col);
+	if (!events)
+		return -ENOMEM;
+
+	events->event_cnt = total_col;
+
+	events->wq = alloc_ordered_workqueue(AMDXDNA_ASYNC_ERR_WQ_NAME, 0);
+	if (!events->wq) {
+		kfree(events);
+		return -ENOMEM;
+	}
+
+	/*
+	 * Publish the pool before arming firmware. amdxdna_async_event_send()
+	 * leaves a mailbox message holding &event[i] as its handle, so on a
+	 * partial-registration failure the pool must outlive the mailbox
+	 * channel. The caller's hw_start() error unwind stops the mailbox and
+	 * then calls amdxdna_async_events_free(), which drains the workqueue and
+	 * frees the (NULL-safe) slots once firmware can no longer DMA into or
+	 * fire the callback on them.
+	 */
+	aie->async_events = events;
+
+	for (i = 0; i < events->event_cnt; i++) {
+		struct amdxdna_async_event *e = &events->event[i];
+
+		e->hdl = amdxdna_alloc_msg_buff(xdna, ASYNC_BUF_SIZE);
+		if (IS_ERR(e->hdl)) {
+			ret = PTR_ERR(e->hdl);
+			e->hdl = NULL;
+			return ret;
+		}
+
+		INIT_WORK(&e->work, amdxdna_async_error_worker);
+
+		e->resp.status = xdna->dev_info->async_max_status_code;
+		e->addr = to_dma_addr(e->hdl, 0);
+		e->buf = to_cpu_addr(e->hdl, 0);
+		e->size = ASYNC_BUF_SIZE;
+		e->events = events;
+		e->aie = aie;
+
+		ret = amdxdna_async_event_send(e);
+		if (ret) {
+			amdxdna_free_msg_buff(e->hdl);
+			e->hdl = NULL;
+			return ret;
+		}
+	}
+
+	XDNA_DBG(xdna, "Async event count %d, per-event buf size 0x%x",
+		 events->event_cnt, ASYNC_BUF_SIZE);
+	return 0;
+}
+
+void amdxdna_async_events_free(struct aie_device *aie)
+{
+	struct amdxdna_dev *xdna = aie->xdna;
+	struct amdxdna_async_events *events = aie->async_events;
+	int i;
+
+	drm_WARN_ON(&xdna->ddev, !mutex_is_locked(&xdna->dev_lock));
+
+	if (!events)
+		return;
+
+	aie->async_events = NULL;
+
+	/* Drop dev_lock so in-flight workers can complete before teardown. */
+	mutex_unlock(&xdna->dev_lock);
+	destroy_workqueue(events->wq);
+	mutex_lock(&xdna->dev_lock);
+
+	for (i = 0; i < events->event_cnt; i++)
+		amdxdna_free_msg_buff(events->event[i].hdl);
+	kfree(events);
+}
+
+/**
+ * amdxdna_get_array_last_async_error - return the last asynchronous error.
+ * @aie: shared aie device holding the cached error.
+ * @args: GET_ARRAY ioctl arguments.
+ *
+ * Today only the single most recent async error is cached. Caller must hold
+ * dev_lock.
+ *
+ * Return: 0 on success, negative error code on failure.
+ */
+int amdxdna_get_array_last_async_error(struct aie_device *aie,
+				       struct amdxdna_drm_get_array *args)
+{
+	struct amdxdna_async_error *last = &aie->last_async_err;
+
+	if (!args->num_element)
+		return -EINVAL;
+
+	args->num_element = 1;
+	args->element_size = min(args->element_size, sizeof(*last));
+	if (copy_to_user(u64_to_user_ptr(args->buffer), last, args->element_size))
+		return -EFAULT;
+
+	return 0;
+}

--- a/drivers/accel/amdxdna/amdxdna_error.h
+++ b/drivers/accel/amdxdna/amdxdna_error.h
@@ -8,6 +8,8 @@
 
 #include <linux/bitfield.h>
 #include <linux/bits.h>
+#include <linux/sizes.h>
+#include <linux/types.h>
 
 #define AMDXDNA_ERR_DRV_AIE		4
 #define AMDXDNA_ERR_SEV_CRITICAL	3
@@ -30,6 +32,8 @@ enum amdxdna_error_num {
 	AMDXDNA_ERROR_NUM_AIE_LOCK,
 	AMDXDNA_ERROR_NUM_AIE_DMA,
 	AMDXDNA_ERROR_NUM_AIE_MEM_PARITY,
+	AMDXDNA_ERROR_NUM_KDS_CU = 13,
+	AMDXDNA_ERROR_NUM_KDS_EXEC,
 	AMDXDNA_ERROR_NUM_UNKNOWN = 15,
 };
 
@@ -55,5 +59,137 @@ enum amdxdna_error_module {
 #define AMDXDNA_EXTRA_ERR_ENCODE(row, col)				\
 	(FIELD_PREP(AMDXDNA_EXTRA_ERR_COL_MASK, col) |			\
 	 FIELD_PREP(AMDXDNA_EXTRA_ERR_ROW_MASK, row))
+
+#define AMDXDNA_EXTRA_ERR_CTX_ID_MASK		GENMASK_U64(31, 0)
+#define AMDXDNA_EXTRA_ERR_CTX_STATUS_MASK	GENMASK_U64(63, 32)
+
+#define AMDXDNA_EXTRA_ERR_CTX_ENCODE(status, ctx_id)			\
+	(FIELD_PREP(AMDXDNA_EXTRA_ERR_CTX_ID_MASK, ctx_id) |		\
+	 FIELD_PREP(AMDXDNA_EXTRA_ERR_CTX_STATUS_MASK, status))
+
+/*
+ * Shared asynchronous error framework used by both the aie2 and aie4 back ends.
+ *
+ * The genuinely-common scaffolding lives in amdxdna_error.c: the async event
+ * buffer pool (alloc, free, mailbox callback, re-register worker), the column
+ * backtrack and last-error encode, and the GET_ARRAY query. The device specific
+ * pieces come from the device tables: the register-event and handle-event
+ * callbacks in struct amdxdna_dev_ops, and the MAX status code and the
+ * per-generation AIE tile-error categorization tables (luts) in
+ * struct amdxdna_dev_info.
+ */
+
+/* Per-event async report buffer size. Shared by aie2 and aie4 firmware. */
+#define ASYNC_BUF_SIZE		SZ_8K
+
+struct aie_device;
+struct amdxdna_async_error;
+struct amdxdna_async_events;
+struct amdxdna_drm_get_array;
+
+/*
+ * AIE module type and error category. These enums are common to all AIE
+ * generations; only the event_id lookup tables that map to them are per-arch
+ * (see the aie2 / aie4 event-category tables in aie2_error.c / aie4_error.c).
+ */
+enum aie_module_type {
+	AIE_MEM_MOD = 0,
+	AIE_CORE_MOD,
+	AIE_PL_MOD,
+	AIE_UNKNOWN_MOD,
+};
+
+enum aie_error_category {
+	AIE_ERROR_SATURATION = 0,
+	AIE_ERROR_FP,
+	AIE_ERROR_STREAM,
+	AIE_ERROR_ACCESS,
+	AIE_ERROR_BUS,
+	AIE_ERROR_INSTRUCTION,
+	AIE_ERROR_ECC,
+	AIE_ERROR_LOCK,
+	AIE_ERROR_DMA,
+	AIE_ERROR_MEM_PARITY,
+	/* Unknown is not a hardware category, added for better categorization */
+	AIE_ERROR_UNKNOWN,
+};
+
+/**
+ * struct aie_error_event - one AIE tile error event lookup entry
+ * @event_id: hardware event id.
+ * @category: error category the event belongs to.
+ * @name: human-readable event name for logging.
+ *
+ * The per-arch tables are arrays of these entries.
+ */
+struct aie_error_event {
+	u8			event_id;
+	enum aie_error_category	category;
+	const char		*name;
+};
+
+#define AIE_ERROR_EVENT(id, cat, nm) \
+	{ .event_id = (id), .category = (cat), .name = (nm) }
+
+/**
+ * struct aie_error_lut_set - per-arch set of module event-category tables
+ * @shim: table for AIE_PL_MOD (shim tile).
+ * @core: table for AIE_CORE_MOD.
+ * @mem_tile: table for AIE_MEM_MOD when the row falls within the firmware
+ *            provided mem-tile row range (a dedicated mem tile).
+ * @mem: table for AIE_MEM_MOD otherwise (the core-tile memory module).
+ *
+ * Each table is terminated by a sentinel entry with a NULL @name.
+ */
+struct aie_error_lut_set {
+	const struct aie_error_event	*shim;
+	const struct aie_error_event	*core;
+	const struct aie_error_event	*mem_tile;
+	const struct aie_error_event	*mem;
+};
+
+/*
+ * Shared module-dispatch + lookup for the per-arch event-category tables. Sets
+ * *name (default "unknown"), selects the table by module (and row for MEM),
+ * runs the match loop, and returns the error category.
+ */
+enum aie_error_category
+aie_lookup_error_category(struct aie_device *aie,
+			  u8 row, u8 event_id, u32 mod_type, const char **name);
+
+/**
+ * struct amdxdna_aie_err_decode - one decoded AIE tile error
+ * @err_num: driver error number (enum amdxdna_error_num).
+ * @err_mod: driver error module (enum amdxdna_error_module).
+ * @mod_str: human-readable AIE module name for logging.
+ * @cat_str: human-readable error category name for logging.
+ * @event_str: human-readable event name for logging.
+ *
+ * The event_id to category mapping is specific to the AIE generation, so the
+ * tables (luts) that produce this decode live on the aie2 / aie4 side, not in
+ * the shared core.
+ */
+struct amdxdna_aie_err_decode {
+	enum amdxdna_error_num		err_num;
+	enum amdxdna_error_module	err_mod;
+	const char			*mod_str;
+	const char			*cat_str;
+	const char			*event_str;
+};
+
+/*
+ * Fill the generic (arch-independent) parts of a decode: the driver error
+ * number / module and the human-readable module, category and event strings.
+ * The shared backtrack code calls this after looking up the category and event
+ * name in the per-arch tables (via ops->luts).
+ */
+void amdxdna_aie_fill_decode(enum aie_error_category cat, u32 mod_type,
+			     const char *event_name,
+			     struct amdxdna_aie_err_decode *out);
+
+int amdxdna_async_events_alloc(struct aie_device *aie, u32 total_col);
+void amdxdna_async_events_free(struct aie_device *aie);
+int amdxdna_get_array_last_async_error(struct aie_device *aie,
+				       struct amdxdna_drm_get_array *args);
 
 #endif /* _AMDXDNA_ERROR_H_ */

--- a/drivers/accel/amdxdna/amdxdna_pci_drv.h
+++ b/drivers/accel/amdxdna/amdxdna_pci_drv.h
@@ -53,6 +53,8 @@ struct amdxdna_gem_obj;
 struct amdxdna_hwctx;
 struct amdxdna_sched_job;
 struct amdxdna_msg_buf_hdl;
+struct aie_device;
+struct aie_error_lut_set;
 
 /*
  * struct amdxdna_dev_ops - Device hardware operation callbacks
@@ -78,6 +80,17 @@ struct amdxdna_dev_ops {
 			     u32 *settle_ms);
 	int (*get_array)(struct amdxdna_client *client, struct amdxdna_drm_get_array *args);
 	int (*get_dev_revision)(struct amdxdna_dev *xdna, u32 *rev);
+
+	/* Asynchronous error reporting callbacks. */
+	int (*register_async_event)(struct aie_device *aie, dma_addr_t addr, u32 size,
+				    void *handle, int (*cb)(void *, void __iomem *, size_t));
+	/*
+	 * Handle a device/architecture-specific async event type (beyond the
+	 * generic AIE tile error). Returns true when it consumed the event, so
+	 * the shared AIE tile error decode is skipped; false to let the caller
+	 * run the shared tile decode.
+	 */
+	bool (*handle_dev_async_event)(struct aie_device *aie, u32 type, void *vaddr);
 };
 
 struct amdxdna_fw_feature_tbl {
@@ -110,6 +123,10 @@ struct amdxdna_dev_info {
 	const struct amdxdna_fw_feature_tbl *fw_feature_tbl;
 	const struct amdxdna_fw_feature_tbl *cert_feature_tbl;
 	const struct amdxdna_dev_ops	*ops;
+
+	/* Asynchronous error reporting data (per AIE generation). */
+	const struct aie_error_lut_set	*luts;
+	u32				async_max_status_code;
 };
 
 struct amdxdna_carveout;

--- a/drivers/accel/amdxdna/npu1_regs.c
+++ b/drivers/accel/amdxdna/npu1_regs.c
@@ -146,4 +146,6 @@ const struct amdxdna_dev_info dev_npu1_info = {
 	.dev_priv          = &npu1_dev_priv,
 	.fw_feature_tbl    = npu1_fw_feature_table,
 	.ops               = &aie2_ops,
+	.luts              = &aie2_error_luts,
+	.async_max_status_code = MAX_AIE2_STATUS_CODE,
 };

--- a/drivers/accel/amdxdna/npu3_regs.c
+++ b/drivers/accel/amdxdna/npu3_regs.c
@@ -6,6 +6,7 @@
 #include "drm/amdxdna_accel.h"
 #include <drm/drm_device.h>
 
+#include "aie4_msg_priv.h"
 #include "aie4_pci.h"
 #include "amdxdna_pci_drv.h"
 #include "amdxdna_sensors.h"
@@ -164,6 +165,8 @@ const struct amdxdna_dev_info dev_npu3_pf_info = {
 	.fw_feature_tbl		= npu3_fw_feature_table,
 	.cert_feature_tbl	= npu3_cert_feature_table,
 	.ops			= &aie4_pf_ops,
+	.luts			= &aie4_error_luts,
+	.async_max_status_code	= MAX_AIE4_MSG_STATUS_CODE,
 };
 
 const struct amdxdna_dev_info dev_npu3_vf_info = {
@@ -176,6 +179,8 @@ const struct amdxdna_dev_info dev_npu3_vf_info = {
 	.fw_feature_tbl		= npu3_fw_feature_table,
 	.cert_feature_tbl	= npu3_cert_feature_table,
 	.ops			= &aie4_vf_ops,
+	.luts			= &aie4_error_luts,
+	.async_max_status_code	= MAX_AIE4_MSG_STATUS_CODE,
 };
 
 const struct amdxdna_dev_info dev_npu3_classic_info = {
@@ -190,6 +195,8 @@ const struct amdxdna_dev_info dev_npu3_classic_info = {
 	.fw_feature_tbl		= npu3_fw_feature_table,
 	.cert_feature_tbl	= npu3_cert_feature_table,
 	.ops			= &aie4_classic_ops,
+	.luts			= &aie4_error_luts,
+	.async_max_status_code	= MAX_AIE4_MSG_STATUS_CODE,
 };
 
 const struct amdxdna_dev_info dev_npu9_pf_info = {
@@ -203,6 +210,8 @@ const struct amdxdna_dev_info dev_npu9_pf_info = {
 	.fw_feature_tbl		= npu3_fw_feature_table,
 	.cert_feature_tbl	= npu3_cert_feature_table,
 	.ops			= &aie4_pf_ops,
+	.luts			= &aie4_error_luts,
+	.async_max_status_code	= MAX_AIE4_MSG_STATUS_CODE,
 };
 
 const struct amdxdna_dev_info dev_npu9_vf_info = {
@@ -215,6 +224,8 @@ const struct amdxdna_dev_info dev_npu9_vf_info = {
 	.fw_feature_tbl		= npu3_fw_feature_table,
 	.cert_feature_tbl	= npu3_cert_feature_table,
 	.ops			= &aie4_vf_ops,
+	.luts			= &aie4_error_luts,
+	.async_max_status_code	= MAX_AIE4_MSG_STATUS_CODE,
 };
 
 const struct amdxdna_dev_info dev_npu9_classic_info = {
@@ -229,6 +240,8 @@ const struct amdxdna_dev_info dev_npu9_classic_info = {
 	.fw_feature_tbl		= npu3_fw_feature_table,
 	.cert_feature_tbl	= npu3_cert_feature_table,
 	.ops			= &aie4_classic_ops,
+	.luts			= &aie4_error_luts,
+	.async_max_status_code	= MAX_AIE4_MSG_STATUS_CODE,
 };
 
 const struct amdxdna_dev_info dev_npu11_pf_info = {
@@ -242,6 +255,8 @@ const struct amdxdna_dev_info dev_npu11_pf_info = {
 	.fw_feature_tbl		= npu3_fw_feature_table,
 	.cert_feature_tbl	= npu3_cert_feature_table,
 	.ops			= &aie4_pf_ops,
+	.luts			= &aie4_error_luts,
+	.async_max_status_code	= MAX_AIE4_MSG_STATUS_CODE,
 };
 
 const struct amdxdna_dev_info dev_npu11_vf_info = {
@@ -254,6 +269,8 @@ const struct amdxdna_dev_info dev_npu11_vf_info = {
 	.fw_feature_tbl		= npu3_fw_feature_table,
 	.cert_feature_tbl	= npu3_cert_feature_table,
 	.ops			= &aie4_vf_ops,
+	.luts			= &aie4_error_luts,
+	.async_max_status_code	= MAX_AIE4_MSG_STATUS_CODE,
 };
 
 const struct amdxdna_dev_info dev_npu11_classic_info = {
@@ -268,4 +285,6 @@ const struct amdxdna_dev_info dev_npu11_classic_info = {
 	.fw_feature_tbl		= npu3_fw_feature_table,
 	.cert_feature_tbl	= npu3_cert_feature_table,
 	.ops			= &aie4_classic_ops,
+	.luts			= &aie4_error_luts,
+	.async_max_status_code	= MAX_AIE4_MSG_STATUS_CODE,
 };

--- a/drivers/accel/amdxdna/npu4_regs.c
+++ b/drivers/accel/amdxdna/npu4_regs.c
@@ -213,4 +213,6 @@ const struct amdxdna_dev_info dev_npu4_info = {
 	.dev_priv          = &npu4_dev_priv,
 	.fw_feature_tbl    = npu4_fw_feature_table,
 	.ops               = &aie2_ops, /* NPU4 can share NPU1's callback */
+	.luts              = &aie2_error_luts,
+	.async_max_status_code = MAX_AIE2_STATUS_CODE,
 };

--- a/drivers/accel/amdxdna/npu5_regs.c
+++ b/drivers/accel/amdxdna/npu5_regs.c
@@ -113,4 +113,6 @@ const struct amdxdna_dev_info dev_npu5_info = {
 	.dev_priv          = &npu5_dev_priv,
 	.fw_feature_tbl    = npu4_fw_feature_table,
 	.ops               = &aie2_ops,
+	.luts              = &aie2_error_luts,
+	.async_max_status_code = MAX_AIE2_STATUS_CODE,
 };

--- a/drivers/accel/amdxdna/npu6_regs.c
+++ b/drivers/accel/amdxdna/npu6_regs.c
@@ -114,4 +114,6 @@ const struct amdxdna_dev_info dev_npu6_info = {
 	.dev_priv          = &npu6_dev_priv,
 	.fw_feature_tbl    = npu4_fw_feature_table,
 	.ops               = &aie2_ops,
+	.luts              = &aie2_error_luts,
+	.async_max_status_code = MAX_AIE2_STATUS_CODE,
 };

--- a/test/shim_test/shim_test.cpp
+++ b/test/shim_test/shim_test.cpp
@@ -1477,7 +1477,7 @@ std::vector<test_case> test_list {
   // get async error in multi thread before running any other tests
   // there may or may not be async error.
   test_case{ "get async error in multithread - INITIAL", {},
-    TEST_POSITIVE, dev_filter_is_aie2, TEST_async_error_multi, {false}
+    TEST_POSITIVE, dev_filter_is_aie, TEST_async_error_multi, {false}
   },
   //test_case{ "non_xdna_userpf: query(rom_vbnv)", {},
   //  TEST_POSITIVE, dev_filter_not_xdna, TEST_query_userpf<query::rom_vbnv>, {}
@@ -1535,7 +1535,7 @@ std::vector<test_case> test_list {
   },
   // Keep bad run before normal run to test recovery of hw ctx
   test_case{ "io test async error", {},
-    TEST_POSITIVE, dev_filter_is_npu4, TEST_async_error_io_any, {}
+    TEST_POSITIVE, dev_filter_is_aie4_or_npu4, TEST_async_error_io_any, {}
   },
   test_case{ "io test real kernel good run", {},
     TEST_POSITIVE, dev_filter_xdna, TEST_io, { IO_TEST_NORMAL_RUN, 1 }
@@ -1668,7 +1668,7 @@ std::vector<test_case> test_list {
   //},
   // get async error in multi thread after async error has raised.
   test_case{ "get async error in multithread - HAS ASYNC ERROR", {},
-    TEST_POSITIVE, dev_filter_is_npu4, TEST_async_error_multi, {true}
+    TEST_POSITIVE, dev_filter_is_aie4_or_npu4, TEST_async_error_multi, {true}
   },
   test_case{ "gemm and debug BO", {},
     TEST_POSITIVE, dev_filter_is_npu4, TEST_io_gemm, {}


### PR DESCRIPTION
This series adds asynchronous error handling for aie4 (NPU4) to the amdxdna
driver, reusing the aie2 path as much as possible.

The first patch factors the existing aie2 async error handling into a shared
framework so both generations share the event registration, worker, and error
decode logic. The remaining patches build the aie4 support on top: wiring up
the aie4 async event path, caching the firmware context app-health report,
and completing in-flight jobs on an aie4 critical context reset so a failing
context recovers cleanly and each timed-out job reports its cached health data.
The final patch extends shim_test to exercise the aie4 async error path.

Tested on AIE2 and AIE4: full shim_test regression passes including the async
error tests (#7, #24, #67).