### PR TITLE
accel/amdxdna: fix VE2 host queue header layout for CERT firmware

### DIFF
--- a/drivers/accel/amdxdna/amdxdna_ctx.h
+++ b/drivers/accel/amdxdna/amdxdna_ctx.h
@@ -129,6 +129,55 @@ struct amdxdna_cmd {
 	u32 data[];
 };
 
+/*
+ * Context health data written into a command BO payload when a command
+ * completes with ERT_CMD_STATE_TIMEOUT. Userspace (XRT) parses the payload
+ * starting at @version and selects the per-generation union member from
+ * @npu_gen. This layout is an ABI shared with the XRT shim.
+ */
+struct uc_health_info {
+	u32 uc_idx;
+	u32 uc_idle_status;
+	u32 misc_status;
+	u32 fw_state;
+	u32 page_idx;
+	u32 offset;
+	u32 restore_page;
+	u32 restore_offset;
+	u32 uc_ear;
+	u32 uc_esr;
+	u32 uc_pc;
+};
+
+struct amdxdna_ctx_health_data_aie2 {
+	u32 txn_op_idx;
+	u32 ctx_pc;
+	u32 fatal_error_type;
+	u32 fatal_error_exception_type;
+	u32 fatal_error_exception_pc;
+	u32 fatal_error_app_module;
+};
+
+struct amdxdna_ctx_health_data_aie4 {
+	u32 ctx_state;
+	u32 num_uc;
+	u32 ctx_error_type;
+	struct uc_health_info uc_info[];
+};
+
+struct amdxdna_ctx_health_data {
+#define AMDXDNA_CTX_HEALTH_DATA_V0	0
+#define AMDXDNA_CTX_HEALTH_DATA_V1	1
+	u32 version;
+#define AMDXDNA_NPU_GEN_AIE2		0
+#define AMDXDNA_NPU_GEN_AIE4		1
+	u32 npu_gen;
+	union {
+		struct amdxdna_ctx_health_data_aie2 aie2;
+		struct amdxdna_ctx_health_data_aie4 aie4;
+	};
+};
+
 #define INVALID_CU_IDX		(~0U)
 #define AMDXDNA_INVALID_DOORBELL_OFFSET	(~0U)
 
@@ -231,6 +280,20 @@ amdxdna_cmd_get_state(struct amdxdna_gem_obj *abo)
 		return ERT_CMD_STATE_INVALID;
 
 	return FIELD_GET(AMDXDNA_CMD_STATE, cmd->header);
+}
+
+static inline void *
+amdxdna_cmd_get_data(struct amdxdna_gem_obj *abo, u32 *size)
+{
+	struct amdxdna_cmd *cmd = amdxdna_gem_vmap(abo);
+
+	if (!cmd) {
+		*size = 0;
+		return NULL;
+	}
+
+	*size = abo->mem.size - offsetof(struct amdxdna_cmd, data);
+	return cmd->data;
 }
 
 void *amdxdna_cmd_get_payload(struct amdxdna_gem_obj *abo, u32 *size);

--- a/drivers/accel/amdxdna/ve2_aux.c
+++ b/drivers/accel/amdxdna/ve2_aux.c
@@ -124,6 +124,70 @@ out:
 	return ret;
 }
 
+static int ve2_capture_col_firmware_status(struct amdxdna_dev *xdna,
+					   struct amdxdna_mgmtctx *mgmtctx,
+					   u32 lead_col, u32 col)
+{
+	struct amdxdna_dev_hdl *hdl = ve2_dev_hdl(xdna);
+	struct ve2_firmware_status *cs;
+	struct handshake *hs;
+	u32 offset;
+	int ret;
+
+	if (!hdl->fw_slots || !hdl->fw_slots[lead_col + col])
+		return -EINVAL;
+
+	cs = hdl->fw_slots[lead_col + col];
+
+	hs = kzalloc(sizeof(*hs), GFP_KERNEL);
+	if (!hs)
+		return -ENOMEM;
+
+	offset = CERT_HANDSHAKE_OFF(col) + offsetof(struct handshake, mpaie_alive);
+	ret = aie_partition_read_privileged_mem(mgmtctx->aie_dev, offset,
+						sizeof(*hs), hs);
+	if (ret < 0) {
+		XDNA_ERR(xdna, "read fw status col %u failed: %d", col, ret);
+		goto done;
+	}
+
+	cs->state = hs->vm.fw_state;
+	cs->abs_page_index = hs->vm.abs_page_index;
+	cs->ppc = hs->vm.ppc;
+	cs->idle_status = hs->cert_idle_status;
+	cs->misc_status = hs->misc_status;
+
+	XDNA_DBG(xdna,
+		 "FW status col %u: state=%u abs_page=%u ppc=%u idle=%u misc=%u",
+		 lead_col + col, cs->state, cs->abs_page_index, cs->ppc,
+		 cs->idle_status, cs->misc_status);
+done:
+	kfree(hs);
+	return ret;
+}
+
+int ve2_get_firmware_status(struct amdxdna_hwctx *hwctx)
+{
+	struct amdxdna_dev *xdna = hwctx->client->xdna;
+	struct amdxdna_ctx_priv *vp = ve2_hw_priv(hwctx);
+	struct amdxdna_mgmtctx *mgmtctx;
+	int ret = 0;
+
+	if (!vp || !vp->mgmtctx || !vp->mgmtctx->aie_dev)
+		return -ENODEV;
+
+	mgmtctx = vp->mgmtctx;
+
+	for (u32 col = 0; col < mgmtctx->num_col; col++) {
+		int r = ve2_capture_col_firmware_status(xdna, mgmtctx,
+							mgmtctx->start_col, col);
+		if (r < 0)
+			ret = r;
+	}
+
+	return ret;
+}
+
 void ve2_auto_select_mem_bitmap(struct amdxdna_dev *xdna, struct amdxdna_hwctx *hwctx)
 {
 	struct amdxdna_ctx_priv *vp = ve2_hw_priv(hwctx);
@@ -169,6 +233,20 @@ int ve2_probe(struct amdxdna_dev *xdna, struct amdxdna_dev_hdl *hdl)
 		return ret;
 	}
 
+	/* Per-column firmware status slots, filled on hwctx teardown. */
+	hdl->fw_slots = devm_kcalloc(xdna->ddev.dev, hdl->aie_dev_info.cols,
+				     sizeof(*hdl->fw_slots), GFP_KERNEL);
+	if (!hdl->fw_slots)
+		return -ENOMEM;
+
+	for (u32 col = 0; col < hdl->aie_dev_info.cols; col++) {
+		hdl->fw_slots[col] = devm_kzalloc(xdna->ddev.dev,
+						  sizeof(*hdl->fw_slots[col]),
+						  GFP_KERNEL);
+		if (!hdl->fw_slots[col])
+			return -ENOMEM;
+	}
+
 	ret = ve2_load_fw(hdl);
 	if (ret) {
 		XDNA_ERR(xdna, "aie load %s failed with err %d", hdl->priv->fw_path, ret);
@@ -184,6 +262,8 @@ int ve2_probe(struct amdxdna_dev *xdna, struct amdxdna_dev_hdl *hdl)
 
 static const struct amdxdna_dev_priv ve2_aux_priv = {
 	.fw_path		= "amdnpu/release_cert_ve2.elf",
+	.hwctx_limit		= 255,
+	.ctx_limit		= 255,
 };
 
 const struct amdxdna_dev_info dev_ve2_info = {

--- a/drivers/accel/amdxdna/ve2_aux.h
+++ b/drivers/accel/amdxdna/ve2_aux.h
@@ -16,6 +16,12 @@
 
 struct amdxdna_dev_priv {
 	const char			*fw_path;
+	/*
+	 * Max hardware/scheduling contexts. Advertised for parity with the
+	 * other backends; VE2 does not yet enforce these limits (TODO).
+	 */
+	u32				hwctx_limit;
+	u32				ctx_limit;
 };
 
 struct amdxdna_dev;
@@ -36,7 +42,17 @@ struct ve2_firmware_version {
 	u8 build;
 };
 
+/* Per-column CERT firmware status snapshot, captured on hwctx teardown. */
+struct ve2_firmware_status {
+	u32 state;
+	u32 abs_page_index;
+	u32 ppc;
+	u32 idle_status;
+	u32 misc_status;
+};
+
 struct amdxdna_mgmtctx;
+struct amdxdna_hwctx;
 
 struct amdxdna_dev_hdl {
 	struct amdxdna_dev		*xdna;
@@ -44,6 +60,7 @@ struct amdxdna_dev_hdl {
 	struct aie_device_info		aie_dev_info;
 	struct ve2_firmware_version	fw_version;
 	struct amdxdna_mgmtctx		*ve2_mgmtctx;
+	struct ve2_firmware_status	**fw_slots;	/* [cols] per-column FW status */
 };
 
 extern const struct amdxdna_dev_ops ve2_ops;
@@ -55,5 +72,8 @@ static inline struct amdxdna_dev_hdl *ve2_dev_hdl(struct amdxdna_dev *xdna)
 
 int ve2_probe(struct amdxdna_dev *xdna, struct amdxdna_dev_hdl *hdl);
 void ve2_auto_select_mem_bitmap(struct amdxdna_dev *xdna, struct amdxdna_hwctx *hwctx);
+
+/* Capture the per-column CERT firmware status for @hwctx's partition. */
+int ve2_get_firmware_status(struct amdxdna_hwctx *hwctx);
 
 #endif /* _VE2_AUX_H_ */

--- a/drivers/accel/amdxdna/ve2_host_queue.h
+++ b/drivers/accel/amdxdna/ve2_host_queue.h
@@ -12,6 +12,9 @@
 #define HOST_QUEUE_ENTRY        32
 #define HOST_INDIRECT_PKT_NUM   36
 
+#define HOST_QUEUE_MAJOR_VERSION 1
+#define HOST_QUEUE_MINOR_VERSION 0
+
 #define LAST_CMD (0)
 #define NOT_LAST_CMD (1)
 
@@ -29,15 +32,17 @@ struct exec_buf {
 };
 
 struct host_queue_header {
-	u64	read_index;
+	u64	read_index;		/* 0x00 — device updates this */
 	struct {
 		u16 major;
 		u16 minor;
-	} version;
-	u32	capacity;
-	u64	write_index;
-	u64	data_address;
-};
+	} version;			/* 0x08 */
+	u32	capacity;		/* 0x0c — must be a power of two */
+	u64	padding0[6];		/* 0x10 — pad to 64-byte boundary */
+	u64	write_index;		/* 0x40 — host updates this */
+	u64	padding1[6];		/* 0x48 — pad to next 64-byte boundary */
+	u64	data_address;		/* 0x78 — DMA address of packet ring */
+} __aligned(64);
 
 struct host_indirect_packet_entry {
 	u32	host_addr_low;

--- a/drivers/accel/amdxdna/ve2_hwctx.c
+++ b/drivers/accel/amdxdna/ve2_hwctx.c
@@ -938,13 +938,87 @@ static void ve2_process_hqc_completion(struct amdxdna_hwctx *hwctx, struct amdxd
 	amdxdna_cmd_set_state(job->cmd_bo, state);
 }
 
+/*
+ * Capture CERT firmware health telemetry for each column of the context and
+ * write it into the timed-out command BO payload, so XRT can surface per-uC
+ * state (idle/misc status, FW state, fault PC/EAR/ESR, ...) via the timed-out
+ * run object. The layout matches struct amdxdna_ctx_health_data, which is an
+ * ABI shared with the XRT shim.
+ */
+static void ve2_fill_health_data(struct amdxdna_hwctx *hwctx, void *cmd_data, u32 data_total)
+{
+	size_t hdr_size = offsetof(struct amdxdna_ctx_health_data, aie4.uc_info);
+	struct amdxdna_ctx_priv *vp = ve2_hw_priv(hwctx);
+	struct amdxdna_dev *xdna = hwctx->client->xdna;
+	struct amdxdna_ctx_health_data *health;
+	struct amdxdna_mgmtctx *mgmtctx;
+	struct handshake *hs;
+	u32 max_uc, num_uc;
+	u32 col;
+	int ret;
+
+	if (!vp || !vp->mgmtctx || !vp->mgmtctx->aie_dev)
+		return;
+	mgmtctx = vp->mgmtctx;
+
+	if (!cmd_data || data_total < hdr_size) {
+		XDNA_WARN(xdna, "Health data buffer too small: %u < %zu", data_total, hdr_size);
+		return;
+	}
+
+	memset(cmd_data, 0, data_total);
+	health = cmd_data;
+	health->version = AMDXDNA_CTX_HEALTH_DATA_V1;
+	health->npu_gen = AMDXDNA_NPU_GEN_AIE4;
+	health->aie4.ctx_state = vp->state;
+	health->aie4.ctx_error_type = 0;
+
+	max_uc = (data_total - hdr_size) / sizeof(struct uc_health_info);
+	num_uc = min(hwctx->num_col, max_uc);
+
+	hs = kzalloc(sizeof(*hs), GFP_KERNEL);
+	if (!hs)
+		return;
+
+	for (col = 0; col < num_uc; col++) {
+		ret = aie_partition_read_privileged_mem(mgmtctx->aie_dev,
+							CERT_HANDSHAKE_OFF(col) +
+							offsetof(struct handshake, mpaie_alive),
+							sizeof(*hs), hs);
+		if (ret < 0) {
+			XDNA_ERR(xdna, "handshake read failed col %u ret %d", col, ret);
+			break;
+		}
+
+		health->aie4.uc_info[col].uc_idx = hwctx->start_col + col;
+		health->aie4.uc_info[col].uc_idle_status = hs->cert_idle_status;
+		health->aie4.uc_info[col].misc_status = hs->misc_status;
+		health->aie4.uc_info[col].fw_state = hs->vm.fw_state;
+		health->aie4.uc_info[col].page_idx = hs->vm.abs_page_index;
+		health->aie4.uc_info[col].offset = hs->vm.ppc;
+		health->aie4.uc_info[col].restore_page =
+			hs->ctx_save.contents.restore_page.page_index;
+		health->aie4.uc_info[col].restore_offset =
+			hs->ctx_save.contents.restore_page.page_offset;
+		health->aie4.uc_info[col].uc_ear = hs->exception.ear;
+		health->aie4.uc_info[col].uc_esr = hs->exception.esr;
+		health->aie4.uc_info[col].uc_pc = hs->exception.pc;
+	}
+
+	health->aie4.num_uc = col;
+	kfree(hs);
+}
+
 static void ve2_handle_timeout(struct amdxdna_hwctx *hwctx, struct amdxdna_sched_job *job, u64 seq)
 {
 	struct amdxdna_ctx_priv *vp = ve2_hw_priv(hwctx);
 	struct amdxdna_dev *xdna = hwctx->client->xdna;
+	void *cmd_data;
+	u32 data_total;
 
 	if (amdxdna_cmd_get_op(job->cmd_bo) == ERT_CMD_CHAIN) {
 		struct amdxdna_cmd_chain *cc = amdxdna_cmd_get_payload(job->cmd_bo, NULL);
+		struct amdxdna_gem_obj *target_bo;
 		u32 fail_cmd_idx = 0;
 		u32 rl_read_idx = 0;
 		int ret;
@@ -961,7 +1035,26 @@ static void ve2_handle_timeout(struct amdxdna_hwctx *hwctx, struct amdxdna_sched
 			cc->error_index = fail_cmd_idx;
 			XDNA_ERR(xdna, "Chain timeout at index %u, runlist_read_idx %u",
 				 fail_cmd_idx, rl_read_idx);
+
+			/*
+			 * Write health telemetry into the failing sub-command BO so XRT
+			 * can read it back from the individual timed-out run object.
+			 */
+			target_bo = amdxdna_gem_get_obj(hwctx->client, (u32)cc->data[fail_cmd_idx],
+							AMDXDNA_BO_SHARE);
+			if (target_bo) {
+				cmd_data = amdxdna_cmd_get_data(target_bo, &data_total);
+				ve2_fill_health_data(hwctx, cmd_data, data_total);
+				amdxdna_cmd_set_state(target_bo, ERT_CMD_STATE_TIMEOUT);
+				amdxdna_gem_put_obj(target_bo);
+			} else {
+				XDNA_ERR(xdna, "Failed to find sub-cmd BO %u at chain index %u",
+					 (u32)cc->data[fail_cmd_idx], fail_cmd_idx);
+			}
 		}
+	} else {
+		cmd_data = amdxdna_cmd_get_data(job->cmd_bo, &data_total);
+		ve2_fill_health_data(hwctx, cmd_data, data_total);
 	}
 
 	amdxdna_cmd_set_state(job->cmd_bo, ERT_CMD_STATE_TIMEOUT);

--- a/drivers/accel/amdxdna/ve2_hwctx.c
+++ b/drivers/accel/amdxdna/ve2_hwctx.c
@@ -505,6 +505,8 @@ static int ve2_create_host_queue(struct amdxdna_hwctx *hwctx)
 	queue->hsa_queue_p->hq_header.data_address =
 		dma_handle + sizeof(struct host_queue_header);
 	queue->hsa_queue_p->hq_header.capacity = HOST_QUEUE_ENTRY;
+	queue->hsa_queue_p->hq_header.version.major = HOST_QUEUE_MAJOR_VERSION;
+	queue->hsa_queue_p->hq_header.version.minor = HOST_QUEUE_MINOR_VERSION;
 
 	/* Set hsa queue slots to invalid and initialize indirect regions */
 	for (slot = 0; slot < HOST_QUEUE_ENTRY; slot++) {
@@ -588,7 +590,7 @@ static void ve2_free_hsa_queue(struct amdxdna_hwctx *hwctx)
 
 static void ve2_hwctx_poll_timer(struct timer_list *t)
 {
-	struct amdxdna_ctx_priv *vp = from_timer(vp, t, event_timer);
+	struct amdxdna_ctx_priv *vp = timer_container_of(vp, t, event_timer);
 
 	wake_up_interruptible_all(&vp->waitq);
 	mod_timer(&vp->event_timer, jiffies + CTX_TIMER);
@@ -693,12 +695,16 @@ void ve2_hwctx_fini(struct amdxdna_hwctx *hwctx)
 
 	vp = priv->hw_priv;
 
+	/* Snapshot per-column CERT firmware status before tearing the partition down. */
+	if (vp && vp->mgmtctx)
+		ve2_get_firmware_status(hwctx);
+
 	ve2_mgmt_destroy_partition(hwctx);
 	ve2_free_hsa_queue(hwctx);
 
 	if (vp) {
 		if (enable_polling)
-			del_timer_sync(&vp->event_timer);
+			timer_delete_sync(&vp->event_timer);
 		kfree(vp->hwctx_config);
 		vp->hwctx_config = NULL;
 		mutex_destroy(&vp->privctx_lock);

--- a/drivers/accel/amdxdna/ve2_mgmt.c
+++ b/drivers/accel/amdxdna/ve2_mgmt.c
@@ -68,6 +68,7 @@ static void cert_setup_partition(struct amdxdna_mgmtctx *mgmtctx,
 	struct amdxdna_ctx_priv *vp = ve2_hw_priv(hwctx);
 	struct ve2_config_hwctx *cfg = NULL;
 	u64 hsa_addr = U64_MAX;
+	u64 host_time;
 
 	if (col == 0 && vp && vp->hsa_queue.hsa_queue_dma_addr)
 		hsa_addr = vp->hsa_queue.hsa_queue_dma_addr;
@@ -79,6 +80,15 @@ static void cert_setup_partition(struct amdxdna_mgmtctx *mgmtctx,
 	cert_hs->aie_info.partition_size = mgmtctx->num_col;
 	cert_hs->hsa_addr_high = upper_32_bits(hsa_addr);
 	cert_hs->hsa_addr_low = lower_32_bits(hsa_addr);
+
+	/* Provide the host wall-clock time so firmware can correlate/telemetry. */
+	host_time = ktime_get_ns();
+	cert_hs->host_time_high = upper_32_bits(host_time);
+	cert_hs->host_time_low = lower_32_bits(host_time);
+
+	/* No debug HSA queue: mark the debug HSA address explicitly invalid. */
+	cert_hs->dbg.hsa_addr_high = 0xFFFFFFFF;
+	cert_hs->dbg.hsa_addr_low = 0xFFFFFFFF;
 
 	if (cfg) {
 		cert_hs->log_addr_high = upper_32_bits(cfg->log_buf_addr);


### PR DESCRIPTION
-Fix the host queue header to align with latest CERT firmware queue header format.
-Latest kernel is 6.16+ in xdna, so old timer API names were removed/renamed:
    from_timer() → timer_container_of()
    del_timer_sync() → timer_delete_sync()
-Initialise the host-queue version in the header, program the host clock time in the partition handshake
-Save per-column CERT firmware status on hwctx teardown, and expose hwctx/ctx limit fields.