### PR TITLE
accel/amdxdna: fix WRITE_AIE_REG user payload offset

### DIFF
--- a/drivers/accel/amdxdna/aie.c
+++ b/drivers/accel/amdxdna/aie.c
@@ -1006,7 +1006,7 @@ static int amdxdna_aie_tile_write_reg(struct amdxdna_hwctx *hwctx,
 		return -EINVAL;
 	}
 
-	if (copy_from_user(&reg_val, wa->buf + sizeof(wa->access),
+	if (copy_from_user(&reg_val, wa->buf + sizeof(*wa->access),
 			   sizeof(reg_val))) {
 		XDNA_ERR(xdna, "Failed to copy register data from user");
 		return -EFAULT;


### PR DESCRIPTION
amdxdna_aie_tile_write_reg() copied the 32-bit register value from wa->buf + sizeof(wa->access). wa->access is a pointer, so sizeof() yields the pointer width (8 bytes) rather than the size of the struct amdxdna_drm_aie_tile_access header (32 bytes) that precedes the payload in the user buffer. The kernel therefore read the wrong 4 bytes from inside the header instead of the register payload, writing a bad value to the AIE tile register.