### PR TITLE
shim: populate aie-partitions frame and layer preemption events

### DIFF
--- a/src/shim/device.cpp
+++ b/src/shim/device.cpp
@@ -20,8 +20,11 @@
 #include <algorithm>
 #include <climits>
 #include <cstdio>
+#include <map>
+#include <optional>
 #include <sstream>
 #include <string>
+#include <utility>
 
 namespace {
 
@@ -270,6 +273,58 @@ struct aie_info
   }
 };
 
+// Preemption frame and layer boundary event counters for a single
+// hardware context, extracted from RTOS telemetry.
+struct preemption_events
+{
+  uint64_t frame_events = 0;  // Preemptions taken at a frame boundary.
+  uint64_t layer_events = 0;  // Preemptions taken at a layer checkpoint.
+};
+
+// Build a map of hardware context id to its preemption frame and layer
+// boundary event counters.
+//
+// The counters live in the RTOS telemetry payload (already parsed by the
+// rtos_telemetry query handler) and are keyed there by slot_index. On AIE2
+// the driver populates slot_index with the hardware context id from the
+// amdxdna ctx_map, which matches amdxdna_drm_hwctx_entry::context_id. On AIE4
+// there is no such mapping and slot_index is the firmware micro-controller
+// slot, which lines up with amdxdna_drm_hwctx_entry::hwctx_id instead. Callers
+// therefore select the lookup key by device generation (hwctx_id on AIE4,
+// context_id otherwise); probing context_id unconditionally could false-match
+// an unrelated AIE4 telemetry slot since context_id is allocated cyclically
+// from a small value.
+//
+// Reusing the rtos_telemetry query keeps the telemetry parsing in a single
+// place so both the aie-partitions report and the preemption report share the
+// same source of frame and layer event data.
+//
+// @param device Device to query.
+// @return Map of hardware context id to its preemption event counters. Empty
+//         when RTOS telemetry is not supported on the device.
+static std::map<uint32_t, preemption_events>
+get_preemption_events(const xrt_core::device* device)
+{
+  std::map<uint32_t, preemption_events> events;
+  try {
+    const auto telemetry = xrt_core::device_query<xrt_core::query::rtos_telemetry>(device);
+    for (const auto& task : telemetry) {
+      const auto& preempt = task.preemption_data;
+      events[static_cast<uint32_t>(preempt.slot_index)] =
+        preemption_events{preempt.preemption_frame_boundary_events,
+                          preempt.preemption_checkpoint_event};
+    }
+  }
+  catch (const std::exception& e) {
+    // RTOS telemetry is optional. It may be unsupported on this device or the
+    // query may fail; enriching with preemption events is best effort, so
+    // report zero events rather than failing the aie_partition_info query.
+    // Log at debug level to aid diagnosis without spamming the normal path.
+    shim_debug("preemption event enrichment skipped: %s", e.what());
+  }
+  return events;
+}
+
 struct partition_info
 {
   using result_type = std::any;
@@ -279,6 +334,26 @@ struct partition_info
   {
     if (key != key_type::aie_partition_info)
       throw xrt_core::query::no_such_key(key, "Not implemented");
+
+    // The RTOS telemetry preemption counters are keyed differently per
+    // device generation: on AIE4 by the firmware micro-controller slot
+    // (amdxdna_drm_hwctx_entry::hwctx_id) and on AIE2 by the hardware context
+    // id (amdxdna_drm_hwctx_entry::context_id). Select the join key by
+    // generation rather than probing both, because context_id is allocated
+    // cyclically from a small value and could otherwise false-match an
+    // unrelated telemetry slot on AIE4.
+    //
+    // Reading the PCI device id can throw. Preemption enrichment is best
+    // effort, so if the generation cannot be determined leave the optional
+    // unset and skip enrichment (counters stay zero) rather than guessing a
+    // key that could attach wrong counts, or failing the whole query.
+    std::optional<bool> is_aie4_dev;
+    try {
+      is_aie4_dev = is_aie4(xrt_core::device_query<query::pcie_id>(device).device_id);
+    }
+    catch (const std::exception& e) {
+      shim_debug("preemption enrichment skipped, device generation unknown: %s", e.what());
+    }
 
     amdxdna_drm_hwctx_entry* data;
     const uint32_t output_entries = 1024;
@@ -321,6 +396,8 @@ struct partition_info
         data_size = legacy_arg.buffer_size / sizeof(*legacy_data);
         legacy_data = reinterpret_cast<decltype(legacy_data)>(legacy_payload.data());
 
+        const auto legacy_preemption_event_map = get_preemption_events(device);
+
         query::aie_partition_info::result_type output;
         for (uint32_t i = 0; i < data_size; i++) {
           const auto& entry = legacy_data[i];
@@ -335,6 +412,22 @@ struct partition_info
           new_entry.command_completions = entry.command_completions;
           new_entry.migrations = entry.migrations;
           new_entry.preemptions = entry.preemptions;
+          // The legacy amdxdna_drm_query_hwctx struct only exposes context_id,
+          // not hwctx_id, so the generation-based key selection used on the
+          // modern path is not possible here. This legacy ioctl is the AIE2-era
+          // path where the telemetry slot_index is the hardware context id, so
+          // the join by context_id is correct; AIE4 (keyed by hwctx_id) always
+          // supports the modern DRM_AMDXDNA_HW_CONTEXT_ALL ioctl below, so it
+          // never reaches this path. Only enrich when the device is known to be
+          // non-AIE4 so an unknown generation does not attach a context_id keyed
+          // count that could be wrong; otherwise the counters stay at zero.
+          if (is_aie4_dev && !*is_aie4_dev) {
+            const auto preempt_it = legacy_preemption_event_map.find(entry.context_id);
+            if (preempt_it != legacy_preemption_event_map.end()) {
+              new_entry.preemption_frame_event = preempt_it->second.frame_events;
+              new_entry.preemption_layer_event = preempt_it->second.layer_events;
+            }
+          }
           new_entry.errors = entry.errors;
           output.push_back(std::move(new_entry));
         }
@@ -361,6 +454,8 @@ struct partition_info
       }
     }
 
+    const auto preemption_event_map = get_preemption_events(device);
+
     query::aie_partition_info::result_type output;
     for (uint32_t i = 0; i < data_size; i++) {
       const auto& entry = data[i];
@@ -375,6 +470,16 @@ struct partition_info
       new_entry.command_completions = entry.command_completions;
       new_entry.migrations = entry.migrations;
       new_entry.preemptions = entry.preemptions;
+      // Only enrich when the device generation is known; guessing a key could
+      // attach wrong counters (see is_aie4_dev above).
+      if (is_aie4_dev) {
+        const auto preempt_key = *is_aie4_dev ? entry.hwctx_id : entry.context_id;
+        const auto preempt_it = preemption_event_map.find(preempt_key);
+        if (preempt_it != preemption_event_map.end()) {
+          new_entry.preemption_frame_event = preempt_it->second.frame_events;
+          new_entry.preemption_layer_event = preempt_it->second.layer_events;
+        }
+      }
       new_entry.errors = entry.errors;
       new_entry.qos.priority = entry.priority;
       new_entry.qos.gops = entry.gops;

--- a/test/shim_test/io_test.cpp
+++ b/test/shim_test/io_test.cpp
@@ -229,17 +229,22 @@ io_test_cmd_submit_and_wait_thruput(
   }
 }
 
-std::vector<std::pair<int, uint64_t>>
+std::vector<std::pair<uint32_t, uint64_t>>
 get_fine_preemption_counters(device *dev)
 {
-  std::vector<std::pair<int, uint64_t>> counters;
+  std::vector<std::pair<uint32_t, uint64_t>> counters;
 
-  const auto telemetry = device_query<query::rtos_telemetry>(dev);
-  for (auto& task : telemetry) {
-    auto user_tid = task.preemption_data.slot_index;
-    auto value = task.preemption_data.preemption_checkpoint_event;
+  // Per hardware context preemption layer (checkpoint) counters are now
+  // exported through the aie-partitions report, so query aie_partition_info
+  // instead of the raw RTOS telemetry. The counters are keyed by context id,
+  // which matches hw_ctx::get_slotidx(). The context id is an unsigned 32-bit
+  // uAPI value, so parse it as such to avoid signed narrowing/overflow.
+  const auto partitions = device_query<query::aie_partition_info>(dev);
+  for (const auto& partition : partitions) {
+    auto ctx_id = static_cast<uint32_t>(std::stoul(partition.metadata.id));
+    auto value = partition.preemption_layer_event;
 
-    counters.emplace_back(user_tid, value);
+    counters.emplace_back(ctx_id, value);
   }
   return counters;
 }
@@ -264,29 +269,31 @@ force_fine_preemption(device *dev, bool control)
 }
 
 uint64_t
-get_fine_preemption_counter_delta(device *dev, hw_ctx& ctx, std::vector<std::pair<int, uint64_t>>& pre)
+get_fine_preemption_counter_delta(device *dev, hw_ctx& ctx, std::vector<std::pair<uint32_t, uint64_t>>& pre)
 {
   auto ctx_id = ctx.get()->get_slotidx();
   auto cur = get_fine_preemption_counters(dev);
-  uint64_t fine_preemption_count;
-  int index = -1;
 
-  // Find the user task ID for the ctx id
-  for (int i = 0; i < cur.size(); i++) {
-    auto id = cur[i].first;
-    if (id == ctx_id) {
-      fine_preemption_count = cur[i].second;
-      index = i;
-      break;
+  // Look up the layer preemption counter for a context by its id. The
+  // aie-partitions report only lists active hardware contexts, so unlike the
+  // old fixed-slot telemetry the counters must be matched by context id rather
+  // than vector index. Both snapshots are taken while the context is alive, so
+  // the entry must exist in each.
+  auto counter_for = [](const std::vector<std::pair<uint32_t, uint64_t>>& counters,
+                        uint32_t id) -> uint64_t {
+    for (const auto& counter : counters) {
+      if (counter.first == id)
+        return counter.second;
     }
-  }
+    throw std::runtime_error("Can't determine preemption counter for ctx!");
+  };
 
-  if (index == -1)
-    throw std::runtime_error("Can't determine user task ID for ctx!");
-  if (fine_preemption_count < pre.at(index).second)
-    throw std::runtime_error("Find preemption counter is smaller after the run!");
+  auto cur_count = counter_for(cur, ctx_id);
+  auto pre_count = counter_for(pre, ctx_id);
+  if (cur_count < pre_count)
+    throw std::runtime_error("Fine preemption counter is smaller after the run!");
 
-  return fine_preemption_count - pre.at(index).second;
+  return cur_count - pre_count;
 }
 
 uint64_t
@@ -341,16 +348,21 @@ io_test(device::id_type id, device* dev, int total_hwq_submit, int num_cmdlist,
     bo_set.push_back(std::move(alloc_and_init_bo_set(dev, tag, flow)));
 
   bool preemption_enabled = false;
-  std::vector<std::pair<int, uint64_t>> pre_cntrs;
-  if (io_test_parameters.type == IO_TEST_FORCE_PREEMPTION) {
-    // Enable force preemption and take snapshot of current fw counters before running any cmd.
+  if (io_test_parameters.type == IO_TEST_FORCE_PREEMPTION)
     preemption_enabled = !force_fine_preemption(dev, true);
-    pre_cntrs = get_fine_preemption_counters(dev);
-  }
 
   // Creating HW context for cmd submission
   hw_ctx hwctx{dev, tag, flow};
   auto hwq = hwctx.get()->get_hw_queue();
+
+  // Snapshot the preemption counters after the context exists but before any
+  // command runs. The counters are now sourced from the aie-partitions report,
+  // which only lists active hardware contexts, so the baseline must be read
+  // once this context is present. The firmware counter is cumulative per slot,
+  // so this captures the correct starting value for the delta below.
+  std::vector<std::pair<uint32_t, uint64_t>> pre_cntrs;
+  if (preemption_enabled)
+    pre_cntrs = get_fine_preemption_counters(dev);
 
   // Initialize cmd before submission
   for (auto& boset : bo_set) {


### PR DESCRIPTION
The aie-partitions report has Frame Evts and Layer Evts columns, but the shim never filled preemption_frame_event or preemption_layer_event in the aie_partition_info query, so they always reported zero.

Add a get_preemption_events() helper that reads the frame and layer boundary counters from RTOS telemetry and keys them by hardware context id (the same id carried in amdxdna_drm_hwctx_entry::context_id via the driver ctx_map). partition_info::get() joins this map into each context entry for both the current and legacy hwctx query paths.

Reusing the rtos_telemetry query keeps the telemetry parsing in one place so the aie-partitions report and the preemption report share the same source of frame and layer event data. No driver change is required.