### PR TITLE
Update xrt commit to the latest version

### DIFF
--- a/tools/info.json
+++ b/tools/info.json
@@ -1,7 +1,7 @@
 {
 	"copyright": "Copyright (C) 2023-2026 Advanced Micro Devices, Inc. All rights reserved.",
 	"xrt" : {
-		"version": "202620.2.26.51",
+		"version": "202620.2.26.60",
 		"os_rel": ["22.04", "24.04"]
 	},
 	"firmwares": [


### PR DESCRIPTION
Update xrt commit to the latest version

Changelog:
   Update xdp submodule to 237c4dacca3976719ab086a47c9dd93200a009d1 (#9922)
   Fix windows regression from SWSPLAT-24084 (#9915) (#9921)
   SWSPLAT-24084 AIESW-32875 fix env-controlled library injection and add coreutil-relative shim loading (#9915)
   hip: vendor minimal HIP host headers and drop external ROCm dependency (#9918)
   Remove use of npu3 dll for ML Timeline (#9916)
   Add xrt_ci_test.yml workflow for u50 board testing (#9919)
   Fix OOB access issue when caching bd data ptrs during ELF patching (#9910)
   SWSPLAT-30732 fix off-by-one in device::get_memory_type() bounds check (#9914)
   SWSPLAT-30733 fix negative array index in ert_write/read_return_code macros (#9913)
   SWSPLAT-39875 fix xrt.ini CWD config injection when running with elevated privileges (#9912)
   SWSPLAT-30717 fix unvalidated mpo_ offsets causing heap OOB read in xclbinutil sections (#9908)
   SWSPLAT-30722 fix m_numSections underflow and unbounded FDT walk in XBUtilities (#9905)
   Fix regression from #9845 (#9911)
   SWSPLAT-30728 fix offset+sz integer overflow bypasses bounds check in HIP memory (#9901)
   Add Windows PE security compiler and linker flags (#9909)
   SWSPLAT-30720 fix path traversal in file_repo::resolve_key() (#9906)
   SWSPLAT-30723 fix device-supplied num_uc indexes uc_info[] with no size check (#9904)
   SWSPLAT-30726 fix extract_value() OOB memcpy reads past firmware log buffer (#9903)
   SWSPLAT-30730 XclBinUtilities::exec() require boost::process (#9900)
   SWSPLAT-30710 elf_patcher validate patch offset against BO size before write (#9894)
   Enable dtrace for npu3 (#9888)