### PR TITLE
accel/amdxdna: report process name and memory usage in aie-partitions

### DIFF
--- a/drivers/accel/amdxdna/aie.c
+++ b/drivers/accel/amdxdna/aie.c
@@ -316,6 +316,7 @@ static int amdxdna_fill_hwctx_status_entry(struct aie_device *aie,
 		return -ENOMEM;
 
 	tmp->pid = hwctx->client->pid;
+	strscpy(tmp->name, hwctx->client->name, sizeof(tmp->name));
 	tmp->context_id = hwctx->id;
 	tmp->start_col = hwctx->start_col;
 	tmp->num_col = hwctx->num_col;
@@ -455,7 +456,9 @@ int amdxdna_query_ctx_status_by_id(struct aie_device *aie,
 	struct amdxdna_dev *xdna = client->xdna;
 	struct amdxdna_client *tmp_client;
 	int ret = -ENOENT;
+	size_t min_input_sz;
 	size_t buf_size;
+	size_t min_sz;
 
 	drm_WARN_ON(&xdna->ddev, !mutex_is_locked(&xdna->dev_lock));
 
@@ -470,13 +473,36 @@ int amdxdna_query_ctx_status_by_id(struct aie_device *aie,
 		return -EINVAL;
 	}
 
+	/*
+	 * BY_ID is an input query: the caller must supply at least @context_id
+	 * and @pid so the target context can be looked up. Reject an
+	 * element_size too small to cover them (including 0), otherwise the
+	 * missing bytes would read back as zero and fail later with a
+	 * misleading "Invalid context ID or PID".
+	 */
+	min_input_sz = offsetofend(struct amdxdna_drm_hwctx_entry, pid);
+	if (args->element_size < min_input_sz) {
+		XDNA_ERR(xdna, "Invalid element size %u, need at least %zu",
+			 args->element_size, min_input_sz);
+		return -EINVAL;
+	}
+
+	/*
+	 * Negotiate the element size against the caller's struct the same way
+	 * the HW_CONTEXT_ALL walk does, so user space built against an older
+	 * (smaller) amdxdna_drm_hwctx_entry still works after the struct grows.
+	 * Only the negotiated number of bytes are read from and written back to
+	 * the user buffer; @input is zero-initialized so any field the caller
+	 * did not provide reads as zero.
+	 */
+	min_sz = min_t(size_t, args->element_size, sizeof(input));
 	buf_size = (size_t)args->num_element * args->element_size;
-	if (buf_size < sizeof(input)) {
+	if (buf_size < min_sz) {
 		XDNA_ERR(xdna, "Insufficient buffer size: 0x%zx", buf_size);
 		return -EINVAL;
 	}
 
-	if (copy_from_user(&input, u64_to_user_ptr(args->buffer), sizeof(input))) {
+	if (copy_from_user(&input, u64_to_user_ptr(args->buffer), min_sz)) {
 		XDNA_ERR(xdna, "Failed to copy hwctx entry from user");
 		return -EFAULT;
 	}

--- a/drivers/accel/amdxdna/aie4_pci.c
+++ b/drivers/accel/amdxdna/aie4_pci.c
@@ -18,6 +18,7 @@
 #include "aie4_msg_priv.h"
 #include "amdxdna_ctx.h"
 #include "amdxdna_dpt.h"
+#include "amdxdna_gem.h"
 #include "amdxdna_mailbox.h"
 #include "amdxdna_mailbox_helper.h"
 #include "amdxdna_pci_drv.h"
@@ -1001,6 +1002,9 @@ static int aie4_get_array(struct amdxdna_client *client,
 		break;
 	case DRM_AMDXDNA_HW_LAST_ASYNC_ERR:
 		ret = aie4_get_array_async_error(ndev, args);
+		break;
+	case DRM_AMDXDNA_BO_USAGE:
+		ret = amdxdna_drm_get_bo_usage(&xdna->ddev, args);
 		break;
 	case DRM_AMDXDNA_FW_LOG:
 		ret = amdxdna_get_fw_log(&ndev->aie, args);

--- a/drivers/accel/amdxdna/amdxdna_pci_drv.c
+++ b/drivers/accel/amdxdna/amdxdna_pci_drv.c
@@ -170,6 +170,7 @@ static int amdxdna_drm_open(struct drm_device *ddev, struct drm_file *filp)
 	}
 
 	client->pid = pid_nr(rcu_access_pointer(filp->pid));
+	get_task_comm(client->name, current);
 	client->xdna = xdna;
 	client->pasid = IOMMU_PASID_INVALID;
 	client->mm = current->mm;

--- a/drivers/accel/amdxdna/amdxdna_pci_drv.h
+++ b/drivers/accel/amdxdna/amdxdna_pci_drv.h
@@ -16,6 +16,7 @@
 #include <linux/idr.h>
 #include <linux/iommu.h>
 #include <linux/iova.h>
+#include <linux/sched.h>
 #include <linux/srcu.h>
 #include <linux/workqueue.h>
 #include <linux/xarray.h>
@@ -197,6 +198,7 @@ struct amdxdna_io_stats {
 struct amdxdna_client {
 	struct list_head		node;
 	pid_t				pid;
+	char				name[TASK_COMM_LEN];
 	/*
 	 * Guards hwctx lifetime against this client's own blocking submit/wait.
 	 * A lookup only ever returns this client's own hwctx (per-client xa), so a

--- a/include/uapi/drm/amdxdna_accel.h
+++ b/include/uapi/drm/amdxdna_accel.h
@@ -591,6 +591,9 @@ struct amdxdna_drm_get_info {
 #define AMDXDNA_HWCTX_STATE_IDLE	0
 #define AMDXDNA_HWCTX_STATE_ACTIVE	1
 
+/* Length of the process name reported per hardware context (matches TASK_COMM_LEN). */
+#define AMDXDNA_HWCTX_PROC_NAME_LEN	16
+
 /**
  * struct amdxdna_drm_hwctx_entry - The hardware context array entry
  */
@@ -653,6 +656,8 @@ struct amdxdna_drm_hwctx_entry {
 	__u32 fatal_error_app_module;
 	/** @pad: Structure pad. */
 	__u32 pad;
+	/** @name: Name of the process which created this context. */
+	char name[AMDXDNA_HWCTX_PROC_NAME_LEN];
 };
 
 /**

--- a/src/include/uapi/drm_local/amdxdna_accel.h
+++ b/src/include/uapi/drm_local/amdxdna_accel.h
@@ -660,6 +660,8 @@ struct amdxdna_drm_get_info {
  * @fatal_error_exception_type: LX7 exception type
  * @fatal_error_exception_pc: LX7 program counter at the time of the exception
  * @fatal_error_app_module: module name where the exception occurred
+ * @pad: Structure padding.
+ * @name: name of the process which created this context
  */
 struct amdxdna_drm_hwctx_entry {
 	__u32 context_id;
@@ -690,6 +692,9 @@ struct amdxdna_drm_hwctx_entry {
 	__u32 fatal_error_exception_type;
 	__u32 fatal_error_exception_pc;
 	__u32 fatal_error_app_module;
+	__u32 pad;
+#define AMDXDNA_HWCTX_PROC_NAME_LEN	16
+	char name[AMDXDNA_HWCTX_PROC_NAME_LEN];
 };
 
 /**

--- a/src/shim/device.cpp
+++ b/src/shim/device.cpp
@@ -20,10 +20,13 @@
 #include <algorithm>
 #include <climits>
 #include <cstdio>
+#include <cstring>
 #include <map>
 #include <optional>
 #include <sstream>
 #include <string>
+#include <unordered_map>
+#include <unordered_set>
 #include <utility>
 
 namespace {
@@ -325,6 +328,36 @@ get_preemption_events(const xrt_core::device* device)
   return events;
 }
 
+// Query the device BO memory footprint for a given process via
+// DRM_AMDXDNA_BO_USAGE. Best-effort: returns 0 both for a genuine
+// zero-footprint process and when the query is unsupported or fails - the two
+// cannot be distinguished here. Callers use 0 as a numeric value (a per-context
+// memory_usage of 0 renders as "N/A"; total_mem_usage sums it in), so a failed
+// lookup degrades to 0 rather than failing the whole query.
+static uint64_t
+get_bo_total_usage(const shim_xdna::pdev& pdev, int64_t pid)
+{
+  if (pid < 0)
+    return 0;
+
+  amdxdna_drm_bo_usage usage = {};
+  usage.pid = pid;
+  amdxdna_drm_get_array arg = {
+    .param = DRM_AMDXDNA_BO_USAGE,
+    .element_size = sizeof(usage),
+    .num_element = 1,
+    .buffer = reinterpret_cast<uintptr_t>(&usage)
+  };
+
+  try {
+    pdev.drv_ioctl(shim_xdna::drv_ioctl_cmd::get_info_array, &arg);
+  }
+  catch (const xrt_core::system_error&) {
+    return 0;
+  }
+  return usage.total_usage;
+}
+
 struct partition_info
 {
   using result_type = std::any;
@@ -355,15 +388,16 @@ struct partition_info
       shim_debug("preemption enrichment skipped, device generation unknown: %s", e.what());
     }
 
-    amdxdna_drm_hwctx_entry* data;
     const uint32_t output_entries = 1024;
-    const uint32_t output_size = output_entries * sizeof(*data);
+    const uint32_t output_size = output_entries * sizeof(amdxdna_drm_hwctx_entry);
+    const char* raw = nullptr;  // base of the returned entry array
+    size_t buf_bytes = 0;       // size of the buffer 'raw' points into
 
     std::vector<char> payload(output_size);
-    std::vector<char> updated_payload;  // outer scope for ENOSPC retry; data may point here
+    std::vector<char> updated_payload;  // outer scope for ENOSPC retry; raw may point here
     amdxdna_drm_get_array arg = {
       .param = DRM_AMDXDNA_HW_CONTEXT_ALL,
-      .element_size = sizeof(*data),
+      .element_size = sizeof(amdxdna_drm_hwctx_entry),
       .num_element = output_entries,
       .buffer = reinterpret_cast<uintptr_t>(payload.data())
     };
@@ -372,8 +406,8 @@ struct partition_info
     uint32_t data_size = 0;
     try {
       pci_dev_impl.drv_ioctl(shim_xdna::drv_ioctl_cmd::get_info_array, &arg);
-      data_size = std::min(arg.num_element, static_cast<uint32_t>(output_size / sizeof(*data)));
-      data = reinterpret_cast<decltype(data)>(payload.data());
+      raw = payload.data();
+      buf_bytes = output_size;
     } catch (const xrt_core::system_error& e) {
       if (e.get_code() == EINVAL) {
         // If ioctl not supported, use legacy ioctl.
@@ -399,6 +433,9 @@ struct partition_info
         const auto legacy_preemption_event_map = get_preemption_events(device);
 
         query::aie_partition_info::result_type output;
+        // The legacy hwctx struct carries no process name; leave it empty so
+        // the report shows "N/A". Memory usage is still resolved per process.
+        std::unordered_map<int64_t, uint64_t> mem_usage_cache;
         for (uint32_t i = 0; i < data_size; i++) {
           const auto& entry = legacy_data[i];
 
@@ -429,26 +466,38 @@ struct partition_info
             }
           }
           new_entry.errors = entry.errors;
+
+          auto mit = mem_usage_cache.find(entry.pid);
+          if (mit == mem_usage_cache.end())
+            mit = mem_usage_cache.emplace(entry.pid, get_bo_total_usage(pci_dev_impl, entry.pid)).first;
+          new_entry.memory_usage = mit->second;
+
           output.push_back(std::move(new_entry));
         }
         return output;
       }
       if (e.get_code() == ENOSPC) {
-        // Retry ioctl with driver-returned number of elements.
-        const uint32_t updated_output_size = arg.num_element * sizeof(*data);
+        // Retry ioctl with driver-returned number of elements. element_size and
+        // num_element are each __u32, so their product can exceed UINT32_MAX;
+        // compute all byte counts in size_t so a large driver-reported
+        // num_element cannot overflow and yield an undersized allocation.
+        const size_t updated_output_size =
+          static_cast<size_t>(arg.num_element) * sizeof(amdxdna_drm_hwctx_entry);
 
         updated_payload.resize(updated_output_size);
         arg.buffer = reinterpret_cast<uintptr_t>(updated_payload.data());
 
         pci_dev_impl.drv_ioctl(shim_xdna::drv_ioctl_cmd::get_info_array, &arg);
 
-        if (updated_output_size < arg.element_size * arg.num_element) {
+        const size_t required_bytes =
+          static_cast<size_t>(arg.element_size) * arg.num_element;
+        if (updated_output_size < required_bytes) {
           throw xrt_core::query::exception(
-            boost::str(boost::format("DRM_AMDXDNA_HW_CONTEXT_ALL - Insufficient buffer size. Need: %u") % arg.element_size));
+            boost::str(boost::format("DRM_AMDXDNA_HW_CONTEXT_ALL - Insufficient buffer size. Need: %zu bytes") % required_bytes));
         }
 
-        data_size = std::min(arg.num_element, static_cast<uint32_t>(updated_payload.size() / sizeof(*data)));
-        data = reinterpret_cast<decltype(data)>(updated_payload.data());
+        raw = updated_payload.data();
+        buf_bytes = updated_payload.size();
       } else {
         throw;
       }
@@ -456,9 +505,23 @@ struct partition_info
 
     const auto preemption_event_map = get_preemption_events(device);
 
+    // The driver negotiates the element size (the min of what the shim asked for
+    // and the struct the running driver knows about) and packs entries at that
+    // stride. Copy each element into a zero-initialized struct so that fields a
+    // newer shim knows about but an older driver did not fill (e.g. name) read
+    // as empty. This keeps a new shim working with an old staging driver.
+    const uint32_t elem_sz = arg.element_size ? arg.element_size
+      : static_cast<uint32_t>(sizeof(amdxdna_drm_hwctx_entry));
+    data_size = std::min(arg.num_element, static_cast<uint32_t>(buf_bytes / elem_sz));
+
     query::aie_partition_info::result_type output;
+    // Cache per-process BO usage so multiple contexts owned by the same process
+    // only issue a single DRM_AMDXDNA_BO_USAGE ioctl.
+    std::unordered_map<int64_t, uint64_t> mem_usage_cache;
     for (uint32_t i = 0; i < data_size; i++) {
-      const auto& entry = data[i];
+      amdxdna_drm_hwctx_entry entry{};
+      std::memcpy(&entry, raw + static_cast<size_t>(i) * elem_sz,
+                  std::min<size_t>(elem_sz, sizeof(entry)));
 
       xrt_core::query::aie_partition_info::data new_entry{};
       new_entry.metadata.id = std::to_string(entry.context_id);
@@ -491,9 +554,43 @@ struct partition_info
       new_entry.pasid = entry.pasid;
       new_entry.suspensions = entry.suspensions;
       new_entry.is_suspended = entry.state == AMDXDNA_HWCTX_STATE_IDLE;
+      new_entry.process_name = std::string(entry.name, ::strnlen(entry.name, sizeof(entry.name)));
+
+      auto mit = mem_usage_cache.find(entry.pid);
+      if (mit == mem_usage_cache.end())
+        mit = mem_usage_cache.emplace(entry.pid, get_bo_total_usage(pci_dev_impl, entry.pid)).first;
+      new_entry.memory_usage = mit->second;
+
       output.push_back(std::move(new_entry));
     }
     return output;
+  }
+};
+
+struct total_mem_usage
+{
+  using result_type = std::any;
+
+  static result_type
+  get(const xrt_core::device* device, key_type key)
+  {
+    if (key != key_type::total_mem_usage)
+      throw xrt_core::query::no_such_key(key, "Not implemented");
+
+    // Reuse the aie_partition_info query, which already resolves per-process
+    // memory usage, and aggregate over the set of unique PIDs so a process
+    // owning several contexts is only counted once.
+    auto data = xrt_core::device_query<query::aie_partition_info>(device);
+
+    std::unordered_set<int64_t> seen_pids;
+    uint64_t total = 0;
+    for (const auto& entry : data) {
+      if (entry.pid < 0)
+        continue;
+      if (seen_pids.insert(entry.pid).second)
+        total += entry.memory_usage;
+    }
+    return static_cast<query::total_mem_usage::result_type>(total);
   }
 };
 
@@ -526,26 +623,36 @@ struct context_health_info {
       throw xrt_core::query::no_such_key(key, "Not implemented");
 
     // Query all contexts
-    amdxdna_drm_hwctx_entry* data;
     const uint32_t output_entries = 1024;
-    const uint32_t output_size = output_entries * sizeof(*data);
+    const uint32_t output_size = output_entries * sizeof(amdxdna_drm_hwctx_entry);
     std::vector<char> payload(output_size);
     amdxdna_drm_get_array arg = {
       .param = DRM_AMDXDNA_HW_CONTEXT_ALL,
-      .element_size = sizeof(*data),
+      .element_size = sizeof(amdxdna_drm_hwctx_entry),
       .num_element = output_entries,
       .buffer = reinterpret_cast<uintptr_t>(payload.data())
     };
 
     auto& pci_dev_impl = get_pcidev_impl(device);
-    uint32_t data_size = 0;
     pci_dev_impl.drv_ioctl(shim_xdna::drv_ioctl_cmd::get_info_array, &arg);
-    data_size = std::min(arg.num_element, static_cast<uint32_t>(output_size / sizeof(*data)));
-    data = reinterpret_cast<decltype(data)>(payload.data());
+
+    // The driver negotiates element_size down to the struct the running driver
+    // knows about and packs entries at that stride. Stride by the negotiated
+    // size and copy each entry into a zero-initialized struct (matching the
+    // aie_partition_info walk) so a newer shim still parses an older driver's
+    // packed entries correctly instead of assuming a fixed sizeof() stride.
+    const uint32_t elem_sz = arg.element_size ? arg.element_size
+      : static_cast<uint32_t>(sizeof(amdxdna_drm_hwctx_entry));
+    const uint32_t data_size = std::min(arg.num_element,
+                                        static_cast<uint32_t>(output_size / elem_sz));
+    const char* raw = payload.data();
 
     query::context_health_info::result_type output;
     for (uint32_t i = 0; i < data_size; i++) {
-      output.push_back(fill_health_entry(data[i]));
+      amdxdna_drm_hwctx_entry entry{};
+      std::memcpy(&entry, raw + static_cast<size_t>(i) * elem_sz,
+                  std::min<size_t>(elem_sz, sizeof(entry)));
+      output.push_back(fill_health_entry(entry));
     }
     return output;
   }
@@ -2123,6 +2230,7 @@ static void
 initialize_query_table()
 {
   emplace_func0_request<query::aie_partition_info,             partition_info>();
+  emplace_func0_request<query::total_mem_usage,               total_mem_usage>();
   emplace_func0_request<query::xocl_errors,                    xocl_errors>();
   emplace_func1_request<query::context_health_info,            context_health_info>();
   emplace_func0_request<query::aie_status_version,             aie_info>();

--- a/test/shim_test/shim_test.cpp
+++ b/test/shim_test/shim_test.cpp
@@ -1371,6 +1371,80 @@ TEST_hw_context_all(device::id_type id, std::shared_ptr<device>& sdev, arg_type&
     throw std::runtime_error("HW_CONTEXT_ALL did not report the created context");
 }
 
+// Fetch per-context and total memory usage through the query keys
+// (query::aie_partition_info and query::total_mem_usage) instead of issuing the
+// raw DRM_AMDXDNA_BO_USAGE ioctl. These keys go through the shim's already-open
+// device fd, so no forked helper is needed. A partition entry (and thus a
+// non-zero memory_usage / a process_name) only exists while a hw context is
+// live, so create one and allocate a known amount of BO memory to bound the
+// reported usage from below. Exact total/internal/heap accounting is covered
+// separately by TEST_create_free_internal_bo.
+void
+TEST_query_memory_usage(device::id_type id, std::shared_ptr<device>& sdev, arg_type& arg)
+{
+  auto dev = sdev.get();
+
+  // A live context is required for this process to appear in aie_partition_info.
+  hw_ctx hwctx{dev};
+
+  // Allocate application (SHARE) and internal (CMD) BOs so this process has a
+  // known, non-zero BO footprint counted in total_usage.
+  auto boflags = XRT_BO_FLAGS_HOST_ONLY;
+  auto ext_boflags = XRT_BO_USE_CTRLPKT << 4;
+  size_t size = 0x4000;
+  auto ext_bo = std::make_unique<bo>(dev, size * 5, boflags, 0);
+  auto int_bo = std::make_unique<bo>(dev, size * 3, boflags, ext_boflags);
+  const uint64_t bo_bytes = ext_bo->size() + int_bo->size();
+
+  const int self_pid = static_cast<int>(getpid());
+
+  // Per-context memory_usage and process_name via aie_partition_info.
+  const auto partitions = device_query<query::aie_partition_info>(dev);
+  uint64_t self_mem = 0;
+  bool found_self = false;
+  for (const auto& p : partitions) {
+    if (p.pid != self_pid)
+      continue;
+    found_self = true;
+    self_mem = p.memory_usage;
+
+    // process_name is copied from the driver-provided hwctx entry name. A new
+    // shim on an older staging driver reads it back empty (-> "N/A"), so only
+    // validate it when populated. current->comm is capped at 15 chars, matching
+    // the value the kernel stores, so /proc/self/comm is an exact reference.
+    if (!p.process_name.empty()) {
+      std::string comm;
+      std::ifstream comm_file("/proc/self/comm");
+      if (!std::getline(comm_file, comm))
+        throw std::runtime_error("failed to read /proc/self/comm to verify process_name");
+      if (p.process_name != comm)
+        throw std::runtime_error("process_name mismatch: got '" + p.process_name +
+                                 "', expected '" + comm + "'");
+    }
+    break;
+  }
+
+  if (!found_self)
+    throw std::runtime_error("aie_partition_info did not report this process's context");
+
+  // memory_usage is the owning process's total BO footprint (S + C + H); it must
+  // at least cover the BOs allocated above.
+  if (self_mem < bo_bytes) {
+    std::cout << "memory_usage " << self_mem << " < allocated BO bytes " << bo_bytes
+              << std::endl;
+    throw std::runtime_error("aie_partition_info memory_usage too small");
+  }
+
+  // total_mem_usage aggregates unique PIDs, so the device-wide total must be at
+  // least this process's own usage.
+  const uint64_t total = device_query<query::total_mem_usage>(dev);
+  if (total < self_mem) {
+    std::cout << "total_mem_usage " << total << " < this process memory_usage "
+              << self_mem << std::endl;
+    throw std::runtime_error("total_mem_usage smaller than per-process usage");
+  }
+}
+
 constexpr uint32_t TELEMETRY_DATA_SIZE = 256 * 1024;
 constexpr uint32_t TELEMETRY_MAP_CAPACITY = 256;
 // aie4 selects a telemetry category via the type field; older NPUs require 0.
@@ -1656,6 +1730,9 @@ std::vector<test_case> test_list {
   },
   test_case{ "hw_context_all (get_array)", {},
     TEST_POSITIVE, dev_filter_is_aie_and_amdxdna_drv, TEST_hw_context_all, {}
+  },
+  test_case{ "query memory usage (total_mem_usage/aie_partition_info)", {},
+    TEST_POSITIVE, dev_filter_is_aie_and_amdxdna_drv, TEST_query_memory_usage, {}
   },
   test_case{ "query telemetry", {},
     TEST_POSITIVE, dev_filter_is_aie_and_amdxdna_drv, TEST_query_telemetry, {}


### PR DESCRIPTION
This series adds the missing pieces the "xrt-smi aie-partitions" report
needs on STX and aie4: total memory usage, per-context memory usage, and
the process name that created each hardware context. All three previously
rendered as "N/A" on this shim.
Patch 1 (kernel) captures the creating process's name (current->comm) on
the client at device open and reports it per hardware context via a new
field in struct amdxdna_drm_hwctx_entry. The name is appended after the
reserved pad so all existing member offsets are preserved, and the
DRM_AMDXDNA_HW_CONTEXT_ALL walk already negotiates element_size, so old
user space keeps working. The DRM_AMDXDNA_HW_CONTEXT_BY_ID path is updated
to negotiate element_size the same way, so growing the struct does not
reject user space built against the older, smaller struct.
Patch 2 (shim) populates the aie_partition_info fields and implements
query::total_mem_usage:
 - process_name is copied straight from the driver-provided entry.name.
 - per-context memory_usage is the owning process's total BO footprint,
   read via DRM_AMDXDNA_BO_USAGE (total_usage), cached per PID.
 - total_mem_usage sums total_usage over the set of unique PIDs, so a
   process owning several contexts is only counted once.
The HW_CONTEXT_ALL walk copies each entry into a zero-initialized struct
using the driver-negotiated element_size, so a new shim also works with an
older staging driver (name reads back empty -> "N/A").
BO accounting for the reported values (per client == per PID):
  S = AMDXDNA_BO_SHARE    (application/external buffers)
  C = AMDXDNA_BO_CMD      (command packets, internal)
  H = AMDXDNA_BO_DEV_HEAP (device heap region, internal)
  D = AMDXDNA_BO_DEV      (heap sub-allocations, e.g. instruction code)
  Memory Usage       = bo_usage.total_usage = S + C + H
  Instr BO           = hwctx_entry.heap_usage = D   (unchanged)
  Total Memory Usage = sum over unique PIDs of (S + C + H)
D is excluded from total_usage because it is sub-allocated from the
already-counted heap region H; it is reported separately as Instr BO.
