### PR TITLE
shim/buffer: fence the x86 CLFLUSH loop in host-only BO sync

### DIFF
--- a/src/shim/buffer.cpp
+++ b/src/shim/buffer.cpp
@@ -149,10 +149,18 @@ clflush_data(const void *base, size_t offset, size_t len)
   const char *cur = (const char *)base;
   cur += offset;
   uintptr_t lastline = (uintptr_t)(cur + len - 1) | (cacheline_size - 1);
+#if defined(__x86_64__) || defined(_M_X64)
+  // x86 CLFLUSH is not ordered vs younger loads; fence so the flush is globally
+  // observed before the host reads the line back (cf. kernel clflush_cache_range).
+  _mm_mfence();
+#endif
   do {
     flush_cache_line(cur);
     cur += cacheline_size;
   } while (cur <= (const char *)lastline);
+#if defined(__x86_64__) || defined(_M_X64)
+  _mm_mfence();
+#endif
 }
 
 bool


### PR DESCRIPTION
On KMQ / non-cache-coherent NPUs (Strix / npu4, `is_cache_coherent() == false`), a host-only BO `sync(FROM_DEVICE)` runs an unfenced x86 CLFLUSH loop in `buffer.cpp`'s `clflush_data()`. The cache-line invalidate is not ordered against the host's next load, so a compare-read can catch a stale line while the DMA'd value lands a moment later. It shows up as an intermittent "equal values reported unequal" mismatch, for example `idx 0: 5 != 5`.

## Root cause

- `flush_cache_line` (x86): bare `_mm_clflush`, no fence.
- `flush_cache_line` (aarch64): `DC CIVAC` then `DSB SY; ISB SY`. Fenced.
- `clflush_data`: loops over `flush_cache_line`, with no MFENCE before or after on x86.

Modern x86 CLFLUSH / CLFLUSHOPT is weakly ordered with respect to younger loads, so without a fence the subsequent host read can be reordered ahead of the flush and observe stale data. The x86 path is the odd one out: the aarch64 path in the same file already fences, and the Linux kernel's own `clflush_cache_range` brackets its CLFLUSH loop with `mb()` for exactly this reason.

## Fix

Bracket the CLFLUSH loop in `clflush_data` with `_mm_mfence()` on x86 (the file already includes `<x86intrin.h>`). No change on aarch64 (already fenced) and no change for cache-coherent (UMQ) parts, which skip the flush entirely.

## Evidence (on device, controlled)

Reproduced on npu4 (Strix, KMQ) by hammering an on-device test that reads a host-only BO back and compares (mlir-aie's `add_multi_arg_runlist`), 3200 runs each at 8-way concurrency:

| build | equal-value races / 3200 |
| --- | --- |
| stock XRT 2.21.75 | 238 (7.4%) |
| from-source 2.26.0, unpatched | 43 (1.34%) |
| from-source 2.26.0, this patch | 0 |

Row 1 is a stock package on a different version; it shows the race in the wild. The controlled A/B is rows 2 and 3: the same from-source 2.26.0 build, the two `_mm_mfence()` calls the only difference, races 43 -> 0 with zero crashes and every run passing. A firmware early-completion explanation is ruled out: if the completion token retired before the write were globally visible, a userspace fence could not drive races to zero.

This is the same failure that dropped an otherwise-green PR out of the `Xilinx/mlir-aie` merge queue: that runner's XRT 2.21.0 fails `add_multi_arg_runlist` with `idx 0: 5 != 5` (the interim CI-side guard for it is Xilinx/mlir-aie#3359). The stock shipped driver (XRT 2.21.75) was tested as installed, with no rebuild, and reproduces the race (row 1). The patched-vs-unpatched A/B is on a 2.26.0 from-source build, but it is the same `clflush_data` code path across 2.21.0, 2.21.75 and 2.26.0.
