### PR TITLE
accel/amdxdna: initialize ret to -ENOENT in aie tile access helpers

### DIFF
--- a/drivers/accel/amdxdna/aie.c
+++ b/drivers/accel/amdxdna/aie.c
@@ -749,9 +749,9 @@ int amdxdna_get_coredump(struct aie_device *aie,
 	struct amdxdna_dev *xdna = client->xdna;
 	struct amdxdna_coredump_walk_arg wa;
 	struct amdxdna_client *tmp_client;
+	int ret = -ENOENT;
 	size_t buf_size;
 	u8 __user *buf;
-	int ret;
 
 	drm_WARN_ON(&xdna->ddev, !mutex_is_locked(&xdna->dev_lock));
 
@@ -911,9 +911,9 @@ int amdxdna_aie_tile_read(struct aie_device *aie,
 	struct amdxdna_dev *xdna = client->xdna;
 	struct amdxdna_tile_rw_walk_arg wa;
 	struct amdxdna_client *tmp_client;
+	int ret = -ENOENT;
 	size_t buf_size;
 	u8 __user *buf;
-	int ret;
 
 	drm_WARN_ON(&xdna->ddev, !mutex_is_locked(&xdna->dev_lock));
 
@@ -1091,8 +1091,8 @@ int amdxdna_aie_tile_write(struct aie_device *aie,
 	struct amdxdna_dev *xdna = client->xdna;
 	struct amdxdna_tile_rw_walk_arg wa;
 	struct amdxdna_client *tmp_client;
+	int ret = -ENOENT;
 	u8 __user *buf;
-	int ret;
 
 	drm_WARN_ON(&xdna->ddev, !mutex_is_locked(&xdna->dev_lock));
 


### PR DESCRIPTION
Initialize ret to -ENOENT in amdxdna_get_coredump(), amdxdna_aie_tile_read() and amdxdna_aie_tile_write() so that the subsequent 'if (ret == -ENOENT)' check and 'return ret' are well defined even if the amdxdna_for_each_client loop body never executes. This makes each function locally correct instead of relying on the calling client always being present in client_list, and silences static-analysis warnings about reading an uninitialized variable.