### PR TITLE
shim/buffer: fence the x86 CLFLUSH loop in host-only BO sync

### DIFF
--- a/src/shim/buffer.cpp
+++ b/src/shim/buffer.cpp
@@ -149,10 +149,18 @@ clflush_data(const void *base, size_t offset, size_t len)
   const char *cur = (const char *)base;
   cur += offset;
   uintptr_t lastline = (uintptr_t)(cur + len - 1) | (cacheline_size - 1);
+#if defined(__x86_64__) || defined(_M_X64)
+  // x86 CLFLUSH is not ordered vs younger loads; fence so the flush is globally
+  // observed before the host reads the line back (cf. kernel clflush_cache_range).
+  _mm_mfence();
+#endif
   do {
     flush_cache_line(cur);
     cur += cacheline_size;
   } while (cur <= (const char *)lastline);
+#if defined(__x86_64__) || defined(_M_X64)
+  _mm_mfence();
+#endif
 }
 
 bool


### PR DESCRIPTION
On KMQ / non-cache-coherent NPUs a host-only BO sync(FROM_DEVICE) runs an unfenced x86 CLFLUSH loop in clflush_data(). Modern x86 CLFLUSH is weakly ordered vs younger loads, so the host's next read can reorder ahead of the flush and observe a stale cache line while the DMA'd value lands a moment later. It surfaces as an intermittent equal-value mismatch (e.g. idx 0: 5 != 5).

The aarch64 path in this file already fences (DC CIVAC; DSB SY; ISB SY), and the kernel's clflush_cache_range brackets its CLFLUSH loop with mb() for the same reason. Bracket the x86 CLFLUSH loop with _mm_mfence() to match. No change on aarch64 or on cache-coherent parts (which skip the flush).

(cherry picked from commit 49fbb59c6f7913a83ed5c5b7035140a384db6222)