### PR TITLE
accel/amdxdna: remove artificial timeout from HMM range fault retry loop

### DIFF
--- a/drivers/accel/amdxdna/aie2_ctx.c
+++ b/drivers/accel/amdxdna/aie2_ctx.c
@@ -1083,12 +1083,10 @@ static int aie2_populate_range(struct amdxdna_gem_obj *abo)
 {
 	struct amdxdna_dev *xdna = to_xdna_dev(to_gobj(abo)->dev);
 	struct amdxdna_umap *mapp;
-	unsigned long timeout;
 	struct mm_struct *mm;
 	bool found;
 	int ret;
 
-	timeout = jiffies + msecs_to_jiffies(HMM_RANGE_DEFAULT_TIMEOUT);
 again:
 	found = false;
 	down_write(&xdna->notifier_lock);
@@ -1118,11 +1116,6 @@ again:
 	ret = hmm_range_fault(&mapp->range);
 	mmap_read_unlock(mm);
 	if (ret) {
-		if (time_after(jiffies, timeout)) {
-			ret = -ETIME;
-			goto put_mm;
-		}
-
 		if (ret == -EBUSY) {
 			amdxdna_umap_put(mapp);
 			mmput(mm);
@@ -1157,7 +1150,6 @@ int aie2_cmd_submit(struct amdxdna_hwctx *hwctx, struct amdxdna_sched_job *job, 
 	struct ww_acquire_ctx acquire_ctx;
 	struct dma_fence_chain *chain;
 	struct amdxdna_gem_obj *abo;
-	unsigned long timeout = 0;
 	int ret, i;
 
 	ret = down_interruptible(&hwctx->priv->job_sem);
@@ -1206,14 +1198,6 @@ retry:
 		if (abo->mem.map_invalid) {
 			up_read(&xdna->notifier_lock);
 			drm_gem_unlock_reservations(job->bos, job->bo_cnt, &acquire_ctx);
-			if (!timeout) {
-				timeout = jiffies +
-					msecs_to_jiffies(HMM_RANGE_DEFAULT_TIMEOUT);
-			} else if (time_after(jiffies, timeout)) {
-				ret = -ETIME;
-				goto cleanup_job;
-			}
-
 			ret = aie2_populate_range(abo);
 			if (ret)
 				goto cleanup_job;

--- a/drivers/accel/amdxdna/amdxdna_gem.c
+++ b/drivers/accel/amdxdna/amdxdna_gem.c
@@ -274,8 +274,9 @@ static bool amdxdna_hmm_invalidate(struct mmu_interval_notifier *mni,
 	struct amdxdna_dev *xdna;
 
 	xdna = to_xdna_dev(to_gobj(abo)->dev);
-	XDNA_DBG(xdna, "Invalidating range 0x%lx, 0x%lx, type %d",
-		 mapp->range.start, mapp->range.end, abo->type);
+	XDNA_DBG(xdna, "Invalidating range 0x%lx, 0x%lx, type %d, evt %d, pending fences %d",
+		 mapp->range.start, mapp->range.end, abo->type, range->event,
+		 !dma_resv_test_signaled(to_gobj(abo)->resv, DMA_RESV_USAGE_BOOKKEEP));
 
 	if (!mmu_notifier_range_blockable(range))
 		return false;


### PR DESCRIPTION
Remove the 1-second timeout (HMM_RANGE_DEFAULT_TIMEOUT) that caused EXEC_CMD to return -ETIME when hmm_range_fault() repeatedly returned -EBUSY or when map_invalid was repeatedly set during command submission.

This artificial timeout does not work reliably during testing and may cause failures uncessarily.