### PR TITLE
tools: prune stale info.json entries for the RAI firmware layout

### DIFF
--- a/tools/info.json
+++ b/tools/info.json
@@ -7,18 +7,10 @@
 	"firmwares": [
 		{
 			"device": "npu1",
-			"url": "https://gitlab.com/kernel-firmware/drm-firmware/-/raw/amd-ipu-staging/amdnpu/1502_00/npu.sbin.1.5.5.391",
+			"url": "https://gitlab.com/kernel-firmware/drm-firmware/-/raw/amd-ipu-staging/amdnpu/1502_00/1.5_npu.sbin.1.5.5.391",
 			"pci_device_id": "1502",
 			"pci_revision_id": "00",
 			"version": "1.5.5.391",
-			"fw_name": "npu.dev.sbin"
-		},
-		{
-			"device": "npu2",
-			"url": "https://gitlab.com/kernel-firmware/drm-firmware/-/raw/amd-ipu-staging/amdnpu/17f0_00/npu.sbin.0.7.22.185",
-			"pci_device_id": "17f0",
-			"pci_revision_id": "00",
-			"version": "0.7.22.185",
 			"fw_name": "npu.dev.sbin"
 		},
 		{
@@ -38,9 +30,6 @@
 			"fw_name": "npu.dev.sbin"
 		}
 	],
-	"aie4_firmwares" : {
-		"umq_version": "20251013-7f7d8dc"
-	},
 	"vtd_archives": [
 		{
 			"device": "strx",


### PR DESCRIPTION
Align the release firmware manifest with the de-duplicated drm-firmware amdnpu layout and drop metadata that nothing consumes:

- Remove the npu2 (17f0_00) firmware entry; that device's firmware is being dropped from the amdnpu tree.
- Remove the aie4_firmwares/umq_version block, which is dead metadata that no build or runtime code reads.
- Repoint npu1 to the locked-down 1.5_npu.sbin.1.5.5.391, matching the renamed file in the post-merge amd-ipu-staging drm-firmware layout (the plain npu.sbin.1.5.5.391 is removed by the lockdown).

info.json still drives the firmware and VTD downloads on this release branch (the WHENCE-driven flow is main-only); npu4/npu5, xrt and vtd_archives are unchanged, so the build is unaffected (verified compiling on Linux 6.13).