### PR TITLE
AIESW-39288 Update xrt sumodule for ML Timeline buffer config changes

### DIFF
--- a/tools/info.json
+++ b/tools/info.json
@@ -1,7 +1,7 @@
 {
 	"copyright": "Copyright (C) 2023-2026 Advanced Micro Devices, Inc. All rights reserved.",
 	"xrt" : {
-		"version": "202620.2.26.60",
+		"version": "202620.2.26.67",
 		"os_rel": ["22.04", "24.04"]
 	},
 	"firmwares": [


### PR DESCRIPTION
Updated xrt package to version 2.26.67 with xrt submodule at commit 8bf2fc4c090540dcf7872243ab67779ae74ef5e3 

XDP ML Timeline now adds a new xrt ini config to specify uC config for debug buffer segments
https://jira.xilinx.com/browse/AIESW-39288