### PR TITLE
accel/amdxdna: add context switch hysteresis with debugfs control

### DIFF
--- a/drivers/accel/amdxdna/aie4_message.c
+++ b/drivers/accel/amdxdna/aie4_message.c
@@ -491,6 +491,23 @@ int aie4_set_runtime_cfg(struct amdxdna_dev_hdl *ndev, u32 type,
 	return ret;
 }
 
+int aie4_set_ctx_hysteresis(struct amdxdna_dev_hdl *ndev, u32 timeout_us)
+{
+	struct aie4_msg_runtime_config_ctx_switch_hysteresis cfg = {
+		.timeout_us = timeout_us,
+	};
+	int ret;
+
+	ret = aie4_set_runtime_cfg(ndev, AIE4_RUNTIME_CONFIG_CTX_SWITCH_HYSTERESIS,
+				   &cfg, sizeof(cfg));
+	if (ret)
+		return ret;
+
+	XDNA_DBG(ndev->aie.xdna, "Context switch hysteresis set to %u us", timeout_us);
+
+	return 0;
+}
+
 int aie4_start_fw_log(struct amdxdna_dev_hdl *ndev,
 		      struct amdxdna_msg_buf_hdl *buf_hdl, u8 level,
 		      size_t size, u32 *msi_idx, u32 *msi_address)

--- a/drivers/accel/amdxdna/aie4_msg_priv.h
+++ b/drivers/accel/amdxdna/aie4_msg_priv.h
@@ -93,8 +93,15 @@ struct aie4_msg_runtime_config_force_preemption {
 	__u8 padding[3];
 } __packed;
 
+/*
+ * Type selector for AIE4_MSG_OP_SET_RUNTIME_CONFIG. Values match the firmware
+ * ABI enum npu_msg_runtime_config_type; only the configs the driver programs
+ * are enumerated here.
+ */
 enum aie4_msg_runtime_config_type {
-	AIE4_RUNTIME_CONFIG_FORCE_PREEMPTION = 1,
+	AIE4_RUNTIME_CONFIG_FORCE_PREEMPTION		= 0x1,
+	AIE4_RUNTIME_CONFIG_FW_LOG_LEVEL		= 0x5,
+	AIE4_RUNTIME_CONFIG_CTX_SWITCH_HYSTERESIS	= 0xD,
 	AIE4_MAX_RUNTIME_CONFIG
 };
 
@@ -483,11 +490,6 @@ enum aie4_fw_log_level {
 	AIE4_FW_LOG_LEVEL_MAX,
 };
 
-/* Index of NPU_RUNTIME_CONFIG_DYNAMIC_LOGGING_LEVEL in the firmware ABI enum
- * npu_msg_runtime_config_type (mpnpu-api/aie4/npu_msg_priv.h).
- */
-#define AIE4_RUNTIME_CONFIG_FW_LOG_LEVEL 0x5
-
 struct aie4_msg_start_fw_log_req {
 	__u64	buff_addr;
 	__u32	buff_size;
@@ -515,6 +517,16 @@ struct aie4_msg_stop_fw_log_resp {
 
 struct aie4_msg_runtime_config_fw_log_level {
 	__u32 log_level;
+} __packed;
+
+/*
+ * Context switch hysteresis configuration.
+ *
+ * @timeout_us: Hysteresis time in microseconds for keeping a context loaded
+ *              in the AIE after it becomes idle, or 0 to disable hysteresis.
+ */
+struct aie4_msg_runtime_config_ctx_switch_hysteresis {
+	__u32 timeout_us;
 } __packed;
 
 enum aie4_fw_trace_destination {

--- a/drivers/accel/amdxdna/aie4_pci.c
+++ b/drivers/accel/amdxdna/aie4_pci.c
@@ -386,6 +386,18 @@ static int aie4_pf_hw_start(struct amdxdna_dev_hdl *ndev)
 	if (ret)
 		goto mbox_fini;
 
+	/*
+	 * Context switch hysteresis is a best-effort tuning knob; warn but do
+	 * not fail hw start (or a later runtime resume) if the firmware does not
+	 * support the runtime config. ret is overwritten by the next mandatory
+	 * step below, so a failure here never affects hw start.
+	 */
+	ret = aie4_set_ctx_hysteresis(ndev, ndev->ctx_switch_hysteresis_us);
+	if (ret)
+		XDNA_WARN(ndev->aie.xdna,
+			  "Failed to set ctx switch hysteresis to %u us (%d), using fw default",
+			  ndev->ctx_switch_hysteresis_us, ret);
+
 #ifdef AMDXDNA_NPU3A
 	ret = aie4_iommu_bypass_echo(ndev);
 	if (ret)
@@ -493,6 +505,18 @@ static int aie4_classic_hw_start(struct amdxdna_dev_hdl *ndev)
 				      to_buf_size(ndev->work_buf_hdl));
 	if (ret)
 		goto mbox_fini;
+
+	/*
+	 * Context switch hysteresis is a best-effort tuning knob; warn but do
+	 * not fail hw start (or a later runtime resume) if the firmware does not
+	 * support the runtime config. ret is overwritten by the next mandatory
+	 * step below, so a failure here never affects hw start.
+	 */
+	ret = aie4_set_ctx_hysteresis(ndev, ndev->ctx_switch_hysteresis_us);
+	if (ret)
+		XDNA_WARN(ndev->aie.xdna,
+			  "Failed to set ctx switch hysteresis to %u us (%d), using fw default",
+			  ndev->ctx_switch_hysteresis_us, ret);
 
 #ifdef AMDXDNA_NPU3A
 	ret = aie4_iommu_bypass_echo(ndev);
@@ -659,6 +683,7 @@ static int aie4m_pcidev_init(struct amdxdna_dev *xdna)
 	ndev->priv = xdna->dev_info->dev_priv;
 	ndev->aie.xdna = xdna;
 	ndev->kernel_submit = true;
+	ndev->ctx_switch_hysteresis_us = AIE4_CTX_HYSTERESIS_US;
 	xdna->dev_handle = ndev;
 
 	xa_init_flags(&ndev->cert_comp_xa, XA_FLAGS_ALLOC);
@@ -1622,18 +1647,82 @@ dev_exit:
 	return ret;
 }
 
+static int aie4_ctx_hysteresis_get(void *data, u64 *val)
+{
+	struct amdxdna_dev_hdl *ndev = data;
+	struct amdxdna_dev *xdna = ndev->aie.xdna;
+
+	guard(mutex)(&xdna->dev_lock);
+	*val = ndev->ctx_switch_hysteresis_us;
+
+	return 0;
+}
+
+static int aie4_ctx_hysteresis_set(void *data, u64 val)
+{
+	struct amdxdna_dev_hdl *ndev = data;
+	struct amdxdna_dev *xdna = ndev->aie.xdna;
+	int ret, idx;
+
+	if (val > U32_MAX)
+		return -EINVAL;
+
+	if (!drm_dev_enter(&xdna->ddev, &idx))
+		return -ENODEV;
+
+	mutex_lock(&xdna->dev_lock);
+
+	ret = amdxdna_pm_resume_get_locked(xdna);
+	if (ret)
+		goto unlock;
+
+	ret = aie4_set_ctx_hysteresis(ndev, (u32)val);
+	if (!ret)
+		ndev->ctx_switch_hysteresis_us = (u32)val;
+
+	amdxdna_pm_suspend_put(xdna);
+
+unlock:
+	mutex_unlock(&xdna->dev_lock);
+	drm_dev_exit(idx);
+
+	return ret;
+}
+
+/* Context switch hysteresis timeout in microseconds; 0 disables hysteresis. */
+DEFINE_DEBUGFS_ATTRIBUTE(aie4_ctx_hysteresis_fops, aie4_ctx_hysteresis_get,
+			 aie4_ctx_hysteresis_set, "%llu\n");
+
 static void aie4_debugfs_init(struct amdxdna_dev *xdna)
 {
 	struct amdxdna_dev_hdl *ndev = xdna->dev_handle;
 
-	/* 0 - submit by user space, 1 - submit by driver (default). */
-	debugfs_create_bool("kernel_mode_submission", 0600,
-			    xdna->ddev.accel->debugfs_root, &ndev->kernel_submit);
+	/*
+	 * Submission mode only applies where the driver runs hw contexts (the
+	 * VF and classic paths); the SR-IOV PF has no submission path, so do
+	 * not expose the knob there.
+	 * 0 - submit by user space, 1 - submit by driver (default).
+	 */
+	if (xdna->dev_info->ops != &aie4_pf_ops)
+		debugfs_create_bool("kernel_mode_submission", 0600,
+				    xdna->ddev.accel->debugfs_root,
+				    &ndev->kernel_submit);
+
+	/*
+	 * Context switch hysteresis is a system-control runtime config that is
+	 * only programmed on the PF/classic hw start paths, never on a VF.
+	 * Only expose the knob where the driver actually applies it.
+	 */
+	if (!to_pci_dev(xdna->ddev.dev)->is_virtfn)
+		debugfs_create_file_unsafe("ctx_switch_hysteresis_us", 0600,
+					   xdna->ddev.accel->debugfs_root, ndev,
+					   &aie4_ctx_hysteresis_fops);
 }
 
 const struct amdxdna_dev_ops aie4_pf_ops = {
 	.init			= aie4_pf_init,
 	.fini			= aie4_pf_fini,
+	.debugfs_init		= aie4_debugfs_init,
 	.sriov_configure        = aie4_sriov_configure,
 	.resume			= aie4_pf_resume,
 	.suspend		= aie4_pf_suspend,

--- a/drivers/accel/amdxdna/aie4_pci.h
+++ b/drivers/accel/amdxdna/aie4_pci.h
@@ -22,6 +22,9 @@ struct host_queue_packet;
 struct host_indirect_packet_data;
 struct amdxdna_hwctx;
 
+/* Default context switch hysteresis timeout in microseconds. */
+#define AIE4_CTX_HYSTERESIS_US	1000
+
 struct cert_comp {
 	struct amdxdna_dev_hdl          *ndev;
 	u32                             msix_idx;
@@ -128,6 +131,12 @@ struct amdxdna_dev_hdl {
 	/* aie4 kernel-mode submission default; tunable via debugfs. */
 	bool				kernel_submit;
 
+	/*
+	 * Context switch hysteresis timeout in microseconds; pushed to the
+	 * firmware at hw start and tunable at runtime via debugfs.
+	 */
+	u32				ctx_switch_hysteresis_us;
+
 	struct amdxdna_drm_query_firmware_version cert_version;
 };
 
@@ -175,6 +184,7 @@ int aie4_suspend_fw(struct amdxdna_dev_hdl *ndev);
 int aie4_attach_work_buffer(struct amdxdna_dev_hdl *ndev, dma_addr_t addr, u32 size);
 int aie4_msg_set_power_mode(struct amdxdna_dev_hdl *ndev, u8 power_mode);
 int aie4_force_preemption(struct amdxdna_dev_hdl *ndev);
+int aie4_set_ctx_hysteresis(struct amdxdna_dev_hdl *ndev, u32 timeout_us);
 int aie4_configure_hw_context_cert_log(struct amdxdna_dev_hdl *ndev,
 				       u32 hw_context_id, u32 property,
 				       const struct aie4_msg_context_config_cert_logging *cl);


### PR DESCRIPTION
Add aie4_set_ctx_hysteresis() to configure the AIE4 context switch hysteresis timeout via the SET_RUNTIME_CONFIG message, applied at hw start (PF and classic paths) with a default of 1000 us.

Expose a debugfs node 'ctx_switch_hysteresis_us' to change the timeout at runtime (0 disables hysteresis). The stored value is re-applied on every hw start so it survives runtime suspend/resume.