### PR TITLE
amdxdna: ve2: add per-hwctx auto coredump capture when cmd timeouts

### DIFF
--- a/src/driver/amdxdna/ve2_debug.c
+++ b/src/driver/amdxdna/ve2_debug.c
@@ -109,10 +109,13 @@ static int ve2_get_array_hwctx(struct amdxdna_client *client,
 		list_for_each_entry(tmp_client, &xdna->client_list, node) {
 			unsigned long id;
 			struct amdxdna_ctx *ctx;
+			int srcu_idx;
 
+			srcu_idx = srcu_read_lock(&tmp_client->ctx_srcu);
 			xa_for_each(&tmp_client->ctx_xa, id, ctx)
 				if (ctx->priv)
 					ctx_cnt++;
+			srcu_read_unlock(&tmp_client->ctx_srcu, srcu_idx);
 		}
 
 		if (args->num_element < ctx_cnt) {
@@ -377,6 +380,46 @@ static int ve2_aie_read(struct amdxdna_client *client, struct amdxdna_drm_get_ar
 	return 0;
 }
 
+/*
+ * Serve the last auto-captured coredump from this context's cache. The dump is
+ * retained after being read so it can be fetched again; it is dropped when the
+ * context is re-initialized or is torn down.
+ * Returns -ENODATA when there is no cached dump, so the caller can fall back to a live capture.
+ */
+static int ve2_coredump_read_cached(struct amdxdna_dev *xdna, struct amdxdna_drm_get_array *args,
+				    u32 buf_size, struct amdxdna_ctx *hwctx)
+{
+	struct ve2_coredump_cache *cache = &hwctx->priv->coredump_cache;
+	int ret = 0;
+
+	mutex_lock(&cache->lock);
+	if (!cache->valid || !cache->buf) {
+		XDNA_DBG(xdna, "No cached coredump for hwctx %u pid %d", hwctx->id,
+			 hwctx->client->pid);
+		ret = -ENODATA;
+		goto out;
+	}
+	if (cache->size > buf_size) {
+		XDNA_DBG(xdna, "Cached coredump too big: buf %u, need %u", buf_size, cache->size);
+		args->element_size = cache->size;
+		ret = -ENOBUFS;
+		goto out;
+	}
+	if (copy_to_user(u64_to_user_ptr(args->buffer), cache->buf, cache->size)) {
+		XDNA_ERR(xdna, "Failed to copy cached coredump to user");
+		ret = -EFAULT;
+		goto out;
+	}
+	XDNA_DBG(xdna, "Served cached coredump: hwctx %u pid %d seq %llu size %u", hwctx->id,
+		 hwctx->client->pid, cache->seq, cache->size);
+
+	ve2_coredump_cache_invalidate(hwctx);
+
+out:
+	mutex_unlock(&cache->lock);
+	return ret;
+}
+
 static int ve2_coredump_read(struct amdxdna_client *client, struct amdxdna_drm_get_array *args)
 {
 	struct amdxdna_dev *xdna = client->xdna;
@@ -421,6 +464,14 @@ static int ve2_coredump_read(struct amdxdna_client *client, struct amdxdna_drm_g
 	XDNA_DBG(xdna, "cl_pid: %u, hwctx_id: %u, start_col %u, ncol %u\n",
 		 hwctx->client->pid, hwctx->id, hwctx->start_col,
 		 hwctx->num_col);
+
+	/*
+	 * Prefer auto-captured timeout coredump. It is served once and then cleared;
+	 * If cache is empty then go for a fresh live capture using ve2_create_coredump().
+	 */
+	ret = ve2_coredump_read_cached(xdna, args, buf_size, hwctx);
+	if (ret != -ENODATA)
+		return ret;
 
 	rel_size = hwctx->priv->num_col * xdna->dev_handle->aie_dev_info.rows * TILE_ADDRESS_SPACE;
 	if (rel_size > buf_size) {

--- a/src/driver/amdxdna/ve2_hwctx.c
+++ b/src/driver/amdxdna/ve2_hwctx.c
@@ -7,6 +7,7 @@
 #include <linux/dma-buf.h>
 #include <linux/timer.h>
 #include <linux/version.h>
+#include <linux/vmalloc.h>
 
 #include "amdxdna_ctx.h"
 #include "amdxdna_gem.h"
@@ -1304,6 +1305,13 @@ static void ve2_handle_timeout(struct amdxdna_dev *xdna,
 		ve2_fill_health_data(xdna, hwctx, cmd_data, data_total);
 	}
 
+	/*
+	 * Snapshot the AIE partition while this hwctx is still the active
+	 * context on its partition. Auto-capture is always on. Best-effort:
+	 * failures are logged, not fatal.
+	 */
+	ve2_cache_coredump(xdna, hwctx, seq);
+
 	hwctx->health_reported = true;
 	amdxdna_cmd_set_state(job->cmd_bo, ERT_CMD_STATE_TIMEOUT);
 }
@@ -1478,6 +1486,7 @@ int ve2_hwctx_init(struct amdxdna_ctx *hwctx)
 		ve2_clear_firmware_status(xdna, hwctx);
 
 	mutex_init(&priv->privctx_lock);
+	mutex_init(&priv->coredump_cache.lock);
 	priv->state = AMDXDNA_HWCTX_STATE_IDLE;
 
 	XDNA_DBG(xdna, "hwctx init: ready hwctx=%p start_col=%u pid=%d",
@@ -1565,6 +1574,8 @@ void ve2_hwctx_fini(struct amdxdna_ctx *hwctx)
 	ve2_mgmt_destroy_partition(hwctx);
 	ve2_free_hsa_queue(xdna, &hwctx->priv->hwctx_hsa_queue);
 	kfree(hwctx->priv->hwctx_config);
+	vfree(hwctx->priv->coredump_cache.buf);
+	mutex_destroy(&hwctx->priv->coredump_cache.lock);
 	mutex_destroy(&hwctx->priv->privctx_lock);
 
 	XDNA_DBG(xdna,

--- a/src/driver/amdxdna/ve2_mgmt.c
+++ b/src/driver/amdxdna/ve2_mgmt.c
@@ -7,6 +7,7 @@
 #include <linux/completion.h>
 #include <linux/atomic.h>
 #include <linux/delay.h>
+#include <linux/vmalloc.h>
 
 #include "amdxdna_ctx.h"
 #include "ve2_of.h"
@@ -1312,6 +1313,97 @@ int ve2_create_coredump(struct amdxdna_dev *xdna,
 	XDNA_DBG(xdna, "Reading coredump ret:%d\n", rel_size);
 
 	return rel_size;
+}
+
+int ve2_cache_coredump(struct amdxdna_dev *xdna, struct amdxdna_ctx *hwctx, u64 seq)
+{
+	struct amdxdna_dev_hdl *dev_hdl = xdna->dev_handle;
+	struct amdxdna_ctx_priv *priv = hwctx->priv;
+	struct ve2_coredump_cache *cache = &priv->coredump_cache;
+	void *buf, *old_buf;
+	u32 size;
+	int ret;
+
+	size = priv->num_col * dev_hdl->aie_dev_info.rows * TILE_ADDRESS_SPACE;
+	if (!size) {
+		XDNA_WARN(xdna, "Auto coredump: zero size for hwctx %u", hwctx->id);
+		return -EINVAL;
+	}
+
+	XDNA_INFO(xdna,
+		  "Auto coredump: capture start hwctx %u pid %u seq %llu start_col %u num_col %u size %u",
+		  hwctx->id, hwctx->client->pid, seq, priv->start_col, priv->num_col, size);
+
+	buf = vmalloc(size);
+	if (!buf)
+		return -ENOMEM;
+
+	/* hwctx is the active ctx on this partition during the timeout path. */
+	ret = ve2_create_coredump(xdna, hwctx, buf, size);
+	if (ret < 0) {
+		XDNA_ERR(xdna, "Auto coredump capture failed for hwctx %u, err:%d",
+			 hwctx->id, ret);
+		vfree(buf);
+		return ret;
+	}
+
+	/*
+	 * Keep-latest: swap in the new snapshot, then free the previous one.
+	 * The cache is per-hwctx and is consumed (cleared) on the next coredump
+	 * request for this context.
+	 */
+	mutex_lock(&cache->lock);
+	old_buf = cache->buf;
+	cache->buf = buf;
+	cache->size = ret;
+	cache->seq = seq;
+	cache->start_col = priv->start_col;
+	cache->num_col = priv->num_col;
+	cache->timestamp = ktime_get();
+	cache->valid = true;
+
+	/* Dump the full coredump cache structure for debugging. */
+	XDNA_DBG(xdna,
+		 "ve2_coredump_cache: hwctx=%u pid=%u buf=%p size=%u seq=%llu start_col=%u num_col=%u timestamp=%lld valid=%d",
+		 hwctx->id, hwctx->client->pid, cache->buf, cache->size,
+		 cache->seq, cache->start_col, cache->num_col,
+		 ktime_to_ns(cache->timestamp), cache->valid);
+
+	mutex_unlock(&cache->lock);
+
+	XDNA_INFO(xdna,
+		  "Auto coredump cached OK: hwctx %u pid %u seq %llu size %d%s (head: %08x %08x %08x %08x)",
+		  hwctx->id, hwctx->client->pid, seq, ret,
+		  old_buf ? " [overwrote previous dump]" : "",
+		  ((u32 *)buf)[0], ((u32 *)buf)[1], ((u32 *)buf)[2], ((u32 *)buf)[3]);
+
+	/* Dump the first bytes so a zero/garbage capture is easy to spot. */
+	print_hex_dump_debug("ve2 auto-coredump head: ", DUMP_PREFIX_OFFSET, 16, 4, buf,
+			     min_t(u32, ret, 64u), false);
+
+	vfree(old_buf);
+
+	return 0;
+}
+
+/*
+ * Drop any auto-captured coredump held for this context. The dump is kept after
+ * a timeout so it can be read back; it is released here once the context makes
+ * forward progress again (a new command is submitted), since a stale snapshot
+ * no longer reflects the live partition state.
+ */
+void ve2_coredump_cache_invalidate(struct amdxdna_ctx *hwctx)
+{
+	struct ve2_coredump_cache *cache = &hwctx->priv->coredump_cache;
+
+	mutex_lock(&cache->lock);
+	if (cache->valid || cache->buf) {
+		vfree(cache->buf);
+		cache->buf = NULL;
+		cache->size = 0;
+		cache->valid = false;
+	}
+	mutex_unlock(&cache->lock);
 }
 
 static int ve2_xrs_release(struct amdxdna_dev *xdna, struct amdxdna_ctx *hwctx,

--- a/src/driver/amdxdna/ve2_mgmt.h
+++ b/src/driver/amdxdna/ve2_mgmt.h
@@ -180,6 +180,20 @@ int ve2_xrs_col_list(struct amdxdna_dev *xdna, struct alloc_requests *xrs_req,
 
 int ve2_create_coredump(struct amdxdna_dev *xdna, struct amdxdna_ctx *hwctx,
 			void *buffer, u32 size);
+void ve2_coredump_cache_invalidate(struct amdxdna_ctx *hwctx);
+/**
+ * ve2_cache_coredump - Auto-capture an AIE coredump into the device cache.
+ * @xdna: Pointer to the device structure.
+ * @hwctx: Pointer to the hardware context that timed out.
+ * @seq: Sequence number of the failing command.
+ *
+ * Always-on: captures on every command timeout. Keep-latest: overwrites any
+ * previously cached dump (device-scoped). Must be called while @hwctx is still
+ * the active context on its partition (i.e. from the timeout path).
+ *
+ * Returns 0 on success or a negative errno.
+ */
+int ve2_cache_coredump(struct amdxdna_dev *xdna, struct amdxdna_ctx *hwctx, u64 seq);
 /**
  * ve2_mgmt_destroy_partition - Destroy a VE2 hardware partition for a context.
  * @hwctx: Pointer to the hardware context.

--- a/src/driver/amdxdna/ve2_of.h
+++ b/src/driver/amdxdna/ve2_of.h
@@ -83,6 +83,26 @@ struct amdxdna_ctx_command_fifo {
 	struct list_head                list;
 };
 
+/*
+ * ve2_coredump_cache - Last AIE coredump auto-captured on command timeout.
+ *
+ * This cache is per-hardware-context (lives in struct amdxdna_ctx_priv). Auto-
+ * capture is always on: the driver snapshots the AIE partition into @buf when a
+ * command on this context times out. Keep-latest: a newer timeout overwrites
+ * the previous snapshot.
+ * If the cache is empty the driver performs a live capture instead.
+ */
+struct ve2_coredump_cache {
+	void		*buf;		/* vmalloc'd snapshot, or NULL */
+	u32		size;		/* valid bytes in @buf */
+	u64		seq;		/* failing command sequence number */
+	u32		start_col;	/* partition start column */
+	u32		num_col;	/* partition column count */
+	ktime_t		timestamp;	/* capture time */
+	bool		valid;		/* @buf holds a captured dump */
+	struct mutex	lock;		/* protects all fields above */
+};
+
 struct amdxdna_ctx_priv {
 	u64				id; /* Unique incrementing hwctx ID */
 	u32				start_col;
@@ -98,6 +118,7 @@ struct amdxdna_ctx_priv {
 	struct timer_list		event_timer;
 	bool			misc_intrpt_flag; /* Hardware sync required */
 	struct mutex			privctx_lock; /* protect private ctx */
+	struct ve2_coredump_cache	coredump_cache; /* last timeout coredump (per hwctx) */
 };
 
 struct amdxdna_dev_priv {


### PR DESCRIPTION
-Auto-capture an AIE coredump when a command times out, and cache it for the next coredump request for that context.
-The coredump cache is per-hardware-context (lives in amdxdna_ctx_priv). Capture is always on: on timeout the driver snapshots the partition into a vmalloc'd buffer (keep-latest, a newer timeout overwrites the previous).
-Retrieval is consume-on-read: a coredump request is served from the hwctx cache and it is then cleared.
-If the cache is empty, the driver falls back to a live coredump capture req.