### PR TITLE
accel/amdxdna: label Total Power sensor in W, not mW

### DIFF
--- a/drivers/accel/amdxdna/amdxdna_sensors.c
+++ b/drivers/accel/amdxdna/amdxdna_sensors.c
@@ -61,7 +61,7 @@ int amdxdna_query_sensors(struct amdxdna_drm_get_info *args, u32 total_col)
 	sensor.input = npu_metrics.npu_power;
 	sensor.unitm = -3;
 	scnprintf(sensor.label, sizeof(sensor.label), "Total Power");
-	scnprintf(sensor.units, sizeof(sensor.units), "mW");
+	scnprintf(sensor.units, sizeof(sensor.units), "W");
 
 	if (args->buffer_size < sizeof(sensor))
 		goto out;

--- a/include/uapi/drm/amdxdna_accel.h
+++ b/include/uapi/drm/amdxdna_accel.h
@@ -441,7 +441,8 @@ enum amdxdna_sensor_type {
  * @average: The average value of the sensor.
  * @highest: The highest recorded sensor value for this driver load for the sensor.
  * @status: The sensor status.
- * @units: The sensor units.
+ * @units: The unit of the scaled value (pow(10, unitm) * value), not of the raw
+ *         @input, @max, @average and @highest members.
  * @unitm: Translates value member variables into the correct unit via (pow(10, unitm) * value).
  * @type: The sensor type from enum amdxdna_sensor_type.
  * @pad: Structure padding.


### PR DESCRIPTION
`DRM_AMDXDNA_QUERY_SENSORS` describes the NPU power sensor with units that do not match the value it reports. `amdxdna_query_sensors()` sets `unitm = -3` on `npu_power` and names the units `mW`, so per the UAPI (`pow(10, unitm) * input`) a raw reading of 1118 is described as 1.118 mW when it is 1.118 W.

## Root cause

`npu_power` comes from `struct amd_pmf_npu_metrics`, which `include/linux/amd-pmf-io.h` documents as `@npu_power`: NPU power [mW]. `unitm = -3` therefore converts mW to W, which is exactly what the consumer expects: XRT's `read_data_driven_electrical()` (`xrt/src/runtime_src/core/common/sensor.cpp`) computes `input * pow(10, unitm)` and stores the result as `power_consumption_watts`. The scale factor is right; the units string labelling it is not.

## Fix

Set `units` to `W` and leave `unitm = -3` alone. The sensor becomes self-consistent under the UAPI contract, and the value every consumer sees is unchanged, so no paired userspace change is needed. `units` is not read on the XRT power path at all: only the `Total Power` label and `unitm` are.

Dropping `unitm` to 0 instead would keep `input`, `max`, `average` and `highest` exact `__u32`, but it would break the end-to-end report, since `xrt-smi` would then show 1118 W. v1 of this PR did that; see the review thread.

A second commit fixes the kernel-doc that made this easy to get wrong. `@units` was described only as "The sensor units", with nothing saying which value it names, which is what let `mW` sit next to a raw mW `input` and look right. It now names the scaled value:

```
 * @units: The unit of the scaled value (pow(10, unitm) * value), not of the raw
 *         @input, @max, @average and @highest members.
```

Comment only, no ABI or behaviour change.

## Evidence

Read on a Strix part (npu4) through `DRM_AMDXDNA_QUERY_SENSORS`, sampling the Total Power sensor at 50 Hz while dispatching a prebuilt design back-to-back:

| state | raw `input` |
| --- | --- |
| idle | 0.209 mean, max 1 |
| sustained load | 979.82 mean, peak 1118 |

At `unitm = -3` that is ~0 W idle and ~1.1 W under load, a plausible figure for this part, which is what establishes the reported quantity is watts and not milliwatts.

## hwmon

`amdxdna_hwmon_read()` converts `npu_power` with `MICROWATT_PER_MILLIWATT` and does not go through `unitm`, so hwmon `power1_input` is unaffected by this change.

