### PR TITLE
accel/amdxdna: add firmware-log dmesg-dump, parsers and debugfs nodes

### DIFF
--- a/drivers/accel/amdxdna/aie.h
+++ b/drivers/accel/amdxdna/aie.h
@@ -39,6 +39,7 @@ struct aie_msg_ops {
 	int  (*fw_log_init)(struct amdxdna_dev *xdna, size_t size, u32 level);
 	int  (*fw_log_config)(struct amdxdna_dev *xdna, u32 level);
 	int  (*fw_log_fini)(struct amdxdna_dev *xdna);
+	void (*fw_log_parse)(struct amdxdna_dev *xdna, char *buf, size_t size);
 
 	int  (*fw_trace_init)(struct amdxdna_dev *xdna, size_t size, u32 categories);
 	int  (*fw_trace_config)(struct amdxdna_dev *xdna, u32 categories);

--- a/drivers/accel/amdxdna/aie2_message.c
+++ b/drivers/accel/amdxdna/aie2_message.c
@@ -1048,6 +1048,7 @@ void aie2_msg_init(struct amdxdna_dev_hdl *ndev)
 		ndev->aie.msg_ops.fw_log_init   = aie2_fw_log_init;
 		ndev->aie.msg_ops.fw_log_config = aie2_fw_log_config;
 		ndev->aie.msg_ops.fw_log_fini   = aie2_fw_log_fini;
+		ndev->aie.msg_ops.fw_log_parse  = aie2_fw_log_parse;
 	}
 
 	if (AIE_FEATURE_ON(&ndev->aie, AIE2_FW_TRACE)) {

--- a/drivers/accel/amdxdna/aie2_pci.c
+++ b/drivers/accel/amdxdna/aie2_pci.c
@@ -11,6 +11,7 @@
 #include <drm/drm_managed.h>
 #include <drm/drm_print.h>
 #include <drm/gpu_scheduler.h>
+#include <linux/bitfield.h>
 #include <linux/cleanup.h>
 #include <linux/errno.h>
 #include <linux/firmware.h>
@@ -1085,6 +1086,182 @@ static int aie2_get_dev_rev(struct amdxdna_dev *xdna, u32 *rev)
 		*rev = (u32)aie2_rev;
 
 	return ret;
+}
+
+#define AIE2_MGMT_APP_ID		0xFF
+
+static const char * const aie2_fw_log_level_str[] = {
+	"OFF",
+	"ERR",
+	"WRN",
+	"INF",
+	"DBG",
+	"MAX"
+};
+
+/*
+ * AIE2 firmware log entries are structured (unlike the plain newline-
+ * delimited AIE4 stream): each record is a header, a u64-aligned payload,
+ * and a footer. The header and footer carry a magic byte and a matching
+ * sequence number / word length so a torn or overwritten record in the
+ * wrapping DRAM ring can be detected and skipped.
+ */
+struct aie2_fw_log_header {
+#define AIE2_DPT_ENTRY_MAGIC_HEAD	0xCA
+	u8	magic;
+	u8	data_word_len;
+	__le16	seq_num;
+	u32	reserved;
+} __packed;
+
+/*
+ * The two 32-bit words following the timestamp pack the record metadata.
+ * The kernel avoids C bitfields for wire/DRAM layouts (their bit ordering
+ * and padding are implementation-defined), so the fields are decoded with
+ * explicit masks via FIELD_GET on this little-endian target. Only @level
+ * and @appn (word0) are consumed today; the remaining masks document the
+ * firmware layout.
+ */
+struct aie2_fw_log_data {
+	u64	timestamp;
+	u32	word0;
+	u32	word1;
+} __packed;
+
+/* word0 */
+#define AIE2_FW_LOG_FORMAT	GENMASK(0, 0)
+#define AIE2_FW_LOG_LEVEL	GENMASK(10, 8)
+#define AIE2_FW_LOG_APPN	GENMASK(23, 16)
+#define AIE2_FW_LOG_ARGC	GENMASK(31, 24)
+/* word1 */
+#define AIE2_FW_LOG_LINE	GENMASK(15, 0)
+#define AIE2_FW_LOG_MODULE	GENMASK(31, 16)
+
+struct aie2_fw_log_footer {
+	u32	reserved;
+	__le16	seq_num;
+	u8	data_word_len;
+#define AIE2_DPT_ENTRY_MAGIC_FOOTER	0xBA
+	u8	magic;
+} __packed;
+
+static void aie2_fw_log_print(struct amdxdna_dev *xdna, const char *payload,
+			      size_t size)
+{
+	u32 level, appn, word0;
+	const char *level_str;
+	__le64 raw_timestamp;
+	__le32 raw_word0;
+	char appid[20];
+	u64 timestamp;
+
+	if (size < sizeof(struct aie2_fw_log_data))
+		return;
+
+	/*
+	 * The resync path (aie2_fw_log_parse) advances in 4-byte steps, so a
+	 * valid-looking header can be found at 4-byte alignment and @payload
+	 * may not be 8-byte aligned. Copy the little-endian wire fields into
+	 * aligned locals before converting, instead of dereferencing a
+	 * possibly misaligned struct. This also makes the DRAM layout
+	 * endianness explicit rather than baking in host endianness, and
+	 * avoids depending on <linux/unaligned.h>, which does not exist on
+	 * kernels older than 6.12.
+	 */
+	memcpy(&raw_timestamp, payload, sizeof(raw_timestamp));
+	memcpy(&raw_word0, payload + offsetof(struct aie2_fw_log_data, word0),
+	       sizeof(raw_word0));
+	timestamp = le64_to_cpu(raw_timestamp);
+	word0 = le32_to_cpu(raw_word0);
+
+	level = FIELD_GET(AIE2_FW_LOG_LEVEL, word0);
+	appn = FIELD_GET(AIE2_FW_LOG_APPN, word0);
+
+	if (level < ARRAY_SIZE(aie2_fw_log_level_str))
+		level_str = aie2_fw_log_level_str[level];
+	else
+		level_str = "UNK";
+
+	if (appn == AIE2_MGMT_APP_ID)
+		scnprintf(appid, sizeof(appid), "MGMNT");
+	else
+		scnprintf(appid, sizeof(appid), "APP%2d", appn);
+
+	XDNA_INFO(xdna, "[FW LOG] [%llu] [%s] [%s]: %.*s", timestamp,
+		  level_str, appid, (int)(size - sizeof(struct aie2_fw_log_data)),
+		  payload + sizeof(struct aie2_fw_log_data));
+}
+
+/*
+ * Walk the fetched ring payload record by record, validating each entry's
+ * header/footer magic, sequence continuity and length before emitting it.
+ * On any inconsistency, advance by the minimum alignment (4 bytes) and
+ * resynchronize on the next valid header rather than trusting a possibly
+ * corrupted length.
+ */
+void aie2_fw_log_parse(struct amdxdna_dev *xdna, char *buffer, size_t size)
+{
+	char *end = buffer + size;
+	bool has_prev_seq = false;
+	char *p = buffer;
+	u16 prev_seq = 0;
+
+	if (!buffer || size == 0)
+		return;
+
+	while ((size_t)(end - p) >= sizeof(struct aie2_fw_log_header)) {
+		const struct aie2_fw_log_header *hdr = (const struct aie2_fw_log_header *)p;
+		unsigned int increment_bytes = 4; /* default resync step */
+		bool corrupted = true;
+
+		if (likely(hdr->magic == AIE2_DPT_ENTRY_MAGIC_HEAD)) {
+			size_t payload_bytes = hdr->data_word_len * sizeof(u64);
+			size_t total_entry_size = sizeof(struct aie2_fw_log_header) +
+						  payload_bytes +
+						  sizeof(struct aie2_fw_log_footer);
+			const char *payload = p + sizeof(struct aie2_fw_log_header);
+			const struct aie2_fw_log_footer *ftr;
+			u16 seq = le16_to_cpu(hdr->seq_num);
+			bool valid;
+
+			/* Partial entry at the ring end: stop to avoid overread. */
+			if ((size_t)(end - p) < total_entry_size)
+				break;
+
+			ftr = (const struct aie2_fw_log_footer *)(payload + payload_bytes);
+			valid = (ftr->magic == AIE2_DPT_ENTRY_MAGIC_FOOTER) &&
+				(seq > 0) && (seq == le16_to_cpu(ftr->seq_num)) &&
+				(hdr->data_word_len == ftr->data_word_len);
+
+			if (likely(valid) &&
+			    likely(!has_prev_seq || seq == (u16)(prev_seq + 1))) {
+				has_prev_seq = true;
+				prev_seq = seq;
+				aie2_fw_log_print(xdna, payload, payload_bytes);
+				corrupted = false;
+				increment_bytes = (unsigned int)total_entry_size;
+			}
+
+			if (unlikely(corrupted)) {
+				/*
+				 * Torn/overwritten records are expected at the
+				 * wrap boundary of a continuously overwritten
+				 * ring and the poll worker runs every
+				 * AMDXDNA_DPT_POLL_INTERVAL_MS, so ratelimit to
+				 * avoid drowning the log in the resync path.
+				 */
+				dev_warn_ratelimited(xdna->ddev.dev,
+						     "FW log entry overwritten/corrupted\n");
+				has_prev_seq = false;
+			}
+		}
+
+		if (unlikely(increment_bytes == 0) ||
+		    (size_t)(end - p) < increment_bytes)
+			break;
+
+		p += increment_bytes;
+	}
 }
 
 int aie2_fw_log_init(struct amdxdna_dev *xdna, size_t size, u32 level)

--- a/drivers/accel/amdxdna/aie2_pci.h
+++ b/drivers/accel/amdxdna/aie2_pci.h
@@ -267,6 +267,7 @@ int aie2_start_fw_trace(struct amdxdna_dev_hdl *ndev,
 int aie2_fw_log_init(struct amdxdna_dev *xdna, size_t size, u32 level);
 int aie2_fw_log_config(struct amdxdna_dev *xdna, u32 level);
 int aie2_fw_log_fini(struct amdxdna_dev *xdna);
+void aie2_fw_log_parse(struct amdxdna_dev *xdna, char *buffer, size_t size);
 
 int aie2_fw_trace_init(struct amdxdna_dev *xdna, size_t size, u32 categories);
 int aie2_fw_trace_config(struct amdxdna_dev *xdna, u32 categories);

--- a/drivers/accel/amdxdna/aie4_message.c
+++ b/drivers/accel/amdxdna/aie4_message.c
@@ -612,6 +612,7 @@ void aie4_msg_init(struct amdxdna_dev_hdl *ndev)
 		ndev->aie.msg_ops.fw_log_init   = aie4_fw_log_init;
 		ndev->aie.msg_ops.fw_log_config = aie4_fw_log_config;
 		ndev->aie.msg_ops.fw_log_fini   = aie4_fw_log_fini;
+		ndev->aie.msg_ops.fw_log_parse  = aie4_fw_log_parse;
 	}
 
 	if (AIE_FEATURE_ON(&ndev->aie, AIE4_FW_TRACE)) {

--- a/drivers/accel/amdxdna/aie4_pci.c
+++ b/drivers/accel/amdxdna/aie4_pci.c
@@ -1548,6 +1548,32 @@ int aie4_fw_log_fini(struct amdxdna_dev *xdna)
 	return ret;
 }
 
+/* Max bytes printed per dmesg line; firmware entries are newline-delimited
+ * text, so split on '\n' and cap overly long lines at this chunk size.
+ */
+#define AIE4_FW_LOG_CHUNK	800
+
+void aie4_fw_log_parse(struct amdxdna_dev *xdna, char *buffer, size_t size)
+{
+	size_t offset = 0;
+
+	if (!buffer || size == 0)
+		return;
+
+	while (offset < size) {
+		const char *p = buffer + offset;
+		size_t remaining = size - offset;
+		size_t n = remaining < AIE4_FW_LOG_CHUNK ? remaining : AIE4_FW_LOG_CHUNK;
+		const char *nl = memchr(p, '\n', n);
+
+		if (nl)
+			n = (size_t)(nl - p) + 1;
+
+		XDNA_INFO(xdna, "[FW LOG] %.*s", (int)n, p);
+		offset += n;
+	}
+}
+
 int aie4_fw_trace_init(struct amdxdna_dev *xdna, size_t size, u32 categories)
 {
 	struct amdxdna_dev_hdl *ndev = xdna->dev_handle;

--- a/drivers/accel/amdxdna/aie4_pci.h
+++ b/drivers/accel/amdxdna/aie4_pci.h
@@ -249,6 +249,7 @@ int aie4_start_fw_trace(struct amdxdna_dev_hdl *ndev,
 int aie4_fw_log_init(struct amdxdna_dev *xdna, size_t size, u32 level);
 int aie4_fw_log_config(struct amdxdna_dev *xdna, u32 level);
 int aie4_fw_log_fini(struct amdxdna_dev *xdna);
+void aie4_fw_log_parse(struct amdxdna_dev *xdna, char *buf, size_t size);
 
 int aie4_fw_trace_init(struct amdxdna_dev *xdna, size_t size, u32 categories);
 int aie4_fw_trace_config(struct amdxdna_dev *xdna, u32 categories);

--- a/drivers/accel/amdxdna/amdxdna_debugfs.c
+++ b/drivers/accel/amdxdna/amdxdna_debugfs.c
@@ -5,8 +5,11 @@
 
 #include "amdxdna_cbuf.h"
 #include "amdxdna_debugfs.h"
+#include "amdxdna_dpt.h"
+#include "amdxdna_pm.h"
 
 #include <drm/drm_file.h>
+#include <linux/cleanup.h>
 #include <linux/debugfs.h>
 #include <linux/pm_runtime.h>
 #include <linux/seq_file.h>
@@ -102,12 +105,139 @@ static int amdxdna_carveout_show(struct seq_file *m, void *unused)
  */
 AMDXDNA_DBGFS_FOPS(carveout, amdxdna_carveout_show, amdxdna_carveout_write);
 
+/*
+ * fw_log_level: enable/disable firmware logging or change verbosity.
+ * Write 0 to disable; 1..AMDXDNA_DPT_FW_LOG_LEVEL_MAX-1 to enable/relevel.
+ * Read prints the current level (0 if inactive).
+ */
+static ssize_t fw_log_level_write(struct file *file, const char __user *ptr,
+				  size_t len, loff_t *off)
+{
+	struct amdxdna_dev *xdna = file_to_xdna(file);
+	u32 level;
+	int ret;
+
+	ret = kstrtouint_from_user(ptr, len, 0, &level);
+	if (ret)
+		return ret;
+
+	guard(mutex)(&xdna->dev_lock);
+
+	/*
+	 * (Re)configuring firmware logging exchanges a message with the
+	 * firmware, so the device must be awake. On an idle device runtime PM
+	 * has suspended it (and the DPT), which would otherwise fail the write
+	 * with -EBUSY; resume it for the duration of the config and let it
+	 * autosuspend again afterwards.
+	 */
+	ret = amdxdna_pm_resume_get_locked(xdna);
+	if (ret)
+		return ret;
+
+	ret = amdxdna_fw_log_set_state(xdna, level);
+	amdxdna_pm_suspend_put(xdna);
+	if (ret) {
+		XDNA_ERR(xdna, "Failed to set FW log level %u: %d", level, ret);
+		return ret;
+	}
+
+	return len;
+}
+
+static int fw_log_level_show(struct seq_file *m, void *unused)
+{
+	struct amdxdna_dev *xdna = m->private;
+	struct amdxdna_dpt *dpt;
+	u32 level = 0;
+	int idx;
+
+	dpt = amdxdna_dpt_enter_kind(xdna, AMDXDNA_DPT_FW_LOG, &idx);
+	if (dpt) {
+		level = READ_ONCE(dpt->config);
+		srcu_read_unlock(&xdna->dpt_srcu, idx);
+	}
+
+	seq_printf(m, "%u\n", level);
+	return 0;
+}
+
+AMDXDNA_DBGFS_FOPS(fw_log_level, fw_log_level_show, fw_log_level_write);
+
+/*
+ * fw_log_dump_to_dmesg: toggle kernel-side streaming of FW log entries to
+ * dmesg. Returns -EINVAL if FW logging is not ACTIVE.
+ */
+static ssize_t fw_log_dump_to_dmesg_write(struct file *file, const char __user *ptr,
+					  size_t len, loff_t *off)
+{
+	struct amdxdna_dev *xdna = file_to_xdna(file);
+	struct amdxdna_dpt *dpt;
+	bool dump;
+	int ret;
+
+	ret = kstrtobool_from_user(ptr, len, &dump);
+	if (ret)
+		return ret;
+
+	guard(mutex)(&xdna->dev_lock);
+
+	/*
+	 * Enabling/disabling the dmesg stream touches the DPT poll timer and
+	 * buffer, so the device (and DPT) must be resumed first; an idle
+	 * device is runtime-suspended with the DPT in SUSPENDED state. Resume
+	 * for the operation and let it autosuspend again afterwards.
+	 */
+	ret = amdxdna_pm_resume_get_locked(xdna);
+	if (ret)
+		return ret;
+
+	dpt = rcu_dereference_protected(xdna->fw_log,
+					lockdep_is_held(&xdna->dev_lock));
+	if (!dpt || READ_ONCE(dpt->status) != AMDXDNA_DPT_ACTIVE) {
+		amdxdna_pm_suspend_put(xdna);
+		XDNA_ERR(xdna, "FW logging is not active");
+		return -EINVAL;
+	}
+
+	ret = amdxdna_dpt_dump_to_dmesg(dpt, dump);
+	amdxdna_pm_suspend_put(xdna);
+	if (ret) {
+		XDNA_ERR(xdna, "Failed to %s FW log dmesg: %d",
+			 dump ? "enable" : "disable", ret);
+		return ret;
+	}
+
+	return len;
+}
+
+static int fw_log_dump_to_dmesg_show(struct seq_file *m, void *unused)
+{
+	struct amdxdna_dev *xdna = m->private;
+	struct amdxdna_dpt *dpt;
+	bool dump = false;
+	int idx;
+
+	dpt = amdxdna_dpt_enter_kind(xdna, AMDXDNA_DPT_FW_LOG, &idx);
+	if (dpt) {
+		dump = READ_ONCE(dpt->dump_to_dmesg);
+		srcu_read_unlock(&xdna->dpt_srcu, idx);
+	}
+
+	seq_printf(m, "%d\n", dump ? 1 : 0);
+	return 0;
+}
+
+AMDXDNA_DBGFS_FOPS(fw_log_dump_to_dmesg, fw_log_dump_to_dmesg_show,
+		   fw_log_dump_to_dmesg_write);
+
 static const struct {
 	const char *name;
 	const struct file_operations *fops;
 	umode_t mode;
 } amdxdna_dbgfs_files[] = {
 	AMDXDNA_DBGFS_FILE(carveout, 0600),
+	AMDXDNA_DBGFS_FILE(fw_log_level, 0600),
+	AMDXDNA_DBGFS_FILE(fw_log_dump_to_dmesg, 0600),
 };
 
 void amdxdna_debugfs_init(struct amdxdna_dev *xdna)

--- a/drivers/accel/amdxdna/amdxdna_dpt.c
+++ b/drivers/accel/amdxdna/amdxdna_dpt.c
@@ -52,7 +52,7 @@ amdxdna_dpt_slot(struct amdxdna_dev *xdna, enum amdxdna_dpt_kind kind)
 	return NULL;
 }
 
-static struct amdxdna_dpt *
+struct amdxdna_dpt *
 amdxdna_dpt_enter_kind(struct amdxdna_dev *xdna, enum amdxdna_dpt_kind kind,
 		       int *idx)
 {
@@ -82,6 +82,20 @@ static bool amdxdna_dpt_watch_ready(const struct amdxdna_dpt *dpt, u64 offset)
 {
 	return READ_ONCE(dpt->status) != AMDXDNA_DPT_ACTIVE ||
 	       offset != READ_ONCE(dpt->tail);
+}
+
+static int amdxdna_dpt_copy_to_kernel(void *to, const void *from, size_t n)
+{
+	memcpy(to, from, n);
+	return 0;
+}
+
+static void amdxdna_dpt_call_parse(struct amdxdna_dpt *dpt, char *buf, size_t size)
+{
+	struct aie_device *aie = dpt->aie;
+
+	if (dpt->kind == AMDXDNA_DPT_FW_LOG && aie->msg_ops.fw_log_parse)
+		aie->msg_ops.fw_log_parse(dpt->xdna, buf, size);
 }
 
 static int amdxdna_dpt_copy_to_user(void *to, const void *from, size_t n)
@@ -117,49 +131,49 @@ static int amdxdna_dpt_fetch_payload(struct amdxdna_dpt *dpt, u8 *buf,
 		goto exit;
 	}
 
+	/*
+	 * When the reader has fallen more than one full ring behind, the
+	 * oldest in-ring bytes have already been overwritten. Skip forward to
+	 * the start of the still-valid window (tail - log_size) instead of
+	 * repeatedly re-reading (and, in the dmesg path, re-logging) the same
+	 * beginning-of-ring bytes on every fetch until the cursor catches up.
+	 */
+	if (tail - *offset > log_size)
+		*offset = tail - log_size;
+
 	start = *offset % log_size;
 	end = tail % log_size;
 
 	/*
-	 * When the firmware has wrapped past our slot by more than one full
-	 * buffer, re-anchor at the start of the buffer to deliver the most
-	 * recent entries.
+	 * start == end here means the reader is exactly one full ring behind,
+	 * so the entire ring is pending (req_size == log_size). It never means
+	 * "empty" because the tail == *offset case already returned above.
 	 */
-	if (tail - *offset >= log_size + start)
-		start = 0;
-
-	if (end > start) {
+	if (end > start)
 		req_size = end - start;
-		if (req_size > *size) {
-			XDNA_DPT_DBG(dpt, "Insufficient buffer size: 0x%zx", req_size);
-			end = start + *size;
-			req_size = *size;
-		}
-	} else {
+	else
 		req_size = log_size - start + end;
-		if (req_size > *size) {
-			XDNA_DPT_DBG(dpt, "Insufficient buffer size: 0x%zx", req_size);
-			if (start + *size <= log_size)
-				end = start + *size;
-			else
-				end = *size - (log_size - start);
-			req_size = *size;
-		}
+
+	if (req_size > *size) {
+		XDNA_DPT_DBG(dpt, "Insufficient buffer size: 0x%zx", req_size);
+		req_size = *size;
 	}
 
-	if (start > end) {
+	if (start + req_size > log_size) {
+		size_t first = log_size - start;
+
 		/* First chunk: from start to end of log buffer */
-		drm_clflush_virt_range(to_cpu_addr(hdl, start), log_size - start);
-		if (cpy(buf, to_cpu_addr(hdl, start), log_size - start))
+		drm_clflush_virt_range(to_cpu_addr(hdl, start), first);
+		if (cpy(buf, to_cpu_addr(hdl, start), first))
 			return -EFAULT;
 
-		/* Wrap-around chunk: from 0 to end */
-		drm_clflush_virt_range(to_cpu_addr(hdl, 0), end);
-		if (cpy(buf + (log_size - start), to_cpu_addr(hdl, 0), end))
+		/* Wrap-around chunk: from 0 to the remainder */
+		drm_clflush_virt_range(to_cpu_addr(hdl, 0), req_size - first);
+		if (cpy(buf + first, to_cpu_addr(hdl, 0), req_size - first))
 			return -EFAULT;
 	} else {
-		drm_clflush_virt_range(to_cpu_addr(hdl, start), end - start);
-		if (cpy(buf, to_cpu_addr(hdl, start), end - start))
+		drm_clflush_virt_range(to_cpu_addr(hdl, start), req_size);
+		if (cpy(buf, to_cpu_addr(hdl, start), req_size))
 			return -EFAULT;
 	}
 exit:
@@ -294,11 +308,134 @@ static void amdxdna_dpt_timer_put(struct amdxdna_dpt *dpt)
 	mutex_unlock(&dpt->timer_lock);
 }
 
+static void amdxdna_dpt_fetch_and_dump_to_dmesg(struct amdxdna_dpt *dpt)
+{
+	/*
+	 * A single fetch is capped at the local_buffer size and the poll
+	 * worker only re-fetches when the tail advances, so drain the whole
+	 * backlog up to the current tail here. Otherwise a batch larger than
+	 * local_buffer would leave head behind tail and stall until the next
+	 * tail advance. Only amdxdna_dpt_update_tail() moves the tail, so it
+	 * is a fixed snapshot for the duration of this loop and the loop is
+	 * bounded.
+	 */
+	while (dpt->head != READ_ONCE(dpt->tail)) {
+		u32 size = dpt->size;
+		int ret;
+
+		ret = amdxdna_dpt_fetch_payload(dpt, dpt->local_buffer, &dpt->head,
+						&size, amdxdna_dpt_copy_to_kernel);
+		if (ret) {
+			XDNA_DPT_ERR(dpt, "Failed to fetch FW buffer: %d", ret);
+			return;
+		}
+		if (!size)
+			break;
+
+		amdxdna_dpt_call_parse(dpt, dpt->local_buffer, size);
+	}
+}
+
+static void amdxdna_dpt_drain_pending_data(struct amdxdna_dpt *dpt)
+{
+	/*
+	 * Refresh the tail from the firmware footer before draining. At enable
+	 * time (for example right after resume, before the IRQ or poll worker
+	 * has run) the cached tail may lag the ring, so snapshot the latest
+	 * first to avoid leaving already-buffered entries until a later worker
+	 * run.
+	 */
+	amdxdna_dpt_update_tail(dpt);
+	amdxdna_dpt_fetch_and_dump_to_dmesg(dpt);
+}
+
 static void amdxdna_dpt_worker(struct work_struct *w)
 {
 	struct amdxdna_dpt *dpt = container_of(w, struct amdxdna_dpt, work);
 
-	amdxdna_dpt_update_tail(dpt);
+	/*
+	 * The worker is the sole consumer of local_buffer / head once
+	 * dumping is enabled. Pair the acquire load with the store-release
+	 * in amdxdna_dpt_dump_to_dmesg() so that observing dump_to_dmesg
+	 * true guarantees local_buffer has been published.
+	 */
+	if (amdxdna_dpt_update_tail(dpt) && smp_load_acquire(&dpt->dump_to_dmesg))
+		amdxdna_dpt_fetch_and_dump_to_dmesg(dpt);
+}
+
+int amdxdna_dpt_dump_to_dmesg(struct amdxdna_dpt *dpt, bool enable)
+{
+	if (!dpt)
+		return -EINVAL;
+
+	/*
+	 * The poll worker reads dump_to_dmesg with smp_load_acquire() without
+	 * taking dev_lock, so use READ_ONCE() here to keep the compare
+	 * race-free (a plain read is a data race under KCSAN).
+	 */
+	if (READ_ONCE(dpt->dump_to_dmesg) == enable)
+		return 0;
+
+	if (enable) {
+		/*
+		 * dmesg dumping only makes sense when the backend can parse the
+		 * fetched ring payload (see amdxdna_dpt_call_parse). Reject the
+		 * request for any kind or generation that installs no fw_log_parse
+		 * hook, whose fetched batches would otherwise be silently
+		 * discarded, rather than pinning a multi-megabyte buffer and
+		 * running the poll worker for nothing.
+		 */
+		if (dpt->kind != AMDXDNA_DPT_FW_LOG || !dpt->aie->msg_ops.fw_log_parse)
+			return -EOPNOTSUPP;
+
+		/*
+		 * local_buffer is only a CPU memcpy staging area for the ring
+		 * payload (amdxdna_dpt_copy_to_kernel), never a DMA target, so
+		 * a virtually contiguous allocation is sufficient and far more
+		 * robust than a multi-megabyte physically contiguous kmalloc.
+		 */
+		dpt->local_buffer = kvzalloc(dpt->size, GFP_KERNEL);
+		if (!dpt->local_buffer) {
+			XDNA_DPT_ERR(dpt, "Failed to allocate FW fetch buffer");
+			return -ENOMEM;
+		}
+		dpt->head = 0;
+
+		/*
+		 * Drain whatever is already in the ring from this (debugfs)
+		 * context while dump_to_dmesg is still false, so the worker
+		 * skips fetch_and_dump and cannot touch local_buffer / head
+		 * concurrently. Only after the initial drain do we publish the
+		 * buffer and hand ownership of local_buffer / head to the
+		 * worker, which then becomes the sole consumer.
+		 */
+		amdxdna_dpt_drain_pending_data(dpt);
+
+		/*
+		 * Publish local_buffer before dump_to_dmesg becomes visible;
+		 * pairs with the acquire load in amdxdna_dpt_worker().
+		 */
+		smp_store_release(&dpt->dump_to_dmesg, true);
+		amdxdna_dpt_timer_get(dpt);
+	} else {
+		/*
+		 * Stop dumping, then quiesce the host pipeline before freeing:
+		 * a worker queued by the IRQ handler or poll timer reads
+		 * local_buffer, so it must not run past the kvfree. timer_put
+		 * may stop the poll timer, and cancel_work_sync waits for any
+		 * in-flight worker; a worker requeued afterwards observes
+		 * dump_to_dmesg false and skips the dump.
+		 */
+		WRITE_ONCE(dpt->dump_to_dmesg, false);
+		amdxdna_dpt_timer_put(dpt);
+		cancel_work_sync(&dpt->work);
+
+		kvfree(dpt->local_buffer);
+		dpt->local_buffer = NULL;
+		dpt->head = 0;
+	}
+
+	return 0;
 }
 
 static void amdxdna_dpt_timer(struct timer_list *t)
@@ -402,6 +539,7 @@ amdxdna_dpt_publish(struct aie_device *aie, enum amdxdna_dpt_kind kind,
 		return ERR_PTR(ret);
 	}
 	dpt->buf = hdl;
+	dpt->size = to_buf_size(hdl);
 
 	memset(to_cpu_addr(hdl, 0), 0, to_buf_size(hdl));
 	drm_clflush_virt_range(to_cpu_addr(hdl, 0), to_buf_size(hdl));
@@ -628,6 +766,18 @@ static int amdxdna_dpt_fini_kind(struct aie_device *aie, enum amdxdna_dpt_kind k
 	cancel_work_sync(&dpt->work);
 
 	/*
+	 * The dmesg consumer (if enabled) held a timer ref and a local
+	 * buffer. The timer is already shut down, so release the buffer
+	 * directly rather than through amdxdna_dpt_dump_to_dmesg().
+	 */
+	if (dpt->dump_to_dmesg) {
+		dpt->dump_to_dmesg = false;
+		kvfree(dpt->local_buffer);
+		dpt->local_buffer = NULL;
+		dpt->head = 0;
+	}
+
+	/*
 	 * Release any watcher still parked. Required for the steady-state
 	 * "FW idle, no tail advance" case where amdxdna_dpt_update_tail's
 	 * conditional wake_up did not fire; otherwise the watcher would
@@ -758,6 +908,20 @@ static int amdxdna_dpt_resume_kind(struct amdxdna_dev *xdna,
 
 	WRITE_ONCE(dpt->status, AMDXDNA_DPT_ACTIVE);
 
+	/*
+	 * Suspend stopped the poll timer with timer_delete_sync but left
+	 * timer_refs untouched, so a consumer that held a reference across
+	 * suspend (e.g. dmesg dump) can no longer trigger the 0->1 arm in
+	 * amdxdna_dpt_timer_get. Re-arm it here under timer_lock now that
+	 * the device is ACTIVE again, otherwise polling stays dead and, if
+	 * the IRQ is also unavailable, FW-log consumption silently stalls.
+	 */
+	mutex_lock(&dpt->timer_lock);
+	if (refcount_read(&dpt->timer_refs))
+		mod_timer(&dpt->timer,
+			  jiffies + msecs_to_jiffies(AMDXDNA_DPT_POLL_INTERVAL_MS));
+	mutex_unlock(&dpt->timer_lock);
+
 	XDNA_DPT_DBG(dpt, "Resumed");
 	return 0;
 }
@@ -788,6 +952,44 @@ static int amdxdna_fw_log_set_level(struct aie_device *aie, u32 level)
 	WRITE_ONCE(dpt->config, level);
 	XDNA_DBG(xdna, "FW log level changed to %d", level);
 	return 0;
+}
+
+/*
+ * debugfs fw_log_level entry point. Starts logging from INACTIVE, changes
+ * the live level while ACTIVE, or stops logging when @level is NONE. Uses
+ * the xdna->dpt_aie back-pointer so the common debugfs layer need not know
+ * the generation-specific dev_handle layout.
+ */
+int amdxdna_fw_log_set_state(struct amdxdna_dev *xdna, u32 level)
+{
+	struct aie_device *aie = xdna->dpt_aie;
+	enum amdxdna_dpt_status status;
+	struct amdxdna_dpt *dpt;
+
+	drm_WARN_ON(&xdna->ddev, !mutex_is_locked(&xdna->dev_lock));
+
+	if (level >= AMDXDNA_DPT_FW_LOG_LEVEL_MAX)
+		return -EINVAL;
+	if (!aie)
+		return -ENODEV;
+
+	dpt = rcu_dereference_protected(xdna->fw_log,
+					lockdep_is_held(&xdna->dev_lock));
+	status = dpt ? READ_ONCE(dpt->status) : AMDXDNA_DPT_INACTIVE;
+
+	switch (status) {
+	case AMDXDNA_DPT_INACTIVE:
+		if (level == AMDXDNA_DPT_FW_LOG_LEVEL_NONE)
+			return 0;
+		return amdxdna_fw_log_init(aie, level);
+	case AMDXDNA_DPT_ACTIVE:
+		if (level == AMDXDNA_DPT_FW_LOG_LEVEL_NONE)
+			return amdxdna_dpt_fini_kind(aie, AMDXDNA_DPT_FW_LOG);
+		return amdxdna_fw_log_set_level(aie, level);
+	default:
+		XDNA_ERR(xdna, "FW logging not in a stable state, retry");
+		return -EBUSY;
+	}
 }
 
 static int amdxdna_fw_trace_init(struct aie_device *aie, u32 categories)
@@ -843,6 +1045,11 @@ int amdxdna_dpt_init(struct aie_device *aie)
 {
 	int ret;
 
+	/* Record the aie back-pointer so common code (debugfs) can reach
+	 * msg_ops without the generation-specific dev_handle layout.
+	 */
+	aie->xdna->dpt_aie = aie;
+
 	ret = amdxdna_fw_log_init(aie, AMDXDNA_DPT_FW_LOG_LEVEL_DEFAULT);
 	if (ret)
 		XDNA_WARN(aie->xdna, "Failed to enable FW logging: %d", ret);
@@ -853,6 +1060,14 @@ int amdxdna_dpt_init(struct aie_device *aie)
 int amdxdna_dpt_fini(struct aie_device *aie)
 {
 	int ret;
+
+	/*
+	 * Clear the back-pointer before tearing the DPT kinds down so a
+	 * concurrent or in-flight debugfs handler (amdxdna_fw_log_set_state)
+	 * observes a NULL dpt_aie and fails cleanly with -ENODEV instead of
+	 * reaching a DPT that teardown is about to free.
+	 */
+	aie->xdna->dpt_aie = NULL;
 
 	ret = amdxdna_dpt_fini_kind(aie, AMDXDNA_DPT_FW_LOG);
 	if (ret)

--- a/drivers/accel/amdxdna/amdxdna_dpt.h
+++ b/drivers/accel/amdxdna/amdxdna_dpt.h
@@ -125,6 +125,13 @@ struct amdxdna_dpt {
 
 	/* xrt-smi watchers park here */
 	struct wait_queue_head		 wait;
+
+	/* dmesg-dump consumer (head / local_buffer valid only while dump_to_dmesg) */
+	bool				 dump_to_dmesg;
+	u64				 head;
+	u8				*local_buffer;
+	/* ring payload size, set at publish time; valid regardless of dump_to_dmesg */
+	u32				 size;
 };
 
 /*
@@ -140,6 +147,12 @@ int amdxdna_dpt_init(struct aie_device *aie);
 int amdxdna_dpt_fini(struct aie_device *aie);
 int amdxdna_dpt_suspend(struct amdxdna_dev *xdna);
 int amdxdna_dpt_resume(struct amdxdna_dev *xdna);
+
+/* dmesg-dump consumer control (debugfs). */
+int amdxdna_dpt_dump_to_dmesg(struct amdxdna_dpt *dpt, bool enable);
+int amdxdna_fw_log_set_state(struct amdxdna_dev *xdna, u32 level);
+struct amdxdna_dpt *amdxdna_dpt_enter_kind(struct amdxdna_dev *xdna,
+					   enum amdxdna_dpt_kind kind, int *idx);
 
 int amdxdna_get_fw_log(struct aie_device *aie,
 		       struct amdxdna_drm_get_array *args);

--- a/drivers/accel/amdxdna/amdxdna_pci_drv.h
+++ b/drivers/accel/amdxdna/amdxdna_pci_drv.h
@@ -135,6 +135,7 @@ struct amdxdna_dev_info {
 
 struct amdxdna_carveout;
 struct amdxdna_dpt;
+struct aie_device;
 
 struct amdxdna_dev {
 	struct drm_device		ddev;
@@ -176,6 +177,12 @@ struct amdxdna_dev {
 
 	/* Allow auto core dump for hardware contexts, if true. */
 	bool				auto_coredump;
+
+	/* Back-pointer to the per-generation aie_device, set at DPT init so
+	 * common code (e.g. debugfs) can reach msg_ops without knowing the
+	 * generation-specific struct amdxdna_dev_hdl layout.
+	 */
+	struct aie_device		*dpt_aie;
 };
 
 /*


### PR DESCRIPTION
Build a firmware-log consumption layer on top of main's evolved DPT framework, shared across generations:

- DPT framework dmesg-dump path: a per-kind fw_log_parse msg_op hook, amdxdna_dpt_call_parse/fetch_and_dump_to_dmesg driven by the poll worker, and amdxdna_dpt_dump_to_dmesg() to enable/disable streaming. The enable path is rejected for any generation that installs no fw_log_parse hook, whose fetched batches would otherwise be discarded.
- AIE4 firmware-log parser (aie4_fw_log_parse): splits the newline- delimited firmware text and emits it to the kernel log.
- AIE2 firmware-log parser (aie2_fw_log_parse): the AIE2 stream is a structured record format (header/data/footer with magic, sequence and length fields) rather than plain text, so it validates and skips torn or overwritten entries in the wrapping ring before emitting each record.
- debugfs nodes fw_log_level and fw_log_dump_to_dmesg, routed through amdxdna_fw_log_set_state() which uses a new struct amdxdna_dev.dpt_aie back-pointer so the common debugfs layer can reach msg_ops without the generation-specific struct amdxdna_dev_hdl layout.