### PR TITLE
accel/amdxdna: annotate PF/VF dev_lock nesting for lockdep

### DIFF
--- a/drivers/accel/amdxdna/amdxdna_pci_drv.c
+++ b/drivers/accel/amdxdna/amdxdna_pci_drv.c
@@ -458,7 +458,18 @@ static int amdxdna_probe(struct pci_dev *pdev, const struct pci_device_id *id)
 	if (ret)
 		return ret;
 
-	drmm_mutex_init(ddev, &xdna->dev_lock);
+	ret = drmm_mutex_init(ddev, &xdna->dev_lock);
+	if (ret)
+		return ret;
+
+	/*
+	 * A VF's dev_lock is acquired in probe() while the PF still holds its
+	 * own dev_lock across pci_enable_sriov(). They are distinct instances
+	 * sharing one lock class, so nest the VF at a deeper subclass to keep
+	 * lockdep from misreporting the hierarchical PF -> VF order.
+	 */
+	lockdep_set_subclass(&xdna->dev_lock,
+			     pdev->is_virtfn ? SINGLE_DEPTH_NESTING : 0);
 	init_rwsem(&xdna->notifier_lock);
 	INIT_LIST_HEAD(&xdna->client_list);
 	ida_init(&xdna->hwctx_ida);


### PR DESCRIPTION
pci_enable_sriov() is called from amdxdna_sriov_configure() with the PF's dev_lock held and synchronously probes each VF, whose amdxdna_probe() takes that VF's own dev_lock. Both are initialized from the same drmm_mutex_init() call site, so they share one lock class and lockdep misreports the strictly hierarchical PF -> VF acquisition as "possible recursive locking".

The PF and VF dev_locks are distinct instances and a VF never takes the PF's dev_lock, so there is no real deadlock. Place the VF instance in a deeper lockdep subclass to express the valid nesting.