### PR TITLE
accel/amdxdna: add automatic AIE coredump on command timeout

### DIFF
--- a/drivers/accel/amdxdna/aie.c
+++ b/drivers/accel/amdxdna/aie.c
@@ -23,6 +23,8 @@
 #include "amdxdna_pci_drv.h"
 #include "amdxdna_pm.h"
 
+static const size_t coredump_data_chunk_size = SZ_1M;
+
 void aie_dump_mgmt_chann_debug(struct aie_device *aie)
 {
 	struct amdxdna_dev *xdna = aie->xdna;
@@ -675,42 +677,41 @@ struct amdxdna_tile_rw_walk_arg {
 static_assert(offsetof(struct amdxdna_tile_rw_walk_arg, key) == 0,
 	      "key must be the first member for amdxdna_hwctx_match()");
 
-static int amdxdna_get_coredump_cb(struct amdxdna_hwctx *hwctx, void *arg)
+static size_t amdxdna_coredump_total_buf_size(struct aie_device *aie, struct amdxdna_hwctx *hwctx)
+{
+	u32 orig_col = hwctx->num_col - hwctx->num_unused_col;
+	u32 num_bufs = aie->metadata.rows * orig_col;
+
+	return num_bufs * coredump_data_chunk_size;
+}
+
+char *amdxdna_get_hwctx_coredump(struct aie_device *aie, struct amdxdna_hwctx *hwctx)
 {
 	struct amdxdna_dev *xdna = hwctx->client->xdna;
 	struct amdxdna_msg_buf_hdl **data_hdls = NULL;
 	struct amdxdna_msg_buf_hdl *list_hdl = NULL;
 	struct amdxdna_coredump_buf_entry *buf_list;
-	struct amdxdna_coredump_walk_arg *wa = arg;
-	size_t data_buf_size = SZ_1M;
-	size_t offset = 0;
 	size_t total_size;
-	int ret = 0, i;
+	size_t offset;
 	u32 num_bufs;
-	u32 orig_col;
+	int ret = 0;
+	char *buf;
+	int i;
 
-	if (!amdxdna_client_visible(hwctx->client)) {
-		XDNA_ERR(xdna, "Permission denied for context %u", wa->key.ctx_id);
-		return -EPERM;
-	}
+	if (!aie->msg_ops.get_coredump)
+		return ERR_PTR(-EOPNOTSUPP);
 
-	orig_col = hwctx->num_col - hwctx->num_unused_col;
-	num_bufs = wa->aie->metadata.rows * orig_col;
-	total_size = (size_t)num_bufs * data_buf_size;
+	total_size = amdxdna_coredump_total_buf_size(aie, hwctx);
+	buf = kvmalloc(total_size, GFP_KERNEL);
+	if (!buf)
+		return ERR_PTR(-ENOMEM);
 
-	if (wa->buf_size < total_size) {
-		XDNA_DBG(xdna, "Insufficient buffer size %zu, need %zu",
-			 wa->buf_size, total_size);
-		wa->args->element_size = total_size;
-		ret = -ENOSPC;
-		goto out;
-	}
-
+	num_bufs = total_size / coredump_data_chunk_size;
 	list_hdl = amdxdna_alloc_msg_buff(xdna, num_bufs * sizeof(*buf_list));
 	if (IS_ERR(list_hdl)) {
-		XDNA_ERR(xdna, "Failed to allocate buffer list");
 		ret = PTR_ERR(list_hdl);
 		list_hdl = NULL;
+		XDNA_ERR(xdna, "Failed to allocate buffer list: %d", ret);
 		goto out;
 	}
 
@@ -720,51 +721,85 @@ static int amdxdna_get_coredump_cb(struct amdxdna_hwctx *hwctx, void *arg)
 	data_hdls = kzalloc_objs(*data_hdls, num_bufs);
 	if (!data_hdls) {
 		ret = -ENOMEM;
-		goto free_list_hdl;
+		goto out;
 	}
 
 	for (i = 0; i < num_bufs; i++) {
-		data_hdls[i] = amdxdna_alloc_msg_buff(xdna, data_buf_size);
+		data_hdls[i] = amdxdna_alloc_msg_buff(xdna, coredump_data_chunk_size);
 		if (IS_ERR(data_hdls[i])) {
-			XDNA_ERR(xdna, "Failed to allocate data buffer %d", i);
 			ret = PTR_ERR(data_hdls[i]);
 			data_hdls[i] = NULL;
-			goto free_data_hdls;
+			XDNA_ERR(xdna, "Failed to allocate data buffer %d: %d", i, ret);
+			goto out;
 		}
 
 		memset(to_cpu_addr(data_hdls[i], 0), 0, to_buf_size(data_hdls[i]));
 		drm_clflush_virt_range(to_cpu_addr(data_hdls[i], 0), to_buf_size(data_hdls[i]));
 
 		buf_list[i].buf_addr = to_dma_addr(data_hdls[i], 0);
-		buf_list[i].buf_size = data_buf_size;
+		buf_list[i].buf_size = coredump_data_chunk_size;
 	}
 
 	drm_clflush_virt_range(buf_list, to_buf_size(list_hdl));
 
-	ret = wa->aie->msg_ops.get_coredump(hwctx, list_hdl, num_bufs);
+	ret = aie->msg_ops.get_coredump(hwctx, list_hdl, num_bufs);
 	if (ret) {
-		XDNA_ERR(xdna, "Failed to get coredump from firmware, ret=%d",
-			 ret);
-		goto free_data_hdls;
+		XDNA_ERR(xdna, "Failed to get coredump from firmware: %d", ret);
+		goto out;
 	}
 
-	for (i = 0; i < num_bufs; i++) {
-		if (copy_to_user(wa->buf + offset, to_cpu_addr(data_hdls[i], 0),
-				 data_buf_size)) {
-			ret = -EFAULT;
-			goto free_data_hdls;
-		}
-		offset += data_buf_size;
-	}
+	for (i = 0, offset = 0; i < num_bufs; i++, offset += coredump_data_chunk_size)
+		memcpy(buf + offset, to_cpu_addr(data_hdls[i], 0), coredump_data_chunk_size);
 
-free_data_hdls:
-	for (i = 0; i < num_bufs; i++)
-		amdxdna_free_msg_buff(data_hdls[i]);
-	kfree(data_hdls);
-free_list_hdl:
-	amdxdna_free_msg_buff(list_hdl);
 out:
-	return ret;
+	if (data_hdls) {
+		for (i = 0; i < num_bufs; i++)
+			amdxdna_free_msg_buff(data_hdls[i]);
+	}
+	kfree(data_hdls);
+	amdxdna_free_msg_buff(list_hdl);
+	if (!ret)
+		return buf;
+
+	kvfree(buf);
+	return ERR_PTR(ret);
+}
+
+static int amdxdna_get_coredump_cb(struct amdxdna_hwctx *hwctx, void *arg)
+{
+	struct amdxdna_dev *xdna = hwctx->client->xdna;
+	struct amdxdna_coredump_walk_arg *wa = arg;
+	size_t total_size;
+	char *buf;
+	int ret;
+
+	if (!amdxdna_client_visible(hwctx->client)) {
+		XDNA_ERR(xdna, "Permission denied for context %u", wa->key.ctx_id);
+		return -EPERM;
+	}
+
+	total_size = amdxdna_coredump_total_buf_size(wa->aie, hwctx);
+	if (wa->buf_size < total_size) {
+		XDNA_DBG(xdna, "Insufficient buffer size %zu, need %zu",
+			 wa->buf_size, total_size);
+		wa->args->element_size = total_size;
+		return -ENOSPC;
+	}
+
+	if (hwctx->coredump) {
+		buf = hwctx->coredump;
+		hwctx->coredump = NULL;
+	} else {
+		buf = amdxdna_get_hwctx_coredump(wa->aie, hwctx);
+	}
+	if (IS_ERR(buf))
+		return PTR_ERR(buf);
+	ret = copy_to_user(wa->buf, buf, total_size);
+	kvfree(buf);
+	if (ret)
+		return -EFAULT;
+
+	return 0;
 }
 
 int amdxdna_get_coredump(struct aie_device *aie,
@@ -1191,4 +1226,68 @@ int amdxdna_aie_tile_write(struct aie_device *aie,
 		XDNA_ERR(xdna, "Context %u for pid %llu not found",
 			 access.context_id, access.pid);
 	return ret;
+}
+
+static int amdxdna_free_saved_coredump_cb(struct amdxdna_hwctx *hwctx, void *arg)
+{
+	kvfree(hwctx->coredump);
+	hwctx->coredump = NULL;
+	return 0;
+}
+
+static bool amdxdna_saved_coredump_filter(struct amdxdna_hwctx *hwctx, void *arg)
+{
+	return !!hwctx->coredump;
+}
+
+int
+amdxdna_set_auto_coredump_mode(struct amdxdna_client *client,
+			       struct amdxdna_drm_set_state *args)
+{
+	struct amdxdna_drm_attribute_state state = {};
+	struct amdxdna_dev *xdna = client->xdna;
+	struct amdxdna_client *tmp_client;
+	u32 buf_sz;
+
+	drm_WARN_ON(&xdna->ddev, !mutex_is_locked(&xdna->dev_lock));
+
+	buf_sz = min(args->buffer_size, sizeof(state));
+	if (copy_from_user(&state, u64_to_user_ptr(args->buffer), buf_sz))
+		return -EFAULT;
+
+	if (state.state > 1)
+		return -EINVAL;
+
+	if (XDNA_MBZ_DBG(client->xdna, state.pad, sizeof(state.pad)))
+		return -EINVAL;
+
+	XDNA_DBG(xdna, "Setting auto coredump to %d", state.state);
+
+	xdna->auto_coredump = state.state;
+
+	/* auto core dump is disabled, clean up all saved cores. */
+	if (!state.state) {
+		amdxdna_for_each_client(xdna, tmp_client) {
+			amdxdna_hwctx_walk(tmp_client, NULL, amdxdna_saved_coredump_filter,
+					   amdxdna_free_saved_coredump_cb);
+		}
+	}
+
+	return 0;
+}
+
+int
+amdxdna_get_auto_coredump_mode(struct amdxdna_client *client,
+			       struct amdxdna_drm_get_info *args)
+{
+	struct amdxdna_drm_attribute_state state = {};
+	struct amdxdna_dev *xdna = client->xdna;
+	u32 buf_sz;
+
+	state.state = xdna->auto_coredump;
+	buf_sz = min(args->buffer_size, sizeof(state));
+	if (copy_to_user(u64_to_user_ptr(args->buffer), &state, buf_sz))
+		return -EFAULT;
+
+	return 0;
 }

--- a/drivers/accel/amdxdna/aie.h
+++ b/drivers/accel/amdxdna/aie.h
@@ -209,6 +209,7 @@ struct amdxdna_coredump_buf_entry {
 int amdxdna_get_coredump(struct aie_device *aie,
 			 struct amdxdna_client *client,
 			 struct amdxdna_drm_get_array *args);
+char *amdxdna_get_hwctx_coredump(struct aie_device *aie, struct amdxdna_hwctx *hwctx);
 int amdxdna_aie_tile_read(struct aie_device *aie,
 			  struct amdxdna_client *client,
 			  struct amdxdna_drm_get_array *args);
@@ -232,5 +233,13 @@ int aie_smu_set_dpm(struct smu_device *smu, u32 dpm_level);
 void amdxdna_io_stats_job_start(struct amdxdna_client *client);
 void amdxdna_io_stats_job_done(struct amdxdna_client *client);
 u64 amdxdna_io_stats_busy_time_ns(struct amdxdna_client *client);
+
+/*
+ * Set or get the global auto core dump mode on device.
+ */
+int amdxdna_get_auto_coredump_mode(struct amdxdna_client *client,
+				   struct amdxdna_drm_get_info *args);
+int amdxdna_set_auto_coredump_mode(struct amdxdna_client *client,
+				   struct amdxdna_drm_set_state *args);
 
 #endif /* _AIE_H_ */

--- a/drivers/accel/amdxdna/aie2_ctx.c
+++ b/drivers/accel/amdxdna/aie2_ctx.c
@@ -486,10 +486,14 @@ aie2_sched_job_timedout(struct drm_sched_job *sched_job)
 	struct amdxdna_sched_job *job = drm_job_to_xdna_job(sched_job);
 	struct amdxdna_hwctx *hwctx = job->hwctx;
 	struct app_health_report *report;
+	struct amdxdna_dev_hdl *ndev;
 	struct amdxdna_dev *xdna;
+	struct aie_device *aie;
 	int ret;
 
 	xdna = hwctx->client->xdna;
+	ndev = xdna->dev_handle;
+	aie = &ndev->aie;
 
 	guard(mutex)(&xdna->dev_lock);
 
@@ -499,16 +503,24 @@ aie2_sched_job_timedout(struct drm_sched_job *sched_job)
 #endif
 
 	report = kzalloc_obj(*report);
-	if (!report)
-		goto reset_hwctx;
+	if (report) {
+		ret = aie2_query_app_health(ndev, hwctx->fw_ctx_id, report);
+		if (ret)
+			kfree(report);
+		else
+			job->aie2_job_health = report;
+	}
 
-	ret = aie2_query_app_health(xdna->dev_handle, hwctx->fw_ctx_id, report);
-	if (ret)
-		kfree(report);
-	else
-		job->aie2_job_health = report;
+	if (xdna->auto_coredump) {
+		kvfree(hwctx->coredump);
+		hwctx->coredump = amdxdna_get_hwctx_coredump(aie, hwctx);
+		if (IS_ERR(hwctx->coredump)) {
+			XDNA_ERR(xdna, "Failed to get core dump on job timing out: %ld",
+				 PTR_ERR(hwctx->coredump));
+			hwctx->coredump = NULL;
+		}
+	}
 
-reset_hwctx:
 	job->job_timeout = true;
 	aie2_hwctx_stop(xdna, hwctx, sched_job);
 

--- a/drivers/accel/amdxdna/aie2_pci.c
+++ b/drivers/accel/amdxdna/aie2_pci.c
@@ -874,6 +874,9 @@ static int aie2_get_info(struct amdxdna_client *client, struct amdxdna_drm_get_i
 	case DRM_AMDXDNA_GET_FRAME_BOUNDARY_PREEMPT_STATE:
 		ret = aie2_get_frame_boundary_preempt_state(client, args);
 		break;
+	case DRM_AMDXDNA_GET_AUTO_COREDUMP:
+		ret = amdxdna_get_auto_coredump_mode(client, args);
+		break;
 	default:
 		XDNA_ERR(xdna, "Not supported request parameter %u", args->param);
 		ret = -EOPNOTSUPP;
@@ -1053,6 +1056,9 @@ static int aie2_set_state(struct amdxdna_client *client,
 		break;
 	case DRM_AMDXDNA_SET_FW_TRACE_STATE:
 		ret = amdxdna_set_fw_trace_state(&ndev->aie, args);
+		break;
+	case DRM_AMDXDNA_SET_AUTO_COREDUMP:
+		ret = amdxdna_set_auto_coredump_mode(client, args);
 		break;
 	default:
 		XDNA_ERR(xdna, "Not supported request parameter %u", args->param);

--- a/drivers/accel/amdxdna/aie2_tdr.c
+++ b/drivers/accel/amdxdna/aie2_tdr.c
@@ -77,17 +77,29 @@ static bool aie2_legacy_tdr_detect(struct amdxdna_dev *xdna)
 static int aie2_tdr_stop_hwctx(struct amdxdna_hwctx *hwctx, void *arg)
 {
 	struct amdxdna_dev *xdna = hwctx->client->xdna;
+	struct amdxdna_dev_hdl *ndev = xdna->dev_handle;
 	struct app_health_report *report = NULL;
+	struct aie_device *aie = &ndev->aie;
 	struct drm_gpu_scheduler *sched;
 	struct drm_sched_job *s_job;
 	int ret;
 
 	report = kzalloc_obj(*report);
 	if (report) {
-		ret = aie2_query_app_health(xdna->dev_handle, hwctx->fw_ctx_id, report);
+		ret = aie2_query_app_health(ndev, hwctx->fw_ctx_id, report);
 		if (ret) {
 			kfree(report);
 			report = NULL;
+		}
+	}
+
+	if (xdna->auto_coredump) {
+		kvfree(hwctx->coredump);
+		hwctx->coredump = amdxdna_get_hwctx_coredump(aie, hwctx);
+		if (IS_ERR(hwctx->coredump)) {
+			XDNA_ERR(xdna, "Failed to get core dump on hwctx timing out: %ld",
+				 PTR_ERR(hwctx->coredump));
+			hwctx->coredump = NULL;
 		}
 	}
 
@@ -113,7 +125,7 @@ static int aie2_tdr_stop_hwctx(struct amdxdna_hwctx *hwctx, void *arg)
 
 	kfree(report);
 
-	aie2_destroy_context(xdna->dev_handle, hwctx);
+	aie2_destroy_context(ndev, hwctx);
 #ifdef HAVE_6_13_drm_sched_start_errno
 	drm_sched_start(sched, 0);
 #elif defined(HAVE_6_10_drm_sched_start_full_recovery)

--- a/drivers/accel/amdxdna/aie4_ctx.c
+++ b/drivers/accel/amdxdna/aie4_ctx.c
@@ -1514,8 +1514,7 @@ put_meta_bo:
 	return ret;
 }
 
-int aie4_hwctx_config(struct amdxdna_hwctx *hwctx, u32 type, u64 value,
-		      void *buf, u32 size)
+int aie4_hwctx_config(struct amdxdna_hwctx *hwctx, u32 type, u64 value, void *buf, u32 size)
 {
 	struct amdxdna_dev *xdna = hwctx->client->xdna;
 

--- a/drivers/accel/amdxdna/aie4_pci.c
+++ b/drivers/accel/amdxdna/aie4_pci.c
@@ -910,6 +910,9 @@ static int aie4_get_info(struct amdxdna_client *client, struct amdxdna_drm_get_i
 	case DRM_AMDXDNA_GET_FORCE_PREEMPT_STATE:
 		ret = amdxdna_get_force_preempt_state(&ndev->aie, args);
 		break;
+	case DRM_AMDXDNA_GET_AUTO_COREDUMP:
+		ret = amdxdna_get_auto_coredump_mode(client, args);
+		break;
 	default:
 		XDNA_ERR(xdna, "Not supported request parameter %u", args->param);
 		ret = -EOPNOTSUPP;
@@ -1608,6 +1611,12 @@ static int aie4_set_state(struct amdxdna_client *client,
 		break;
 	case DRM_AMDXDNA_SET_FW_TRACE_STATE:
 		ret = amdxdna_set_fw_trace_state(&ndev->aie, args);
+		break;
+	case DRM_AMDXDNA_SET_AUTO_COREDUMP:
+		/* TODO: enable debug mode on FW if auto coredump is enabled,
+		 * then call amdxdna_set_auto_coredump_mode(client, args).
+		 */
+		ret = -EOPNOTSUPP;
 		break;
 	default:
 		XDNA_ERR(xdna, "Not supported request parameter %u", args->param);

--- a/drivers/accel/amdxdna/amdxdna_ctx.c
+++ b/drivers/accel/amdxdna/amdxdna_ctx.c
@@ -90,6 +90,7 @@ static void amdxdna_hwctx_destroy_rcu(struct amdxdna_hwctx *hwctx,
 		xdna->dev_info->ops->hwctx_fini(hwctx);
 
 	amdxdna_hwctx_release_expanded_heap(hwctx);
+	kvfree(hwctx->coredump);
 	kfree(hwctx->name);
 	kfree(hwctx);
 }
@@ -113,7 +114,10 @@ int amdxdna_hwctx_walk(struct amdxdna_client *client, void *arg,
 	amdxdna_for_each_hwctx(client, hwctx_id, hwctx) {
 		if (filter && !filter(hwctx, arg))
 			continue;
-		ret = walk(hwctx, arg);
+		if (walk)
+			ret = walk(hwctx, arg);
+		else
+			ret = 0;
 		if (ret)
 			break;
 	}

--- a/drivers/accel/amdxdna/amdxdna_ctx.h
+++ b/drivers/accel/amdxdna/amdxdna_ctx.h
@@ -193,6 +193,9 @@ struct amdxdna_hwctx {
 
 	atomic64_t			job_submit_cnt;
 	atomic64_t			job_free_cnt ____cacheline_aligned_in_smp;
+
+	/* Saved core dump, captured automatically on timeout if device auto_coredump is set. */
+	char				*coredump;
 };
 
 #define drm_job_to_xdna_job(j) \

--- a/drivers/accel/amdxdna/amdxdna_pci_drv.c
+++ b/drivers/accel/amdxdna/amdxdna_pci_drv.c
@@ -74,9 +74,10 @@ MODULE_FIRMWARE("amdnpu/1b0b_00/cert.dev.sbin");
  * 0.14: Expose firmware log GET/GET_CONFIG/SET_STATE ioctls and
  *       struct amdxdna_dpt_metadata, _set_dpt_state, _get_dpt_state
  * 0.15: Expose firmware trace GET/GET_CONFIG/SET_STATE ioctls
+ * 0.16: Expose auto core dump SET_STATE/GET_INFO ioctls
  */
 #define AMDXDNA_DRIVER_MAJOR		0
-#define AMDXDNA_DRIVER_MINOR		15
+#define AMDXDNA_DRIVER_MINOR		16
 
 /*
  * Bind the driver base on (vendor_id, device_id) pair and later use the

--- a/drivers/accel/amdxdna/amdxdna_pci_drv.h
+++ b/drivers/accel/amdxdna/amdxdna_pci_drv.h
@@ -173,6 +173,9 @@ struct amdxdna_dev {
 	struct srcu_struct		dpt_srcu;
 	struct amdxdna_dpt __rcu	*fw_log;
 	struct amdxdna_dpt __rcu	*fw_trace;
+
+	/* Allow auto core dump for hardware contexts, if true. */
+	bool				auto_coredump;
 };
 
 /*

--- a/include/uapi/drm/amdxdna_accel.h
+++ b/include/uapi/drm/amdxdna_accel.h
@@ -532,6 +532,7 @@ enum amdxdna_drm_get_param {
 	DRM_AMDXDNA_QUERY_RESOURCE_INFO,
 	DRM_AMDXDNA_GET_FRAME_BOUNDARY_PREEMPT_STATE,
 	DRM_AMDXDNA_QUERY_CERT_FIRMWARE_VERSION = 14,
+	DRM_AMDXDNA_GET_AUTO_COREDUMP,
 };
 
 /**
@@ -961,6 +962,7 @@ enum amdxdna_drm_set_param {
 	DRM_AMDXDNA_SET_FW_LOG_STATE,
 	DRM_AMDXDNA_SET_FW_TRACE_STATE,
 	DRM_AMDXDNA_AIE_TILE_WRITE,
+	DRM_AMDXDNA_SET_AUTO_COREDUMP = 9,
 };
 
 /**
@@ -1026,6 +1028,11 @@ struct amdxdna_drm_set_state {
 	 *
 	 * Access: requires CAP_SYS_ADMIN (the SET_STATE ioctl is
 	 * DRM_ROOT_ONLY).
+	 *
+	 * %DRM_AMDXDNA_SET_AUTO_COREDUMP:
+	 * Controls automatic AIE tile core dump capture on timeout.
+	 * 0 - disable auto core dump capture.
+	 * 1 - capture a core dump into the hardware context on timeout.
 	 */
 	__u32 param;
 	/**

--- a/src/include/uapi/drm_local/amdxdna_accel.h
+++ b/src/include/uapi/drm_local/amdxdna_accel.h
@@ -626,6 +626,7 @@ struct amdxdna_drm_get_info {
 #define	DRM_AMDXDNA_QUERY_RESOURCE_INFO			12
 #define	DRM_AMDXDNA_GET_FRAME_BOUNDARY_PREEMPT_STATE	13
 #define	DRM_AMDXDNA_QUERY_CERT_FIRMWARE_VERSION		14
+#define	DRM_AMDXDNA_GET_AUTO_COREDUMP			15
 	__u32 param; /* in */
 	__u32 buffer_size; /* in/out */
 	__u64 buffer; /* in/out */
@@ -883,6 +884,7 @@ struct amdxdna_drm_set_state {
 #define	DRM_AMDXDNA_SET_FW_TRACE_STATE		6
 #define	DRM_AMDXDNA_AIE_TILE_WRITE		7
 #define	DRM_AMDXDNA_SET_CLOCK_FREQ		8
+#define	DRM_AMDXDNA_SET_AUTO_COREDUMP		9
 	__u32 param; /* in */
 	__u32 buffer_size; /* in */
 	__u64 buffer; /* in */

--- a/src/shim/device.cpp
+++ b/src/shim/device.cpp
@@ -85,6 +85,39 @@ is_aie4(uint16_t device_id)
   return false;
 }
 
+uint8_t
+get_amdxdna_attr_state(const xrt_core::device* device, uint32_t param)
+{
+  amdxdna_drm_attribute_state st = {};
+
+  amdxdna_drm_get_info arg = {
+    .param = param,
+    .buffer_size = sizeof(st),
+    .buffer = reinterpret_cast<uintptr_t>(&st)
+  };
+
+  auto& pci_dev_impl = get_pcidev_impl(device);
+  pci_dev_impl.drv_ioctl(shim_xdna::drv_ioctl_cmd::get_info, &arg);
+
+  return st.state;
+}
+
+void
+set_amdxdna_attr_state(const xrt_core::device* device, uint32_t param, uint8_t state)
+{
+  amdxdna_drm_attribute_state st = {};
+
+  st.state = state;
+  amdxdna_drm_set_state arg = {
+    .param = param,
+    .buffer_size = sizeof(st),
+    .buffer = reinterpret_cast<uintptr_t>(&st)
+  };
+
+  auto& pci_dev_impl = get_pcidev_impl(device);
+  pci_dev_impl.drv_ioctl(shim_xdna::drv_ioctl_cmd::set_state, &arg);
+}
+
 template <typename ValueType>
 struct sysfs_fcn
 {
@@ -828,38 +861,18 @@ struct performance_mode
 struct preemption
 {
   using result_type = query::preemption::result_type;
+  using value_type = query::preemption::value_type;
 
   static result_type
   get(const xrt_core::device* device, key_type)
   {
-    amdxdna_drm_attribute_state force = {};
-
-    amdxdna_drm_get_info arg = {
-      .param = DRM_AMDXDNA_GET_FORCE_PREEMPT_STATE,
-      .buffer_size = sizeof(force),
-      .buffer = reinterpret_cast<uintptr_t>(&force)
-    };
-
-    auto& pci_dev_impl = get_pcidev_impl(device);
-    pci_dev_impl.drv_ioctl(shim_xdna::drv_ioctl_cmd::get_info, &arg);
-
-    return force.state;
+    return static_cast<result_type>(get_amdxdna_attr_state(device, DRM_AMDXDNA_GET_FORCE_PREEMPT_STATE));
   }
 
   static void
   put(const xrt_core::device* device, key_type key, const std::any& any)
   {
-    amdxdna_drm_attribute_state force = {};
-    force.state = std::any_cast<uint32_t>(any);
-
-    amdxdna_drm_set_state arg = {
-      .param = DRM_AMDXDNA_SET_FORCE_PREEMPT,
-      .buffer_size = sizeof(force),
-      .buffer = reinterpret_cast<uintptr_t>(&force)
-    };
-
-    auto& pci_dev_impl = get_pcidev_impl(device);
-    pci_dev_impl.drv_ioctl(shim_xdna::drv_ioctl_cmd::set_state, &arg);
+    set_amdxdna_attr_state(device, DRM_AMDXDNA_SET_FORCE_PREEMPT, std::any_cast<value_type>(any));
   }
 };
 
@@ -1163,38 +1176,18 @@ struct archive_path
 struct frame_boundary_preemption
 {
   using result_type = query::frame_boundary_preemption::result_type;
+  using value_type = query::frame_boundary_preemption::value_type;
 
   static result_type
   get(const xrt_core::device* device, key_type)
   {
-    amdxdna_drm_attribute_state preempt = {};
-
-    amdxdna_drm_get_info arg = {
-      .param = DRM_AMDXDNA_GET_FRAME_BOUNDARY_PREEMPT_STATE,
-      .buffer_size = sizeof(preempt),
-      .buffer = reinterpret_cast<uintptr_t>(&preempt)
-    };
-
-    auto& pci_dev_impl = get_pcidev_impl(device);
-    pci_dev_impl.drv_ioctl(shim_xdna::drv_ioctl_cmd::get_info, &arg);
-
-    return preempt.state;
+    return static_cast<result_type>(get_amdxdna_attr_state(device, DRM_AMDXDNA_GET_FRAME_BOUNDARY_PREEMPT_STATE));
   }
 
   static void
   put(const xrt_core::device* device, key_type key, const std::any& any)
   {
-    amdxdna_drm_attribute_state preempt = {};
-    preempt.state = std::any_cast<uint32_t>(any);
-
-    amdxdna_drm_set_state arg = {
-      .param = DRM_AMDXDNA_SET_FRAME_BOUNDARY_PREEMPT,
-      .buffer_size = sizeof(preempt),
-      .buffer = reinterpret_cast<uintptr_t>(&preempt)
-    };
-
-    auto& pci_dev_impl = get_pcidev_impl(device);
-    pci_dev_impl.drv_ioctl(shim_xdna::drv_ioctl_cmd::set_state, &arg);
+    set_amdxdna_attr_state(device, DRM_AMDXDNA_SET_FRAME_BOUNDARY_PREEMPT, std::any_cast<value_type>(any));
   }
 };
 
@@ -2122,6 +2115,24 @@ struct sub_device_path
   }
 };
 
+struct auto_coredump
+{
+  using value_type = query::auto_coredump::value_type;
+  using result_type = query::auto_coredump::result_type;
+
+  static result_type
+  get(const xrt_core::device* device, key_type key)
+  {
+    return static_cast<result_type>(get_amdxdna_attr_state(device, DRM_AMDXDNA_GET_AUTO_COREDUMP));
+  }
+
+  static void
+  put(const xrt_core::device* device, key_type key, const std::any& any)
+  {
+    set_amdxdna_attr_state(device, DRM_AMDXDNA_SET_AUTO_COREDUMP, std::any_cast<value_type>(any));
+  }
+};
+
 template <typename QueryRequestType>
 struct sysfs_get : virtual QueryRequestType
 {
@@ -2286,6 +2297,7 @@ initialize_query_table()
   emplace_func1_request<query::aie_coredump,                   aie_coredump>();
   emplace_func1_request<query::aie_read,                       aie_read>();
   emplace_func1_request<query::aie_write,                      aie_write>();
+  emplace_func0_getput<query::auto_coredump,                   auto_coredump>();
 }
 
 struct X { X() { initialize_query_table(); }};
@@ -2350,12 +2362,23 @@ device::
   m_pdev.close();
 }
 
-
 const pdev&
 device::
 get_pdev() const
 {
   return m_pdev;
+}
+
+uint32_t
+device::
+get_core_rows() const
+{
+  std::call_once(m_core_rows_once, [this]() {
+    m_core_rows = xrt_core::device_query<
+      xrt_core::query::aie_tiles_stats>(this).core_rows;
+  });
+
+  return m_core_rows;
 }
 
 void
@@ -2406,9 +2429,9 @@ create_hw_context(uint32_t partition_size, const xrt::hw_context::qos_type& qos,
                   xrt::hw_context::access_mode mode) const
 {
   if (m_pdev.is_umq())
-    return std::make_unique<hwctx_umq>(*this, partition_size);
+    return std::make_unique<hwctx_umq>(*this, partition_size, qos);
   else
-    return std::make_unique<hwctx_kmq>(*this, partition_size);
+    return std::make_unique<hwctx_kmq>(*this, partition_size, qos);
 }
 
 std::unique_ptr<xrt_core::buffer_handle>

--- a/src/shim/device.h
+++ b/src/shim/device.h
@@ -25,12 +25,19 @@ private:
   const xrt_core::query::request&
   lookup_query(xrt_core::query::key_type query_key) const override;
 
+  // Save core rows to avoid repeatedly retrieving from driver, query only once.
+  mutable std::once_flag m_core_rows_once;
+  mutable uint32_t m_core_rows = 0;
+
 public:
   device(const pdev& pdev, handle_type shim_handle, id_type device_id);
   ~device();
 
   const pdev&
   get_pdev() const;
+
+  uint32_t
+  get_core_rows() const;
 
 // ISHIM APIs supported are listed below
 public:

--- a/src/shim/hwctx.cpp
+++ b/src/shim/hwctx.cpp
@@ -132,7 +132,8 @@ get_cu_pdi(int idx) const
 hwctx::
 hwctx(const device& dev, const qos_type& qos, const xrt::xclbin& xclbin,
   std::unique_ptr<hwq> queue)
-  : m_device(dev)
+  : m_ctx(dev)
+  , m_device(dev)
   , m_q(std::move(queue))
 {
   xclbin_parser xp(xclbin);
@@ -143,29 +144,29 @@ hwctx(const device& dev, const qos_type& qos, const xrt::xclbin& xclbin,
   for (int i = 0; i < n_cu; i++)
     m_cu_names.push_back(xp.get_cu_name(i));
 
-  init_qos_info(qos);
-
-  create_ctx_on_device();
+  create_ctx_on_device(qos);
 }
 
 hwctx::
-hwctx(const device& dev, uint32_t partition_size, std::unique_ptr<hwq> queue)
-  : m_device(dev)
+hwctx(const device& dev, const qos_type& qos, uint32_t partition_size,
+  std::unique_ptr<hwq> queue)
+  : m_ctx(dev)
+  , m_device(dev)
   , m_q(std::move(queue))
 {
   m_col_cnt = partition_size;
   m_ops_per_cycle = 0;
 
-  create_ctx_on_device();
+  create_ctx_on_device(qos);
 }
 
 hwctx::
 ~hwctx()
 {
   try {
-    delete_ctx_on_device();
+    m_q->unbind_hwctx();
   } catch (const xrt_core::system_error& e) {
-    shim_debug("Failed to delete context on device: %s", e.what());
+    shim_debug("Failed to unbind context: %s", e.what());
   }
 }
 
@@ -261,36 +262,55 @@ init_qos_info(const qos_type& qos)
 
 void
 hwctx::
-create_ctx_on_device()
+create_ctx_on_device(const qos_type& qos)
 {
-  create_ctx_arg arg = {
-    .qos = m_qos,
-    .umq_bo = m_q->get_queue_bo(),
-    .log_buf_bo = { AMDXDNA_INVALID_BO_HANDLE, AMDXDNA_INVALID_BO_HANDLE },
-    .max_opc = m_ops_per_cycle,
-    .num_tiles = m_col_cnt * xrt_core::device_query<xrt_core::query::aie_tiles_stats>(&m_device).core_rows,
-  };
-  m_device.get_pdev().drv_ioctl(drv_ioctl_cmd::create_ctx, &arg);
+  init_qos_info(qos);
 
-  m_handle = arg.ctx_handle;
-  m_doorbell = arg.umq_doorbell;
-  m_syncobj = arg.syncobj_handle;
+  auto [hdl, sobj, db] = m_ctx.create(m_qos, m_q->get_queue_bo(), m_ops_per_cycle, m_col_cnt);
+  m_handle = hdl;
+  m_syncobj = sobj;
+  m_doorbell = db;
+
   m_q->bind_hwctx(*this);
 }
 
-void
-hwctx::
-delete_ctx_on_device()
+std::tuple<hwctx::slot_id, uint32_t, uint32_t>
+hwctx::ctx::
+create(const amdxdna_qos_info& qos, const bo_id& q_bo, uint32_t max_opc, uint32_t n_cols)
+{
+  create_ctx_arg arg = {
+    .qos = qos,
+    .umq_bo = q_bo,
+    .log_buf_bo = { AMDXDNA_INVALID_BO_HANDLE, AMDXDNA_INVALID_BO_HANDLE },
+    .max_opc = max_opc,
+    .num_tiles = n_cols * m_device.get_core_rows()
+  };
+  m_device.get_pdev().drv_ioctl(drv_ioctl_cmd::create_ctx, &arg);
+  m_handle = arg.ctx_handle;
+  m_syncobj = arg.syncobj_handle;
+  return { m_handle, m_syncobj, arg.umq_doorbell};
+}
+
+hwctx::ctx::
+ctx(const device& device) : m_device(device)
+{
+}
+
+hwctx::ctx::
+~ctx()
 {
   if (m_handle == AMDXDNA_INVALID_CTX_HANDLE)
     return;
 
-  m_q->unbind_hwctx();
-  struct destroy_ctx_arg arg = {
+  destroy_ctx_arg arg = {
     .ctx_handle = m_handle,
     .syncobj_handle = m_syncobj,
   };
-  m_device.get_pdev().drv_ioctl(drv_ioctl_cmd::destroy_ctx, &arg);
+  try {
+    m_device.get_pdev().drv_ioctl(drv_ioctl_cmd::destroy_ctx, &arg);
+  } catch (const xrt_core::system_error& e) {
+    shim_debug("Failed to destroy context: %s", e.what());
+  }
 }
 
 uint32_t

--- a/src/shim/hwctx.h
+++ b/src/shim/hwctx.h
@@ -58,7 +58,8 @@ class hwctx : public xrt_core::hwctx_handle
 public:
   hwctx(const device& dev, const qos_type& qos, const xrt::xclbin& xclbin,
     std::unique_ptr<hwq> queue);
-  hwctx(const device& dev, uint32_t partition_size, std::unique_ptr<hwq> queue);
+  hwctx(const device& dev, const qos_type& qos, uint32_t partition_size,
+    std::unique_ptr<hwq> queue);
   ~hwctx();
 
   slot_id
@@ -97,6 +98,21 @@ public:
   get_syncobj() const;
 
 private:
+
+  class ctx {
+  public:
+    ctx(const device& device);
+    ~ctx();
+
+    std::tuple<slot_id, uint32_t, uint32_t>
+    create(const amdxdna_qos_info& qos, const bo_id& q_bo, uint32_t max_opc, uint32_t n_cols);
+
+  private:
+    const device& m_device;
+    slot_id m_handle = AMDXDNA_INVALID_CTX_HANDLE;
+    uint32_t m_syncobj = AMDXDNA_INVALID_FENCE_HANDLE;
+  } m_ctx;
+
   const device& m_device;
   slot_id m_handle = AMDXDNA_INVALID_CTX_HANDLE;
   std::vector<std::string> m_cu_names;
@@ -108,10 +124,7 @@ private:
   amdxdna_qos_info m_qos = {};
 
   void
-  create_ctx_on_device();
-
-  void
-  delete_ctx_on_device();
+  create_ctx_on_device(const qos_type& qos);
 
   void
   init_qos_info(const qos_type& qos);

--- a/src/shim/kmq/hwctx.cpp
+++ b/src/shim/kmq/hwctx.cpp
@@ -60,8 +60,8 @@ hwctx_kmq(const device& device, const xrt::xclbin& xclbin, const qos_type& qos)
 }
 
 hwctx_kmq::
-hwctx_kmq(const device& device, uint32_t partition_size)
-  : hwctx(device, partition_size, std::make_unique<hwq_kmq>(device))
+hwctx_kmq(const device& device, uint32_t partition_size, const qos_type& qos)
+  : hwctx(device, qos, partition_size, std::make_unique<hwq_kmq>(device))
 {
   shim_debug("Created KMQ HW context (%d)", get_slotidx());
 }

--- a/src/shim/kmq/hwctx.h
+++ b/src/shim/kmq/hwctx.h
@@ -11,7 +11,7 @@ namespace shim_xdna {
 class hwctx_kmq : public hwctx {
 public:
   hwctx_kmq(const device& dev, const xrt::xclbin& xclbin, const qos_type& qos);
-  hwctx_kmq(const device& device, uint32_t partition_size);
+  hwctx_kmq(const device& dev, uint32_t partition_size, const qos_type& qos);
   ~hwctx_kmq();
 
 private:

--- a/src/shim/umq/hwctx.cpp
+++ b/src/shim/umq/hwctx.cpp
@@ -20,8 +20,8 @@ hwctx_umq(const device& device, const xrt::xclbin& xclbin, const qos_type& qos)
 }
 
 hwctx_umq::
-hwctx_umq(const device& device, uint32_t partition_size)
-  : hwctx(device, partition_size, std::make_unique<hwq_umq>(device, total_queue_slots))
+hwctx_umq(const device& device, uint32_t partition_size, const qos_type& qos)
+  : hwctx(device, qos, partition_size, std::make_unique<hwq_umq>(device, total_queue_slots))
   , m_pdev(device.get_pdev())
 {
   m_col_cnt = partition_size;

--- a/src/shim/umq/hwctx.h
+++ b/src/shim/umq/hwctx.h
@@ -15,7 +15,7 @@ namespace shim_xdna {
 class hwctx_umq : public hwctx {
 public:
   hwctx_umq(const device& device, const xrt::xclbin& xclbin, const qos_type& qos);
-  hwctx_umq(const device& device, uint32_t partition_size);
+  hwctx_umq(const device& device, uint32_t partition_size, const qos_type& qos);
   ~hwctx_umq();
 
 private:


### PR DESCRIPTION
This PR added the support for auto core dump when commands times out.

By default, this feature is disabled. Privileged user can enable this feature on NPU device via:
`# XRTSMIAdvanced=1 xrt-smi configure --advanced  --auto-coredump --enable`
Anyone can query the state of the feature on the NPU device via:
`# XRTSMIAdvanced=1 xrt-smi examine --advanced -r debug`

After the feature is enabled, any user who wants to collect the core dump when commands times out can add below text to the xrt.ini:
```
[Runtime]
aie_coredump_file=<path-to-the-coredump-file>
```
When commands times out, XRT will automatically save the core dump to the file as requested.

This is the initial implementation which only enables the feature on AIE2p platforms. The support for AIE4 has to wait until below features are done on AIE4:

- TDR
- Coredump
- FW debug mode configuration

Shim test will be enabled with a follow-up PR.