### PR TITLE
[XRT-SMI] Use smi_hardware_config for validate archive path lookup.

### DIFF
--- a/src/shim/device.cpp
+++ b/src/shim/device.cpp
@@ -1134,34 +1134,17 @@ struct archive_path
   static result_type
   get(const xrt_core::device* device, key_type key)
   {
-    const auto& pcie_id = xrt_core::device_query<xrt_core::query::pcie_id>(device);
-    xrt_core::smi::smi_hardware_config smi_hrdw;
-    auto hardware_type = smi_hrdw.get_hardware_type(pcie_id);
-
     switch (key) {
     case key_type::archive_path:
     {
-      switch (hardware_type)
-      {
-      case xrt_core::smi::smi_hardware_config::hardware_type::stxA0:
-      case xrt_core::smi::smi_hardware_config::hardware_type::stxB0:
-      case xrt_core::smi::smi_hardware_config::hardware_type::stxH:
-      case xrt_core::smi::smi_hardware_config::hardware_type::krk1:
-        return std::string("amdxdna/bins/xrt_smi_strx.a");
-      case xrt_core::smi::smi_hardware_config::hardware_type::phx:
+      const auto& pcie_id = xrt_core::device_query<xrt_core::query::pcie_id>(device);
+      xrt_core::smi::smi_hardware_config smi_hrdw;
+      switch (smi_hrdw.get_family(pcie_id)) {
+      case xrt_core::smi::smi_hardware_config::hardware_family::phoenix:
         return std::string("amdxdna/bins/xrt_smi_phx.a");
-      case xrt_core::smi::smi_hardware_config::hardware_type::npu3_f0:
-      case xrt_core::smi::smi_hardware_config::hardware_type::npu3_f1:
-      case xrt_core::smi::smi_hardware_config::hardware_type::npu3_f2:
-      case xrt_core::smi::smi_hardware_config::hardware_type::npu3_f3:
-      case xrt_core::smi::smi_hardware_config::hardware_type::npu3_f4:
-      case xrt_core::smi::smi_hardware_config::hardware_type::npu3_f5:
-      case xrt_core::smi::smi_hardware_config::hardware_type::npu3_f6:
-      case xrt_core::smi::smi_hardware_config::hardware_type::npu3_f7:
-      case xrt_core::smi::smi_hardware_config::hardware_type::npu3_f10:
-      case xrt_core::smi::smi_hardware_config::hardware_type::npu3_B01:
-      case xrt_core::smi::smi_hardware_config::hardware_type::npu3_B02:
-      case xrt_core::smi::smi_hardware_config::hardware_type::npu3_B03:
+      case xrt_core::smi::smi_hardware_config::hardware_family::strix:
+        return std::string("amdxdna/bins/xrt_smi_strx.a");
+      case xrt_core::smi::smi_hardware_config::hardware_family::npu3:
         return std::string("amdxdna/bins/xrt_smi_npu3.a");
       default:
         throw xrt_core::generic_error(ENOTSUP, "Unsupported hardware type");

--- a/tools/info.json
+++ b/tools/info.json
@@ -1,7 +1,7 @@
 {
 	"copyright": "Copyright (C) 2023-2026 Advanced Micro Devices, Inc. All rights reserved.",
 	"xrt" : {
-		"version": "202620.2.26.67",
+		"version": "202620.2.26.74",
 		"os_rel": ["22.04", "24.04"]
 	}
 }


### PR DESCRIPTION
Delegate the archive_path device query to get_validate_archive_path() so archive routing stays centralized in smi_hardware_config.