### PR TITLE
accel/amdxdna: add aie4 frame boundary preempt state query

### DIFF
--- a/drivers/accel/amdxdna/aie.c
+++ b/drivers/accel/amdxdna/aie.c
@@ -586,6 +586,21 @@ int amdxdna_set_force_preempt_state(struct aie_device *aie, struct amdxdna_clien
 	return 0;
 }
 
+int amdxdna_get_frame_boundary_preempt_state(struct aie_device *aie,
+					     struct amdxdna_drm_get_info *args)
+{
+	struct amdxdna_drm_attribute_state state = {};
+	u32 buf_sz;
+
+	state.state = aie->frame_boundary_preempt_enabled;
+
+	buf_sz = min(args->buffer_size, sizeof(state));
+	if (copy_to_user(u64_to_user_ptr(args->buffer), &state, buf_sz))
+		return -EFAULT;
+
+	return 0;
+}
+
 struct amdxdna_msg_buf_hdl *amdxdna_alloc_msg_buff(struct amdxdna_dev *xdna, u32 size)
 {
 	struct amdxdna_msg_buf_hdl *hdl;

--- a/drivers/accel/amdxdna/aie.h
+++ b/drivers/accel/amdxdna/aie.h
@@ -63,6 +63,7 @@ struct aie_device {
 	struct amdxdna_drm_query_aie_metadata metadata;
 	struct aie_msg_ops msg_ops;
 	u32	force_preempt_enabled;
+	u32	frame_boundary_preempt_enabled;
 
 	/* FW hwctx slot count for the telemetry map; 0 if arch has no map. */
 	u32 hwctx_limit;
@@ -183,6 +184,8 @@ int amdxdna_get_force_preempt_state(struct aie_device *aie, struct amdxdna_drm_g
 int amdxdna_set_force_preempt_state(struct aie_device *aie, struct amdxdna_client *client,
 				    struct amdxdna_drm_set_state *args);
 int amdxdna_populate_range(struct amdxdna_gem_obj *abo);
+int amdxdna_get_frame_boundary_preempt_state(struct aie_device *aie,
+					     struct amdxdna_drm_get_info *args);
 struct amdxdna_msg_buf_hdl {
 	struct amdxdna_dev	*xdna;
 	void			*vaddr;

--- a/drivers/accel/amdxdna/aie2_pci.c
+++ b/drivers/accel/amdxdna/aie2_pci.c
@@ -809,22 +809,6 @@ int aie2_fill_hwctx_map(struct aie_device *aie, u32 *map)
 	return 0;
 }
 
-static int aie2_get_frame_boundary_preempt_state(struct amdxdna_client *client,
-						 struct amdxdna_drm_get_info *args)
-{
-	struct amdxdna_drm_attribute_state state = {};
-	struct amdxdna_dev_hdl *ndev = client->xdna->dev_handle;
-	u32 buf_sz;
-
-	state.state = ndev->frame_boundary_preempt;
-
-	buf_sz = min(args->buffer_size, sizeof(state));
-	if (copy_to_user(u64_to_user_ptr(args->buffer), &state, buf_sz))
-		return -EFAULT;
-
-	return 0;
-}
-
 static int aie2_get_info(struct amdxdna_client *client, struct amdxdna_drm_get_info *args)
 {
 	struct amdxdna_dev *xdna = client->xdna;
@@ -873,7 +857,7 @@ static int aie2_get_info(struct amdxdna_client *client, struct amdxdna_drm_get_i
 		ret = amdxdna_get_force_preempt_state(&ndev->aie, args);
 		break;
 	case DRM_AMDXDNA_GET_FRAME_BOUNDARY_PREEMPT_STATE:
-		ret = aie2_get_frame_boundary_preempt_state(client, args);
+		ret = amdxdna_get_frame_boundary_preempt_state(&ndev->aie, args);
 		break;
 	case DRM_AMDXDNA_GET_AUTO_COREDUMP:
 		ret = amdxdna_get_auto_coredump_mode(client, args);
@@ -1020,7 +1004,7 @@ static int aie2_set_frame_boundary_preempt(struct amdxdna_client *client,
 	if (ret)
 		return ret;
 
-	ndev->frame_boundary_preempt = state.state;
+	ndev->aie.frame_boundary_preempt_enabled = state.state;
 
 	return 0;
 }

--- a/drivers/accel/amdxdna/aie2_pci.h
+++ b/drivers/accel/amdxdna/aie2_pci.h
@@ -145,7 +145,6 @@ struct amdxdna_dev_hdl {
 	u32				dpm_level;
 	u32				dft_dpm_level;
 	u32				max_dpm_level;
-	u32				frame_boundary_preempt;
 
 	/* Mailbox and the management channel */
 	struct mailbox			*mbox;

--- a/drivers/accel/amdxdna/aie4_pci.c
+++ b/drivers/accel/amdxdna/aie4_pci.c
@@ -357,6 +357,7 @@ static int aie4_query_aie(struct amdxdna_dev_hdl *ndev)
 	 * override is re-applied to firmware by aie4_restore_power_mode().
 	 */
 	ndev->total_col = min(AIE4_TOTAL_COLUMN, ndev->aie.metadata.cols);
+	ndev->aie.frame_boundary_preempt_enabled = 1;
 
 	ret = aie4_init_dpm_freq_table(ndev);
 	if (ret)
@@ -976,6 +977,9 @@ static int aie4_get_info(struct amdxdna_client *client, struct amdxdna_drm_get_i
 		break;
 	case DRM_AMDXDNA_GET_FORCE_PREEMPT_STATE:
 		ret = amdxdna_get_force_preempt_state(&ndev->aie, args);
+		break;
+	case DRM_AMDXDNA_GET_FRAME_BOUNDARY_PREEMPT_STATE:
+		ret = amdxdna_get_frame_boundary_preempt_state(&ndev->aie, args);
 		break;
 	case DRM_AMDXDNA_GET_AUTO_COREDUMP:
 		ret = amdxdna_get_auto_coredump_mode(client, args);

--- a/test/shim_test/shim_test.cpp
+++ b/test/shim_test/shim_test.cpp
@@ -1539,6 +1539,39 @@ TEST_query_telemetry_short_buf(device::id_type id, std::shared_ptr<device>& sdev
       + std::to_string(err));
 }
 
+struct attribute_state_probe {
+  int ret;
+  int err;
+  uint8_t state;
+};
+
+void
+TEST_query_frame_boundary_preempt(device::id_type id, std::shared_ptr<device>& sdev, arg_type& arg)
+{
+  auto probe = fork_query<attribute_state_probe>(sdev.get(), [](int fd) {
+    amdxdna_drm_attribute_state state{};
+    amdxdna_drm_get_info info = {
+      .param = DRM_AMDXDNA_GET_FRAME_BOUNDARY_PREEMPT_STATE,
+      .buffer_size = sizeof(state),
+      .buffer = reinterpret_cast<uintptr_t>(&state),
+    };
+
+    attribute_state_probe r{};
+    r.ret = ::ioctl(fd, DRM_IOCTL_AMDXDNA_GET_INFO, &info);
+    r.err = errno;
+    r.state = state.state;
+    return r;
+  });
+
+  if (probe.ret == -1)
+    throw std::runtime_error(
+      "ioctl(GET_FRAME_BOUNDARY_PREEMPT_STATE) failed: " + std::string(std::strerror(probe.err)));
+  if (probe.state > 1)
+    throw std::runtime_error("GET_FRAME_BOUNDARY_PREEMPT_STATE returned non-boolean state");
+  if (dev_filter_is_aie4(id, sdev.get()) && probe.state != 1)
+    throw std::runtime_error("aie4 GET_FRAME_BOUNDARY_PREEMPT_STATE expected enabled");
+}
+
 // List of all test cases
 std::vector<test_case> test_list {
   test_case{ "get_xrt_info", {},
@@ -1774,6 +1807,9 @@ std::vector<test_case> test_list {
   },
   test_case{ "query telemetry header-only buffer fails", {},
     TEST_POSITIVE, dev_filter_is_aie_and_amdxdna_drv, TEST_query_telemetry_short_buf, {}
+  },
+  test_case{ "query frame boundary preempt state (get_info)", {},
+    TEST_POSITIVE, dev_filter_is_aie_and_amdxdna_drv, TEST_query_frame_boundary_preempt, {}
   },
   //test_case{ "io test no-op kernel good run", {},
   //  TEST_POSITIVE, dev_filter_is_aie2, TEST_io, { IO_TEST_NOOP_RUN, 1 }


### PR DESCRIPTION
Add DRM_AMDXDNA_GET_FRAME_BOUNDARY_PREEMPT_STATE support for aie4, matching the out-of-tree driver.

Test -
Add a shim_test case that queries the state through the get_info ioctl and verifies aie4 reports it enabled.