### PR TITLE
amdxdna: ve2: Add support for capturing AIE coredump

### DIFF
--- a/src/driver/amdxdna/amdxdna_drm.h
+++ b/src/driver/amdxdna/amdxdna_drm.h
@@ -158,6 +158,9 @@ struct amdxdna_dev {
 	struct amdxdna_cert_ver		cert_ver;
 	struct amdxdna_dpt		*fw_log;
 	struct amdxdna_dpt		*fw_trace;
+
+	/* Allow auto core dump capture on command timeout, if true. */
+	bool				auto_coredump;
 #ifdef AMDXDNA_DEVEL
 	struct ida			pdi_ida;
 #endif

--- a/src/driver/amdxdna/ve2_debug.c
+++ b/src/driver/amdxdna/ve2_debug.c
@@ -109,10 +109,13 @@ static int ve2_get_array_hwctx(struct amdxdna_client *client,
 		list_for_each_entry(tmp_client, &xdna->client_list, node) {
 			unsigned long id;
 			struct amdxdna_ctx *ctx;
+			int srcu_idx;
 
+			srcu_idx = srcu_read_lock(&tmp_client->ctx_srcu);
 			xa_for_each(&tmp_client->ctx_xa, id, ctx)
 				if (ctx->priv)
 					ctx_cnt++;
+			srcu_read_unlock(&tmp_client->ctx_srcu, srcu_idx);
 		}
 
 		if (args->num_element < ctx_cnt) {
@@ -377,6 +380,52 @@ static int ve2_aie_read(struct amdxdna_client *client, struct amdxdna_drm_get_ar
 	return 0;
 }
 
+/*
+ * Serve the last auto-captured coredump from this context's cache. The dump is
+ * consumed on read (one-shot): on a successful copy the cached buffer is freed
+ * and the cache is marked empty so the next request performs a fresh live
+ * capture. Returns -ENODATA when there is no cached dump, so the caller can
+ * fall back to a live capture.
+ */
+static int ve2_coredump_read_cached(struct amdxdna_dev *xdna,
+				    struct amdxdna_drm_get_array *args, u32 buf_size,
+				    struct amdxdna_ctx *hwctx)
+{
+	struct ve2_coredump_cache *cache = &hwctx->priv->coredump_cache;
+	int ret = 0;
+
+	mutex_lock(&cache->lock);
+	if (!cache->valid || !cache->buf) {
+		XDNA_DBG(xdna, "No cached coredump for hwctx %u pid %d",
+			 hwctx->id, hwctx->client->pid);
+		ret = -ENODATA;
+		goto out;
+	}
+	if (cache->size > buf_size) {
+		XDNA_DBG(xdna, "Cached coredump too big: buf %u, need %u",
+			 buf_size, cache->size);
+		args->element_size = cache->size;
+		ret = -ENOBUFS;
+		goto out;
+	}
+	if (copy_to_user(u64_to_user_ptr(args->buffer), cache->buf, cache->size)) {
+		XDNA_ERR(xdna, "Failed to copy cached coredump to user");
+		ret = -EFAULT;
+		goto out;
+	}
+	XDNA_DBG(xdna, "Served cached coredump: hwctx %u pid %d seq %llu size %u (consumed)",
+		 hwctx->id, hwctx->client->pid, cache->seq, cache->size);
+
+	/* One-shot: consume the cached dump so the next request is a live capture. */
+	vfree(cache->buf);
+	cache->buf = NULL;
+	cache->size = 0;
+	cache->valid = false;
+out:
+	mutex_unlock(&cache->lock);
+	return ret;
+}
+
 static int ve2_coredump_read(struct amdxdna_client *client, struct amdxdna_drm_get_array *args)
 {
 	struct amdxdna_dev *xdna = client->xdna;
@@ -421,6 +470,14 @@ static int ve2_coredump_read(struct amdxdna_client *client, struct amdxdna_drm_g
 	XDNA_DBG(xdna, "cl_pid: %u, hwctx_id: %u, start_col %u, ncol %u\n",
 		 hwctx->client->pid, hwctx->id, hwctx->start_col,
 		 hwctx->num_col);
+
+	/*
+	 * Prefer the auto-captured timeout dump for this context. It is served
+	 * once and then cleared; if the cache is empty then read live data below.
+	 */
+	ret = ve2_coredump_read_cached(xdna, args, buf_size, hwctx);
+	if (ret != -ENODATA)
+		return ret;
 
 	rel_size = hwctx->priv->num_col * xdna->dev_handle->aie_dev_info.rows * TILE_ADDRESS_SPACE;
 	if (rel_size > buf_size) {
@@ -652,6 +709,28 @@ static int ve2_get_hwctx_mem_bitmap(struct amdxdna_client *client,
 	return 0;
 }
 
+/* Query the device-wide auto coredump mode. */
+static int ve2_get_auto_coredump_mode(struct amdxdna_client *client,
+				      struct amdxdna_drm_get_info *args)
+{
+	struct amdxdna_drm_attribute_state state = {};
+	struct amdxdna_dev *xdna = client->xdna;
+	int min;
+
+	if (!access_ok(u64_to_user_ptr(args->buffer), args->buffer_size)) {
+		XDNA_ERR(xdna, "Failed to access buffer size %d", args->buffer_size);
+		return -EFAULT;
+	}
+
+	state.state = xdna->auto_coredump ? 1 : 0;
+
+	min = min(args->buffer_size, sizeof(state));
+	if (copy_to_user(u64_to_user_ptr(args->buffer), &state, min))
+		return -EFAULT;
+
+	return 0;
+}
+
 int ve2_get_aie_info(struct amdxdna_client *client, struct amdxdna_drm_get_info *args)
 {
 	struct amdxdna_dev *xdna = client->xdna;
@@ -672,6 +751,9 @@ int ve2_get_aie_info(struct amdxdna_client *client, struct amdxdna_drm_get_info 
 		break;
 	case DRM_AMDXDNA_QUERY_CLOCK_METADATA:
 		ret = ve2_get_clock_metadata(client, args);
+		break;
+	case DRM_AMDXDNA_GET_AUTO_COREDUMP:
+		ret = ve2_get_auto_coredump_mode(client, args);
 		break;
 	default:
 		XDNA_ERR(xdna, "Not supported request parameter %u", args->param);
@@ -977,6 +1059,69 @@ set_freq:
 	return ret;
 }
 
+/* Drop this context's cached auto-coredump, if any. */
+static void ve2_drop_cached_coredump(struct amdxdna_ctx *hwctx)
+{
+	struct ve2_coredump_cache *cache;
+
+	if (!hwctx->priv)
+		return;
+
+	cache = &hwctx->priv->coredump_cache;
+	mutex_lock(&cache->lock);
+	vfree(cache->buf);
+	cache->buf = NULL;
+	cache->size = 0;
+	cache->valid = false;
+	mutex_unlock(&cache->lock);
+}
+
+/*
+ * Enable or disable the device-wide auto coredump mode. When disabled, any
+ * previously cached per-context dumps are dropped.
+ */
+static int ve2_set_auto_coredump_mode(struct amdxdna_client *client,
+				      struct amdxdna_drm_set_state *args)
+{
+	struct amdxdna_drm_attribute_state state = {};
+	struct amdxdna_dev *xdna = client->xdna;
+	struct amdxdna_client *tmp_client;
+	int min;
+
+	if (!access_ok(u64_to_user_ptr(args->buffer), args->buffer_size)) {
+		XDNA_ERR(xdna, "Failed to access buffer size %d", args->buffer_size);
+		return -EFAULT;
+	}
+
+	min = min(args->buffer_size, sizeof(state));
+	if (copy_from_user(&state, u64_to_user_ptr(args->buffer), min))
+		return -EFAULT;
+
+	if (state.state > 1) {
+		XDNA_ERR(xdna, "Invalid state: %d", state.state);
+		return -EINVAL;
+	}
+
+	XDNA_DBG(xdna, "Setting auto coredump to %d", state.state);
+	xdna->auto_coredump = state.state;
+
+	/* Auto coredump disabled: drop all cached dumps across all contexts. */
+	if (!state.state) {
+		list_for_each_entry(tmp_client, &xdna->client_list, node) {
+			struct amdxdna_ctx *hwctx;
+			unsigned long ctx_id;
+			int idx;
+
+			idx = srcu_read_lock(&tmp_client->ctx_srcu);
+			amdxdna_for_each_ctx(tmp_client, ctx_id, hwctx)
+				ve2_drop_cached_coredump(hwctx);
+			srcu_read_unlock(&tmp_client->ctx_srcu, idx);
+		}
+	}
+
+	return 0;
+}
+
 int ve2_set_aie_state(struct amdxdna_client *client, struct amdxdna_drm_set_state *args)
 {
 	struct amdxdna_dev *xdna = client->xdna;
@@ -995,6 +1140,9 @@ int ve2_set_aie_state(struct amdxdna_client *client, struct amdxdna_drm_set_stat
 	case DRM_AMDXDNA_SET_CLOCK_FREQ:
 		XDNA_DBG(xdna, "Setting AIE clock frequency");
 		ret = ve2_set_clock_freq(client, args);
+		break;
+	case DRM_AMDXDNA_SET_AUTO_COREDUMP:
+		ret = ve2_set_auto_coredump_mode(client, args);
 		break;
 	default:
 		XDNA_ERR(xdna, "Not supported request parameter %u", args->param);

--- a/src/driver/amdxdna/ve2_hwctx.c
+++ b/src/driver/amdxdna/ve2_hwctx.c
@@ -7,6 +7,7 @@
 #include <linux/dma-buf.h>
 #include <linux/timer.h>
 #include <linux/version.h>
+#include <linux/vmalloc.h>
 
 #include "amdxdna_ctx.h"
 #include "amdxdna_gem.h"
@@ -1305,6 +1306,14 @@ static void ve2_handle_timeout(struct amdxdna_dev *xdna,
 		ve2_fill_health_data(xdna, hwctx, cmd_data, data_total);
 	}
 
+	/*
+	 * Snapshot the AIE partition while this hwctx is still the active
+	 * context on its partition. Only capture when the device-wide auto
+	 * coredump mode is enabled. Best-effort: failures are logged, not fatal.
+	 */
+	if (xdna->auto_coredump)
+		ve2_cache_coredump(xdna, hwctx, seq);
+
 	hwctx->health_reported = true;
 	amdxdna_cmd_set_state(job->cmd_bo, ERT_CMD_STATE_TIMEOUT);
 }
@@ -1479,6 +1488,7 @@ int ve2_hwctx_init(struct amdxdna_ctx *hwctx)
 		ve2_clear_firmware_status(xdna, hwctx);
 
 	mutex_init(&priv->privctx_lock);
+	mutex_init(&priv->coredump_cache.lock);
 	priv->state = AMDXDNA_HWCTX_STATE_IDLE;
 
 	/* Pre-allocate DMA coherent buffer for handshake data.
@@ -1486,19 +1496,17 @@ int ve2_hwctx_init(struct amdxdna_ctx *hwctx)
 	 */
 	priv->hs_dma_size = priv->num_col * sizeof(struct handshake);
 	if (priv->hs_dma_size && priv->aie_dev) {
-		priv->hs_dma_va = dma_alloc_coherent(priv->aie_dev,
-						      priv->hs_dma_size,
-						      &priv->hs_dma_pa,
-						      GFP_KERNEL);
+		priv->hs_dma_va = dma_alloc_coherent(priv->aie_dev, priv->hs_dma_size,
+						     &priv->hs_dma_pa, GFP_KERNEL);
 		if (!priv->hs_dma_va)
 			XDNA_WARN(xdna, "Failed to pre-alloc handshake DMA buf");
 	}
 
-	XDNA_DBG(xdna, "hwctx init: ready hwctx=%p start_col=%u pid=%d",
-		 hwctx, priv->start_col, hwctx->client->pid);
+	XDNA_DBG(xdna, "hwctx init: ready hwctx=%p start_col=%u pid=%d", hwctx, priv->start_col,
+		 hwctx->client->pid);
 
-	trace_amdxdna_trace_point("XRT_PROFILING_TRACE_EXIT",
-				  hwctx->client->pid, priv->start_col, priv->id, 0);
+	trace_amdxdna_trace_point("XRT_PROFILING_TRACE_EXIT", hwctx->client->pid, priv->start_col,
+				  priv->id, 0);
 	return 0;
 
 cleanup_xrs:
@@ -1587,6 +1595,8 @@ void ve2_hwctx_fini(struct amdxdna_ctx *hwctx)
 	ve2_mgmt_destroy_partition(hwctx);
 	ve2_free_hsa_queue(xdna, &hwctx->priv->hwctx_hsa_queue);
 	kfree(hwctx->priv->hwctx_config);
+	vfree(hwctx->priv->coredump_cache.buf);
+	mutex_destroy(&hwctx->priv->coredump_cache.lock);
 	mutex_destroy(&hwctx->priv->privctx_lock);
 
 	XDNA_DBG(xdna,

--- a/src/driver/amdxdna/ve2_mgmt.c
+++ b/src/driver/amdxdna/ve2_mgmt.c
@@ -7,6 +7,7 @@
 #include <linux/completion.h>
 #include <linux/atomic.h>
 #include <linux/delay.h>
+#include <linux/vmalloc.h>
 
 #include "amdxdna_ctx.h"
 #include "ve2_of.h"
@@ -432,7 +433,7 @@ void ve2_mgmt_handshake_init(struct amdxdna_dev *xdna,
 
 	XDNA_DBG(xdna, "handshake: ve2_partition_initialize ok hwctx=%p", hwctx);
 
-        /* Wake up lead UC only */
+	/* Wake up lead UC only */
 	ve2_partition_uc_wakeup(nhwctx->aie_dev, 0);
 
 	XDNA_DBG(xdna, "partition uc_wakeup done cols=%u hwctx=%p", num_col, hwctx);
@@ -544,15 +545,15 @@ int ve2_mgmt_schedule_cmd(struct amdxdna_dev *xdna, struct amdxdna_ctx *hwctx,
 				 mgmtctx->active_ctx, hwctx);
 		}
 	} else {
-    	if (mgmtctx->is_idle_due_to_context == 1) {
-        	mgmtctx->is_idle_due_to_context = 0;
-            mgmtctx->is_partition_idle = 0;
-            ve2_mgmt_handshake_init(xdna, hwctx);
-            mgmtctx->active_ctx = hwctx;
-        } else {
-        	notify_fw_cmd_ready(mgmtctx->active_ctx);
-        }
-    }
+		if (mgmtctx->is_idle_due_to_context == 1) {
+			mgmtctx->is_idle_due_to_context = 0;
+			mgmtctx->is_partition_idle = 0;
+			ve2_mgmt_handshake_init(xdna, hwctx);
+			mgmtctx->active_ctx = hwctx;
+		} else {
+			notify_fw_cmd_ready(mgmtctx->active_ctx);
+		}
+	}
 
 	mutex_unlock(&mgmtctx->ctx_lock);
 	trace_amdxdna_trace_point("XRT_PROFILING_TRACE_EXIT",
@@ -1352,6 +1353,78 @@ int ve2_create_coredump(struct amdxdna_dev *xdna,
 	XDNA_DBG(xdna, "Reading coredump ret:%d\n", rel_size);
 
 	return rel_size;
+}
+
+int ve2_cache_coredump(struct amdxdna_dev *xdna, struct amdxdna_ctx *hwctx, u64 seq)
+{
+	struct amdxdna_dev_hdl *dev_hdl = xdna->dev_handle;
+	struct amdxdna_ctx_priv *priv = hwctx->priv;
+	struct ve2_coredump_cache *cache = &priv->coredump_cache;
+	void *buf, *old_buf;
+	u32 size;
+	int ret;
+
+	size = priv->num_col * dev_hdl->aie_dev_info.rows * TILE_ADDRESS_SPACE;
+	if (!size) {
+		XDNA_WARN(xdna, "Auto coredump: zero size for hwctx %u", hwctx->id);
+		return -EINVAL;
+	}
+
+	XDNA_INFO(xdna,
+		  "Auto coredump: capture start hwctx %u pid %u seq %llu start_col %u num_col %u size %u",
+		  hwctx->id, hwctx->client->pid, seq, priv->start_col, priv->num_col, size);
+
+	buf = vmalloc(size);
+	if (!buf)
+		return -ENOMEM;
+
+	/* hwctx is the active ctx on this partition during the timeout path. */
+	ret = ve2_create_coredump(xdna, hwctx, buf, size);
+	if (ret < 0) {
+		XDNA_ERR(xdna, "Auto coredump capture failed for hwctx %u, err:%d",
+			 hwctx->id, ret);
+		vfree(buf);
+		return ret;
+	}
+
+	/*
+	 * Keep-latest: swap in the new snapshot, then free the previous one.
+	 * The cache is per-hwctx and is consumed (cleared) on the next coredump
+	 * read; it is also dropped when auto coredump is disabled or when the
+	 * context is destroyed.
+	 */
+	mutex_lock(&cache->lock);
+	old_buf = cache->buf;
+	cache->buf = buf;
+	cache->size = ret;
+	cache->seq = seq;
+	cache->start_col = priv->start_col;
+	cache->num_col = priv->num_col;
+	cache->timestamp = ktime_get();
+	cache->valid = true;
+
+	/* Dump the full coredump cache structure for debugging. */
+	XDNA_DBG(xdna,
+		 "ve2_coredump_cache: hwctx=%u pid=%u buf=%p size=%u seq=%llu start_col=%u num_col=%u timestamp=%lld valid=%d",
+		 hwctx->id, hwctx->client->pid, cache->buf, cache->size,
+		 cache->seq, cache->start_col, cache->num_col,
+		 ktime_to_ns(cache->timestamp), cache->valid);
+
+	mutex_unlock(&cache->lock);
+
+	XDNA_INFO(xdna,
+		  "Auto coredump cached OK: hwctx %u pid %u seq %llu size %d%s (head: %08x %08x %08x %08x)",
+		  hwctx->id, hwctx->client->pid, seq, ret,
+		  old_buf ? " [overwrote previous dump]" : "",
+		  ((u32 *)buf)[0], ((u32 *)buf)[1], ((u32 *)buf)[2], ((u32 *)buf)[3]);
+
+	/* Dump the first bytes so a zero/garbage capture is easy to spot. */
+	print_hex_dump_debug("ve2 auto-coredump head: ", DUMP_PREFIX_OFFSET, 16, 4,
+			     buf, min_t(u32, ret, 64u), false);
+
+	vfree(old_buf);
+
+	return 0;
 }
 
 static int ve2_xrs_release(struct amdxdna_dev *xdna, struct amdxdna_ctx *hwctx,

--- a/src/driver/amdxdna/ve2_mgmt.h
+++ b/src/driver/amdxdna/ve2_mgmt.h
@@ -181,6 +181,20 @@ int ve2_xrs_col_list(struct amdxdna_dev *xdna, struct alloc_requests *xrs_req,
 int ve2_create_coredump(struct amdxdna_dev *xdna, struct amdxdna_ctx *hwctx,
 			void *buffer, u32 size);
 /**
+ * ve2_cache_coredump - Auto-capture an AIE coredump into the device cache.
+ * @xdna: Pointer to the device structure.
+ * @hwctx: Pointer to the hardware context that timed out.
+ * @seq: Sequence number of the failing command.
+ *
+ * Called from the timeout path when the device-wide auto coredump mode is
+ * enabled. Keep-latest: overwrites any previously cached dump for this context.
+ * Must be called while @hwctx is still the active context on its partition
+ * (i.e. from the timeout path).
+ *
+ * Returns 0 on success or a negative errno.
+ */
+int ve2_cache_coredump(struct amdxdna_dev *xdna, struct amdxdna_ctx *hwctx, u64 seq);
+/**
  * ve2_mgmt_destroy_partition - Destroy a VE2 hardware partition for a context.
  * @hwctx: Pointer to the hardware context.
  *

--- a/src/driver/amdxdna/ve2_of.h
+++ b/src/driver/amdxdna/ve2_of.h
@@ -84,6 +84,29 @@ struct amdxdna_ctx_command_fifo {
 	struct list_head                list;
 };
 
+/*
+ * ve2_coredump_cache - Last AIE coredump auto-captured on command timeout.
+ *
+ * This cache is per-hardware-context (lives in struct amdxdna_ctx_priv). Auto-
+ * capture is gated by the device-wide auto coredump mode (amdxdna_dev.
+ * auto_coredump): when enabled, the driver snapshots the AIE partition into
+ * @buf when a command on this context times out. Keep-latest: a newer timeout
+ * overwrites the previous snapshot. A coredump request is served from this
+ * cache and the cache is then cleared (one-shot); the cached dump is also
+ * dropped when auto coredump is disabled or when the context is destroyed. If
+ * the cache is empty the driver performs a live capture instead.
+ */
+struct ve2_coredump_cache {
+	void		*buf;		/* vmalloc'd snapshot, or NULL */
+	u32		size;		/* valid bytes in @buf */
+	u64		seq;		/* failing command sequence number */
+	u32		start_col;	/* partition start column */
+	u32		num_col;	/* partition column count */
+	ktime_t		timestamp;	/* capture time */
+	bool		valid;		/* @buf holds a captured dump */
+	struct mutex	lock;		/* protects all fields above */
+};
+
 struct amdxdna_ctx_priv {
 	u64				id; /* Unique incrementing hwctx ID */
 	u32				start_col;
@@ -104,6 +127,8 @@ struct amdxdna_ctx_priv {
 	void				*hs_dma_va;
 	dma_addr_t			hs_dma_pa;
 	size_t				hs_dma_size;
+
+	struct ve2_coredump_cache	coredump_cache; /* last timeout coredump (per hwctx) */
 };
 
 struct amdxdna_dev_priv {

--- a/src/shim_ve2/smi_ve2.cpp
+++ b/src/shim_ve2/smi_ve2.cpp
@@ -45,7 +45,8 @@ create_examine_subcommand()
       {"host", "Host information", "common"},
       {"clocks", "Clock frequency information", "hidden"},
       {"platform", "Platforms flashed on the device", "common"},
-      {"thermal", "Thermal sensors present on the device", "common"}
+      {"thermal", "Thermal sensors present on the device", "common"},
+      {"debug", "Debug configuration settings for the device", "hidden"}
     };
     
     std::map<std::string, std::shared_ptr<xrt_core::smi::option>> examine_suboptions;
@@ -60,6 +61,18 @@ create_examine_subcommand()
 
   return {"examine", "This command will 'examine' the state of the system/device and will generate a report of interest in a text or JSON format.", "common", std::move(examine_suboptions)};
 }
+
+xrt_core::smi::subcommand
+create_configure_subcommand()
+{
+  std::map<std::string, std::shared_ptr<xrt_core::smi::option>> configure_suboptions;
+  configure_suboptions.emplace("device", std::make_shared<xrt_core::smi::option>("device", "d", "The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest", "common", "", "string"));
+  configure_suboptions.emplace("help", std::make_shared<xrt_core::smi::option>("help", "h", "Help to use this sub-command", "common", "", "none"));
+  configure_suboptions.emplace("auto-coredump", std::make_shared<xrt_core::smi::option>("auto-coredump", "", "Enable|disable automatic coredump on error", "hidden", "", "string", true));
+
+  return {"configure", "Device and host configuration", "common", std::move(configure_suboptions)};
+}
+
 std::string
 get_smi_config()
 {
@@ -69,6 +82,7 @@ get_smi_config()
   // Add subcommands
   smi_instance->add_subcommand("validate", create_validate_subcommand());
   smi_instance->add_subcommand("examine", create_examine_subcommand());
+  smi_instance->add_subcommand("configure", create_configure_subcommand());
 
   return smi_instance->build_json();
 }

--- a/src/shim_ve2/xdna_device.cpp
+++ b/src/shim_ve2/xdna_device.cpp
@@ -28,10 +28,6 @@ namespace {
 namespace query = xrt_core::query;
 using key_type = query::key_type;
 
-// Address space of a single AIE tile (must match the driver's TILE_ADDRESS_SPACE).
-// The coredump size is num_cols * rows_per_col * this value.
-constexpr size_t VE2_TILE_ADDRESS_SPACE = 0x100000; // 1 MB
-
 std::string
 get_shim_lib_path()
 {
@@ -531,28 +527,10 @@ struct aie_coredump
     const auto& aie_coredump_args = std::any_cast<const query::aie_coredump::args&>(args_any);
     auto edev = get_edgedev(device);
 
-    // Pre-size the coredump buffer from the whole-device AIE geometry so that a
-    // single ioctl is normally enough. This mirrors the aie2/aie4 shim, which
-    // sizes the buffer as (core_rows + mem_rows + shim_rows) * cols * 1MB using
-    // the cached aie_tiles_stats query. It is an over-estimate of the driver's
-    // per-partition dump (num_cols * rows * TILE_ADDRESS_SPACE) that always
-    // fits, so the ENOBUFS size-probe path below is only a safety fallback.
-    //
-    // Unlike aie2/aie4 (config struct at the start of the buffer), the ve2
-    // driver reads the config as a footer at the end of the buffer and reports
-    // the required footer-less size via ENOBUFS, so keep the struct at the end
-    // and retry on ENOBUFS.
-    size_t dump_size = 0;
-    try {
-      auto aie_stats = xrt_core::device_query<xrt_core::query::aie_tiles_stats>(device);
-      auto total_rows = aie_stats.core_rows + aie_stats.mem_rows + aie_stats.shim_rows;
-      dump_size = static_cast<size_t>(total_rows) * aie_stats.cols * VE2_TILE_ADDRESS_SPACE;
-    } catch (const std::exception&) {
-      dump_size = 0; // fall back to the ENOBUFS size probe below
-    }
-
     // The driver expects the amdxdna_drm_aie_coredump config as a footer at the
-    // end of the payload (buffer + payload_size - sizeof(footer)).
+    // end of the payload (buffer + payload_size - sizeof(footer)). It reports the
+    // required footer-less dump size via ENOBUFS, so start with a footer-only
+    // payload and retry once the driver tells us how big the dump is.
     auto set_footer = [&](std::vector<char>& buf, size_t footer_off) {
       auto* dump = reinterpret_cast<amdxdna_drm_aie_coredump *>(buf.data() + footer_off);
       dump->context_id = aie_coredump_args.context_id;
@@ -571,8 +549,8 @@ struct aie_coredump
         std::to_string(aie_coredump_args.pid) + "). Check dmesg for details.");
     };
 
-    std::vector<char> payload(dump_size + sizeof(amdxdna_drm_aie_coredump));
-    set_footer(payload, dump_size);
+    std::vector<char> payload(sizeof(amdxdna_drm_aie_coredump));
+    set_footer(payload, 0);
 
     amdxdna_drm_get_array arg = {
       .param = DRM_AMDXDNA_AIE_COREDUMP,
@@ -1281,7 +1259,7 @@ create_hw_context(uint32_t partition_size,
     else
       mutable_qos["priority"] = AMDXDNA_QOS_NORMAL_PRIORITY;
   }
-  
+
   if (mutable_qos.find("start_col") == mutable_qos.end())
     mutable_qos["start_col"] = USER_START_COL_NOT_REQUESTED;
 
@@ -1333,7 +1311,7 @@ import_bo(pid_t pid, xrt_core::shared_handle::export_handle ehdl)
 {
   if (pid == 0 || getpid() == pid)
      return std::make_unique<xdna_bo>(*this, ehdl);
-  
+
 #if defined(SYS_pidfd_open) && defined(SYS_pidfd_getfd)
   auto pidfd = syscall(SYS_pidfd_open, pid, 0);
   if (pidfd < 0) {

--- a/src/shim_ve2/xdna_device.cpp
+++ b/src/shim_ve2/xdna_device.cpp
@@ -28,6 +28,10 @@ namespace {
 namespace query = xrt_core::query;
 using key_type = query::key_type;
 
+// Address space of a single AIE tile (must match the driver's TILE_ADDRESS_SPACE).
+// The coredump size is num_cols * rows_per_col * this value.
+constexpr size_t VE2_TILE_ADDRESS_SPACE = 0x100000; // 1 MB
+
 std::string
 get_shim_lib_path()
 {
@@ -263,6 +267,8 @@ struct xrt_smi_lists
       return xrt_core::smi::get_list("validate", "run");
     case xrt_core::query::xrt_smi_lists::type::examine_reports:
       return xrt_core::smi::get_list("examine", "report");
+    case xrt_core::query::xrt_smi_lists::type::configure_option_options:
+      return xrt_core::smi::get_option_options("configure");
     default:
       throw xrt_core::query::no_such_key(key, "Not implemented");
     }
@@ -523,10 +529,50 @@ struct aie_coredump
       throw xrt_core::query::no_such_key(key, "Not implemented");
 
     const auto& aie_coredump_args = std::any_cast<const query::aie_coredump::args&>(args_any);
-    std::vector<char> payload(sizeof(amdxdna_drm_aie_coredump));
-    amdxdna_drm_aie_coredump *dump = reinterpret_cast<amdxdna_drm_aie_coredump *>(payload.data());
-    dump->context_id = aie_coredump_args.context_id;
-    dump->pid = aie_coredump_args.pid;
+    auto edev = get_edgedev(device);
+
+    // Pre-size the coredump buffer from the whole-device AIE geometry so that a
+    // single ioctl is normally enough. This mirrors the aie2/aie4 shim, which
+    // sizes the buffer as (core_rows + mem_rows + shim_rows) * cols * 1MB using
+    // the cached aie_tiles_stats query. It is an over-estimate of the driver's
+    // per-partition dump (num_cols * rows * TILE_ADDRESS_SPACE) that always
+    // fits, so the ENOBUFS size-probe path below is only a safety fallback.
+    //
+    // Unlike aie2/aie4 (config struct at the start of the buffer), the ve2
+    // driver reads the config as a footer at the end of the buffer and reports
+    // the required footer-less size via ENOBUFS, so keep the struct at the end
+    // and retry on ENOBUFS.
+    size_t dump_size = 0;
+    try {
+      auto aie_stats = xrt_core::device_query<xrt_core::query::aie_tiles_stats>(device);
+      auto total_rows = aie_stats.core_rows + aie_stats.mem_rows + aie_stats.shim_rows;
+      dump_size = static_cast<size_t>(total_rows) * aie_stats.cols * VE2_TILE_ADDRESS_SPACE;
+    } catch (const std::exception&) {
+      dump_size = 0; // fall back to the ENOBUFS size probe below
+    }
+
+    // The driver expects the amdxdna_drm_aie_coredump config as a footer at the
+    // end of the payload (buffer + payload_size - sizeof(footer)).
+    auto set_footer = [&](std::vector<char>& buf, size_t footer_off) {
+      auto* dump = reinterpret_cast<amdxdna_drm_aie_coredump *>(buf.data() + footer_off);
+      dump->context_id = aie_coredump_args.context_id;
+      dump->pid = aie_coredump_args.pid;
+    };
+
+    // Map a driver errno to a user-facing message; shared by both attempts.
+    auto coredump_error = [&](int code) -> std::runtime_error {
+      if (code == EPERM)
+        return std::runtime_error(
+          "Cannot get coredump: Either no context has been scheduled or the requested context "
+          "is not the last scheduled. Check dmesg for details.");
+      return std::runtime_error(
+        "Cannot get coredump: Invalid hardware context (context_id=" +
+        std::to_string(aie_coredump_args.context_id) + ", pid=" +
+        std::to_string(aie_coredump_args.pid) + "). Check dmesg for details.");
+    };
+
+    std::vector<char> payload(dump_size + sizeof(amdxdna_drm_aie_coredump));
+    set_footer(payload, dump_size);
 
     amdxdna_drm_get_array arg = {
       .param = DRM_AMDXDNA_AIE_COREDUMP,
@@ -535,49 +581,70 @@ struct aie_coredump
       .buffer = reinterpret_cast<uintptr_t>(payload.data())
     };
 
-    auto edev = get_edgedev(device);
     try {
       edev->ioctl(DRM_IOCTL_AMDXDNA_GET_ARRAY, &arg);
     } catch (const xrt_core::system_error& e) {
       if (e.code().value() == ENOBUFS) {
-        payload.resize(arg.element_size + sizeof(amdxdna_drm_aie_coredump));
-        dump = reinterpret_cast<amdxdna_drm_aie_coredump *>(payload.data()+arg.element_size);
-        dump->context_id = aie_coredump_args.context_id;
-        dump->pid = aie_coredump_args.pid;
+        // Driver reported the required footer-less dump size in element_size.
+        u32 need = arg.element_size;
+        payload.resize(need + sizeof(amdxdna_drm_aie_coredump));
+        set_footer(payload, need);
         arg.buffer = reinterpret_cast<uintptr_t>(payload.data());
         arg.element_size = static_cast<u32>(payload.size());
 
-        // Retry ioctl with resized buffer
         try {
           edev->ioctl(DRM_IOCTL_AMDXDNA_GET_ARRAY, &arg);
         } catch (const xrt_core::system_error& retry_err) {
-          if (retry_err.code().value() == EPERM) {
-            throw std::runtime_error(
-              "Cannot get coredump: Either no context has been scheduled or the requested context "
-              "is not the last scheduled. Check dmesg for details.");
-          } else if (retry_err.code().value() == EINVAL) {
-            throw std::runtime_error(
-              "Cannot get coredump: Invalid hardware context (context_id=" +
-              std::to_string(aie_coredump_args.context_id) + ", pid=" +
-              std::to_string(aie_coredump_args.pid) + "). Check dmesg for details.");
-          }
+          int code = retry_err.code().value();
+          if (code == EPERM || code == EINVAL)
+            throw coredump_error(code);
           throw;
         }
-      } else if (e.code().value() == EPERM) {
-        throw std::runtime_error(
-          "Cannot get coredump: Either no context has been scheduled or the requested context "
-          "is not the last scheduled. Check dmesg for details.");
-      } else if (e.code().value() == EINVAL) {
-        throw std::runtime_error(
-          "Cannot get coredump: Invalid hardware context (context_id=" +
-          std::to_string(aie_coredump_args.context_id) + ", pid=" +
-          std::to_string(aie_coredump_args.pid) + "). Check dmesg for details.");
+      } else if (e.code().value() == EPERM || e.code().value() == EINVAL) {
+        throw coredump_error(e.code().value());
       } else {
         throw;
       }
     }
 
     return payload;
+  }
+};
+
+// Implement auto_coredump query (device-wide auto coredump on command timeout).
+// GET reads the current mode via DRM_AMDXDNA_GET_AUTO_COREDUMP; PUT enables or
+// disables it via DRM_AMDXDNA_SET_AUTO_COREDUMP. Both use the shared
+// amdxdna_drm_attribute_state buffer, mirroring the aie2/aie4 preemption query.
+struct auto_coredump
+{
+  using result_type = query::auto_coredump::result_type;
+
+  static result_type
+  get(const xrt_core::device* device, key_type)
+  {
+    amdxdna_drm_attribute_state state = {};
+    amdxdna_drm_get_info arg = {
+      .param = DRM_AMDXDNA_GET_AUTO_COREDUMP,
+      .buffer_size = sizeof(state),
+      .buffer = reinterpret_cast<uintptr_t>(&state)
+    };
+
+    get_edgedev(device)->ioctl(DRM_IOCTL_AMDXDNA_GET_INFO, &arg);
+    return state.state;
+  }
+
+  static void
+  put(const xrt_core::device* device, key_type, const std::any& any)
+  {
+    amdxdna_drm_attribute_state state = {};
+    state.state = static_cast<decltype(state.state)>(std::any_cast<uint32_t>(any));
+    amdxdna_drm_set_state arg = {
+      .param = DRM_AMDXDNA_SET_AUTO_COREDUMP,
+      .buffer_size = sizeof(state),
+      .buffer = reinterpret_cast<uintptr_t>(&state)
+    };
+
+    get_edgedev(device)->ioctl(DRM_IOCTL_AMDXDNA_SET_STATE, &arg);
   }
 };
 
@@ -1008,6 +1075,27 @@ struct function4_get : virtual QueryRequestType
   }
 };
 
+// Query handler that supports both get() and put() (e.g. attribute-state
+// toggles like auto_coredump). GetPut must expose static get(device, key) and
+// put(device, key, any).
+template <typename QueryRequestType, typename GetPut>
+struct function0_getput : QueryRequestType
+{
+  std::any
+  get(const xrt_core::device* device) const
+  {
+    auto k = QueryRequestType::key;
+    return GetPut::get(device, k);
+  }
+
+  void
+  put(const xrt_core::device* device, const std::any& any) const
+  {
+    auto k = QueryRequestType::key;
+    GetPut::put(device, k, any);
+  }
+};
+
 template <typename QueryRequestType>
 static void
 emplace_sysfs_get(const char* entry)
@@ -1056,6 +1144,14 @@ emplace_func4_request()
   query_tbl.emplace(k, std::make_unique<function4_get<QueryRequestType, Getter>>());
 }
 
+template <typename QueryRequestType, typename GetPut>
+static void
+emplace_func0_getput()
+{
+  auto k = QueryRequestType::key;
+  query_tbl.emplace(k, std::make_unique<function0_getput<QueryRequestType, GetPut>>());
+}
+
 static void
 initialize_query_table()
 {
@@ -1077,6 +1173,7 @@ initialize_query_table()
   emplace_func1_request<query::aie_get_freq,            aie_get_freq>();
   emplace_func2_request<query::aie_set_freq,            aie_set_freq>();
   emplace_func1_request<query::aie_coredump,            aie_coredump>();
+  emplace_func0_getput<query::auto_coredump,            auto_coredump>();
   emplace_func4_request<query::xrt_smi_config,          xrt_smi_config>();
   emplace_func4_request<query::xrt_smi_lists,           xrt_smi_lists>();
   emplace_func1_request<query::sdm_sensor_info,         sensor_info>();


### PR DESCRIPTION
-ve2 driver caches AIE coredump when cmd gets timed out.
-ve2 driver returns the coredump from cache or live data when user requests.
-Live coredump captured when there is no coredump available in driver cache.
-Enable or disable the device-wide auto coredump mode. When disabled, any previously cached per-context dumps are dropped.
-Expose auto-coredump enable|disable via xrt-smi tool
 -Align the ve2 aie_coredump shim with the aie2/aie4 shim: pre-size the coredump payload from the whole-device AIE geometry via the cached aie_tiles_stats query, using (core_rows + mem_rows + shim_rows) * cols * 1MB, so a single DRM_AMDXDNA_AIE_COREDUMP GET_ARRAY ioctl normally suffices. 
-Also expose the device-controlled auto-coredump mode (already implemented in the ve2 driver) to userspace so xrt-smi can drive it:
    - Add an auto_coredump get/put query backed by DRM_AMDXDNA_GET_AUTO_COREDUMP
      (GET_INFO) and DRM_AMDXDNA_SET_AUTO_COREDUMP (SET_STATE), plus a
      function0_getput template/helper to register get+put handlers.
    - Advertise the configure sub-options via xrt_smi_lists
      (configure_option_options) and add a ve2 configure subcommand with the
      hidden auto-coredump option, plus the hidden "debug" examine report.
 
Usage:
    export XRTSMIAdvanced=1
    xrt-smi configure --advanced -d <ve2-bdf> --auto-coredump --enable
    xrt-smi examine  --advanced -d <ve2-bdf> -r debug