### PR TITLE
accel/amdxdna: flush only the requested range in amdxdna_flush_bo

### DIFF
--- a/drivers/accel/amdxdna/amdxdna_gem.c
+++ b/drivers/accel/amdxdna/amdxdna_gem.c
@@ -1349,6 +1349,7 @@ int amdxdna_drm_get_bo_info_ioctl(struct drm_device *dev, void *data, struct drm
 
 static int amdxdna_flush_bo(struct amdxdna_gem_obj *abo, u64 offset, u64 size)
 {
+	unsigned long first, nr_pages;
 	u64 end;
 
 	if (offset >= abo->mem.size)
@@ -1358,14 +1359,17 @@ static int amdxdna_flush_bo(struct amdxdna_gem_obj *abo, u64 offset, u64 size)
 		return -EINVAL;
 
 	size = min(abo->mem.size, end) - offset;
-	if (is_import_bo(abo))
-		drm_clflush_sg(abo->base.sgt);
-	else if (amdxdna_gem_vmap(abo))
+	first = offset >> PAGE_SHIFT;
+	nr_pages = (PAGE_ALIGN(offset + size) >> PAGE_SHIFT) - first;
+
+	if (amdxdna_gem_vmap(abo))
 		drm_clflush_virt_range(amdxdna_gem_vmap(abo) + offset, size);
+	else if (is_import_bo(abo))
+		drm_clflush_sg(abo->base.sgt);
 	else if (abo->base.pages)
-		drm_clflush_pages(abo->base.pages, abo->mem.size >> PAGE_SHIFT);
+		drm_clflush_pages(&abo->base.pages[first], nr_pages);
 	else if (abo->mem.pages)
-		drm_clflush_pages(abo->mem.pages, abo->mem.nr_pages);
+		drm_clflush_pages(&abo->mem.pages[first], nr_pages);
 	else
 		return -EINVAL;
 

--- a/drivers/accel/amdxdna/amdxdna_gem.c
+++ b/drivers/accel/amdxdna/amdxdna_gem.c
@@ -211,13 +211,11 @@ void amdxdna_gem_destroy_obj(struct amdxdna_gem_obj *abo)
 }
 
 /*
- * Obtains a kernel virtual address on the BO (usually of small size).
- * The mapping is established on the first call and stays valid until
- * amdxdna_gem_vunmap() is called.
+ * Returns the error rather than logging it, for a caller that has a fallback:
+ * an imported BO whose exporter implements no vmap op fails on every call.
  */
-void *amdxdna_gem_vmap(struct amdxdna_gem_obj *abo)
+static void *amdxdna_gem_vmap_try(struct amdxdna_gem_obj *abo)
 {
-	struct amdxdna_dev *xdna = to_xdna_dev(to_gobj(abo)->dev);
 	struct iosys_map map = IOSYS_MAP_INIT_VADDR(NULL);
 	int ret;
 
@@ -230,11 +228,27 @@ void *amdxdna_gem_vmap(struct amdxdna_gem_obj *abo)
 	if (!abo->mem.kva) {
 		ret = drm_gem_vmap(to_gobj(abo), &map);
 		if (ret)
-			XDNA_ERR(xdna, "Vmap bo failed, ret %d", ret);
-		else
-			abo->mem.kva = map.vaddr;
+			return ERR_PTR(ret);
+		abo->mem.kva = map.vaddr;
 	}
 	return abo->mem.kva;
+}
+
+/*
+ * Obtains a kernel virtual address on the BO (usually of small size).
+ * The mapping is established on the first call and stays valid until
+ * amdxdna_gem_vunmap() is called.
+ */
+void *amdxdna_gem_vmap(struct amdxdna_gem_obj *abo)
+{
+	struct amdxdna_dev *xdna = to_xdna_dev(to_gobj(abo)->dev);
+	void *kva = amdxdna_gem_vmap_try(abo);
+
+	if (IS_ERR(kva)) {
+		XDNA_ERR(xdna, "Vmap bo failed, ret %ld", PTR_ERR(kva));
+		return NULL;
+	}
+	return kva;
 }
 
 /*
@@ -1350,6 +1364,7 @@ int amdxdna_drm_get_bo_info_ioctl(struct drm_device *dev, void *data, struct drm
 static int amdxdna_flush_bo(struct amdxdna_gem_obj *abo, u64 offset, u64 size)
 {
 	unsigned long first, nr_pages;
+	void *kva;
 	u64 end;
 
 	if (offset >= abo->mem.size)
@@ -1362,8 +1377,9 @@ static int amdxdna_flush_bo(struct amdxdna_gem_obj *abo, u64 offset, u64 size)
 	first = offset >> PAGE_SHIFT;
 	nr_pages = (PAGE_ALIGN(offset + size) >> PAGE_SHIFT) - first;
 
-	if (amdxdna_gem_vmap(abo))
-		drm_clflush_virt_range(amdxdna_gem_vmap(abo) + offset, size);
+	kva = amdxdna_gem_vmap_try(abo);
+	if (!IS_ERR(kva))
+		drm_clflush_virt_range(kva + offset, size);
 	else if (is_import_bo(abo))
 		drm_clflush_sg(abo->base.sgt);
 	else if (abo->base.pages)


### PR DESCRIPTION
## Problem

`SYNC_BO` carries an offset and a size, but `amdxdna_flush_bo()` honours them on one path out of
four. An imported BO flushes its whole scatterlist, and the `base.pages` / `mem.pages` fallbacks
flush every page of the BO. The cost of a sync is set by the size of the buffer rather than by the
range the caller asked to maintain.

## Fix

`amdxdna_gem_obj_vmap()` already maps imported BOs through `dma_buf_vmap()`, so try the vmap path
first and leave `drm_clflush_sg()` as the fallback for an exporter that cannot vmap. Index the
page-array fallbacks from the requested offset.

## Evidence

npu4, kernel 7.1.5, 64 MiB BO, sync size swept, pinned to one core, minimum of 50 runs. Both
modules built from this tree; they differ only by this commit.

| sync size | driver-owned, before | driver-owned, after | imported, before | imported, after |
|---|---|---|---|---|
| 4 KiB | 0.6 us | 0.6 us | 1056 us | 0.7 us |
| 32 KiB | 1.1 us | 1.1 us | 1056 us | 1.1 us |
| 1 MiB | 17.1 us | 17.1 us | 1055 us | 17.1 us |
| 16 MiB | 264 us | 264 us | 1056 us | 264 us |
| 64 MiB (whole) | 1056 us | 1055 us | 1056 us | 1056 us |

The imported column before the patch is flat: a 4 KiB sync costs what a 64 MiB sync costs. After, it
tracks the driver-owned column at every size, and the whole-BO case is unchanged. The driver-owned
column is the control and does not move.

Reproducer is below, ioctl-only against `/dev/accel/accel0`.

`checkpatch.pl --strict`, freshly downloaded from mainline: clean.

## Scope

An imported BO now holds a kernel mapping from its first sync until it is freed, as a shmem BO
already does; `amdxdna_gem_obj_free()` releases it through `amdxdna_gem_vunmap()`.

The `base.pages` and `mem.pages` arms are reached only when `amdxdna_gem_vmap()` fails.

Mainline carries the same function with three arms rather than four, so the fix applies there as a
smaller diff. I'll post that version to dri-devel myself, so it does not need forwarding from here.

<details>
<summary>Reproducer (ioctl only, no kernel run, no root)</summary>

```c
/*
 * Does DRM_IOCTL_AMDXDNA_SYNC_BO cost scale with the range it is given?
 *
 * Sweeps sync sizes over one BO, for a BO the driver owns and for the same BO
 * imported into a second DRM client. Reports the first sync separately, since
 * that is where any one-time mapping cost lands.
 */
#define _GNU_SOURCE
#include <errno.h>
#include <fcntl.h>
#include <sched.h>
#include <stdio.h>
#include <string.h>
#include <sys/ioctl.h>
#include <sys/mman.h>
#include <time.h>
#include <unistd.h>

#include <libdrm/drm.h>
#include "amdxdna_accel.h"

#define BO_SIZE   (64ull << 20)
#define REPS      50

static const unsigned long long sizes[] = {
	4096, 32ull << 10, 1ull << 20, 16ull << 20, BO_SIZE,
};

static int xioctl(int fd, unsigned long req, void *arg, const char *what)
{
	int ret = ioctl(fd, req, arg);

	if (ret)
		fprintf(stderr, "%s: %s\n", what, strerror(errno));
	return ret;
}

static double now_us(void)
{
	struct timespec ts;

	clock_gettime(CLOCK_MONOTONIC, &ts);
	return ts.tv_sec * 1e6 + ts.tv_nsec / 1e3;
}

static double sync_once(int fd, unsigned int handle, unsigned long long off,
			unsigned long long size)
{
	struct amdxdna_drm_sync_bo sync = {
		.handle = handle,
		.direction = SYNC_DIRECT_TO_DEVICE,
		.offset = off,
		.size = size,
	};
	double t0 = now_us();

	if (xioctl(fd, DRM_IOCTL_AMDXDNA_SYNC_BO, &sync, "SYNC_BO"))
		return -1;
	return now_us() - t0;
}

/* minimum over REPS, which is the figure least polluted by scheduling noise */
static double sync_min(int fd, unsigned int handle, unsigned long long off,
		       unsigned long long size)
{
	double best = 1e12;

	for (int i = 0; i < REPS; i++) {
		double dt = sync_once(fd, handle, off, size);

		if (dt < 0)
			return -1;
		if (dt < best)
			best = dt;
	}
	return best;
}

static void sweep(const char *label, int fd, unsigned int handle)
{
	printf("%s\n", label);
	printf("  first sync (4 KiB): %8.1f us\n", sync_once(fd, handle, 0, 4096));
	for (unsigned i = 0; i < sizeof(sizes) / sizeof(sizes[0]); i++)
		printf("  %8llu KiB %10.1f us\n", sizes[i] >> 10,
		       sync_min(fd, handle, 0, sizes[i]));
}

int main(void)
{
	cpu_set_t set;
	CPU_ZERO(&set);
	CPU_SET(2, &set);
	if (sched_setaffinity(0, sizeof(set), &set))
		perror("sched_setaffinity");

	int fd_a = open("/dev/accel/accel0", O_RDWR);
	int fd_b = open("/dev/accel/accel0", O_RDWR);

	if (fd_a < 0 || fd_b < 0) {
		perror("open /dev/accel/accel0");
		return 1;
	}

	struct amdxdna_drm_create_bo create = {
		.size = BO_SIZE,
		.type = AMDXDNA_BO_SHARE,
	};
	if (xioctl(fd_a, DRM_IOCTL_AMDXDNA_CREATE_BO, &create, "CREATE_BO"))
		return 1;

	struct amdxdna_drm_get_bo_info info = { .handle = create.handle };
	if (xioctl(fd_a, DRM_IOCTL_AMDXDNA_GET_BO_INFO, &info, "GET_BO_INFO"))
		return 1;

	void *va = mmap(NULL, BO_SIZE, PROT_READ | PROT_WRITE, MAP_SHARED,
			fd_a, info.map_offset);
	if (va == MAP_FAILED) {
		perror("mmap");
		return 1;
	}
	memset(va, 0xa5, BO_SIZE);	/* fault the pages in and dirty them */

	struct drm_prime_handle exp = { .handle = create.handle, .flags = DRM_RDWR };
	if (xioctl(fd_a, DRM_IOCTL_PRIME_HANDLE_TO_FD, &exp, "PRIME_HANDLE_TO_FD"))
		return 1;

	struct drm_prime_handle imp = { .fd = exp.fd };
	if (xioctl(fd_b, DRM_IOCTL_PRIME_FD_TO_HANDLE, &imp, "PRIME_FD_TO_HANDLE"))
		return 1;

	printf("BO %llu MiB, min of %d\n", BO_SIZE >> 20, REPS);
	sweep("driver-owned BO", fd_a, create.handle);
	sweep("same BO, imported", fd_b, imp.handle);

	munmap(va, BO_SIZE);
	close(exp.fd);
	close(fd_b);
	close(fd_a);
	return 0;
}
```

</details>
