### PR TITLE
amdxdna: flush the requested pages in amdxdna_drm_clflush

### DIFF
--- a/src/driver/amdxdna/amdxdna_gem.c
+++ b/src/driver/amdxdna/amdxdna_gem.c
@@ -1300,11 +1300,11 @@ amdxdna_drm_clflush(struct amdxdna_gem_obj *abo, u32 start, u32 size)
 	if (start_page_off)
 		drm_clflush_virt_range(addr, PAGE_SIZE - start_page_off);
 	else
-		drm_clflush_pages(&pages[0], 1);
+		drm_clflush_pages(&pages[start_page], 1);
 
 	pages_in_middle = end_page - start_page - 1;
 	if (pages_in_middle)
-		drm_clflush_pages(&pages[1], pages_in_middle);
+		drm_clflush_pages(&pages[start_page + 1], pages_in_middle);
 
 	addr = page_to_virt(pages[end_page]);
 	if (end_page_size < PAGE_SIZE)


### PR DESCRIPTION
## Problem

`amdxdna_drm_clflush()` takes the head and middle pages from the start of the BO rather than from
`start_page`:

```c
	if (start_page_off)
		drm_clflush_virt_range(addr, PAGE_SIZE - start_page_off);
	else
		drm_clflush_pages(&pages[0], 1);

	pages_in_middle = end_page - start_page - 1;
	if (pages_in_middle)
		drm_clflush_pages(&pages[1], pages_in_middle);
```

Any multi-page range at a non-zero page offset therefore maintains the wrong pages and leaves the
requested ones dirty. Only the tail, indexed by `end_page`, is right. The unaligned-start arm is
also right, because it goes through `page_to_virt(pages[start_page])`.

## Fix

Index both from `start_page`.

## Evidence

Running the function's arithmetic over a 32-page BO and recording which bytes it actually maintains:
465 of the 528 page-aligned ranges leave part of the request unflushed. A 32 KiB range at page 16
misses 7 of its 8 pages and flushes 7 unrelated ones in their place. With the fix, 0 of 528.

The model is below; it runs both variants against the requested range and reports missed and stray
bytes.

The module builds clean against kernel 7.1.5.

## Scope

The sync ioctl tries `amdxdna_gem_vmap()` before this arm, so this is the path taken when vmap
fails rather than the common one. The in-tree `drivers/accel/amdxdna` tree has no equivalent
function and is unaffected.

<details>
<summary>Model used for the numbers</summary>

```c
/*
 * Userspace model of amdxdna_drm_clflush() (src/driver/amdxdna/amdxdna_gem.c).
 * Records which BO bytes each variant actually maintains, and compares that
 * against the range the caller asked for.
 */
#include <stdio.h>
#include <string.h>
#include <stdint.h>

#define PAGE_SHIFT 12
#define PAGE_SIZE  (1u << PAGE_SHIFT)
#define PAGE_MASK  (~(PAGE_SIZE - 1))

#define BO_PAGES 32
#define BO_SIZE  (BO_PAGES * PAGE_SIZE)

static unsigned char covered[BO_SIZE];

/* stand-ins for the DRM helpers: page index / byte offset is all we need */
static void clflush_pages(unsigned first_page, unsigned nr)
{
	for (unsigned i = 0; i < nr; i++)
		memset(covered + (size_t)(first_page + i) * PAGE_SIZE, 1, PAGE_SIZE);
}

static void clflush_virt_range(uint64_t byte_off, uint32_t len)
{
	memset(covered + byte_off, 1, len);
}

/* page_to_virt(pages[i]) modelled as byte offset i * PAGE_SIZE */
static void amdxdna_drm_clflush(uint32_t start, uint32_t size, int fixed)
{
	uint32_t start_page, start_page_off;
	uint32_t end_page, end_page_size;
	uint32_t end = start + size - 1;
	uint32_t pages_in_middle;
	uint64_t addr;

	start_page = start >> PAGE_SHIFT;
	end_page = end >> PAGE_SHIFT;
	start_page_off = start & ~PAGE_MASK;
	end_page_size = (end & ~PAGE_MASK) + 1;

	addr = (uint64_t)start_page * PAGE_SIZE + start_page_off;
	if (start_page == end_page) {
		clflush_virt_range(addr, size);
		return;
	}

	if (start_page_off)
		clflush_virt_range(addr, PAGE_SIZE - start_page_off);
	else
		clflush_pages(fixed ? start_page : 0, 1);

	pages_in_middle = end_page - start_page - 1;
	if (pages_in_middle)
		clflush_pages(fixed ? start_page + 1 : 1, pages_in_middle);

	addr = (uint64_t)end_page * PAGE_SIZE;
	if (end_page_size < PAGE_SIZE)
		clflush_virt_range(addr, end_page_size);
	else
		clflush_pages(end_page, 1);
}

struct result { unsigned missed, stray; };

static struct result run(uint32_t start, uint32_t size, int fixed)
{
	struct result r = { 0, 0 };

	memset(covered, 0, sizeof(covered));
	amdxdna_drm_clflush(start, size, fixed);

	for (uint32_t i = 0; i < BO_SIZE; i++) {
		int want = (i >= start && i < start + size);

		if (want && !covered[i])
			r.missed++;
		else if (!want && covered[i])
			r.stray++;
	}
	return r;
}

int main(void)
{
	static const struct { uint32_t start, size; const char *what; } cases[] = {
		{ 0,		 4096,	  "1 page at offset 0" },
		{ 0,		16384,	  "4 pages at offset 0" },
		{ 8192,		 4096,	  "1 page at page 2" },
		{ 8192,		12288,	  "3 pages at page 2" },
		{ 4096,		 8192,	  "2 pages at page 1" },
		{ 65536,	32768,	  "8 pages at page 16 (32K view in a BO)" },
		{ 8192 + 64,	12288,	  "unaligned start inside page 2" },
		{ 4096 + 2048,	 1024,	  "sub-page, single page" },
	};
	int bad = 0;

	printf("%-42s %18s %18s\n", "requested range", "upstream", "fixed");
	printf("%-42s %18s %18s\n", "", "missed/stray", "missed/stray");
	for (unsigned i = 0; i < sizeof(cases) / sizeof(cases[0]); i++) {
		struct result old = run(cases[i].start, cases[i].size, 0);
		struct result new = run(cases[i].start, cases[i].size, 1);

		printf("%-42s %9u/%-8u %9u/%-8u\n", cases[i].what,
		       old.missed, old.stray, new.missed, new.stray);
		if (new.missed)
			bad = 1;
	}

	/* exhaustive: every page-aligned start, every page-multiple size */
	unsigned old_bad = 0, new_bad = 0, total = 0;
	for (uint32_t sp = 0; sp < BO_PAGES; sp++) {
		for (uint32_t np = 1; sp + np <= BO_PAGES; np++) {
			struct result old = run(sp * PAGE_SIZE, np * PAGE_SIZE, 0);
			struct result new = run(sp * PAGE_SIZE, np * PAGE_SIZE, 1);

			total++;
			old_bad += (old.missed != 0);
			new_bad += (new.missed != 0);
		}
	}
	printf("\npage-aligned sweep over a %u-page BO: %u ranges\n", BO_PAGES, total);
	printf("  upstream: %u ranges leave part of the request unflushed\n", old_bad);
	printf("  fixed:    %u\n", new_bad);
	if (new_bad)
		bad = 1;

	return bad;
}
```

</details>
