### PR TITLE
accel/amdxdna: ve2: Add ve2 amdxdna  module params and fix hwctx ID exhaustion

### DIFF
--- a/drivers/accel/amdxdna/amdxdna_aux_drv.c
+++ b/drivers/accel/amdxdna/amdxdna_aux_drv.c
@@ -29,6 +29,7 @@ static void amdxdna_aux_release(struct drm_device *drm, void *res)
 
 	amdxdna_carveout_fini(xdna);
 	cleanup_srcu_struct(&xdna->dpt_srcu);
+	ida_destroy(&xdna->hwctx_ida);
 }
 
 /**
@@ -54,6 +55,17 @@ int amdxdna_dev_init(struct amdxdna_dev *xdna)
 	drmm_mutex_init(ddev, &xdna->dev_lock);
 	init_rwsem(&xdna->notifier_lock);
 	INIT_LIST_HEAD(&xdna->client_list);
+	/*
+	 * Unlike the PCI path (amdxdna_probe()), nothing else initializes
+	 * hwctx_ida for the auxiliary-bus path. Without ida_init(), the
+	 * backing xarray's xa_flags lack XA_FLAGS_ALLOC, so the free-mark
+	 * bookkeeping ida_alloc_range() relies on is never set up: instead of
+	 * returning the next free ID, allocations return bogus, rapidly
+	 * growing values (observed jumping by 64x per call) until the ID
+	 * space is exhausted and hwctx creation spuriously fails with
+	 * -ENOSPC after only a handful of contexts.
+	 */
+	ida_init(&xdna->hwctx_ida);
 
 	ret = init_srcu_struct(&xdna->dpt_srcu);
 	if (ret)

--- a/drivers/accel/amdxdna/amdxdna_ctx.c
+++ b/drivers/accel/amdxdna/amdxdna_ctx.c
@@ -19,7 +19,15 @@
 #include "amdxdna_pci_drv.h"
 #include "amdxdna_pm.h"
 
-#define MAX_HWCTX_ID		1024
+/*
+ * Upper bound of the device-wide hwctx ID space. Kept at U32_MAX (matching the
+ * legacy VE2 driver's XA_LIMIT(1, U32_MAX)) so the cyclic allocator does not
+ * wrap back onto still-live IDs after only a small number of create/destroy
+ * cycles. A smaller ceiling (e.g. 1024) makes ida_alloc_range() return -ENOSPC
+ * once that many IDs have been consumed cyclically, spuriously failing hwctx
+ * creation.
+ */
+#define MAX_HWCTX_ID		U32_MAX
 #define MAX_ARG_COUNT		4095
 
 struct amdxdna_fence {

--- a/drivers/accel/amdxdna/ve2_aux.c
+++ b/drivers/accel/amdxdna/ve2_aux.c
@@ -246,8 +246,31 @@ int ve2_probe(struct amdxdna_dev *xdna, struct amdxdna_dev_hdl *hdl)
 	XDNA_INFO(xdna, "AIE device: %u columns, %u rows",
 		  hdl->aie_dev_info.cols, hdl->aie_dev_info.rows);
 
+	/*
+	 * Determine the maximum number of hardware contexts. The ve2_hwctx_limit
+	 * test module parameter overrides the per-device default when non-zero.
+	 */
+	if (ve2_hwctx_limit)
+		hdl->hwctx_limit = ve2_hwctx_limit;
+	else
+		hdl->hwctx_limit = hdl->priv->hwctx_limit;
+	XDNA_INFO(xdna, "Maximum limit %u hardware context(s)", hdl->hwctx_limit);
+
 	xrs_cfg.ddev = &xdna->ddev;
 	xrs_cfg.total_col = hdl->aie_dev_info.cols;
+
+	/*
+	 * Test-only override: restrict the resource-solver column window to
+	 * @max_col columns (optionally offset by @start_col) instead of the full
+	 * device column count. Mirrors the legacy driver's module-parameter path.
+	 */
+	if (max_col > 0 && start_col >= 0 &&
+	    (u32)(max_col + start_col) <= hdl->aie_dev_info.cols) {
+		xrs_cfg.total_col = max_col;
+		XDNA_INFO(xdna, "Using module parameter: max_col=%d start_col=%d",
+			  max_col, start_col);
+	}
+
 	xdna->xrs_hdl = xrsm_init(&xrs_cfg);
 	if (!xdna->xrs_hdl) {
 		XDNA_WARN(xdna, "Initialization of Resource resolver failed");

--- a/drivers/accel/amdxdna/ve2_aux.h
+++ b/drivers/accel/amdxdna/ve2_aux.h
@@ -61,6 +61,7 @@ struct amdxdna_dev_hdl {
 	struct ve2_firmware_version	fw_version;
 	struct amdxdna_mgmtctx		*ve2_mgmtctx;
 	struct ve2_firmware_status	**fw_slots;	/* [cols] per-column FW status */
+	u32				hwctx_limit;	/* effective max hw contexts */
 };
 
 extern const struct amdxdna_dev_ops ve2_ops;

--- a/drivers/accel/amdxdna/ve2_host_queue.h
+++ b/drivers/accel/amdxdna/ve2_host_queue.h
@@ -115,6 +115,12 @@ struct ve2_hsa_queue {
 	struct mutex			hq_lock;/* protect host queue submit and wait */
 	u64				reserved_write_index;
 	struct device			*alloc_dev;
+	/*
+	 * Driver-local slot readiness tracking for ordered write_index advance.
+	 * hqc_mem is owned by CERT (firmware writes the completion state there),
+	 * so the host must not write NEW/SUBMITTED into it for commit gating.
+	 */
+	DECLARE_BITMAP(slot_ready, HOST_QUEUE_ENTRY);
 };
 
 static inline void hsa_queue_sync_read_index_for_read(struct ve2_hsa_queue *queue)

--- a/drivers/accel/amdxdna/ve2_hwctx.c
+++ b/drivers/accel/amdxdna/ve2_hwctx.c
@@ -6,6 +6,7 @@
  * (ERT_START_DPU).
  */
 
+#include <linux/bitmap.h>
 #include <linux/dma-mapping.h>
 #include <linux/errno.h>
 #include <linux/module.h>
@@ -35,6 +36,26 @@ MODULE_PARM_DESC(ve2_perf_optimization, "Enable performance-mode partition init 
 static int pktdump;
 module_param(pktdump, int, 0644);
 MODULE_PARM_DESC(pktdump, "Dump host-queue packet contents on submit (debug). Disabled by default.");
+
+int verbosity;
+module_param(verbosity, int, 0644);
+MODULE_PARM_DESC(verbosity, "[Debug] Enabling verbosity. default is 0");
+
+int partition_size = 4;
+module_param(partition_size, int, 0644);
+MODULE_PARM_DESC(partition_size, "Test only option: default partition size");
+
+unsigned int ve2_hwctx_limit;
+module_param(ve2_hwctx_limit, uint, 0400);
+MODULE_PARM_DESC(ve2_hwctx_limit, "[Debug] Maximum number of hwctx. 0 = Use default");
+
+int start_col;
+module_param(start_col, int, 0644);
+MODULE_PARM_DESC(start_col, "Test only option: lead column set to start_col");
+
+int max_col;
+module_param(max_col, int, 0644);
+MODULE_PARM_DESC(max_col, "Max column supported by this driver");
 
 #define CTX_TIMER		(msecs_to_jiffies(1))	/* 1ms */
 #define VE2_RETRY_TIMEOUT_MS	5000	/* max wait for a free host-queue slot */
@@ -177,8 +198,11 @@ hsa_queue_reserve_slot(struct amdxdna_dev *xdna, struct amdxdna_ctx_priv *vp, u6
 	mutex_unlock(&vp->privctx_lock);
 
 	*slot = queue->reserved_write_index++;
-	queue->hq_complete.hqc_mem[slot_idx] = ERT_CMD_STATE_NEW;
-	hsa_queue_sync_completion_for_write(queue, slot_idx);
+	/*
+	 * CERT owns hqc_mem (it writes the completion state there); track slot
+	 * readiness in a driver-local bitmap instead of writing to hqc_mem.
+	 */
+	clear_bit(slot_idx, queue->slot_ready);
 	mutex_unlock(&queue->hq_lock);
 
 	return &queue->hsa_queue_p->hq_entry[slot_idx];
@@ -203,14 +227,14 @@ static void hsa_queue_commit_slot(struct amdxdna_hwctx *hwctx, u64 seq)
 	pkt->xrt_header.common_header.type = HOST_QUEUE_PACKET_TYPE_VENDOR_SPECIFIC;
 	hsa_queue_sync_packet_for_write(queue, slot_idx);
 
-	queue->hq_complete.hqc_mem[slot_idx] = ERT_CMD_STATE_SUBMITTED;
-	hsa_queue_sync_completion_for_write(queue, slot_idx);
+	/* Mark slot ready in driver-local tracking (cert owns hqc_mem) */
+	set_bit(slot_idx, queue->slot_ready);
 
+	/* Advance write_index as far as possible through all ready slots. */
 	while (header->write_index < queue->reserved_write_index) {
 		u32 next_idx = header->write_index % capacity;
 
-		hsa_queue_sync_completion_for_read(queue, next_idx);
-		if (queue->hq_complete.hqc_mem[next_idx] != ERT_CMD_STATE_SUBMITTED)
+		if (!test_bit(next_idx, queue->slot_ready))
 			break;
 		header->write_index++;
 	}
@@ -515,7 +539,7 @@ static int submit_command_indirect(struct amdxdna_hwctx *hwctx, void *cmd_data, 
 	hsa_queue_sync_packet_for_write(&vp->hsa_queue, slot_idx);
 	hsa_queue_sync_indirect_hdr_for_write(&vp->hsa_queue, slot_idx);
 
-	if (pktdump)
+	if (pktdump || verbosity >= VERBOSITY_LEVEL_DBG)
 		packet_dump(xdna, queue, slot_idx);
 
 	hsa_queue_commit_slot(hwctx, *seq);
@@ -599,10 +623,13 @@ static int ve2_create_host_queue(struct amdxdna_hwctx *hwctx)
 
 	mutex_init(&queue->hq_lock);
 	queue->reserved_write_index = 0;
+	bitmap_zero(queue->slot_ready, HOST_QUEUE_ENTRY);
 	queue->hsa_queue_dma_addr = dma_handle;
 	queue->hq_complete.hqc_mem =
 		(u64 *)((char *)queue->hsa_queue_p + sizeof(struct hsa_queue));
 	queue->hq_complete.hqc_dma_addr = dma_handle + sizeof(struct hsa_queue);
+	/* Zero hqc_mem so it starts clean for cert's completion writes. */
+	memset(queue->hq_complete.hqc_mem, 0, sizeof(u64) * HOST_QUEUE_ENTRY);
 	queue->hsa_queue_p->hq_header.data_address =
 		dma_handle + sizeof(struct host_queue_header);
 	queue->hsa_queue_p->hq_header.capacity = HOST_QUEUE_ENTRY;
@@ -635,7 +662,7 @@ static int ve2_create_host_queue(struct amdxdna_hwctx *hwctx)
 		}
 	}
 
-	dma_sync_single_for_device(queue->alloc_dev, dma_handle, sizeof(struct hsa_queue),
+	dma_sync_single_for_device(queue->alloc_dev, dma_handle, alloc_size,
 				   DMA_TO_DEVICE);
 
 	XDNA_DBG(xdna, "Host queue alloc dma=0x%llx capacity=%u", (u64)dma_handle,
@@ -756,17 +783,20 @@ int ve2_hwctx_init(struct amdxdna_hwctx *hwctx)
 	 * (re)initialisation. Sized with mgmtctx->num_col to match the range
 	 * ve2_prepare_hs_data() iterates over.
 	 *
-	 * Use plain kernel memory: the handshake is consumed by
-	 * aie_partition_initialize() and only its CPU virtual address is used.
-	 * Allocating from the AIE device coherent pool here would starve
-	 * aie_partition_initialize()'s own coherent allocation and fail command
-	 * submission with -ENOMEM.
+	 * Allocate DMA-coherent memory from the AIE partition device and hand
+	 * its per-column dma_addr to aie_partition_initialize() via
+	 * aie_op_handshake_data.dma_addr. The AIE driver then uses this buffer
+	 * directly (its "pre-known dma_addr" fast path) instead of doing its
+	 * own per-column dmam_alloc_coherent(), which is not viable here.
 	 */
-	if (vp->mgmtctx && vp->mgmtctx->num_col) {
+	if (vp->mgmtctx && vp->mgmtctx->num_col && vp->mgmtctx->aie_dev) {
 		vp->hs_buf_size = vp->mgmtctx->num_col * sizeof(struct handshake);
-		vp->hs_buf_va = kzalloc(vp->hs_buf_size, GFP_KERNEL);
+		vp->hs_buf_va = dma_alloc_coherent(vp->mgmtctx->aie_dev,
+						   vp->hs_buf_size,
+						   &vp->hs_buf_dma, GFP_KERNEL);
 		if (!vp->hs_buf_va) {
 			vp->hs_buf_size = 0;
+			vp->hs_buf_dma = 0;
 			XDNA_WARN(xdna, "handshake pre-alloc failed; using per-init alloc");
 		}
 	}
@@ -800,9 +830,15 @@ free_hwctx_config:
 	kfree(vp->hwctx_config);
 	vp->hwctx_config = NULL;
 destroy_partition:
+	/* Free the coherent handshake buffer while aie_dev is still valid. */
+	if (vp->hs_buf_va && vp->mgmtctx && vp->mgmtctx->aie_dev) {
+		dma_free_coherent(vp->mgmtctx->aie_dev, vp->hs_buf_size,
+				  vp->hs_buf_va, vp->hs_buf_dma);
+		vp->hs_buf_va = NULL;
+		vp->hs_buf_size = 0;
+	}
 	ve2_mgmt_destroy_partition(hwctx);
 free_priv:
-	kfree(vp->hs_buf_va);
 	mutex_destroy(&vp->coredump_cache.lock);
 	mutex_destroy(&vp->privctx_lock);
 	kfree(vp);
@@ -828,9 +864,13 @@ void ve2_hwctx_fini(struct amdxdna_hwctx *hwctx)
 	if (vp && vp->mgmtctx)
 		ve2_get_firmware_status(hwctx);
 
-	/* Free the pre-allocated handshake buffer before tearing down. */
-	if (vp && vp->hs_buf_va) {
-		kfree(vp->hs_buf_va);
+	/*
+	 * Free the coherent handshake buffer before tearing the partition
+	 * down: aie_dev becomes invalid after aie_partition_release().
+	 */
+	if (vp && vp->hs_buf_va && vp->mgmtctx && vp->mgmtctx->aie_dev) {
+		dma_free_coherent(vp->mgmtctx->aie_dev, vp->hs_buf_size,
+				  vp->hs_buf_va, vp->hs_buf_dma);
 		vp->hs_buf_va = NULL;
 		vp->hs_buf_size = 0;
 	}

--- a/drivers/accel/amdxdna/ve2_hwctx.h
+++ b/drivers/accel/amdxdna/ve2_hwctx.h
@@ -96,13 +96,14 @@ struct amdxdna_ctx_priv {
 	 * every partition (re)initialisation. NULL falls back to a per-init
 	 * allocation.
 	 *
-	 * This is plain kernel memory (not dma_alloc_coherent): the handshake
-	 * contents are consumed by aie_partition_initialize(), only the CPU
-	 * virtual address is ever used, and allocating from the AIE device's
-	 * limited coherent pool here starves aie_partition_initialize()'s own
-	 * coherent allocation (observed as -ENOMEM from EXEC_CMD).
+	 * DMA-coherent memory allocated from the AIE partition device. Its
+	 * per-column dma_addr is handed to aie_partition_initialize() via
+	 * aie_op_handshake_data.dma_addr so the AIE driver uses this buffer
+	 * directly instead of doing its own per-column dmam_alloc_coherent()
+	 * (the latter path is not viable here and fails EXEC_CMD).
 	 */
 	void				*hs_buf_va;
+	dma_addr_t			hs_buf_dma;
 	size_t				hs_buf_size;
 
 	/* Last AIE coredump auto-captured on command timeout (per hwctx). */
@@ -120,7 +121,15 @@ int ve2_hwctx_config(struct amdxdna_hwctx *hwctx, u32 type, u64 value, void *buf
 int ve2_cmd_submit(struct amdxdna_hwctx *hwctx, struct amdxdna_sched_job *job, u64 *seq);
 int ve2_cmd_wait(struct amdxdna_hwctx *hwctx, u64 seq, u32 timeout_ms);
 
+/* verbosity >= this level enables extra VE2 debug dumps (packets, FW state). */
+#define VERBOSITY_LEVEL_DBG	2
+
 extern int enable_polling;
 extern int ve2_perf_optimization;
+extern int verbosity;
+extern int partition_size;
+extern int start_col;
+extern int max_col;
+extern unsigned int ve2_hwctx_limit;
 
 #endif /* _VE2_HWCTX_H_ */

--- a/drivers/accel/amdxdna/ve2_mgmt.c
+++ b/drivers/accel/amdxdna/ve2_mgmt.c
@@ -171,6 +171,13 @@ ve2_prepare_hs_data(struct amdxdna_mgmtctx *mgmtctx, struct amdxdna_hwctx *hwctx
 				cert_setup_partition(mgmtctx, hwctx, col, cert_hs);
 			}
 			hs_data[col].addr = cert_hs;
+			/*
+			 * hs_buf_va is DMA-coherent memory; hand the AIE driver
+			 * the matching per-column dma_addr so it uses this
+			 * buffer directly instead of doing its own per-column
+			 * dmam_alloc_coherent().
+			 */
+			hs_data[col].dma_addr = vp->hs_buf_dma + col * col_size;
 			hs_data[col].size = col_size;
 			hs_data[col].offset = 0x0;
 			hs_data[col].loc = aie_loc;
@@ -201,11 +208,25 @@ ve2_prepare_hs_data(struct amdxdna_mgmtctx *mgmtctx, struct amdxdna_hwctx *hwctx
 	return hs_data;
 }
 
+/*
+ * Effective partition width (columns) for a context. The @partition_size test
+ * module parameter can widen the request: the partition uses the larger of the
+ * user-requested @num_tiles and @partition_size (default 4), matching the
+ * legacy driver's behaviour.
+ */
+static u32 ve2_effective_num_col(u32 num_tiles)
+{
+	if (partition_size > 0 && (u32)partition_size > num_tiles)
+		return (u32)partition_size;
+
+	return num_tiles;
+}
+
 static int ve2_xrs_col_list(struct amdxdna_hwctx *hwctx, u32 total_col)
 {
 	struct amdxdna_dev *xdna = hwctx->client->xdna;
 	u32 user_col = hwctx->qos.user_start_col;
-	u32 num_col = hwctx->num_tiles;
+	u32 num_col = hwctx->num_col;
 	u32 first_col = 0;
 	u32 entries = 0;
 	u32 s, i;
@@ -227,6 +248,17 @@ static int ve2_xrs_col_list(struct amdxdna_hwctx *hwctx, u32 total_col)
 			return -ERANGE;
 		}
 		first_col = user_col;
+	} else if (start_col > 0) {
+		/*
+		 * Test-only override: force the lead column to @start_col (and
+		 * only offer candidate start columns from there onwards).
+		 */
+		if ((u32)start_col + num_col > total_col) {
+			XDNA_ERR(xdna, "start_col %d + num_col %u exceeds total_col %u",
+				 start_col, num_col, total_col);
+			return -ERANGE;
+		}
+		first_col = (u32)start_col;
 	}
 
 	for (s = first_col; s + num_col <= total_col; s += VE2_MIN_COL_SUPPORT)
@@ -262,12 +294,17 @@ int ve2_xrs_request(struct amdxdna_dev *xdna, struct amdxdna_hwctx *hwctx)
 	if (!vp || !hdl || !xrs)
 		return -EINVAL;
 
-	/* Build the candidate start-column list, then let XRS place the partition. */
+	/*
+	 * Determine the partition width (honouring the partition_size test
+	 * override) before building the candidate start-column list, then let
+	 * XRS place the partition.
+	 */
+	hwctx->num_col = ve2_effective_num_col(hwctx->num_tiles);
+
 	ret = ve2_xrs_col_list(hwctx, hdl->aie_dev_info.cols);
 	if (ret)
 		return ret;
 
-	hwctx->num_col = hwctx->num_tiles;
 	mutex_lock(&xrs->xrs_lock);
 	ret = amdxdna_alloc_resource(hwctx, &create_aie_part);
 	mutex_unlock(&xrs->xrs_lock);
@@ -1003,7 +1040,7 @@ static void ve2_aie_error_cb(void *arg)
 	aie_free_errors(aie_errs);
 
 	/* Optional deep dump of HSA queue + firmware handshake state. */
-	if (dbg_dump_on_error)
+	if (dbg_dump_on_error || verbosity >= VERBOSITY_LEVEL_DBG)
 		ve2_dump_debug_state(xdna, mgmtctx);
 
 	/*


### PR DESCRIPTION
Add support for below module parameters in ve2 accel driver.
- verbosity: extra debug dumps (packet dumps, AIE error debug state) once the level reaches VERBOSITY_LEVEL_DBG, ORed with the existing pktdump / dbg_dump_on_error switches.
- partition_size: test override for partition column width. Add ve2_effective_num_col() so a context's partition uses max(partition_size, num_tiles), and thread the result through hwctx->num_col instead of num_tiles so ve2_xrs_col_list() sizes the candidate column list off the effective width.
- start_col: test override for the lead column when userspace does not request one via QoS (user_start_col), with range checking against total_col in ve2_xrs_col_list().
- max_col: test override for the solver's column window; when set together with start_col and both fit within the device's total columns, clamp xrs_cfg.total_col to max_col in ve2_probe().
- ve2_hwctx_limit: debug override for the max hwctx count, stored in the new amdxdna_dev_hdl.hwctx_limit and logged in ve2_probe(), falling back to hdl->priv->hwctx_limit when unset.

-Fix hwctx ID allocation on the VE2 aux-bus path.
-Fix handshake dma_addr ABI and completion tracking