### PR TITLE
CMake: restore XDNA_BUILD_SHIM_TEST gating for VE2 build

### DIFF
--- a/CMake/native.cmake
+++ b/CMake/native.cmake
@@ -10,6 +10,11 @@
 # as amdxdna_legacy.ko.
 option(PACKAGE_LEGACY_DRIVER "Package legacy driver source" OFF)
 
+# The VE2 shim test (test/shim_test) is not part of the normal VE2 runtime
+# build. It is opt-in (e.g. built on demand by a dedicated packaging recipe)
+# so the default xrt/amdxdna build does not compile or install test artifacts.
+option(XDNA_BUILD_SHIM_TEST "Build test/shim_test for the VE2 edge build" OFF)
+
 # By default, build/build.sh downloads binaries to build/amdxdna_bins/
 # Absolute path, cannot be used in install command as destination.
 set(AMDXDNA_BINS_DIR ${CMAKE_BINARY_DIR}/../amdxdna_bins)
@@ -18,6 +23,16 @@ if(XDNA_VE2)
 
 include(${CMAKE_CURRENT_SOURCE_DIR}/CMake/xrt_ve2.cmake)
 add_subdirectory(src)
+
+# Build the shim tests (test/shim_test) only when explicitly requested. The
+# shim_test include dirs reference XRT_SUBMOD_SOURCE_DIR/BINARY_DIR, which are
+# only set on the non-VE2 path below; point them at the same xrt submodule the
+# VE2 build uses so the test target resolves its headers/generated sources.
+if(XDNA_BUILD_SHIM_TEST)
+  set(XRT_SUBMOD_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/xrt)
+  set(XRT_SUBMOD_BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/xrt)
+  add_subdirectory(test)
+endif()
 
 else(XDNA_VE2)
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -2,4 +2,9 @@
 # Copyright (C) 2024, Advanced Micro Devices, Inc. All rights reserved.
 
 add_subdirectory(shim_test)
+
+# xrt_test exercises the public XRT user API and is only wired up for the
+# native (non-VE2) build; the VE2 edge build ships shim_test only.
+if(NOT XDNA_VE2)
 add_subdirectory(xrt_test)
+endif()


### PR DESCRIPTION
The VE2 build path (XDNA_VE2=ON) never enters test/, so shim_test.elf is never built even when Vitis-AI-Telluride's xrt bbappend requests it via -DXDNA_BUILD_SHIM_TEST=ON. do_install then fails trying to mv a shim_test.elf that was never produced.

Restore the XDNA_BUILD_SHIM_TEST option (present on main) and gate add_subdirectory(test) behind it inside the XDNA_VE2 branch of native.cmake, pointing XRT_SUBMOD_SOURCE_DIR/BINARY_DIR at the xrt submodule so shim_test's includes resolve. Also restrict xrt_test to the non-VE2 build in test/CMakeLists.txt, since it exercises the native XRT API and isn't wired up for the VE2 edge build.

Default remains OFF, so this is a no-op unless a consumer explicitly opts in.