### PR TITLE
AIESW-40407: amdxdna shim code to provide PF device as mgmt_ready_lis…

### DIFF
--- a/src/shim/host/pcidrv_amdxdna.cpp
+++ b/src/shim/host/pcidrv_amdxdna.cpp
@@ -11,11 +11,6 @@
 
 namespace {
 
-struct X
-{
-  X() { xrt_core::pci::register_driver(std::make_shared<shim_xdna::drv_amdxdna>()); }
-} x;
-
 int
 get_dev_type(const std::string& sysfs)
 {
@@ -30,6 +25,14 @@ get_dev_type(const std::string& sysfs)
   std::getline(ifs, line);
   return static_cast<int>(std::stoi(line));
 }
+
+struct X
+{
+  X() {
+    xrt_core::pci::register_driver(std::make_shared<shim_xdna::drv_amdxdna>());
+    xrt_core::pci::register_driver(std::make_shared<shim_xdna::drv_amdxdna_mgmt>());
+  }
+} x;
 
 }
 
@@ -77,9 +80,56 @@ create_pcidev(const std::string& sysfs) const
   if (device_type == AMDXDNA_DEV_TYPE_UMQ)
     return std::make_shared<pdev_umq>(platform_driver, sysfs);
   if (device_type == AMDXDNA_DEV_TYPE_PF)
-    return nullptr;
+    return nullptr; // handled by drv_amdxdna_mgmt
 
   shim_err(EINVAL, "Unknown device type: %d", device_type);
+}
+
+bool
+drv_amdxdna_mgmt::
+is_user() const
+{
+  return false;
+}
+
+std::string
+drv_amdxdna_mgmt::
+name() const
+{
+  return "amdxdna";
+}
+
+std::string
+drv_amdxdna_mgmt::
+dev_node_prefix() const
+{
+  return "accel";
+}
+
+std::string
+drv_amdxdna_mgmt::
+dev_node_dir() const
+{
+  return "accel";
+}
+
+std::string
+drv_amdxdna_mgmt::
+sysfs_dev_node_dir() const
+{
+  return "accel";
+}
+
+std::shared_ptr<xrt_core::pci::dev>
+drv_amdxdna_mgmt::
+create_pcidev(const std::string& sysfs) const
+{
+  if (get_dev_type(sysfs) != AMDXDNA_DEV_TYPE_PF)
+    return nullptr;
+  auto driver = std::dynamic_pointer_cast<const drv>(shared_from_this());
+  auto platform_driver = std::dynamic_pointer_cast<const platform_drv>(
+    std::make_shared<const platform_drv_host>(driver));
+  return std::make_shared<pdev_pf>(platform_driver, sysfs);
 }
 
 }

--- a/src/shim/host/pcidrv_amdxdna.h
+++ b/src/shim/host/pcidrv_amdxdna.h
@@ -27,7 +27,32 @@ public:
   std::string
   sysfs_dev_node_dir() const override;
 
-private:  
+private:
+  std::shared_ptr<xrt_core::pci::dev>
+  create_pcidev(const std::string& sysfs) const override;
+};
+
+class drv_amdxdna_mgmt : public drv
+{
+public:
+  using drv::drv;
+
+  bool
+  is_user() const override;
+
+  std::string
+  name() const override;
+
+  std::string
+  dev_node_prefix() const override;
+
+  std::string
+  dev_node_dir() const override;
+
+  std::string
+  sysfs_dev_node_dir() const override;
+
+private:
   std::shared_ptr<xrt_core::pci::dev>
   create_pcidev(const std::string& sysfs) const override;
 };

--- a/src/shim/umq/pcidev.cpp
+++ b/src/shim/umq/pcidev.cpp
@@ -2,6 +2,11 @@
 // Copyright (C) 2022-2025, Advanced Micro Devices, Inc. All rights reserved.
 
 #include "pcidev.h"
+#include "../shim_debug.h"
+#include <algorithm>
+#include <cctype>
+#include <dirent.h>
+#include <memory>
 
 namespace shim_xdna {
 
@@ -52,6 +57,46 @@ pdev_umq::
 create_drm_bo(bo_info *arg) const
 {
   drv_ioctl(drv_ioctl_cmd::create_bo, arg);
+}
+
+pdev_pf::
+pdev_pf(std::shared_ptr<const platform_drv>& driver,
+        const std::string& sysfs_name)
+  : pdev_umq(driver, sysfs_name)
+{
+  // XRT reads 'instance' sysfs for mgmt devices (m_is_mgmt=true) which does
+  // not exist for XDNA PF. Derive m_instance from the accelN dir entry,
+  // same as VF/classic devices do via get_render_value().
+  const std::string accel_dir = "/sys/bus/pci/devices/" + m_sysfs_name + "/accel";
+  std::unique_ptr<DIR, int(*)(DIR*)> dp(opendir(accel_dir.c_str()), closedir);
+  if (!dp)
+    throw std::invalid_argument("No accel dir: " + accel_dir);
+
+  while (auto entry = readdir(dp.get())) {
+    const std::string name{entry->d_name};
+    if (name.size() <= 5 || name.compare(0, 5, "accel") != 0)
+      continue;
+    const std::string suffix = name.substr(5);
+    if (!std::all_of(suffix.begin(), suffix.end(), ::isdigit))
+      continue;
+    m_instance = std::stoi(suffix);
+    return;
+  }
+  throw std::invalid_argument("No accelN entry under: " + accel_dir);
+}
+
+bool
+pdev_pf::
+is_umq() const
+{
+  return false;
+}
+
+void
+pdev_pf::
+create_drm_bo(bo_info *arg) const
+{
+  shim_err(ENOTSUP, "PF device does not support BO creation");
 }
 
 }

--- a/src/shim/umq/pcidev.h
+++ b/src/shim/umq/pcidev.h
@@ -37,6 +37,19 @@ private:
   on_last_close() const override;
 };
 
+class pdev_pf : public pdev_umq
+{
+public:
+  pdev_pf(std::shared_ptr<const platform_drv>& driver,
+          const std::string& sysfs_name);
+
+  bool
+  is_umq() const override;
+
+  void
+  create_drm_bo(bo_info *arg) const override;
+};
+
 }
 
 #endif

--- a/test/shim_test/shim_test.cpp
+++ b/test/shim_test/shim_test.cpp
@@ -648,10 +648,10 @@ TEST_get_bdf_info_and_get_device_id(device::id_type id, std::shared_ptr<device>&
   auto is_user = arg[0];
   auto devinfo = get_total_devices(is_user);
   for (device::id_type i = 0; i < devinfo.first; i++) {
-    auto info = get_bdf_info(i);
+    auto info = get_bdf_info(i, is_user);
     auto bdf = bdf_info2str(info);
     std::cout << "device[" << i << "]: " << bdf << std::endl;
-    auto dev = get_userpf_device(i);
+    auto dev = is_user ? get_userpf_device(i) : get_mgmtpf_device(i);
     try {
       auto devid = device_query<query::pcie_device>(dev);
       std::cout << "device[" << bdf << "]: 0x" << std::hex << devid << std::dec << std::endl;
@@ -1517,18 +1517,18 @@ std::vector<test_case> test_list {
   test_case{ "get_total_devices", {},
     TEST_POSITIVE, no_dev_filter, TEST_get_total_devices, {true}
   },
-  //test_case{ "get_total_devices(mgmtpf)", {},
-  //  TEST_POSITIVE, no_dev_filter, TEST_get_total_devices, {false}
-  //},
+  test_case{ "get_total_devices(mgmtpf)", {},
+    TEST_POSITIVE, no_dev_filter, TEST_get_total_devices, {false}
+  },
   test_case{ "get_bdf_info_and_get_device_id", {},
     TEST_POSITIVE, no_dev_filter, TEST_get_bdf_info_and_get_device_id, {true}
   },
-  //test_case{ "get_bdf_info_and_get_device_id(mgmtpf)", {},
-  //  TEST_POSITIVE, no_dev_filter, TEST_get_bdf_info_and_get_device_id, {false}
-  //},
-  //test_case{ "get_mgmtpf_device", {},
-  //  TEST_POSITIVE, no_dev_filter, TEST_get_mgmtpf_device, {}
-  //},
+  test_case{ "get_bdf_info_and_get_device_id(mgmtpf)", {},
+    TEST_POSITIVE, no_dev_filter, TEST_get_bdf_info_and_get_device_id, {false}
+  },
+  test_case{ "get_mgmtpf_device", {},
+    TEST_POSITIVE, no_dev_filter, TEST_get_mgmtpf_device, {}
+  },
   test_case{ "query(pcie_vendor)", {},
     TEST_POSITIVE, dev_filter_xdna, TEST_query_userpf<query::pcie_vendor>, {}
   },


### PR DESCRIPTION
…t for xrt-smi

test result
```
./bins/bin/shim_test.elf get_total_devices get_total_devices\(mgmtpf\) get_mgmtpf_device
240 (139952882136320): PID(31169): Created pcidev (0000:c6:00.1)
167533 (139952882136320): PID(31169): Created pcidev (0000:c6:00.3)
298749 (139952882136320): PID(31169): Created pcidev (0000:c6:00.5)
431807 (139952882136320): PID(31169): Created pcidev (0000:c6:00.7)
665204 (139952882136320): PID(31169): Created pcidev (0000:c5:00.1)
====== 2: get_total_devices started =====
userpf total: 4
userpf ready: 4
====== 2: get_total_devices passed  =====

====== 3: get_total_devices(mgmtpf) started =====
mgmtpf total: 1
mgmtpf ready: 1
====== 3: get_total_devices(mgmtpf) passed  =====

====== 6: get_mgmtpf_device started =====
4660488 (139952882136320): PID(31169): Opened /dev/accel/accel0 as 3, sysfs: /sys/bus/pci/devices/0000:c5:00.1
4670437 (139952882136320): PID(31169): Created device (0000:c5:00.1) ...
4686857 (139952882136320): PID(31169): Destroying device (0000:c5:00.1) ...
4759533 (139952882136320): PID(31169): Closed 3
====== 6: get_mgmtpf_device passed  =====

0	test(s) skipped: 
3	test(s) executed
ALL 3 executed test(s) PASSED!
4799478 (139952882136320): PID(31169): Destroying pcidev (0000:c5:00.1)
4809196 (139952882136320): PID(31169): Destroying pcidev (0000:c6:00.1)
4814566 (139952882136320): PID(31169): Destroying pcidev (0000:c6:00.3)
4819526 (139952882136320): PID(31169): Destroying pcidev (0000:c6:00.5)
4823373 (139952882136320): PID(31169): Destroying pcidev (0000:c6:00.7)
```