### PR TITLE
accel/amdxdna: add amdxdna_dpt_exit_kind() to pair with enter_kind

### DIFF
--- a/drivers/accel/amdxdna/amdxdna_debugfs.c
+++ b/drivers/accel/amdxdna/amdxdna_debugfs.c
@@ -154,7 +154,7 @@ static int fw_log_level_show(struct seq_file *m, void *unused)
 	dpt = amdxdna_dpt_enter_kind(xdna, AMDXDNA_DPT_FW_LOG, &idx);
 	if (dpt) {
 		level = READ_ONCE(dpt->config);
-		srcu_read_unlock(&xdna->dpt_srcu, idx);
+		amdxdna_dpt_exit_kind(xdna, idx);
 	}
 
 	seq_printf(m, "%u\n", level);
@@ -220,7 +220,7 @@ static int fw_log_dump_to_dmesg_show(struct seq_file *m, void *unused)
 	dpt = amdxdna_dpt_enter_kind(xdna, AMDXDNA_DPT_FW_LOG, &idx);
 	if (dpt) {
 		dump = READ_ONCE(dpt->dump_to_dmesg);
-		srcu_read_unlock(&xdna->dpt_srcu, idx);
+		amdxdna_dpt_exit_kind(xdna, idx);
 	}
 
 	seq_printf(m, "%d\n", dump ? 1 : 0);

--- a/drivers/accel/amdxdna/amdxdna_dpt.c
+++ b/drivers/accel/amdxdna/amdxdna_dpt.c
@@ -23,7 +23,7 @@
 #include "amdxdna_dpt.h"
 #include "amdxdna_pci_drv.h"
 
-const char * const amdxdna_dpt_irq_name[AMDXDNA_DPT_KIND_MAX] = {
+static const char * const amdxdna_dpt_irq_name[AMDXDNA_DPT_KIND_MAX] = {
 	[AMDXDNA_DPT_FW_LOG]   = "xdna_fw_log",
 	[AMDXDNA_DPT_FW_TRACE] = "xdna_fw_trace",
 };
@@ -66,10 +66,15 @@ amdxdna_dpt_enter_kind(struct amdxdna_dev *xdna, enum amdxdna_dpt_kind kind,
 	*idx = srcu_read_lock(&xdna->dpt_srcu);
 	dpt = srcu_dereference(*slot, &xdna->dpt_srcu);
 	if (!dpt || READ_ONCE(dpt->status) != AMDXDNA_DPT_ACTIVE) {
-		srcu_read_unlock(&xdna->dpt_srcu, *idx);
+		amdxdna_dpt_exit_kind(xdna, *idx);
 		return NULL;
 	}
 	return dpt;
+}
+
+void amdxdna_dpt_exit_kind(struct amdxdna_dev *xdna, int idx)
+{
+	srcu_read_unlock(&xdna->dpt_srcu, idx);
 }
 
 /*
@@ -1121,7 +1126,7 @@ int amdxdna_get_fw_log(struct aie_device *aie,
 		return -ESHUTDOWN;
 
 	ret = amdxdna_dpt_get_data(dpt, args);
-	srcu_read_unlock(&xdna->dpt_srcu, idx);
+	amdxdna_dpt_exit_kind(xdna, idx);
 	return ret;
 }
 
@@ -1169,7 +1174,7 @@ int amdxdna_get_fw_log_configs(struct aie_device *aie,
 		config.version = dpt->payload_version;
 		config.status = 1;
 		config.config = READ_ONCE(dpt->config);
-		srcu_read_unlock(&xdna->dpt_srcu, idx);
+		amdxdna_dpt_exit_kind(xdna, idx);
 	}
 
 	if (copy_to_user(buf, &config, sizeof(config)))
@@ -1227,7 +1232,7 @@ int amdxdna_get_fw_trace(struct aie_device *aie,
 		return -ESHUTDOWN;
 
 	ret = amdxdna_dpt_get_data(dpt, args);
-	srcu_read_unlock(&xdna->dpt_srcu, idx);
+	amdxdna_dpt_exit_kind(xdna, idx);
 	return ret;
 }
 
@@ -1275,7 +1280,7 @@ int amdxdna_get_fw_trace_configs(struct aie_device *aie,
 		config.version = dpt->payload_version;
 		config.status = 1;
 		config.config = READ_ONCE(dpt->config);
-		srcu_read_unlock(&xdna->dpt_srcu, idx);
+		amdxdna_dpt_exit_kind(xdna, idx);
 	}
 
 	if (copy_to_user(buf, &config, sizeof(config)))

--- a/drivers/accel/amdxdna/amdxdna_dpt.h
+++ b/drivers/accel/amdxdna/amdxdna_dpt.h
@@ -62,7 +62,6 @@ enum amdxdna_dpt_kind {
 };
 
 const char *amdxdna_dpt_kind_str(enum amdxdna_dpt_kind kind);
-extern const char * const amdxdna_dpt_irq_name[AMDXDNA_DPT_KIND_MAX];
 
 #define XDNA_DPT_PRINTK(level, dpt, fmt, args...) do {				\
 	const struct amdxdna_dpt *__d = (dpt);					\
@@ -153,6 +152,7 @@ int amdxdna_dpt_dump_to_dmesg(struct amdxdna_dpt *dpt, bool enable);
 int amdxdna_fw_log_set_state(struct amdxdna_dev *xdna, u32 level);
 struct amdxdna_dpt *amdxdna_dpt_enter_kind(struct amdxdna_dev *xdna,
 					   enum amdxdna_dpt_kind kind, int *idx);
+void amdxdna_dpt_exit_kind(struct amdxdna_dev *xdna, int idx);
 
 int amdxdna_get_fw_log(struct aie_device *aie,
 		       struct amdxdna_drm_get_array *args);


### PR DESCRIPTION
amdxdna_dpt_enter_kind() takes the dpt_srcu read lock, but callers released it with a bare srcu_read_unlock(&xdna->dpt_srcu, idx). Add a symmetric amdxdna_dpt_exit_kind() helper and convert all call sites in amdxdna_dpt.c and amdxdna_debugfs.c, so entering and exiting the srcu critical section are symmetric and the locking detail stays in one place.

Also make amdxdna_dpt_irq_name[] static as it is only used locally.

No functional change.