### PR TITLE
build: use cmake on fedora, fixes #1558

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -330,7 +330,7 @@ XBUTIL_VALIDATE_BINS_DIR=$DOWNLOAD_BINS_DIR/download_raw/xbutil_validate/bins
 
 # Sanity check
 if [[ $CMAKE_MAJOR_VERSION != 3 ]]; then
-    if [[ $OSDIST == "centos" ]] || [[ $OSDIST == "amzn" ]] || [[ $OSDIST == "rhel" ]] || [[ $OSDIST == "fedora" ]]; then
+    if [[ $OSDIST == "centos" ]] || [[ $OSDIST == "amzn" ]] || [[ $OSDIST == "rhel" ]]; then
         CMAKE=cmake3
         if [[ ! -x "$(command -v $CMAKE)" ]]; then
             echo "$CMAKE is not installed"


### PR DESCRIPTION
Fixes #1558

Fedora no longer provides a `cmake3` executable and ships CMake 4 as `cmake`.

This change removes the Fedora-specific `cmake3` override while preserving the existing behavior for CentOS, RHEL, and Amazon Linux.

Verified on Fedora 44.