### PR TITLE
accel/amdxdna: hold CU BO references for the life of the context

### DIFF
--- a/drivers/accel/amdxdna/aie2_ctx.c
+++ b/drivers/accel/amdxdna/aie2_ctx.c
@@ -858,12 +858,18 @@ static void aie2_hwctx_put_cu_bos(struct amdxdna_hwctx *hwctx)
 {
 	u32 i;
 
-	for (i = 0; i < hwctx->priv->num_cu_bos; i++)
+	if (!hwctx->priv->cu_bos)
+		return;
+
+	/* A partially filled array is left zeroed past the failed lookup. */
+	for (i = 0; i < hwctx->cus->num_cus; i++) {
+		if (!hwctx->priv->cu_bos[i])
+			break;
 		drm_gem_object_put(to_gobj(hwctx->priv->cu_bos[i]));
+	}
 
 	kfree(hwctx->priv->cu_bos);
 	hwctx->priv->cu_bos = NULL;
-	hwctx->priv->num_cu_bos = 0;
 }
 
 void aie2_hwctx_fini(struct amdxdna_hwctx *hwctx)
@@ -922,9 +928,9 @@ static int aie2_config_cu_resp_handler(void *handle, void __iomem *data, size_t 
 /*
  * Resolve each configured CU BO once and keep a reference for the life of the
  * context. hwctx->cus holds userspace GEM handles, which stop resolving as soon
- * as the client drops them -- but aie2_config_cu() runs again on every resume,
- * so a dropped handle turned into a failed hwctx restart and left the device
- * unable to resume at all.
+ * as the client drops them, while aie2_config_cu() runs again on every resume.
+ * A dropped handle would fail the hwctx restart and leave the device unable to
+ * resume at all.
  */
 static int aie2_hwctx_hold_cu_bos(struct amdxdna_hwctx *hwctx)
 {
@@ -944,8 +950,7 @@ static int aie2_hwctx_hold_cu_bos(struct amdxdna_hwctx *hwctx)
 		return -EINVAL;
 	}
 
-	hwctx->priv->cu_bos = kcalloc(num_cus, sizeof(*hwctx->priv->cu_bos),
-				      GFP_KERNEL);
+	hwctx->priv->cu_bos = kzalloc_objs(*hwctx->priv->cu_bos, num_cus);
 	if (!hwctx->priv->cu_bos)
 		return -ENOMEM;
 
@@ -967,7 +972,6 @@ static int aie2_hwctx_hold_cu_bos(struct amdxdna_hwctx *hwctx)
 
 		/* Reference retained; released by aie2_hwctx_put_cu_bos(). */
 		hwctx->priv->cu_bos[i] = abo;
-		hwctx->priv->num_cu_bos = i + 1;
 	}
 
 	return 0;

--- a/drivers/accel/amdxdna/aie2_ctx.c
+++ b/drivers/accel/amdxdna/aie2_ctx.c
@@ -854,6 +854,18 @@ free_priv:
 	return ret;
 }
 
+static void aie2_hwctx_put_cu_bos(struct amdxdna_hwctx *hwctx)
+{
+	u32 i;
+
+	for (i = 0; i < hwctx->priv->num_cu_bos; i++)
+		drm_gem_object_put(to_gobj(hwctx->priv->cu_bos[i]));
+
+	kfree(hwctx->priv->cu_bos);
+	hwctx->priv->cu_bos = NULL;
+	hwctx->priv->num_cu_bos = 0;
+}
+
 void aie2_hwctx_fini(struct amdxdna_hwctx *hwctx)
 {
 	struct amdxdna_dev *xdna;
@@ -893,6 +905,7 @@ void aie2_hwctx_fini(struct amdxdna_hwctx *hwctx)
 	drm_gem_object_put(to_gobj(hwctx->priv->heap));
 
 	mutex_destroy(&hwctx->priv->io_lock);
+	aie2_hwctx_put_cu_bos(hwctx);
 	kfree(hwctx->col_list);
 	kfree(hwctx->priv);
 	kfree(hwctx->cus);
@@ -904,6 +917,64 @@ static int aie2_config_cu_resp_handler(void *handle, void __iomem *data, size_t 
 
 	amdxdna_pm_suspend_put(hwctx->client->xdna);
 	return 0;
+}
+
+/*
+ * Resolve each configured CU BO once and keep a reference for the life of the
+ * context. hwctx->cus holds userspace GEM handles, which stop resolving as soon
+ * as the client drops them -- but aie2_config_cu() runs again on every resume,
+ * so a dropped handle turned into a failed hwctx restart and left the device
+ * unable to resume at all.
+ */
+static int aie2_hwctx_hold_cu_bos(struct amdxdna_hwctx *hwctx)
+{
+	struct amdxdna_dev *xdna = hwctx->client->xdna;
+	u32 num_cus = hwctx->cus->num_cus;
+	struct drm_gem_object *gobj;
+	struct amdxdna_gem_obj *abo;
+	u32 i;
+
+	/* Bound before the lookup loop, not in aie2_config_cu() afterwards:
+	 * num_cus is only limited by the page-sized config buffer, so an
+	 * over-limit request would otherwise take a reference per CU before
+	 * anything rejected it.
+	 */
+	if (num_cus > MAX_NUM_CUS) {
+		XDNA_DBG(xdna, "Exceed maximum CU %d", MAX_NUM_CUS);
+		return -EINVAL;
+	}
+
+	hwctx->priv->cu_bos = kcalloc(num_cus, sizeof(*hwctx->priv->cu_bos),
+				      GFP_KERNEL);
+	if (!hwctx->priv->cu_bos)
+		return -ENOMEM;
+
+	for (i = 0; i < num_cus; i++) {
+		struct amdxdna_cu_config *cu = &hwctx->cus->cu_configs[i];
+
+		gobj = drm_gem_object_lookup(hwctx->client->filp, cu->cu_bo);
+		if (!gobj) {
+			XDNA_ERR(xdna, "Lookup GEM object failed");
+			goto put_bos;
+		}
+
+		abo = to_xdna_obj(gobj);
+		if (abo->type != AMDXDNA_BO_DEV) {
+			drm_gem_object_put(gobj);
+			XDNA_ERR(xdna, "Invalid BO type");
+			goto put_bos;
+		}
+
+		/* Reference retained; released by aie2_hwctx_put_cu_bos(). */
+		hwctx->priv->cu_bos[i] = abo;
+		hwctx->priv->num_cu_bos = i + 1;
+	}
+
+	return 0;
+
+put_bos:
+	aie2_hwctx_put_cu_bos(hwctx);
+	return -EINVAL;
 }
 
 static int aie2_hwctx_cu_config(struct amdxdna_hwctx *hwctx, void *buf, u32 size)
@@ -937,9 +1008,13 @@ static int aie2_hwctx_cu_config(struct amdxdna_hwctx *hwctx, void *buf, u32 size
 	if (!hwctx->cus)
 		return -ENOMEM;
 
-	ret = amdxdna_pm_resume_get(xdna);
+	ret = aie2_hwctx_hold_cu_bos(hwctx);
 	if (ret)
 		goto free_cus;
+
+	ret = amdxdna_pm_resume_get(xdna);
+	if (ret)
+		goto put_cu_bos;
 
 	ret = aie2_config_cu(hwctx, aie2_config_cu_resp_handler);
 	if (ret) {
@@ -953,6 +1028,8 @@ static int aie2_hwctx_cu_config(struct amdxdna_hwctx *hwctx, void *buf, u32 size
 
 pm_suspend_put:
 	amdxdna_pm_suspend_put(xdna);
+put_cu_bos:
+	aie2_hwctx_put_cu_bos(hwctx);
 free_cus:
 	kfree(hwctx->cus);
 	hwctx->cus = NULL;

--- a/drivers/accel/amdxdna/aie2_message.c
+++ b/drivers/accel/amdxdna/aie2_message.c
@@ -617,11 +617,6 @@ int aie2_config_cu(struct amdxdna_hwctx *hwctx,
 		return -EINVAL;
 	}
 
-	if (hwctx->cus->num_cus != hwctx->priv->num_cu_bos) {
-		XDNA_ERR(xdna, "CU BOs not held for this context");
-		return -EINVAL;
-	}
-
 	for (i = 0; i < hwctx->cus->num_cus; i++) {
 		struct amdxdna_cu_config *cu = &hwctx->cus->cu_configs[i];
 

--- a/drivers/accel/amdxdna/aie2_message.c
+++ b/drivers/accel/amdxdna/aie2_message.c
@@ -603,7 +603,6 @@ int aie2_config_cu(struct amdxdna_hwctx *hwctx,
 	u32 shift = xdna->dev_info->dev_mem_buf_shift;
 	struct config_cu_req req = { 0 };
 	struct xdna_mailbox_msg msg;
-	struct drm_gem_object *gobj;
 	struct amdxdna_gem_obj *abo;
 	int i;
 
@@ -618,31 +617,29 @@ int aie2_config_cu(struct amdxdna_hwctx *hwctx,
 		return -EINVAL;
 	}
 
+	if (hwctx->cus->num_cus != hwctx->priv->num_cu_bos) {
+		XDNA_ERR(xdna, "CU BOs not held for this context");
+		return -EINVAL;
+	}
+
 	for (i = 0; i < hwctx->cus->num_cus; i++) {
 		struct amdxdna_cu_config *cu = &hwctx->cus->cu_configs[i];
 
 		if (XDNA_MBZ_DBG(xdna, cu->pad, sizeof(cu->pad)))
 			return -EINVAL;
 
-		gobj = drm_gem_object_lookup(hwctx->client->filp, cu->cu_bo);
-		if (!gobj) {
-			XDNA_ERR(xdna, "Lookup GEM object failed");
-			return -EINVAL;
-		}
-		abo = to_xdna_obj(gobj);
-
-		if (abo->type != AMDXDNA_BO_DEV) {
-			drm_gem_object_put(gobj);
-			XDNA_ERR(xdna, "Invalid BO type");
-			return -EINVAL;
-		}
+		/*
+		 * Resolved and referenced once at config time. Looking the
+		 * handle up here instead would fail on resume, once the client
+		 * has dropped it, and take the whole device resume down with it.
+		 */
+		abo = hwctx->priv->cu_bos[i];
 
 		req.cfgs[i] = FIELD_PREP(AIE2_MSG_CFG_CU_PDI_ADDR,
 					 amdxdna_gem_dev_addr(abo) >> shift);
 		req.cfgs[i] |= FIELD_PREP(AIE2_MSG_CFG_CU_FUNC, cu->cu_func);
 		XDNA_DBG(xdna, "CU %d full addr 0x%llx, cfg 0x%x", i,
 			 amdxdna_gem_dev_addr(abo), req.cfgs[i]);
-		drm_gem_object_put(gobj);
 	}
 	req.num_cus = hwctx->cus->num_cus;
 

--- a/drivers/accel/amdxdna/aie2_pci.h
+++ b/drivers/accel/amdxdna/aie2_pci.h
@@ -96,13 +96,13 @@ struct amdxdna_hwctx_priv {
 	struct drm_syncobj		*syncobj;
 
 	/*
-	 * CU BOs resolved once at config time and held for the life of the
-	 * context. hwctx->cus stores userspace GEM *handles*, which are only
-	 * meaningful while the client still holds them; aie2_config_cu() also
-	 * runs on resume, long after the config ioctl returned.
+	 * One entry per hwctx->cus->cu_configs[], resolved at config time and
+	 * held for the life of the context. hwctx->cus stores userspace GEM
+	 * *handles*, which are only meaningful while the client still holds
+	 * them; aie2_config_cu() also runs on resume, long after the config
+	 * ioctl returned.
 	 */
 	struct amdxdna_gem_obj		**cu_bos;
-	u32				num_cu_bos;
 };
 
 enum aie2_dev_status {

--- a/drivers/accel/amdxdna/aie2_pci.h
+++ b/drivers/accel/amdxdna/aie2_pci.h
@@ -94,6 +94,15 @@ struct amdxdna_hwctx_priv {
 
 	struct amdxdna_gem_obj		*cmd_buf[HWCTX_MAX_CMDS];
 	struct drm_syncobj		*syncobj;
+
+	/*
+	 * CU BOs resolved once at config time and held for the life of the
+	 * context. hwctx->cus stores userspace GEM *handles*, which are only
+	 * meaningful while the client still holds them; aie2_config_cu() also
+	 * runs on resume, long after the config ioctl returned.
+	 */
+	struct amdxdna_gem_obj		**cu_bos;
+	u32				num_cu_bos;
 };
 
 enum aie2_dev_status {


### PR DESCRIPTION
Fixes #1566.

## Problem

`hwctx->cus` stores userspace GEM *handles*, and `aie2_config_cu()` re-resolved them against
`hwctx->client->filp` on every call. It is called a second time from `aie2_hwctx_restart()` on
runtime-PM resume, long after the config ioctl returned. A client that has since dropped the handle
makes that lookup fail, and the failure takes the whole resume down:

```
amdxdna 0000:c5:00.1: [drm] *ERROR* aie2_config_cu: Lookup GEM object failed
amdxdna 0000:c5:00.1: [drm] *ERROR* aie2_hwctx_restart: Config cu failed, ret -22
amdxdna 0000:c5:00.1: [drm] *ERROR* amdxdna_pm_resume_get: Resume failed: -22
```

`aie2_get_info()` calls `amdxdna_pm_resume_get_locked()` before it reaches its
`switch (args->param)`, so the -EINVAL is reported against whichever ioctl happened to trigger the
resume. From userspace it looks like an unrelated GET_INFO failure, and XRT raises it as an uncaught
`xrt_core::system_error`, so the application aborts:

```
terminate called after throwing an instance of 'xrt_core::system_error'
  what():  DRM_IOCTL_AMDXDNA_GET_INFO IOCTL failed (err=-22): Invalid argument
```

## Fix

Resolve and validate each CU BO once in `aie2_hwctx_cu_config()` and hold a reference until the
context is torn down. `aie2_config_cu()` then uses the held objects, so it no longer depends on a
handle still being live in the client's file table.

This matches how the same context already treats its other buffers: `priv->heap` and
`priv->cmd_buf[]` are both referenced for the life of the hwctx and released in `aie2_hwctx_fini()`.

The `num_cus != num_cu_bos` check in `aie2_config_cu()` is a guard against a future path reaching it
without the config step having run; it is not expected to fire.

## Test

Built clean (no new warnings) as an external module against 7.1.5 with `LLVM=1`, on the hardware the
bug was found on:

```
NPU     c5:00.1 [1022:17f0] rev 10  Strix/Krackan/Strix Halo NPU
XRT     2.21.75
fw      amdnpu/17f0_10/npu_7.sbin
```

The reproduction from #1566 is two clients dispatching with an idle window between batches, which
lets the device autosuspend (`autosuspend_delay_ms=5000`) so a resume actually runs. Rates measured
before this patch, counting a missing self-check PASS:

| concurrent clients | runs | failures |
|---|---|---|
| 1 | 150 | 0 |
| 2 | 190 | 2 |
| 4 | 150 | 0 |
| 8 | 135 | 0 |
| 12 | 135 | 0 |

Both failures were dmesg-correlated to the second with the aborting process.

Built as an external module against 7.1.5 and loaded in place of the in-kernel driver, both with and
without this patch. Same tree, same toolchain, same kernel, same workload, so the patch is the only
variable:

| module | GET_INFO occurrences | 2-client jobs |
|---|---|---|
| `main` unpatched | **2** | 300 |
| `main` + this patch | **0** | 870 |

Fisher one-sided p = 0.066. I would not lean on that number -- two events is a thin baseline, and the
argument for the patch is that the failing lookup is gone from the resume path, not that the rate
moved. The useful part of the control is simply that the bug reproduces on current `main`, so this is
not an artifact of the older in-kernel driver the failures were first seen on.

Counting occurrences rather than test failures is deliberate: my harness retries this signature, so
both control hits recovered on the second attempt and the test still reported PASS. The driver-level
event is what the table counts.

Throughput is unchanged with the references held: 15 concurrent runs over 5 designs take 14.9s at 8
clients patched against 16.2s before, and 66.7s against 68.2s at one client.

Unrelated, but seen at probe on 7.1.5 with both builds, so it is not from this change:

```
amdxdna_dpt_publish: fw_log: Failed to allocate buffer: -12
amdxdna_dpt_init: Failed to enable FW logging: -12
```

with a stack trace through `amdxdna_alloc_msg_buff` / `amdxdna_fw_log_init`. Happy to open a separate
issue if it is not already known.

Happy to change where the reference is held if `hwctx->priv` is the wrong home for it.
