### PR TITLE
accel/amdxdna: make the FW log ring size configurable

### DIFF
--- a/drivers/accel/amdxdna/amdxdna_debugfs.c
+++ b/drivers/accel/amdxdna/amdxdna_debugfs.c
@@ -11,6 +11,7 @@
 #include <drm/drm_file.h>
 #include <linux/cleanup.h>
 #include <linux/debugfs.h>
+#include <linux/mmzone.h>
 #include <linux/pm_runtime.h>
 #include <linux/seq_file.h>
 #include <linux/string.h>
@@ -164,6 +165,124 @@ static int fw_log_level_show(struct seq_file *m, void *unused)
 AMDXDNA_DBGFS_FOPS(fw_log_level, fw_log_level_show, fw_log_level_write);
 
 /*
+ * fw_log_size: ring size in bytes for firmware logging. The ring is a
+ * physically contiguous allocation rounded up to a page order, so the size
+ * that fits depends on how fragmented memory is; a smaller ring holds less
+ * history but needs a smaller block. Takes effect at the next enable, or
+ * right away when logging is already on. Read prints the ring in use while
+ * logging is active, and otherwise the size the next enable will ask for.
+ */
+static ssize_t fw_log_size_write(struct file *file, const char __user *ptr,
+				 size_t len, loff_t *off)
+{
+	struct amdxdna_dev *xdna = file_to_xdna(file);
+	struct amdxdna_dpt *dpt;
+	u32 size, old_size, level;
+	bool dump;
+	int ret;
+
+	ret = kstrtouint_from_user(ptr, len, 0, &size);
+	if (ret)
+		return ret;
+
+	if (!size || size > (PAGE_SIZE << MAX_PAGE_ORDER))
+		return -EINVAL;
+
+	guard(mutex)(&xdna->dev_lock);
+
+	old_size = READ_ONCE(xdna->fw_log.buf_size);
+	WRITE_ONCE(xdna->fw_log.buf_size, size);
+
+	dpt = rcu_dereference_protected(xdna->fw_log.data,
+					lockdep_is_held(&xdna->dev_lock));
+	if (!dpt)
+		return len;
+
+	/*
+	 * A published ring only takes the new size by being republished at the
+	 * level already in use, which is the same firmware exchange as
+	 * fw_log_level and so needs the device awake. Resume before reading the
+	 * channel's state, not after: runtime PM parks an enabled channel in
+	 * SUSPENDED with its buffer preserved, so testing for ACTIVE first
+	 * would skip the republish, report success, and then let resume
+	 * reattach the old ring while the size reads back as the new one.
+	 */
+	ret = amdxdna_pm_resume_get_locked(xdna);
+	if (ret) {
+		WRITE_ONCE(xdna->fw_log.buf_size, old_size);
+		return ret;
+	}
+
+	dpt = rcu_dereference_protected(xdna->fw_log.data,
+					lockdep_is_held(&xdna->dev_lock));
+	if (!dpt || READ_ONCE(dpt->status) != AMDXDNA_DPT_ACTIVE) {
+		amdxdna_pm_suspend_put(xdna);
+		return len;
+	}
+
+	/*
+	 * Republishing frees the whole amdxdna_dpt and builds a fresh one, so
+	 * everything living on it has to be carried across by hand: the level,
+	 * and the dmesg consumer, which amdxdna_dpt_fini_chan clears.
+	 */
+	level = READ_ONCE(dpt->config);
+	dump = READ_ONCE(dpt->dump_to_dmesg);
+
+	ret = amdxdna_fw_log_set_state(xdna, AMDXDNA_DPT_FW_LOG_LEVEL_NONE);
+	if (!ret)
+		ret = amdxdna_fw_log_set_state(xdna, level);
+	if (ret) {
+		/*
+		 * The old ring is already gone, and the likeliest failure here
+		 * is the contiguous allocation this knob exists to work around.
+		 * Go back to the size that was working rather than leave the
+		 * device with no logging at all; the write still reports the
+		 * error, so the caller knows the size it asked for did not take.
+		 */
+		XDNA_ERR(xdna, "Failed to republish FW log at %u bytes: %d",
+			 size, ret);
+		WRITE_ONCE(xdna->fw_log.buf_size, old_size);
+		if (amdxdna_fw_log_set_state(xdna, level)) {
+			XDNA_ERR(xdna, "FW log left disabled, %u bytes did not fit either",
+				 old_size);
+			amdxdna_pm_suspend_put(xdna);
+			return ret;
+		}
+	}
+
+	if (dump) {
+		dpt = rcu_dereference_protected(xdna->fw_log.data,
+						lockdep_is_held(&xdna->dev_lock));
+		if (!dpt || amdxdna_dpt_dump_to_dmesg(dpt, true))
+			XDNA_WARN(xdna, "FW log dmesg dumping left off after resize");
+	}
+
+	amdxdna_pm_suspend_put(xdna);
+
+	return ret ? ret : len;
+}
+
+static int fw_log_size_show(struct seq_file *m, void *unused)
+{
+	struct amdxdna_dev *xdna = m->private;
+	struct amdxdna_dpt *dpt;
+	u32 size;
+	int idx;
+
+	size = READ_ONCE(xdna->fw_log.buf_size);
+	dpt = amdxdna_dpt_enter(&xdna->fw_log, &idx);
+	if (dpt) {
+		size = READ_ONCE(dpt->size);
+		amdxdna_dpt_exit(&xdna->fw_log, idx);
+	}
+
+	seq_printf(m, "%u\n", size);
+	return 0;
+}
+
+AMDXDNA_DBGFS_FOPS(fw_log_size, fw_log_size_show, fw_log_size_write);
+
+/*
  * fw_log_dump_to_dmesg: toggle kernel-side streaming of FW log entries to
  * dmesg. Returns -EINVAL if FW logging is not ACTIVE.
  */
@@ -237,6 +356,7 @@ static const struct {
 } amdxdna_dbgfs_files[] = {
 	AMDXDNA_DBGFS_FILE(carveout, 0600),
 	AMDXDNA_DBGFS_FILE(fw_log_level, 0600),
+	AMDXDNA_DBGFS_FILE(fw_log_size, 0600),
 	AMDXDNA_DBGFS_FILE(fw_log_dump_to_dmesg, 0600),
 };
 

--- a/drivers/accel/amdxdna/amdxdna_dpt.c
+++ b/drivers/accel/amdxdna/amdxdna_dpt.c
@@ -117,6 +117,8 @@ int amdxdna_dpt_chan_init(struct amdxdna_dev *xdna)
 
 	xdna->fw_log.desc = &amdxdna_dpt_fw_log_desc;
 	xdna->fw_trace.desc = &amdxdna_dpt_fw_trace_desc;
+	xdna->fw_log.buf_size = xdna->fw_log.desc->buf_size;
+	xdna->fw_trace.buf_size = xdna->fw_trace.desc->buf_size;
 
 	ret = init_srcu_struct(&xdna->fw_log.srcu);
 	if (ret)
@@ -611,10 +613,11 @@ amdxdna_dpt_publish(struct aie_device *aie, struct amdxdna_dpt_chan *chan,
 	dpt->status = AMDXDNA_DPT_INACTIVE;
 	dpt->config = config;
 
-	hdl = amdxdna_alloc_msg_buff(xdna, chan->desc->buf_size);
+	hdl = amdxdna_alloc_msg_buff(xdna, chan->buf_size);
 	if (IS_ERR(hdl)) {
 		ret = PTR_ERR(hdl);
-		XDNA_DPT_ERR(dpt, "Failed to allocate buffer: %d", ret);
+		XDNA_DPT_ERR(dpt, "Failed to allocate %u byte buffer: %d",
+			     chan->buf_size, ret);
 		kfree(dpt);
 		return ERR_PTR(ret);
 	}
@@ -1153,7 +1156,9 @@ int amdxdna_dpt_init(struct aie_device *aie)
 
 	ret = amdxdna_fw_log_init(aie, AMDXDNA_DPT_FW_LOG_LEVEL_DEFAULT);
 	if (ret)
-		XDNA_WARN(aie->xdna, "Failed to enable FW logging: %d", ret);
+		XDNA_WARN(aie->xdna,
+			  "Failed to enable FW logging: %d. Retry through debugfs, lowering fw_log_size first if the ring could not be allocated",
+			  ret);
 
 	return 0;
 }

--- a/drivers/accel/amdxdna/amdxdna_pci_drv.h
+++ b/drivers/accel/amdxdna/amdxdna_pci_drv.h
@@ -153,6 +153,11 @@ struct amdxdna_dpt_chan {
 	struct srcu_struct		srcu;
 	struct amdxdna_dpt __rcu	*data;
 	const struct amdxdna_dpt_desc	*desc;
+	/*
+	 * Ring size the next publish asks for, starting at @desc's default.
+	 * Serialized by dev_lock.
+	 */
+	u32				buf_size;
 };
 
 struct amdxdna_dev {


### PR DESCRIPTION
## Problem

`AMDXDNA_DPT_FW_LOG_SIZE` is `SZ_4M`, an order-10 allocation made from probe. Once memory is
fragmented that block may not be formable, and FW logging stays off for the lifetime of the module
with no way to ask for a size that would fit. Probe itself is unaffected: `amdxdna_dpt_init()`
warns and returns 0.

## Fix

Two commits:

1. Keep the FW log ring size on `struct amdxdna_dev` and expose it as a `fw_log_size` debugfs node.
   A read prints the ring in use while logging is active, otherwise the size the next enable will
   ask for. A write takes effect at the next enable, or right away by republishing at the level
   already in use. `amdxdna_alloc_msg_buff()` is untouched and stays exact-or-fail.
2. Print the requested size in the allocation failure, and point at the node in the FW-log init
   warning. `Failed to allocate buffer: -12` said neither how much was asked for nor what to do.

The automatic shrink to a fixed `SZ_1M` floor from the first revision is dropped.

## Test

Built with `-Werror` per commit; `checkpatch.pl --strict` clean.

On npu4 (0000:c5:00.1), kernel 7.1.8, module built from this branch:

```
== defaults (expect fw_log_size 4194304, fw_log_level 2)
fw_log_size                  -> 4194304
fw_log_level                 -> 2

== shrink to 1M while logging is active
write fw_log_size=1048576 -> accepted
fw_log_size                  -> 1048576
fw_log_level                 -> 2

== off/on cycle keeps the configured size
write fw_log_level=0 -> accepted
write fw_log_level=2 -> accepted
fw_log_size                  -> 1048576
fw_log_level                 -> 2

== rejects (expect both rejected)
write fw_log_size=8388608 -> rejected
write fw_log_size=0 -> rejected
fw_log_size                  -> 1048576

== back to 4M
write fw_log_size=4194304 -> accepted
fw_log_size                  -> 4194304
```

The write at 1M republishes: the read-back is the new ring's size, so the allocation and the
firmware config message both went through, and the level survives it. No new dmesg output beyond
the usual firmware load and init lines.

The allocation-failure branch is not exercised here, since I cannot fragment memory on demand;
only its message changed.

## Scope

FW log only. FW trace publishes from an explicit user request rather than from probe, so it can
simply be retried later; say the word if you want the same node for it.

The node is manual by construction, so a box that loses the allocation at probe has no logging
until someone writes it. That is the case I hit (module reload in CI), and it is not covered here.
