### PR TITLE
accel/amdxdna/ve2: add debug profiling tracepoints to VE2 hwctx/mgmt paths

### DIFF
--- a/drivers/accel/amdxdna/amdxdna_ctx.c
+++ b/drivers/accel/amdxdna/amdxdna_ctx.c
@@ -325,6 +325,21 @@ int amdxdna_drm_create_hwctx_ioctl(struct drm_device *dev, void *data, struct dr
 		goto free_hwctx;
 	}
 
+	/*
+	 * Allocate the hwctx ID before hwctx_init() (rather than after, as
+	 * upstream drm/xe and amdgpu ctx ioctls typically do) so that
+	 * hwctx->id is valid for the whole lifetime of hwctx_init(), matching
+	 * the legacy VE2 driver's ctx_init() ordering. This lets per-backend
+	 * hwctx_init() implementations (and their trace points) identify the
+	 * hwctx being created instead of seeing an unset ID.
+	 */
+	ret = amdxdna_hwctx_id_alloc(xdna);
+	if (ret < 0) {
+		XDNA_ERR(xdna, "Allocate hwctx ID failed, ret %d", ret);
+		goto exit_dev;
+	}
+	hwctx->id = ret;
+
 	ret = xdna->dev_info->ops->hwctx_init(hwctx);
 	if (ret) {
 		XDNA_ERR(xdna, "Init hwctx failed, ret %d", ret);
@@ -337,18 +352,11 @@ int amdxdna_drm_create_hwctx_ioctl(struct drm_device *dev, void *data, struct dr
 		goto fini_hwctx;
 	}
 
-	ret = amdxdna_hwctx_id_alloc(xdna);
-	if (ret < 0) {
-		XDNA_ERR(xdna, "Allocate hwctx ID failed, ret %d", ret);
-		goto free_name;
-	}
-	hwctx->id = ret;
-
 	/* Publish into the per-client map; submit/wait/etc. look up here. */
 	ret = xa_err(xa_store(&client->hwctx_xa, hwctx->id, hwctx, GFP_KERNEL));
 	if (ret) {
 		XDNA_ERR(xdna, "Store hwctx %d failed, ret %d", hwctx->id, ret);
-		goto free_id;
+		goto free_name;
 	}
 
 	args->handle = hwctx->id;
@@ -361,14 +369,14 @@ int amdxdna_drm_create_hwctx_ioctl(struct drm_device *dev, void *data, struct dr
 	drm_dev_exit(idx);
 	return 0;
 
-free_id:
-	ida_free(&xdna->hwctx_ida, hwctx->id);
 free_name:
 	kfree(hwctx->name);
 fini_hwctx:
 	xdna->dev_info->ops->hwctx_fini(hwctx);
 release_expanded_heap:
 	amdxdna_hwctx_release_expanded_heap(hwctx);
+	ida_free(&xdna->hwctx_ida, hwctx->id);
+exit_dev:
 	drm_dev_exit(idx);
 free_hwctx:
 	kfree(hwctx);

--- a/drivers/accel/amdxdna/amdxdna_drv.c
+++ b/drivers/accel/amdxdna/amdxdna_drv.c
@@ -54,7 +54,7 @@ static int amdxdna_sva_init(struct amdxdna_client *client)
 
 	client->sva = iommu_sva_bind_device(xdna->ddev.dev, client->mm);
 	if (IS_ERR(client->sva)) {
-		XDNA_ERR(xdna, "SVA bind device failed, ret %ld", PTR_ERR(client->sva));
+		XDNA_DBG(xdna, "SVA bind device failed, ret %ld", PTR_ERR(client->sva));
 		return PTR_ERR(client->sva);
 	}
 
@@ -106,7 +106,7 @@ static int amdxdna_drm_open(struct drm_device *ddev, struct drm_file *filp)
 	if (!amdxdna_iova_on(xdna)) {
 		/* No need to fail open since user may use pa + carveout later. */
 		if (amdxdna_sva_init(client)) {
-			XDNA_WARN(xdna, "PASID not available for pid %d", client->pid);
+			XDNA_DBG(xdna, "PASID not available for pid %d", client->pid);
 #ifndef AMDXDNA_AUX
 			/*
 			 * PCI/NPU requires either PASID or a pre-configured

--- a/drivers/accel/amdxdna/ve2_hwctx.c
+++ b/drivers/accel/amdxdna/ve2_hwctx.c
@@ -21,6 +21,7 @@
 #include "amdxdna_ctx.h"
 #include "amdxdna_pci_drv.h"
 #include "amdxdna_gem.h"
+#include "trace/events/amdxdna.h"
 #include "ve2_aux.h"
 #include "ve2_hwctx.h"
 #include "ve2_mgmt.h"
@@ -239,6 +240,9 @@ static void hsa_queue_commit_slot(struct amdxdna_hwctx *hwctx, u64 seq)
 		header->write_index++;
 	}
 	hsa_queue_sync_write_index_for_write(queue);
+
+	trace_amdxdna_trace_point("XRT_PROFILING_TRACE_UPDATE_WRITE_INDEX",
+				  hwctx->client->pid, hwctx->id, seq, header->write_index);
 	mutex_unlock(&queue->hq_lock);
 }
 
@@ -736,6 +740,8 @@ int ve2_hwctx_init(struct amdxdna_hwctx *hwctx)
 	struct amdxdna_ctx_priv *vp;
 	int ret;
 
+	trace_amdxdna_trace_point("XRT_PROFILING_TRACE_ENTER", client->pid, 0, hwctx->id, 0);
+
 	hdl = ve2_dev_hdl(xdna);
 	if (!hdl)
 		return -ENODEV;
@@ -824,6 +830,9 @@ int ve2_hwctx_init(struct amdxdna_hwctx *hwctx)
 	} else {
 		XDNA_DBG(xdna, "hwctx %p: interrupt mode", hwctx);
 	}
+
+	trace_amdxdna_trace_point("XRT_PROFILING_TRACE_EXIT", client->pid, hwctx->start_col,
+				  hwctx->id, 0);
 	return 0;
 
 free_hwctx_config:
@@ -860,6 +869,9 @@ void ve2_hwctx_fini(struct amdxdna_hwctx *hwctx)
 
 	vp = priv->hw_priv;
 
+	trace_amdxdna_trace_point("XRT_PROFILING_TRACE_ENTER",
+				  hwctx->client->pid, hwctx->start_col, hwctx->id, 0);
+
 	/* Snapshot per-column CERT firmware status before tearing the partition down. */
 	if (vp && vp->mgmtctx)
 		ve2_get_firmware_status(hwctx);
@@ -879,6 +891,9 @@ void ve2_hwctx_fini(struct amdxdna_hwctx *hwctx)
 	ve2_free_hsa_queue(hwctx);
 
 	if (vp) {
+		u32 submitted = vp->submitted;
+		u32 completed = vp->completed;
+
 		if (enable_polling)
 			timer_delete_sync(&vp->event_timer);
 		kfree(vp->hwctx_config);
@@ -888,6 +903,9 @@ void ve2_hwctx_fini(struct amdxdna_hwctx *hwctx)
 		mutex_destroy(&vp->privctx_lock);
 		kfree(vp);
 		priv->hw_priv = NULL;
+
+		trace_amdxdna_trace_point("XRT_PROFILING_TRACE_EXIT",
+					  hwctx->client->pid, hwctx->id, submitted, completed);
 	}
 
 	kfree(priv);
@@ -979,6 +997,9 @@ int ve2_cmd_submit(struct amdxdna_hwctx *hwctx, struct amdxdna_sched_job *job, u
 		return -EINVAL;
 	}
 
+	trace_amdxdna_trace_point("XRT_PROFILING_TRACE_ENTER",
+				  hwctx->client->pid, hwctx->start_col, hwctx->id, 0);
+
 	if (op == ERT_CMD_CHAIN)
 		ret = ve2_submit_cmd_chain(hwctx, job, seq);
 	else
@@ -1018,6 +1039,9 @@ int ve2_cmd_submit(struct amdxdna_hwctx *hwctx, struct amdxdna_sched_job *job, u
 		XDNA_ERR(xdna, "cmd_submit kick failed ret=%d", ret);
 		return ret;
 	}
+
+	trace_amdxdna_trace_point("XRT_PROFILING_TRACE_EXIT",
+				  hwctx->client->pid, hwctx->start_col, hwctx->id, *seq);
 	return 0;
 }
 
@@ -1035,7 +1059,13 @@ static bool check_read_index(struct amdxdna_hwctx *hwctx, u64 seq)
 	hsa_queue_sync_read_index_for_read(&vp->hsa_queue);
 	read_index = *(u64 *)((char *)vp->hsa_queue.hsa_queue_p + HSA_QUEUE_READ_INDEX_OFFSET);
 
-	return read_index > seq;
+	if (read_index > seq) {
+		trace_amdxdna_trace_point("XRT_PROFILING_TRACE_UPDATE_READ_INDEX",
+					  hwctx->client->pid, hwctx->id, seq, read_index);
+		return true;
+	}
+
+	return false;
 }
 
 /*
@@ -1269,6 +1299,9 @@ int ve2_cmd_wait(struct amdxdna_hwctx *hwctx, u64 seq, u32 timeout_ms)
 	bool timed_out;
 	long ret = 0;
 
+	trace_amdxdna_trace_point("XRT_PROFILING_TRACE_ENTER",
+				  hwctx->client->pid, hwctx->start_col, hwctx->id, seq);
+
 	if (wait_jifs)
 		ret = wait_event_interruptible_timeout(vp->waitq,
 						       check_read_index(hwctx, seq),
@@ -1278,8 +1311,11 @@ int ve2_cmd_wait(struct amdxdna_hwctx *hwctx, u64 seq, u32 timeout_ms)
 					       check_read_index(hwctx, seq));
 
 	/* Interrupted by a signal; the command stays in flight for retry. */
-	if (ret < 0)
+	if (ret < 0) {
+		trace_amdxdna_trace_point("XRT_PROFILING_TRACE_EXIT",
+					  hwctx->client->pid, hwctx->start_col, hwctx->id, seq);
 		return ret;
+	}
 
 	/* Timed wait expired with the completion condition still unmet. */
 	timed_out = wait_jifs && ret == 0;
@@ -1295,6 +1331,8 @@ int ve2_cmd_wait(struct amdxdna_hwctx *hwctx, u64 seq, u32 timeout_ms)
 	/* Already completed and released by another waiter. */
 	if (!job) {
 		mutex_unlock(&vp->hsa_queue.hq_lock);
+		trace_amdxdna_trace_point("XRT_PROFILING_TRACE_EXIT",
+					  hwctx->client->pid, hwctx->start_col, hwctx->id, seq);
 		return 0;
 	}
 
@@ -1313,6 +1351,8 @@ int ve2_cmd_wait(struct amdxdna_hwctx *hwctx, u64 seq, u32 timeout_ms)
 
 	mutex_unlock(&vp->hsa_queue.hq_lock);
 
+	trace_amdxdna_trace_point("XRT_PROFILING_TRACE_EXIT",
+				  hwctx->client->pid, hwctx->start_col, hwctx->id, seq);
 	return 0;
 }
 

--- a/drivers/accel/amdxdna/ve2_mgmt.c
+++ b/drivers/accel/amdxdna/ve2_mgmt.c
@@ -20,6 +20,7 @@
 #include "amdxdna_ctx.h"
 #include "amdxdna_pci_drv.h"
 #include "amdxdna_solver.h"
+#include "trace/events/amdxdna.h"
 #include "ve2_aux.h"
 #include "ve2_hwctx.h"
 #include "ve2_host_queue.h"
@@ -402,11 +403,15 @@ static int ve2_mgmt_handshake_init(struct amdxdna_mgmtctx *mgmtctx,
 				  AIE_PART_INIT_OPT_NMU_CONFIG | AIE_PART_INIT_OPT_DIS_TLAST_ERROR |
 				  AIE_PART_INIT_OPT_ERR_SHIM_INIT | AIE_PART_INIT_OPT_HANDSHAKE);
 
+	trace_amdxdna_trace_point("XRT_PROFILING_TRACE_PARTITION_INIT",
+				  hwctx->client->pid, mgmtctx->start_col, hwctx->id, num_col);
 	ret = aie_partition_initialize(mgmtctx->aie_dev, &args);
 	if (ret < 0) {
 		XDNA_ERR(xdna, "aie partition init failed: %d", ret);
 		goto release_hs_data;
 	}
+	trace_amdxdna_trace_point("XRT_PROFILING_TRACE_PARTITION_DONE",
+				  hwctx->client->pid, mgmtctx->start_col, hwctx->id, num_col);
 
 	/* Wake up the lead UC only */
 	ret = aie_partition_uc_wakeup(mgmtctx->aie_dev, &lead_loc);
@@ -496,11 +501,18 @@ int ve2_mgmt_schedule_cmd(struct amdxdna_dev *xdna, struct amdxdna_hwctx *hwctx,
 
 	mgmtctx = vp->mgmtctx;
 
+	trace_amdxdna_trace_point("XRT_PROFILING_TRACE_ENTER",
+				  hwctx->client->pid, mgmtctx->start_col, hwctx->id,
+				  command_index);
+
 	mutex_lock(&mgmtctx->ctx_lock);
 
 	ret = ve2_fifo_enqueue(mgmtctx, hwctx, command_index);
 	if (ret) {
 		mutex_unlock(&mgmtctx->ctx_lock);
+		trace_amdxdna_trace_point("XRT_PROFILING_TRACE_EXIT",
+					  hwctx->client->pid, mgmtctx->start_col, hwctx->id,
+					  command_index);
 		return ret;
 	}
 
@@ -510,6 +522,9 @@ int ve2_mgmt_schedule_cmd(struct amdxdna_dev *xdna, struct amdxdna_hwctx *hwctx,
 		ret = ve2_mgmt_handshake_init(mgmtctx, hwctx);
 		if (ret) {
 			mutex_unlock(&mgmtctx->ctx_lock);
+			trace_amdxdna_trace_point("XRT_PROFILING_TRACE_EXIT",
+						  hwctx->client->pid, mgmtctx->start_col,
+						  hwctx->id, command_index);
 			return ret;
 		}
 		mgmtctx->active_ctx = hwctx;
@@ -535,6 +550,9 @@ int ve2_mgmt_schedule_cmd(struct amdxdna_dev *xdna, struct amdxdna_hwctx *hwctx,
 
 	mutex_unlock(&mgmtctx->ctx_lock);
 
+	trace_amdxdna_trace_point("XRT_PROFILING_TRACE_EXIT",
+				  hwctx->client->pid, mgmtctx->start_col, hwctx->id,
+				  command_index);
 	return 0;
 }
 
@@ -641,16 +659,21 @@ static void ve2_scheduler_work(struct work_struct *work)
 {
 	struct amdxdna_mgmtctx *mgmtctx = container_of(work, struct amdxdna_mgmtctx,
 						       scheduler_work);
+	struct amdxdna_hwctx *hwctx;
 	struct amdxdna_ctx_priv *vp;
 
 	guard(mutex)(&mgmtctx->ctx_lock);
 
-	if (!mgmtctx->active_ctx)
+	hwctx = mgmtctx->active_ctx;
+	if (!hwctx)
 		return;
 
-	vp = ve2_hw_priv(mgmtctx->active_ctx);
+	vp = ve2_hw_priv(hwctx);
 	if (!vp)
 		return;
+
+	trace_amdxdna_trace_point("XRT_PROFILING_TRACE_ENTER",
+				  hwctx->client->pid, mgmtctx->start_col, hwctx->id, 0);
 
 	/* If a switch was requested, mark the firmware ready to be reprogrammed. */
 	ve2_check_context_req(mgmtctx);
@@ -672,6 +695,9 @@ static void ve2_scheduler_work(struct work_struct *work)
 		XDNA_DBG(mgmtctx->xdna, "Scheduler: no action needed, active_ctx=%p",
 			 mgmtctx->active_ctx);
 	}
+
+	trace_amdxdna_trace_point("XRT_PROFILING_TRACE_EXIT",
+				  hwctx->client->pid, mgmtctx->start_col, hwctx->id, 0);
 }
 
 static void pop_from_ctx_command_fifo_till(struct amdxdna_mgmtctx *mgmtctx,
@@ -703,6 +729,7 @@ static void ve2_irq_handler(u32 partition_id, void *priv)
 	struct amdxdna_mgmtctx *mgmtctx = priv;
 	struct amdxdna_hwctx *active_ctx;
 	struct amdxdna_ctx_priv *vp;
+	u64 write_index = 0;
 	u64 read_index;
 
 	guard(mutex)(&mgmtctx->ctx_lock);
@@ -710,6 +737,9 @@ static void ve2_irq_handler(u32 partition_id, void *priv)
 
 	if (!active_ctx)
 		return;
+
+	trace_amdxdna_trace_point("XRT_PROFILING_TRACE_ENTER",
+				  active_ctx->client->pid, mgmtctx->start_col, active_ctx->id, 0);
 
 	if (get_ctx_read_index(active_ctx, &read_index)) {
 		XDNA_ERR(mgmtctx->xdna, "IRQ: failed to get read index");
@@ -720,6 +750,11 @@ static void ve2_irq_handler(u32 partition_id, void *priv)
 	vp = ve2_hw_priv(active_ctx);
 	if (vp)
 		wake_up_interruptible_all(&vp->waitq);
+
+	get_ctx_write_index(active_ctx, &write_index);
+	trace_amdxdna_trace_point("XRT_PROFILING_TRACE_EXIT",
+				  active_ctx->client->pid, active_ctx->id,
+				  write_index, read_index);
 
 	if (mgmtctx->work_queue &&
 	    (ve2_check_idle_or_queue_not_empty(mgmtctx) || ve2_check_misc_interrupt(mgmtctx))) {

--- a/drivers/accel/amdxdna/ve2_mgmt.h
+++ b/drivers/accel/amdxdna/ve2_mgmt.h
@@ -117,6 +117,27 @@ static inline int get_ctx_read_index(struct amdxdna_hwctx *hwctx, u64 *read_inde
 	return 0;
 }
 
+/*
+ * write_index is host-owned (the driver is the only writer), so unlike
+ * get_ctx_read_index() no dma_sync_single_for_cpu() is needed before reading
+ * it back here.
+ */
+static inline int get_ctx_write_index(struct amdxdna_hwctx *hwctx, u64 *write_index)
+{
+	struct amdxdna_ctx_priv *vp;
+
+	if (!hwctx || !write_index)
+		return -EINVAL;
+
+	vp = ve2_hw_priv(hwctx);
+	if (!vp || !vp->hsa_queue.hsa_queue_p)
+		return -EINVAL;
+
+	*write_index = vp->hsa_queue.hsa_queue_p->hq_header.write_index;
+
+	return 0;
+}
+
 /* Allocate and initialise the per-partition mgmtctx registry (one per column). */
 int ve2_mgmtctx_registry_init(struct amdxdna_dev_hdl *hdl);
 

--- a/include/trace/events/amdxdna.h
+++ b/include/trace/events/amdxdna.h
@@ -128,6 +128,41 @@ DEFINE_EVENT(xdna_mbox_name_id, mbox_poll_handle,
 	     TP_ARGS(name, irq)
 );
 
+/*
+ * Generic profiling tracepoint consumed by the xrt_profile userspace tool/test
+ * (xrt_profiling) to build per hardware-context / per-command timing
+ * breakdowns. Each call site passes a fixed message string (e.g.
+ * XRT_PROFILING_TRACE_ENTER/EXIT) plus up to three numeric arguments whose
+ * meaning depends on the calling function; see trace_amdxdna_trace_point()
+ * call sites in ve2_hwctx.c / ve2_mgmt.c for the argument layout of each.
+ */
+TRACE_EVENT(__amdxdna_trace_point,
+	    TP_PROTO(const char *msg, const char *func, u64 pid, u64 arg1, u64 arg2, u64 arg3),
+
+	    TP_ARGS(msg, func, pid, arg1, arg2, arg3),
+
+	    TP_STRUCT__entry(__string(msg, msg)
+			     __string(func, func)
+			     __field(u64, pid)
+			     __field(u64, arg1)
+			     __field(u64, arg2)
+			     __field(u64, arg3)),
+
+	    TP_fast_assign(__assign_str(msg);
+			   __assign_str(func);
+			   __entry->pid = pid;
+			   __entry->arg1 = arg1;
+			   __entry->arg2 = arg2;
+			   __entry->arg3 = arg3;),
+
+	    TP_printk("%s: %s() pid=%llu [%llu,%llu,%llu]", __get_str(msg), __get_str(func),
+		      __entry->pid, __entry->arg1, __entry->arg2, __entry->arg3)
+);
+
+/* Macro wrapper that automatically captures the function name */
+#define trace_amdxdna_trace_point(msg, pid, arg1, arg2, arg3) \
+	trace___amdxdna_trace_point(msg, __func__, pid, arg1, arg2, arg3)
+
 #endif /* !defined(_AMDXDNA_TRACE_EVENTS_H_) || defined(TRACE_HEADER_MULTI_READ) */
 
 /* This part must be outside protection */


### PR DESCRIPTION
- Add __amdxdna_trace_point to the existing amdxdna trace header and instrument ve2_hwctx.c/ve2_mgmt.c hwctx init/fini, cmd submit/wait, partition init and IRQ/scheduler paths so xrt_profiling can capture per-hwctx and per-command timing, matching the legacy VE2 driver.
- New trace event path "/sys/kernel/debug/tracing/events/amdxdna/__amdxdna_trace_point/enable|disable"
- Also allocate the hwctx ID before calling hwctx_init() so it's valid for the whole init call (needed for correct trace attribution), and add get_ctx_write_index() to report a real write_index from the IRQ handler's trace point instead of a placeholder.
- Modify PASID/SVA bind xdna errors to xdna debug message as these warning messages are expected on ve2.