### PR TITLE
accel/amdxdna: fix missing gem put in amdxdna_cmd_set_error

### DIFF
--- a/drivers/accel/amdxdna/amdxdna_ctx.c
+++ b/drivers/accel/amdxdna/amdxdna_ctx.c
@@ -214,8 +214,10 @@ int amdxdna_cmd_set_error(struct amdxdna_gem_obj *abo,
 		if (!abo)
 			return -EINVAL;
 		cmd = amdxdna_gem_vmap(abo);
-		if (!cmd)
+		if (!cmd) {
+			amdxdna_gem_put_obj(abo);
 			return -ENOMEM;
+		}
 	}
 
 	memset(cmd->data, 0xff, abo->mem.size - sizeof(*cmd));


### PR DESCRIPTION
When amdxdna_cmd_set_error() looks up the first sub-command BO of a chain command and amdxdna_gem_vmap() fails, the function returns -ENOMEM without releasing the reference taken by amdxdna_gem_get_obj(), leaking the BO.

Add the missing amdxdna_gem_put_obj() on the vmap failure path.