### PR TITLE
shim_test: move saved_tbo instead of copying on restore

### DIFF
--- a/test/shim_test/io_test.cpp
+++ b/test/shim_test/io_test.cpp
@@ -759,10 +759,10 @@ TEST_write_to_readonly_uptr_bo(device::id_type id, std::shared_ptr<device>& sdev
   try {
     boset->run();
   } catch (...) {
-    ofm_bo.tbo = saved_tbo;
+    ofm_bo.tbo = std::move(saved_tbo);
     throw;
   }
-  ofm_bo.tbo = saved_tbo;
+  ofm_bo.tbo = std::move(saved_tbo);
 }
 
 void


### PR DESCRIPTION
Fixes Coverity CID 912379 (COPY_INSTEAD_OF_MOVE).