### PR TITLE
accel/amdxdna: add query aie_status support

### DIFF
--- a/drivers/accel/amdxdna/aie.c
+++ b/drivers/accel/amdxdna/aie.c
@@ -226,6 +226,72 @@ int amdxdna_get_metadata(struct aie_device *aie,
 	return ret;
 }
 
+int amdxdna_get_aie_status(struct aie_device *aie,
+			   struct amdxdna_client *client,
+			   struct amdxdna_drm_get_info *args)
+{
+	struct amdxdna_drm_query_aie_status status = {};
+	struct amdxdna_dev *xdna = client->xdna;
+	struct amdxdna_msg_buf_hdl *buf_hdl;
+	u32 cols_filled = 0;
+	u32 resp_size = 0;
+	u32 alloc_sz;
+	u32 buf_sz;
+	int ret;
+
+	if (!aie->msg_ops.query_status)
+		return -EOPNOTSUPP;
+
+	buf_sz = min(args->buffer_size, sizeof(status));
+	if (copy_from_user(&status, u64_to_user_ptr(args->buffer), buf_sz)) {
+		XDNA_ERR(xdna, "Failed to copy AIE request into kernel");
+		return -EFAULT;
+	}
+
+	alloc_sz = aie->metadata.cols * aie->metadata.col_size;
+	if (!alloc_sz)
+		return -EINVAL;
+
+	buf_hdl = amdxdna_alloc_msg_buff(xdna, alloc_sz);
+	if (IS_ERR(buf_hdl))
+		return PTR_ERR(buf_hdl);
+
+	memset(to_cpu_addr(buf_hdl, 0), 0, to_buf_size(buf_hdl));
+	drm_clflush_virt_range(to_cpu_addr(buf_hdl, 0), to_buf_size(buf_hdl));
+
+	ret = aie->msg_ops.query_status(aie, buf_hdl, &cols_filled, &resp_size);
+	if (ret) {
+		XDNA_ERR(xdna, "Failed to get AIE status info, ret %d", ret);
+		goto out_free;
+	}
+
+	if (to_buf_size(buf_hdl) < resp_size) {
+		XDNA_ERR(xdna, "Bad buffer size. Available: %u. Needs: %u",
+			 to_buf_size(buf_hdl), resp_size);
+		ret = -EINVAL;
+		goto out_free;
+	}
+
+	/* Invalidate stale cache lines before reading FW-written data. */
+	drm_clflush_virt_range(to_cpu_addr(buf_hdl, 0), to_buf_size(buf_hdl));
+
+	resp_size = min(status.buffer_size, resp_size);
+	if (copy_to_user(u64_to_user_ptr(status.buffer),
+			 to_cpu_addr(buf_hdl, 0), resp_size)) {
+		XDNA_ERR(xdna, "Failed to copy AIE status to user space");
+		ret = -EFAULT;
+		goto out_free;
+	}
+
+	status.cols_filled = cols_filled;
+	if (copy_to_user(u64_to_user_ptr(args->buffer), &status, buf_sz))
+		ret = -EFAULT;
+
+out_free:
+	amdxdna_free_msg_buff(buf_hdl);
+	return ret;
+}
+
 int amdxdna_get_telemetry(struct aie_device *aie,
 			  struct amdxdna_client *client,
 			  struct amdxdna_drm_get_info *args)

--- a/drivers/accel/amdxdna/aie.h
+++ b/drivers/accel/amdxdna/aie.h
@@ -28,6 +28,10 @@ struct aie_msg_ops {
 		      u8 row, u8 col, u32 aie_addr,
 		      dma_addr_t dram_addr, u32 size);
 
+	int (*query_status)(struct aie_device *aie,
+			    struct amdxdna_msg_buf_hdl *buf_hdl,
+			    u32 *cols_filled, u32 *resp_size);
+
 	int (*query_telemetry)(struct aie_device *aie, char __user *buf, u32 size,
 			       struct amdxdna_drm_query_telemetry_header *header);
 	/* Optional per-arch FW health/map hooks; leave NULL when unsupported. */
@@ -172,6 +176,9 @@ int amdxdna_get_aie_version(struct amdxdna_client *client,
 int amdxdna_get_firmware_version(struct amdxdna_client *client,
 				 struct amdxdna_drm_get_info *args,
 				 struct amdxdna_drm_query_firmware_version *version);
+int amdxdna_get_aie_status(struct aie_device *aie,
+			   struct amdxdna_client *client,
+			   struct amdxdna_drm_get_info *args);
 int amdxdna_get_telemetry(struct aie_device *aie, struct amdxdna_client *client,
 			  struct amdxdna_drm_get_info *args);
 int amdxdna_get_hwctx_status(struct aie_device *aie, struct amdxdna_client *client,

--- a/drivers/accel/amdxdna/aie2_message.c
+++ b/drivers/accel/amdxdna/aie2_message.c
@@ -471,60 +471,36 @@ static int amdxdna_hwctx_col_map(struct amdxdna_hwctx *hwctx, void *arg)
 	return 0;
 }
 
-int aie2_query_status(struct amdxdna_dev_hdl *ndev, char __user *buf,
-		      u32 size, u32 *cols_filled)
+int aie2_query_status(struct aie_device *aie, struct amdxdna_msg_buf_hdl *buf_hdl,
+		      u32 *cols_filled, u32 *resp_size)
 {
 	DECLARE_AIE_MSG(aie_column_info, MSG_OP_QUERY_COL_STATUS);
-	struct amdxdna_dev *xdna = ndev->aie.xdna;
-	struct amdxdna_msg_buf_hdl *buf_hdl;
+	struct amdxdna_dev *xdna = aie->xdna;
 	struct amdxdna_client *client;
 	u32 aie_bitmap = 0;
 	int ret;
-
-	buf_hdl = amdxdna_alloc_msg_buff(xdna, ndev->aie.metadata.cols *
-					 ndev->aie.metadata.col_size);
-	if (IS_ERR(buf_hdl))
-		return PTR_ERR(buf_hdl);
 
 	/* Go through each hardware context and mark the AIE columns that are active */
 	list_for_each_entry(client, &xdna->client_list, node)
 		amdxdna_hwctx_walk(client, &aie_bitmap, NULL,
 				   amdxdna_hwctx_col_map);
 
-	*cols_filled = 0;
 	req.dump_buff_addr = to_dma_addr(buf_hdl, 0);
 	req.dump_buff_size = to_buf_size(buf_hdl);
 	req.num_cols = hweight32(aie_bitmap);
 	req.aie_bitmap = aie_bitmap;
 
-	drm_clflush_virt_range(to_cpu_addr(buf_hdl, 0), to_buf_size(buf_hdl));
-	ret = aie_send_mgmt_msg_wait(&ndev->aie, &msg);
+	ret = aie_send_mgmt_msg_wait(aie, &msg);
 	if (ret) {
 		XDNA_ERR(xdna, "Error during NPU query, status %d", ret);
-		goto fail;
+		return ret;
 	}
 
 	XDNA_DBG(xdna, "Query NPU status completed");
-
-	if (to_buf_size(buf_hdl) < resp.size) {
-		ret = -EINVAL;
-		XDNA_ERR(xdna, "Bad buffer size. Available: %u. Needs: %u",
-			 to_buf_size(buf_hdl), resp.size);
-		goto fail;
-	}
-
-	size = min(size, resp.size);
-	if (copy_to_user(buf, to_cpu_addr(buf_hdl, 0), size)) {
-		ret = -EFAULT;
-		XDNA_ERR(xdna, "Failed to copy NPU status to user space");
-		goto fail;
-	}
-
 	*cols_filled = aie_bitmap;
+	*resp_size = resp.size;
 
-fail:
-	amdxdna_free_msg_buff(buf_hdl);
-	return ret;
+	return 0;
 }
 
 int aie2_query_telemetry(struct amdxdna_dev_hdl *ndev,
@@ -1024,6 +1000,7 @@ void aie2_msg_init(struct amdxdna_dev_hdl *ndev)
 		ndev->exec_msg_ops = &legacy_exec_message_ops;
 
 	ndev->aie.hwctx_limit = ndev->priv->hwctx_limit;
+	ndev->aie.msg_ops.query_status = aie2_query_status;
 	ndev->aie.msg_ops.query_telemetry = aie2_query_telemetry_cb;
 	ndev->aie.msg_ops.fill_hwctx_map = aie2_fill_hwctx_map;
 	ndev->aie.msg_ops.fill_hwctx_health = aie2_fill_hwctx_health;

--- a/drivers/accel/amdxdna/aie2_pci.c
+++ b/drivers/accel/amdxdna/aie2_pci.c
@@ -714,37 +714,6 @@ static void aie2_fini(struct amdxdna_dev *xdna)
 	aie2_hw_stop(xdna);
 }
 
-static int aie2_get_aie_status(struct amdxdna_client *client,
-			       struct amdxdna_drm_get_info *args)
-{
-	struct amdxdna_drm_query_aie_status status = {};
-	struct amdxdna_dev *xdna = client->xdna;
-	struct amdxdna_dev_hdl *ndev;
-	u32 buf_sz;
-	int ret;
-
-	ndev = xdna->dev_handle;
-	buf_sz = min(args->buffer_size, sizeof(status));
-	if (copy_from_user(&status, u64_to_user_ptr(args->buffer), buf_sz)) {
-		XDNA_ERR(xdna, "Failed to copy AIE request into kernel");
-		return -EFAULT;
-	}
-
-	ret = aie2_query_status(ndev, u64_to_user_ptr(status.buffer),
-				status.buffer_size, &status.cols_filled);
-	if (ret) {
-		XDNA_ERR(xdna, "Failed to get AIE status info. Ret: %d", ret);
-		return ret;
-	}
-
-	if (copy_to_user(u64_to_user_ptr(args->buffer), &status, buf_sz)) {
-		XDNA_ERR(xdna, "Failed to copy AIE request info to user space");
-		return -EFAULT;
-	}
-
-	return 0;
-}
-
 static int aie2_get_power_mode(struct amdxdna_client *client,
 			       struct amdxdna_drm_get_info *args)
 {
@@ -888,7 +857,7 @@ static int aie2_get_info(struct amdxdna_client *client, struct amdxdna_drm_get_i
 
 	switch (args->param) {
 	case DRM_AMDXDNA_QUERY_AIE_STATUS:
-		ret = aie2_get_aie_status(client, args);
+		ret = amdxdna_get_aie_status(&ndev->aie, client, args);
 		break;
 	case DRM_AMDXDNA_QUERY_AIE_METADATA:
 		ret = amdxdna_get_metadata(&ndev->aie, client, args);

--- a/drivers/accel/amdxdna/aie2_pci.h
+++ b/drivers/accel/amdxdna/aie2_pci.h
@@ -288,7 +288,8 @@ int aie2_create_context(struct amdxdna_dev_hdl *ndev, struct amdxdna_hwctx *hwct
 int aie2_destroy_context(struct amdxdna_dev_hdl *ndev, struct amdxdna_hwctx *hwctx);
 int aie2_map_host_buf(struct amdxdna_dev_hdl *ndev, u32 context_id, u64 addr, u64 size);
 int aie2_add_host_buf(struct amdxdna_dev_hdl *ndev, u32 context_id, u64 addr, u64 size);
-int aie2_query_status(struct amdxdna_dev_hdl *ndev, char __user *buf, u32 size, u32 *cols_filled);
+int aie2_query_status(struct aie_device *aie, struct amdxdna_msg_buf_hdl *buf_hdl,
+		      u32 *cols_filled, u32 *resp_size);
 int aie2_query_telemetry(struct amdxdna_dev_hdl *ndev,
 			 char __user *buf, u32 size,
 			 struct amdxdna_drm_query_telemetry_header *header);

--- a/drivers/accel/amdxdna/aie4_message.c
+++ b/drivers/accel/amdxdna/aie4_message.c
@@ -588,6 +588,34 @@ int aie4_start_fw_trace(struct amdxdna_dev_hdl *ndev,
 	return 0;
 }
 
+static int aie4_query_status(struct aie_device *aie,
+			     struct amdxdna_msg_buf_hdl *buf_hdl,
+			     u32 *cols_filled, u32 *resp_size)
+{
+	DECLARE_AIE_MSG(aie4_msg_aie_column_info, AIE4_MSG_OP_AIE_COLUMN_INFO);
+	struct amdxdna_dev *xdna = aie->xdna;
+	u32 aie_bitmap;
+	int ret;
+
+	aie_bitmap = GENMASK(aie->metadata.cols - 1, 0);
+
+	req.dump_buff_addr = to_dma_addr(buf_hdl, 0);
+	req.dump_buff_size = to_buf_size(buf_hdl);
+	req.pasid = 0;
+	req.aie4_col_bitmap = aie_bitmap;
+
+	ret = aie_send_mgmt_msg_wait(aie, &msg);
+	if (ret) {
+		XDNA_ERR(xdna, "Error during NPU query, status %d", ret);
+		return ret;
+	}
+
+	*cols_filled = aie_bitmap;
+	*resp_size = resp.size;
+
+	return 0;
+}
+
 void aie4_msg_init(struct amdxdna_dev_hdl *ndev)
 {
 	if (AIE_FEATURE_ON(&ndev->aie, AIE4_GET_COREDUMP))
@@ -598,6 +626,7 @@ void aie4_msg_init(struct amdxdna_dev_hdl *ndev)
 		ndev->aie.msg_ops.rw_mem = aie4_rw_aie_mem;
 	}
 
+	ndev->aie.msg_ops.query_status = aie4_query_status;
 	ndev->aie.msg_ops.query_telemetry = aie4_query_telemetry;
 	/* aie4 has no fw_ctx_id <-> hwctx_id map and no per-ctx FW health. */
 	ndev->aie.hwctx_limit = 0;

--- a/drivers/accel/amdxdna/aie4_msg_priv.h
+++ b/drivers/accel/amdxdna/aie4_msg_priv.h
@@ -40,6 +40,7 @@ enum aie4_msg_opcode {
 	AIE4_MSG_OP_CONFIGURE_HW_CONTEXT             = 0x30005,
 	AIE4_MSG_OP_AIE_TILE_INFO                    = 0x30006,
 	AIE4_MSG_OP_AIE_VERSION_INFO                 = 0x30007,
+	AIE4_MSG_OP_AIE_COLUMN_INFO                  = 0x30008,
 	AIE4_MSG_OP_POWER_OVERRIDE                   = 0x3000B,
 	AIE4_MSG_OP_AIE_RW_ACCESS                    = 0x3000E,
 	AIE4_MSG_OP_AIE_COREDUMP                     = 0x30010,
@@ -318,6 +319,20 @@ struct aie4_msg_get_dpm_level_resp {
 } __packed;
 
 #define AIE4_WORK_BUFFER_MIN_SIZE      SZ_4M
+
+/* AIE4_MSG_OP_AIE_COLUMN_INFO */
+struct aie4_msg_aie_column_info_req {
+	__u64 dump_buff_addr;
+	__u32 dump_buff_size;
+	__u32 pasid;
+	__u32 rsvd;
+	__u32 aie4_col_bitmap;
+} __packed;
+
+struct aie4_msg_aie_column_info_resp {
+	enum aie4_msg_status status;
+	__u32 size;
+} __packed;
 
 /* Telemetry type for AIE4_MSG_OP_GET_TELEMETRY. */
 enum aie4_msg_telemetry_type {

--- a/drivers/accel/amdxdna/aie4_pci.c
+++ b/drivers/accel/amdxdna/aie4_pci.c
@@ -973,6 +973,9 @@ static int aie4_get_info(struct amdxdna_client *client, struct amdxdna_drm_get_i
 		goto dev_exit;
 
 	switch (args->param) {
+	case DRM_AMDXDNA_QUERY_AIE_STATUS:
+		ret = amdxdna_get_aie_status(&ndev->aie, client, args);
+		break;
 	case DRM_AMDXDNA_QUERY_AIE_METADATA:
 		ret = amdxdna_get_metadata(&ndev->aie, client, args);
 		break;


### PR DESCRIPTION
Add DRM_AMDXDNA_QUERY_AIE_STATUS support for AIE4 and refactor the AIE2 path onto a shared helper.
