### PR TITLE
 Enable AMD NPU (amdxdna) from a Xen domU guest over virtio

### DIFF
--- a/drivers/accel/amdxdna/amdxdna_gem.h
+++ b/drivers/accel/amdxdna/amdxdna_gem.h
@@ -36,6 +36,12 @@ struct amdxdna_mem {
 	struct sg_table			*sgt;
 	struct page			**pages;
 	unsigned long			nr_pages;
+	/*
+	 * Pages are borrowed from a Xen foreign (privcmd) mapping's page
+	 * array rather than pinned via pin_user_pages(); they are owned by
+	 * that VMA and must not be unpinned on free.
+	 */
+	bool				foreign;
 	struct mm_struct		*mm;
 };
 

--- a/drivers/accel/amdxdna/amdxdna_ubuf.c
+++ b/drivers/accel/amdxdna/amdxdna_ubuf.c
@@ -11,6 +11,7 @@
 #include <linux/overflow.h>
 #include <linux/pagemap.h>
 #include <linux/vmalloc.h>
+#include <xen/xen.h>
 
 #include "amdxdna_gem.h"
 #include "amdxdna_pci_drv.h"
@@ -38,7 +39,8 @@ static void amdxdna_gem_ubuf_obj_free(struct drm_gem_object *gobj)
 
 	amdxdna_dma_unmap_bo(xdna, abo);
 	amdxdna_ubuf_unmap_dma(abo);
-	if (abo->mem.nr_pages)
+	/* Foreign pages are borrowed from the Xen mapping; never unpin them. */
+	if (abo->mem.nr_pages && !abo->mem.foreign)
 		unpin_user_pages(abo->mem.pages, abo->mem.nr_pages);
 	atomic64_sub(abo->mem.size >> PAGE_SHIFT, &abo->mem.mm->pinned_vm);
 	kvfree(abo->mem.pages);
@@ -137,6 +139,110 @@ static int amdxdna_ubuf_hmm_register(struct amdxdna_gem_obj *abo,
 	return ret;
 }
 
+/*
+ * Xen foreign guest memory (privcmd MMAPBATCH) is mapped VM_IO|VM_PFNMAP, so
+ * pin_user_pages() returns -EFAULT. On an auto-translated (PVH) dom0 privcmd
+ * stores the local page array backing the foreign frames in
+ * vma->vm_private_data (ZONE_DEVICE pages from xen_alloc_unpopulated_pages).
+ *
+ * Detect this heuristically from public VMA state: we cannot compare
+ * vma->vm_ops against privcmd's (it is static in drivers/xen). A value of
+ * (void *)1 is privcmd's PRIV_VMA_LOCKED marker (PV dom0, no local pages).
+ * On success returns the page array and its length in @count.
+ */
+static struct page **amdxdna_xen_foreign_pages(struct vm_area_struct *vma,
+					       unsigned long *count)
+{
+	struct page **pages;
+
+	if (!xen_domain())
+		return NULL;
+	if ((vma->vm_flags & (VM_IO | VM_PFNMAP)) != (VM_IO | VM_PFNMAP))
+		return NULL;
+
+	pages = vma->vm_private_data;
+	if (!pages || pages == (struct page **)1)
+		return NULL;
+
+	*count = vma_pages(vma);
+	return pages;
+}
+
+/*
+ * Populate abo->mem.pages for one VA entry, under mmap_read_lock. When the BO
+ * is a Xen foreign (privcmd) mapping its pages can't be pinned, so borrow them
+ * from the privcmd VMA's local page array; otherwise pin_user_pages() them.
+ * The mode is fixed for the whole BO (see abo->mem.foreign) because free is
+ * all-or-nothing, so a foreign BO validates that every entry is foreign too.
+ * Returns the number of pages added, or a negative errno.
+ */
+static long amdxdna_ubuf_get_pages(struct amdxdna_gem_obj *abo,
+				   struct amdxdna_drm_va_entry *va_ent)
+{
+	struct amdxdna_dev *xdna = to_xdna_dev(to_gobj(abo)->dev);
+	unsigned long npages = va_ent->len >> PAGE_SHIFT;
+	struct vm_area_struct *vma;
+	long ret;
+
+	if (abo->mem.foreign) {
+		unsigned long fcount, off, j;
+		struct page **fpages;
+
+		vma = amdxdna_ubuf_find_vma(va_ent);
+		fpages = vma ? amdxdna_xen_foreign_pages(vma, &fcount) : NULL;
+		if (!fpages) {
+			XDNA_ERR(xdna, "Entry vaddr %llx is not a foreign mapping",
+				 va_ent->vaddr);
+			return -EINVAL;
+		}
+
+		off = (va_ent->vaddr - vma->vm_start) >> PAGE_SHIFT;
+		if (off + npages > fcount) {
+			XDNA_ERR(xdna, "Foreign entry out of range %lu+%lu > %lu",
+				 off, npages, fcount);
+			return -EINVAL;
+		}
+
+		for (j = 0; j < npages; j++)
+			abo->mem.pages[abo->mem.nr_pages++] = fpages[off + j];
+
+		return npages;
+	}
+
+	/*
+	 * Non-foreign entries take the normal pin path. In particular, when a
+	 * Xen guest grants pages to this (dom0) domain and they are mapped via
+	 * gntdev, the mapping is VM_MIXEDMAP backed by local struct pages -- i.e.
+	 * normal, pinnable pages -- unlike privcmd foreign (VM_IO|VM_PFNMAP)
+	 * mappings, which have no pinnable struct page and are borrowed above.
+	 *
+	 * Caveat for grant pages: the FOLL_LONGTERM pin only holds a reference on
+	 * the local (dom0) struct page, not on the grant itself. The grant is
+	 * owned by the guest; if the guest revokes it (or gntdev unmaps) while
+	 * this BO is alive, the local page's p2m/backing machine frame changes,
+	 * but the device's IOMMU mapping (amdxdna_dma_map_bo() programs it from
+	 * the page's physical address) still points at the old frame. The device
+	 * then DMAs to a stale/reused machine frame -- silent corruption. There
+	 * is no notifier here to catch revocation, so the BO must be destroyed
+	 * before the grant is revoked; callers must order teardown accordingly.
+	 */
+	ret = pin_user_pages(va_ent->vaddr, npages,
+			     (abo->readonly ? 0 : FOLL_WRITE) | FOLL_LONGTERM,
+			     &abo->mem.pages[abo->mem.nr_pages]);
+	if (ret < 0) {
+		XDNA_ERR(xdna, "Failed to pin pages ret %ld", ret);
+		return ret;
+	}
+
+	abo->mem.nr_pages += ret;
+	if (ret != npages) {
+		XDNA_ERR(xdna, "Partially pinned pages %ld/%ld", ret, npages);
+		return -ENOMEM;
+	}
+
+	return ret;
+}
+
 struct amdxdna_gem_obj *amdxdna_alloc_ubuf_bo(struct amdxdna_client *client,
 					      u32 num_entries, void __user *va_entries)
 {
@@ -144,6 +250,8 @@ struct amdxdna_gem_obj *amdxdna_alloc_ubuf_bo(struct amdxdna_client *client,
 	unsigned long lock_limit, new_pinned;
 	struct amdxdna_drm_va_entry *va_ent;
 	struct amdxdna_gem_obj *abo;
+	struct vm_area_struct *vma;
+	unsigned long fcount = 0;
 	unsigned long npages;
 	bool need_contig;
 	size_t bufsize;
@@ -229,23 +337,20 @@ struct amdxdna_gem_obj *amdxdna_alloc_ubuf_bo(struct amdxdna_client *client,
 	mmap_read_lock(current->mm);
 	amdxdna_ubuf_check_readonly(abo, va_ent, num_entries);
 
-	for (i = 0; i < num_entries; i++) {
-		npages = va_ent[i].len >> PAGE_SHIFT;
+	/*
+	 * Xen foreign (privcmd) mappings are VM_IO|VM_PFNMAP and can't be
+	 * pinned. Decide the mode once from the first entry so the whole BO is
+	 * uniformly borrowed or pinned (free is all-or-nothing). Grant (gntdev)
+	 * mappings are VM_MIXEDMAP and take the normal pin path.
+	 */
+	vma = amdxdna_ubuf_find_vma(&va_ent[0]);
+	if (vma && amdxdna_xen_foreign_pages(vma, &fcount))
+		abo->mem.foreign = true;
 
-		ret = pin_user_pages(va_ent[i].vaddr, npages,
-				     (abo->readonly ? 0 : FOLL_WRITE) | FOLL_LONGTERM,
-				     &abo->mem.pages[abo->mem.nr_pages]);
-		if (ret >= 0) {
-			abo->mem.nr_pages += ret;
-			if (ret != npages) {
-				XDNA_ERR(xdna, "Partially pinned pages %ld/%ld", ret, npages);
-				ret = -ENOMEM;
-				break;
-			}
-		} else {
-			XDNA_ERR(xdna, "Failed to pin pages ret %ld", ret);
+	for (i = 0; i < num_entries; i++) {
+		ret = amdxdna_ubuf_get_pages(abo, &va_ent[i]);
+		if (ret < 0)
 			break;
-		}
 	}
 	mmap_read_unlock(current->mm);
 

--- a/src/shim/virtio/platform_virtio.cpp
+++ b/src/shim/virtio/platform_virtio.cpp
@@ -10,6 +10,7 @@
 #include "platform_virtio.h"
 #include "core/common/trace.h"
 #include <poll.h>
+#include <cstddef>
 #include <cstring>
 #include <iostream>
 #include <sys/mman.h>
@@ -30,12 +31,64 @@ roundup_64bit(size_t size)
 #define VIRTGPU_DRM_CAPSET_DRM 6
 #endif
 
+// The build-time <drm/virtgpu_drm.h> may predate userptr blob support. Define
+// the flag and the extended RESOURCE_CREATE_BLOB request layout locally so the
+// guest can pin a userptr range and hand it to the host regardless of the UAPI
+// header version. These are defined unconditionally (under our own names) so the
+// wire ABI is fixed by this source, independent of whichever header the build
+// host happens to provide -- the same binary then talks to the guest kernel the
+// same way whether or not the header knew about userptr. Only the flag value
+// defers to the header when it already defines it.
+//
+// Compile safety: the flag is #ifndef-guarded; the struct and ioctl macro use
+// project-local names that never collide with the UAPI header. Runtime safety:
+// on a kernel/VMM without userptr support the ioctl() wrapper below throws
+// (ENOTTY), so drm_bo_alloc_userptr fails cleanly instead of returning a bogus
+// zeroed handle.
+#ifndef VIRTGPU_BLOB_FLAG_USE_USERPTR
+#define VIRTGPU_BLOB_FLAG_USE_USERPTR 0x0008
+#endif
+
+struct virtgpu_resource_create_blob_userptr {
+  uint32_t blob_mem;
+  uint32_t blob_flags;
+  uint32_t bo_handle;
+  uint32_t res_handle;
+  uint64_t size;
+  uint32_t pad;
+  uint32_t cmd_size;
+  uint64_t cmd;
+  uint64_t blob_id;
+  uint64_t userptr;
+  uint64_t blob_svm;
+  uint64_t offset;
+};
+
+// The DRM_IOWR command number encodes sizeof(struct), so it must match the size
+// the guest kernel expects byte-for-byte. Pin the size (guards add/remove of a
+// field) and the offsets of the two fields that define this request (guards a
+// reorder that happens to preserve the total size). If the layout above is ever
+// edited, the build fails loudly rather than silently shifting the ioctl number
+// or field positions (which would surface only at runtime as ENOTTY or garbage).
+static_assert(sizeof(virtgpu_resource_create_blob_userptr) == 72,
+              "virtgpu userptr blob request size must match the guest kernel UAPI");
+static_assert(offsetof(virtgpu_resource_create_blob_userptr, size) == 16,
+              "virtgpu userptr blob 'size' offset must match the guest kernel UAPI");
+static_assert(offsetof(virtgpu_resource_create_blob_userptr, userptr) == 48,
+              "virtgpu userptr blob 'userptr' offset must match the guest kernel UAPI");
+
+#define DRM_IOCTL_VIRTGPU_RESOURCE_CREATE_BLOB_USERPTR \
+  DRM_IOWR(DRM_COMMAND_BASE + DRM_VIRTGPU_RESOURCE_CREATE_BLOB, \
+           struct virtgpu_resource_create_blob_userptr)
+
 std::string
 ioctl_cmd2name(unsigned long cmd)
 {
   switch(cmd) {
   case DRM_IOCTL_VIRTGPU_RESOURCE_CREATE_BLOB:
     return "DRM_IOCTL_VIRTGPU_RESOURCE_CREATE_BLOB";
+  case DRM_IOCTL_VIRTGPU_RESOURCE_CREATE_BLOB_USERPTR:
+    return "DRM_IOCTL_VIRTGPU_RESOURCE_CREATE_BLOB(USERPTR)";
   case DRM_IOCTL_VIRTGPU_MAP:
     return "DRM_IOCTL_VIRTGPU_MAP";
   case DRM_IOCTL_VIRTGPU_EXECBUFFER:
@@ -264,6 +317,21 @@ drm_bo_alloc(int fd, size_t size, uint32_t type, bool use_host_mem = false)
     .blob_id    = blob_id,
   };
   ioctl(fd, DRM_IOCTL_VIRTGPU_RESOURCE_CREATE_BLOB, &args);
+  return {args.res_handle, args.bo_handle};
+}
+
+// Pin a guest userptr range and expose its pages to the host as a virtio-gpu
+// guest resource. The host reads the resource's iovecs to back the BO.
+shim_xdna::bo_id
+drm_bo_alloc_userptr(int fd, void *uptr, size_t size)
+{
+  virtgpu_resource_create_blob_userptr args = {
+    .blob_mem   = VIRTGPU_BLOB_MEM_GUEST,
+    .blob_flags = VIRTGPU_BLOB_FLAG_USE_USERPTR,
+    .size       = size,
+    .userptr    = reinterpret_cast<uintptr_t>(uptr),
+  };
+  ioctl(fd, DRM_IOCTL_VIRTGPU_RESOURCE_CREATE_BLOB_USERPTR, &args);
   return {args.res_handle, args.bo_handle};
 }
 
@@ -520,6 +588,31 @@ create_bo(bo_info& arg) const
   try {
     std::tie(arg.bo.handle, arg.xdna_addr) =
       host_bo_alloc(arg.type, arg.size, id.res_id, arg.xdna_addr_align);
+  } catch (...) {
+    drm_bo_free(fd, arg.bo.res_id);
+    throw;
+  }
+
+  save_bo_info(arg.bo.res_id, arg);
+}
+
+void
+platform_drv_virtio::
+create_uptr_bo(bo_info& arg) const
+{
+  auto fd = dev_fd();
+
+  // Create a virtio-gpu userptr resource blob over the guest user pages, then
+  // let the host allocate a shared BO backed by that resource's iovecs.
+  auto id = drm_bo_alloc_userptr(fd, arg.vaddr, arg.size);
+  arg.bo.res_id = id.handle;
+  // Userptr BOs are accessed through the caller's own mapping, not mmap'ed.
+  arg.map_offset = AMDXDNA_INVALID_ADDR;
+  arg.type = AMDXDNA_BO_SHARE;
+
+  try {
+    std::tie(arg.bo.handle, arg.xdna_addr) =
+      host_bo_alloc(AMDXDNA_BO_SHARE, arg.size, id.res_id, arg.xdna_addr_align);
   } catch (...) {
     drm_bo_free(fd, arg.bo.res_id);
     throw;

--- a/src/shim/virtio/platform_virtio.cpp
+++ b/src/shim/virtio/platform_virtio.cpp
@@ -546,11 +546,11 @@ platform_drv_virtio::
 get_info(amdxdna_drm_get_info& arg) const
 {
   if (arg.param == DRM_AMDXDNA_QUERY_AIE_STATUS)
-    shim_not_supported_err("get_info: DRM_AMDXDNA_QUERY_AIE_METADATA");
+    shim_err(EACCES, "get_info: DRM_AMDXDNA_QUERY_AIE_STATUS");
   if (arg.param == DRM_AMDXDNA_READ_AIE_MEM)
-    shim_not_supported_err("get_info: DRM_AMDXDNA_READ_AIE_MEM");
+    shim_err(EACCES, "get_info: DRM_AMDXDNA_READ_AIE_MEM");
   if (arg.param == DRM_AMDXDNA_READ_AIE_REG)
-    shim_not_supported_err("get_info: DRM_AMDXDNA_READ_AIE_MEM");
+    shim_err(EACCES, "get_info: DRM_AMDXDNA_READ_AIE_REG");
 
   auto resp_buf = std::make_unique<response_buffer>(dev_fd(), arg.buffer_size);
   std::memcpy(resp_buf->get(), reinterpret_cast<char*>(arg.buffer), arg.buffer_size);
@@ -589,6 +589,13 @@ get_info_array(amdxdna_drm_get_array& arg) const
   std::memcpy(reinterpret_cast<char*>(arg.buffer), resp_buf->get(), total_buf_size);
   arg.element_size = rsp.size;
   arg.num_element = rsp.num_element;
+}
+
+void
+platform_drv_virtio::
+set_state(amdxdna_drm_set_state&) const
+{
+  shim_err(EACCES, "set_state is not permitted from a virtio guest");
 }
 
 void

--- a/src/shim/virtio/platform_virtio.h
+++ b/src/shim/virtio/platform_virtio.h
@@ -82,6 +82,9 @@ private:
   get_info_array(amdxdna_drm_get_array& arg) const override;
 
   void
+  set_state(amdxdna_drm_set_state& arg) const override;
+
+  void
   get_sysfs(get_sysfs_arg& arg) const override;
 
   void

--- a/src/shim/virtio/platform_virtio.h
+++ b/src/shim/virtio/platform_virtio.h
@@ -73,6 +73,9 @@ private:
   create_bo(bo_info& arg) const override;
 
   void
+  create_uptr_bo(bo_info& arg) const override;
+
+  void
   destroy_bo(destroy_bo_arg& arg) const override;
 
   void

--- a/src/vxdna/src/vaccel_amdxdna.cpp
+++ b/src/vxdna/src/vaccel_amdxdna.cpp
@@ -169,6 +169,16 @@ hwctx_ring_idx(uint32_t ctx_handle)
  * resources are shared by design.  On mismatch we throw -EACCES; the ccmd
  * error wrapper (or the C-API boundary for INIT) turns that into a logged
  * error response.
+ *
+ * Exception: device-owned resources (is_device_owned(), i.e. AMDXDNA_BO_SHARE)
+ * are legitimately shared across contexts via dma-buf export/import. Their GEM
+ * handle lives on the long-lived device fd; each context opens its own DRM fd
+ * and imports the resource's dma-buf into it (see the host-backed branch of
+ * vxdna_bo). export_resource_fd() restricts export to these resources. Gate on
+ * is_device_owned() rather than get_opaque_handle() > 0: host-backed but
+ * context-scoped BOs (e.g. AMDXDNA_BO_DEV_HEAP, which also have opaque_handle
+ * > 0) are NOT cross-context -- their handle lives on the creating context's
+ * fd, so they must stay protected like guest iovec-backed buffers.
  */
 std::shared_ptr<vaccel_resource>
 lookup_resource_for_ctx(vxdna &device, uint32_t res_id, uint32_t caller_ctx_id,
@@ -180,8 +190,18 @@ lookup_resource_for_ctx(vxdna &device, uint32_t res_id, uint32_t caller_ctx_id,
                          purpose, res_id, caller_ctx_id);
 
     const uint32_t owner_ctx_id = res->get_ctx_id();
+    /*
+     * Reject a cross-context lookup unless:
+     *   - the caller owns the resource, or
+     *   - it is a platform (ctx 0) resource, shared by design, or
+     *   - it is device-owned (AMDXDNA_BO_SHARE), which is legitimately shared
+     *     across contexts via dma-buf export/import (see block comment).
+     * Everything else -- guest iovec-backed buffers AND host-backed but
+     * context-scoped BOs like DEV_HEAP -- stays protected.
+     */
     if (owner_ctx_id != caller_ctx_id &&
-        owner_ctx_id != k_platform_ctx_id)
+        owner_ctx_id != k_platform_ctx_id &&
+        !res->is_device_owned())   /* only SHARE is cross-context; keep the rest protected */
         VACCEL_THROW_MSG(-EACCES,
                          "%s: resource %u not owned by ctx %u (owner ctx %u)",
                          purpose, res_id, caller_ctx_id, owner_ctx_id);
@@ -424,6 +444,20 @@ close_gem_handle(int fd, uint32_t handle)
     }
 }
 
+/* PRIME-export a GEM handle on @fd to a new dma-buf fd (caller closes it). */
+int
+export_gem_fd(int fd, uint32_t handle)
+{
+    struct drm_prime_handle args = {};
+    args.handle = handle;
+    args.flags = DRM_RDWR | DRM_CLOEXEC;
+    args.fd = -1;
+    if (ioctl(fd, DRM_IOCTL_PRIME_HANDLE_TO_FD, &args))
+        VACCEL_THROW_MSG(-errno, "Export gem handle %u failed, errno %d, %s",
+                         handle, errno, strerror(errno));
+    return args.fd;
+}
+
 } // namespace
 
 vxdna_bo::
@@ -523,6 +557,7 @@ vxdna_bo(const std::shared_ptr<vaccel_resource> &res, vxdna_context &ctx,
     auto num_iovs = res->get_iovecs(&iovecs);
 
     bool created_here = false;
+    bool imported_here = false;
     bool use_raw_iovs = false;
     if (m_opaque_handle == AMDXDNA_INVALID_BO_HANDLE) {
         const bool heap_chunk = (m_bo_type == AMDXDNA_BO_DEV_HEAP);
@@ -660,20 +695,47 @@ vxdna_bo(const std::shared_ptr<vaccel_resource> &res, vxdna_context &ctx,
         }
         m_bo_handle = args.handle;
         created_here = true;
-    } else {
+    } else if (!res->is_device_owned()) {
+        /*
+         * Context-scoped host BO (e.g. DEV_HEAP): its GEM handle lives on this
+         * (the creating) context's own fd, so use it directly.
+         */
         m_bo_handle = static_cast<uint32_t>(m_opaque_handle);
+    } else {
+        /*
+         * Device-owned SHARE BO: its GEM lives on the device-wide fd, not in any
+         * context's fd (GEM handles are per-fd -- each context opens its own node
+         * via accel_get_drm_fd()). Export the resource's dma-buf from the device
+         * fd and import it into *this* context's fd to obtain a handle valid
+         * here, with its own GEM/dma_buf reference. This holds for the creating
+         * context too, and lets the backing outlive any single context: each
+         * ~vxdna_bo closes only its own handle, and the device-fd handle is
+         * released in destroy_resource.
+         */
+        int dbuf_fd = ctx.get_device().export_resource_fd(res->get_res_id());
+
+        struct drm_prime_handle prime = {};
+        prime.fd = dbuf_fd;
+        ret = ioctl(m_ctx_fd, DRM_IOCTL_PRIME_FD_TO_HANDLE, &prime);
+        int saved_errno = errno;
+        close(dbuf_fd);
+        if (ret)
+            VACCEL_THROW_MSG(-saved_errno,
+                             "import host BO res %u into ctx %u fd %d failed",
+                             res->get_res_id(), ctx.get_id(), m_ctx_fd);
+        m_bo_handle = prime.handle;
+        imported_here = true;
     }
 
     bo_info.handle = m_bo_handle;
     ret = ioctl(m_ctx_fd, DRM_IOCTL_AMDXDNA_GET_BO_INFO, &bo_info);
     if (ret) {
-        if (created_here) {
+        if (created_here || imported_here)
             close_gem_handle(m_ctx_fd, m_bo_handle);
-            if (m_coalesce_va && m_coalesce_len) {
-                munmap(m_coalesce_va, m_coalesce_len);
-                m_coalesce_va = nullptr;
-                m_coalesce_len = 0;
-            }
+        if (created_here && m_coalesce_va && m_coalesce_len) {
+            munmap(m_coalesce_va, m_coalesce_len);
+            m_coalesce_va = nullptr;
+            m_coalesce_len = 0;
         }
         VACCEL_THROW_MSG(-errno, "Get bo info failed ret %d", ret);
     }
@@ -681,18 +743,108 @@ vxdna_bo(const std::shared_ptr<vaccel_resource> &res, vxdna_context &ctx,
     m_map_offset = bo_info.map_offset;
     m_xdna_addr = bo_info.xdna_addr;
 
-    /* Opaque import: CPU UVA from GET_BO_INFO. Created userptr BOs keep coalesce UVA. */
+    /*
+     * Host-memory BO not created on this CCMD (its GEM already existed: a
+     * context-scoped handle for DEV_HEAP, or a device-fd handle imported into
+     * this context's fd for SHARE). Either way m_bo_handle is now valid in
+     * m_ctx_fd. The amdxdna driver backs host BOs with a user pointer, so mmap
+     * via map_offset to obtain the host CPU VA. This also registers mem.uva in
+     * the driver, which is the device address in SVA/PASID mode. Mirrors the
+     * native shim's mmap_drm_bo().
+     *
+     * A valid map_offset is a DRM VMA fake offset established at create time
+     * (drm_gem_shmem_create). The driver reports AMDXDNA_INVALID_ADDR only for
+     * AMDXDNA_BO_DEV, which is rejected earlier, so a missing offset is an error.
+     */
     if (!created_here) {
-        m_vaddr = bo_info.vaddr;
-        if (m_vaddr == AMDXDNA_INVALID_ADDR || m_vaddr == 0)
-            VACCEL_THROW_MSG(-EINVAL,
-                             "Pre-imported BO without CPU UVA from GET_BO_INFO: handle=%u, type=%u",
-                             m_bo_handle, m_bo_type);
+        /*
+         * The destructor does not run when a constructor throws, so any handle
+         * we imported here must be closed explicitly before rethrowing (the
+         * GET_BO_INFO failure path above does the same). Only imported_here can
+         * be set in this block; a context-scoped handle (DEV_HEAP) is owned
+         * elsewhere and must not be closed.
+         */
+        try {
+            if (m_map_offset == AMDXDNA_INVALID_ADDR || m_map_offset == 0)
+                VACCEL_THROW_MSG(-EINVAL,
+                                 "Host BO without valid map_offset: handle=%u, type=%u, "
+                                 "map_offset=0x%lx",
+                                 m_bo_handle, m_bo_type,
+                                 static_cast<unsigned long>(m_map_offset));
+
+            if (m_bo_type == AMDXDNA_BO_DEV_HEAP)
+                map_dev_heap_chunk(ctx);
+            else
+                map_host_shared();
+        } catch (...) {
+            if (imported_here)
+                close_gem_handle(m_ctx_fd, m_bo_handle);
+            throw;
+        }
     }
 
     vxdna_dbg("Resource BO: res_id=%u, handle=%u, vaddr=0x%lx, xdna_addr=0x%lx, iov_bytes=%lu (coalesced UVA)",
               res->get_res_id(), m_bo_handle, m_vaddr, m_xdna_addr,
               static_cast<unsigned long>(m_iov_bytes));
+}
+
+void
+vxdna_bo::
+map_host_shared()
+{
+    size_t map_len = page_roundup(m_size);
+    void *p = mmap(nullptr, map_len, PROT_READ | PROT_WRITE,
+                   MAP_SHARED | MAP_LOCKED, m_ctx_fd,
+                   static_cast<off_t>(m_map_offset));
+    if (p == MAP_FAILED)
+        VACCEL_THROW_MSG(-errno,
+                         "mmap host BO via map_offset failed: handle=%u, type=%u, "
+                         "map_offset=0x%lx, size=0x%lx",
+                         m_bo_handle, m_bo_type,
+                         static_cast<unsigned long>(m_map_offset),
+                         static_cast<unsigned long>(m_size));
+    m_host_map_va = p;
+    m_host_map_len = map_len;
+    m_vaddr = static_cast<uint64_t>(reinterpret_cast<uintptr_t>(p));
+}
+
+void
+vxdna_bo::
+map_dev_heap_chunk(vxdna_context &ctx)
+{
+    /*
+     * Dev-heap chunks must be contiguous in host VA: a DEV BO may span chunks,
+     * and the driver requires the heap's uva to be contiguous across them (else
+     * "Heap N uva is not contiguous"). Place each chunk at its committed offset
+     * in the context's 64 MiB-aligned heap arena with MAP_FIXED, mirroring the
+     * guest-iovec heap path. m_heap_committed is advanced by create_bo() after
+     * construction.
+     *
+     * The arena owns the unmapping (release_heap_arena() at context teardown),
+     * so do not record m_host_map_va -- unmapping a chunk's slice individually
+     * would leave a hole another mmap could reuse, which the wholesale arena
+     * munmap would then tear down.
+     */
+    size_t map_len = page_roundup(m_size);
+    void *arena = ctx.ensure_heap_arena();
+    uint64_t off = ctx.m_heap_committed;
+    if (off + map_len > vxdna_context::HEAP_MAX_SIZE)
+        VACCEL_THROW_MSG(-ENOSPC,
+                         "heap chunk at 0x%llx + 0x%zx exceeds arena 0x%llx",
+                         static_cast<unsigned long long>(off), map_len,
+                         static_cast<unsigned long long>(vxdna_context::HEAP_MAX_SIZE));
+    void *hint = static_cast<char *>(arena) + off;
+    void *p = mmap(hint, map_len, PROT_READ | PROT_WRITE,
+                   MAP_SHARED | MAP_LOCKED | MAP_FIXED, m_ctx_fd,
+                   static_cast<off_t>(m_map_offset));
+    if (p == MAP_FAILED)
+        VACCEL_THROW_MSG(-errno,
+                         "mmap dev-heap chunk into arena failed: handle=%u, "
+                         "off=0x%llx, map_offset=0x%lx, size=0x%lx",
+                         m_bo_handle, static_cast<unsigned long long>(off),
+                         static_cast<unsigned long>(m_map_offset),
+                         static_cast<unsigned long>(m_size));
+    m_vaddr = static_cast<uint64_t>(reinterpret_cast<uintptr_t>(p));
 }
 
 vxdna_bo::
@@ -713,6 +865,12 @@ vxdna_bo::
             vxdna_err("munmap coalesce va failed errno %d", errno);
         m_coalesce_va = nullptr;
         m_coalesce_len = 0;
+    }
+    if (m_host_map_va && m_host_map_len > 0) {
+        if (munmap(m_host_map_va, m_host_map_len) != 0)
+            vxdna_err("munmap host map va failed errno %d", errno);
+        m_host_map_va = nullptr;
+        m_host_map_len = 0;
     }
 }
 
@@ -1174,9 +1332,9 @@ void
 vxdna_context::
 sync_bo(const struct amdxdna_ccmd_sync_bo_req *req)
 {
-    // The guest BO handle is the host GEM handle, but all guest contexts share
-    // the native client's GEM namespace (single client per QEMU). Validate the
-    // BO is owned by this context before issuing the driver ioctl.
+    // The guest BO handle is this context's own host GEM handle (each context
+    // has its own DRM fd / GEM namespace). Validate the BO belongs to this
+    // context before issuing the driver ioctl on this context's fd.
     auto bo = m_bo_table.lookup(req->handle);
     if (!bo)
         VACCEL_THROW_MSG(-EINVAL, "sync_bo: BO %u not found in ctx %u",
@@ -1378,11 +1536,23 @@ int
 vxdna_context::
 get_blob_impl(const struct vaccel_create_resource_blob_args *args)
 {
-    vxdna_dbg("Getting blob: ctx_id=%u, ctx_fd=%d, blob_id=%ld, blob_size=%zu", get_id(), get_fd(), args->blob_id, args->size);
+    /*
+     * SHARE BOs are context-independent host memory that may be shared across
+     * contexts via dma-buf import. Create them on the device-wide fd so their
+     * backing outlives the creating context (mirroring bare metal, where an
+     * exported BO survives the producer via its dma-buf reference). Other host
+     * blob types (e.g. DEV_HEAP) are context-scoped in the driver
+     * (client->dev_heap) and must stay on the creating context's fd.
+     */
+    bool device_owned = (args->blob_id == AMDXDNA_BO_SHARE);
+    int fd = device_owned ? get_device().get_owned_drm_fd() : get_fd();
+
+    vxdna_dbg("Getting blob: ctx_id=%u, fd=%d, device_owned=%d, blob_id=%ld, blob_size=%zu",
+              get_id(), fd, device_owned, args->blob_id, args->size);
     struct amdxdna_drm_create_bo blob_args = {};
     blob_args.type = args->blob_id;//AMDXDNA_BO_SHMEM;
     blob_args.size = args->size;
-    auto ret = ioctl(get_fd(), DRM_IOCTL_AMDXDNA_CREATE_BO, &blob_args);
+    auto ret = ioctl(fd, DRM_IOCTL_AMDXDNA_CREATE_BO, &blob_args);
     if (ret) {
         VACCEL_THROW_MSG(-errno, "Create blob failed ret %d, %d, %s, type %d, size %lld\n",
                          ret, -errno, strerror(errno), static_cast<uint32_t>(blob_args.type),
@@ -1468,19 +1638,39 @@ create_resource_from_blob(const struct vaccel_create_resource_blob_args *args)
     int opaque_handle = ctx->get_blob(args);
     auto res = std::make_shared<vaccel_resource>(args->res_handle, args->size,
                                                  opaque_handle, args->ctx_id);
+    /*
+     * SHARE blobs were created on the device-wide fd (see get_blob_impl), so the
+     * resource -- not the creating context -- owns the GEM handle. Mark it so
+     * export/import/destroy operate on the device fd instead of a context fd.
+     */
+    res->set_device_owned(args->blob_id == AMDXDNA_BO_SHARE);
     add_resource(args->res_handle, std::move(res));
-    vxdna_dbg("Created resource from blob: res_id=%u, opaque_handle=%d",
-              args->res_handle, opaque_handle);
+    vxdna_dbg("Created resource from blob: res_id=%u, opaque_handle=%d, device_owned=%d",
+              args->res_handle, opaque_handle, args->blob_id == AMDXDNA_BO_SHARE);
+}
+
+int
+vxdna::
+export_gem_on_device_fd(uint32_t handle)
+{
+    return export_gem_fd(get_owned_drm_fd(), handle);
 }
 
 void
 vxdna::
-destroy_resource([[maybe_unused]] const std::shared_ptr<vaccel_resource> &res)
+destroy_resource(const std::shared_ptr<vaccel_resource> &res)
 {
-    // Required by vaccel<T>::destroy_resource
-    // TODO: it is not required for now as guest xdna shim virtio
-    // driver already ensures the sequence by first creating the resource blob
-    // and then creating the BO, and it destroys them in reverse order.
+    /*
+     * Device-owned (SHARE) host blobs own their GEM handle on the device-wide
+     * fd; close it here, when the resource is destroyed. Contexts that imported
+     * it hold their own handles (with dma_buf references), so the backing is
+     * freed only once every importer has also closed its handle. Context-scoped
+     * blobs (e.g. DEV_HEAP) have their handle on a context fd and are cleaned up
+     * with that context, so nothing to do here.
+     */
+    if (res->is_device_owned())
+        close_gem_handle(get_owned_drm_fd(),
+                         static_cast<uint32_t>(res->get_opaque_handle()));
 }
 
 // Forward declarations of handler functions (to be implemented elsewhere)

--- a/src/vxdna/src/vaccel_amdxdna.cpp
+++ b/src/vxdna/src/vaccel_amdxdna.cpp
@@ -1003,16 +1003,43 @@ vxdna_context::vxdna_hwctx::
 ~vxdna_hwctx() noexcept
 {
     vxdna_dbg("HW context finishing: ctx_id=%u, hwctx_handle=%u", m_ctx_id, m_hwctx_handle);
-    // Signal polling thread to stop
-    m_stop_polling.store(true, std::memory_order_relaxed);
+    // Signal polling thread to stop (wakes it if parked in m_cv.wait()).
+    // Set the flag under m_fences_lock so the store cannot land in the window
+    // between the waiter's predicate check and its sleep, which would otherwise
+    // lose the wakeup and hang the join() below.
+    {
+        std::lock_guard<std::mutex> lock(m_fences_lock);
+        m_stop_polling.store(true, std::memory_order_relaxed);
+    }
     m_cv.notify_all();
 
-    // Wait for polling thread to finish
+    /*
+     * Destroy the hardware context BEFORE joining the polling thread.
+     *
+     * The polling thread can be parked in a blocking
+     * DRM_IOCTL_SYNCOBJ_TIMELINE_WAIT on a job that will never complete on its
+     * own (e.g. the guest OOM'd before its command finished). The stop flag is
+     * not observed inside that ioctl, so joining first would deadlock: the wait
+     * only returns once the fence signals, but the fence is only signalled when
+     * the kernel tears down this hwctx. DESTROY_HWCTX aborts/completes the
+     * in-flight jobs and signals their fences, which lets the wait return so the
+     * loop can observe the stop flag and exit.
+     */
+    if (m_hwctx_handle != AMDXDNA_INVALID_CTX_HANDLE) {
+        struct amdxdna_drm_destroy_hwctx arg = {};
+        arg.handle = m_hwctx_handle;
+        auto ret = ioctl(m_ctx_fd, DRM_IOCTL_AMDXDNA_DESTROY_HWCTX, &arg);
+        if (ret)
+            vxdna_err("Close hw context failed ret %d", ret);
+    }
+
+    // Now the syncobj wait can return; wait for the polling thread to finish.
     if (m_polling_thread.joinable()) {
         m_polling_thread.join();
     }
+    m_hwctx_handle = AMDXDNA_INVALID_CTX_HANDLE;
 
-    // Destroy sync object and hardware context
+    // Safe to destroy the syncobj once the polling thread is no longer waiting.
     if (m_syncobj_handle != AMDXDNA_INVALID_FENCE_HANDLE) {
         struct drm_syncobj_destroy arg = {};
         arg.handle = m_syncobj_handle;
@@ -1020,15 +1047,6 @@ vxdna_context::vxdna_hwctx::
         if (ret)
             vxdna_err("Destroy sync object failed ret %d", ret);
         m_syncobj_handle = AMDXDNA_INVALID_FENCE_HANDLE;
-    }
-    // Destroy hardware context
-    if (m_hwctx_handle != AMDXDNA_INVALID_CTX_HANDLE) {
-        struct amdxdna_drm_destroy_hwctx arg = {};
-        arg.handle = m_hwctx_handle;
-        auto ret = ioctl(m_ctx_fd, DRM_IOCTL_AMDXDNA_DESTROY_HWCTX, &arg);
-        if (ret)
-            vxdna_err("Close hw context failed ret %d", ret);
-        m_hwctx_handle = AMDXDNA_INVALID_CTX_HANDLE;
     }
 }
 

--- a/src/vxdna/src/vaccel_amdxdna.h
+++ b/src/vxdna/src/vaccel_amdxdna.h
@@ -56,7 +56,8 @@ public:
      * req->size must not exceed the summed iovec length.
      * Host blob
      * resources may supply a pre-created GEM handle (opaque).  CPU access
-     * uses GET_BO_INFO vaddr; this path does not mmap the DRM device node.
+     * uses GET_BO_INFO vaddr; host-allocated BOs that report no vaddr are
+     * mapped on demand through their GET_BO_INFO map_offset.
      */
     vxdna_bo(const std::shared_ptr<vaccel_resource> &res, vxdna_context &ctx,
              const struct amdxdna_ccmd_create_bo_req *req);
@@ -74,7 +75,7 @@ public:
     vxdna_bo(int ctx_fd_in, const struct amdxdna_ccmd_create_bo_req *req);
 
     /**
-     * @brief Destructor - closes GEM handle (no DRM mmap in this module)
+     * @brief Destructor - closes GEM handle and unmaps any coalesce/host mappings
      */
     ~vxdna_bo() noexcept;
 
@@ -119,9 +120,14 @@ public:
     }
 
 private:
+    // Map a pre-existing host-backed BO into m_ctx_fd via m_map_offset. Splits
+    // the two cases used by the resource constructor to keep it readable.
+    void map_host_shared();                       // SHARE (or other) at any VA
+    void map_dev_heap_chunk(vxdna_context &ctx);  // DEV_HEAP, contiguous in arena
+
     uint64_t m_size = 0;          /**< Buffer size in bytes */
     uint64_t m_vaddr = 0;         /**< CPU VA: coalesce mapping or GET_BO_INFO (opaque import) */
-    uint64_t m_map_offset = 0;    /**< From GET_BO_INFO (DRM mmap offset; not used for mmap here) */
+    uint64_t m_map_offset = 0;    /**< From GET_BO_INFO (DRM mmap offset used for host BO mmap) */
     uint64_t m_xdna_addr = 0;     /**< NPU device address */
     uint64_t m_iov_bytes = 0;     /**< Sum of iovec lengths (guest backing size) */
     uint32_t m_bo_handle = 0;     /**< DRM GEM handle */
@@ -130,6 +136,8 @@ private:
     int m_ctx_fd = -1;            /**< Context file descriptor */
     void *m_coalesce_va = nullptr; /**< Contiguous VA for userptr CREATE_BO; munmap in dtor */
     size_t m_coalesce_len = 0;
+    void *m_host_map_va = nullptr; /**< CPU mapping of host-allocated BO via map_offset; munmap in dtor */
+    size_t m_host_map_len = 0;
 };
 
 
@@ -706,6 +714,18 @@ public:
      * @param res Resource to destroy
      */
     void destroy_resource(const std::shared_ptr<vaccel_resource> &res);
+
+    /**
+     * @brief PRIME-export a GEM handle that lives on the device-wide fd.
+     *
+     * Called by the base export_resource_fd() for device-owned (SHARE) host
+     * BOs, whose GEM is on get_owned_drm_fd(). Returns a new dma-buf fd.
+     *
+     * @param handle GEM handle in the device fd's namespace
+     * @return dma-buf fd on success
+     * @throws vaccel_error on failure
+     */
+    [[nodiscard]] int export_gem_on_device_fd(uint32_t handle);
 
     /** @} */
 

--- a/src/vxdna/src/vaccel_internal.h
+++ b/src/vxdna/src/vaccel_internal.h
@@ -259,6 +259,20 @@ public:
     /** @brief Get opaque handle (DRM GEM handle for host memory) */
     int get_opaque_handle() const noexcept { return m_opaque_handle; }
 
+    /**
+     * @brief Whether the opaque GEM handle lives on the device-wide fd.
+     *
+     * True for host-backed resources whose GEM is owned by the long-lived
+     * device fd (AMDXDNA_BO_SHARE), so the backing survives the creating
+     * context and any context imports it via dma-buf. False for context-scoped
+     * host BOs (e.g. AMDXDNA_BO_DEV_HEAP), whose handle lives on the creating
+     * context's fd.
+     */
+    bool is_device_owned() const noexcept { return m_device_owned; }
+
+    /** @brief Mark that the opaque GEM handle is owned by the device fd. */
+    void set_device_owned(bool v) noexcept { m_device_owned = v; }
+
     /** @brief Get map info for virtio-gpu driver */
     uint32_t get_map_info() const noexcept { return m_map_info; }
 
@@ -402,6 +416,7 @@ private:
     uint32_t m_num_iovecs;        /**< Number of IO vectors */
     uint32_t m_ctx_id;            /**< Owning context ID */
     int m_opaque_handle;          /**< DRM GEM handle for host memory */
+    bool m_device_owned = false;  /**< true: opaque GEM handle lives on the device fd (SHARE), not a context fd */
 };
 
 /**
@@ -819,6 +834,19 @@ public:
             VACCEL_THROW_MSG(-ENOENT, "Resource not found: res_id=%u", res_id);
         if (res->get_opaque_handle() <= 0)
             VACCEL_THROW_MSG(-EINVAL, "Resource is not opaque");
+        /*
+         * Device-owned host BOs (SHARE) live on the long-lived device fd, so we
+         * export from there directly -- independent of the creating context,
+         * which may already be gone while the resource is still shared. The
+         * derived device does the PRIME export on its owned fd.
+         */
+        if (res->is_device_owned())
+            return static_cast<T*>(this)->export_gem_on_device_fd(
+                static_cast<uint32_t>(res->get_opaque_handle()));
+        /*
+         * Context-scoped host BOs (e.g. DEV_HEAP) keep their handle on the
+         * creating context's fd; export through that context.
+         */
         auto ctx_id = res->get_ctx_id();
         auto ctx = get_ctx(ctx_id);
         if (!ctx)
@@ -843,6 +871,18 @@ public:
     {
         return m_callbacks->get_device_fd(get_cookie());
     }
+
+    /**
+     * @brief Get the device-wide DRM fd owned for the device's lifetime.
+     *
+     * Unlike get_drm_fd() (which opens a fresh per-context fd on each call),
+     * this returns the single fd opened at device creation and closed at
+     * device destroy. Host-backed SHARE BOs are created on this fd so their
+     * backing outlives any individual context.
+     *
+     * @return The owned device DRM fd.
+     */
+    int get_owned_drm_fd() const noexcept { return m_drm_fd; }
 
     /**
      * @brief Set owned DRM file descriptor

--- a/test/shim_test/shim_test.cpp
+++ b/test/shim_test/shim_test.cpp
@@ -1710,10 +1710,10 @@ std::vector<test_case> test_list {
     TEST_POSITIVE, dev_filter_is_npu4_and_amdxdna_drv, TEST_preempt_elf_io, { IO_TEST_FORCE_PREEMPTION, 8 }
   },
   test_case{ "create and free user pointer bo", {},
-    TEST_POSITIVE, dev_filter_is_aie_and_amdxdna_drv, TEST_create_free_uptr_bo, {XCL_BO_FLAGS_HOST_ONLY, 0, 128}
+    TEST_POSITIVE, dev_filter_is_aie, TEST_create_free_uptr_bo, {XCL_BO_FLAGS_HOST_ONLY, 0, 128}
   },
   test_case{ "io test with user pointer BOs", {},
-    TEST_POSITIVE, dev_filter_is_aie_and_amdxdna_drv, TEST_io_with_ubuf_bo, {}
+    TEST_POSITIVE, dev_filter_is_aie, TEST_io_with_ubuf_bo, {}
   },
    test_case{ "multi-command preempt full ELF io test real kernel good run", {},
     TEST_POSITIVE, dev_filter_is_aie4_or_npu4_and_amdxdna_drv, TEST_preempt_full_elf_io, { IO_TEST_FORCE_PREEMPTION, 8 }
@@ -1866,7 +1866,7 @@ std::vector<test_case> test_list {
     TEST_POSITIVE, dev_filter_is_aie4_or_npu4, TEST_io_runlist_bad_cmd, {true}
   },
   test_case{ "create and free user ptr BO with mmapped ptr", {},
-    TEST_POSITIVE, dev_filter_is_aie_and_amdxdna_drv, TEST_create_free_mmaped_uptr_bo, {}
+    TEST_POSITIVE, dev_filter_is_aie, TEST_create_free_mmaped_uptr_bo, {}
   },
   test_case{ "DPM noop (no QoS)", {},
     TEST_POSITIVE, dev_filter_is_npu4_and_amdxdna_drv, TEST_dpm_noop_no_qos, {}


### PR DESCRIPTION
 Summary

  This series brings up AMD NPU usage inside a Xen domU guest via the virtio-gpu / vxdna path. It covers the kernel dom0 enablement for guest-foreign memory, the vxdna host-side BO mapping and cross-context sharing model, guest user-pointer buffers, guest-appropriate permission
  semantics, a test-coverage relaxation, and a teardown-deadlock fix.

  What's included

  Kernel (dom0 driver)
  - accel/amdxdna: support Xen foreign guest memory for ubuf BOs — Xen foreign guest memory mapped via privcmd (MMAPBATCH) is VM_IO|VM_PFNMAP and can't be pinned with pin_user_pages(). Detect it from VMA state and borrow privcmd's local page array instead of pinning,
  tracked via amdxdna_mem.foreign so those pages are never unpinned on free. gntdev (grant) pages keep the normal pin path; the grant-revocation-before-BO-destroy hazard is documented.

  vxdna (host-side VMM component)
  -  vxdna: map host-backed BOs via map_offset and share them across contexts — mmap host-backed blob BOs through GET_BO_INFO map_offset (mirroring the native shim); make AMDXDNA_BO_SHARE device-owned on the long-lived device fd and share it across guest contexts via
  dma-buf export/import (each context imports into its own fd, getting a per-fd handle + reference); and map multi-chunk DEV_HEAP contiguously in the per-context heap arena. DEV_HEAP stays context-scoped; only SHARE is cross-context.
  - vxdna: destroy hwctx before joining the fence polling thread — fixes a teardown deadlock: the polling thread blocks in SYNCOBJ_TIMELINE_WAIT, whose fence is only signalled when the kernel tears down the hwctx — which was gated behind the join. Issue DESTROY_HWCTX
  first, then join, then destroy the syncobj; also set m_stop_polling under m_fences_lock to close a lost-wakeup window.

  shim (guest-side)
  - shim/virtio: return EACCES for guest-forbidden get_info/set_state — set_state and the privileged AIE-debug get_info queries aren't forwarded from the guest; return EACCES (was ENOTSUP) so callers degrade gracefully like on bare metal (e.g. xrt-smi validate keeps
  running in default power mode). Also fixes copy-pasted query labels.
  - shim/virtio: create userptr BOs via RESOURCE_CREATE_BLOB userptr — back a guest AMDXDNA_BO_SHARE userptr buffer with the caller's own pages by pinning the range as a virtio-gpu guest resource (VIRTGPU_BLOB_FLAG_USE_USERPTR) and having the host allocate a shared BO
  over its iovecs. The flag/struct/ioctl are defined locally (with a size + offset static_assert) so it builds against headers predating userptr support and fails cleanly on kernels/VMMs without it.