### PR TITLE
accel/amdxdna: backport 15 commits fixes from main accel driver to ve2_accel 

### DIFF
--- a/drivers/accel/amdxdna/aie.c
+++ b/drivers/accel/amdxdna/aie.c
@@ -9,6 +9,7 @@
 #include <drm/drm_print.h>
 #include <drm/gpu_scheduler.h>
 #include <linux/errno.h>
+#include <linux/hmm.h>
 #include <linux/limits.h>
 #include <linux/sched.h>
 #include <linux/sizes.h>
@@ -1236,4 +1237,69 @@ amdxdna_get_auto_coredump_mode(struct amdxdna_client *client,
 		return -EFAULT;
 
 	return 0;
+}
+
+int amdxdna_populate_range(struct amdxdna_gem_obj *abo)
+{
+	struct amdxdna_dev *xdna = to_xdna_dev(to_gobj(abo)->dev);
+	struct amdxdna_umap *mapp;
+	struct mm_struct *mm;
+	bool found;
+	int ret;
+
+again:
+	found = false;
+	down_write(&xdna->notifier_lock);
+	list_for_each_entry(mapp, &abo->mem.umap_list, node) {
+		if (mapp->invalid && kref_get_unless_zero(&mapp->refcnt)) {
+			found = true;
+			break;
+		}
+	}
+
+	if (!found) {
+		abo->mem.map_invalid = false;
+		up_write(&xdna->notifier_lock);
+		return 0;
+	}
+
+	up_write(&xdna->notifier_lock);
+
+	mm = mapp->notifier.mm;
+	if (!mmget_not_zero(mm)) {
+		amdxdna_umap_put(mapp);
+		return -EFAULT;
+	}
+
+	mapp->range.notifier_seq = mmu_interval_read_begin(&mapp->notifier);
+	mmap_read_lock(mm);
+	ret = hmm_range_fault(&mapp->range);
+	mmap_read_unlock(mm);
+	if (ret) {
+		if (ret == -EBUSY) {
+			amdxdna_umap_put(mapp);
+			mmput(mm);
+			goto again;
+		}
+
+		goto put_mm;
+	}
+
+	down_write(&xdna->notifier_lock);
+	if (mmu_interval_read_retry(&mapp->notifier, mapp->range.notifier_seq)) {
+		up_write(&xdna->notifier_lock);
+		amdxdna_umap_put(mapp);
+		mmput(mm);
+		goto again;
+	}
+	mapp->invalid = false;
+	up_write(&xdna->notifier_lock);
+	amdxdna_umap_put(mapp);
+	mmput(mm);
+	goto again;
+
+put_mm:
+	amdxdna_umap_put(mapp);
+	mmput(mm);
+	return ret;
 }

--- a/drivers/accel/amdxdna/aie.c
+++ b/drivers/accel/amdxdna/aie.c
@@ -547,6 +547,21 @@ int amdxdna_set_force_preempt_state(struct aie_device *aie, struct amdxdna_clien
 	return 0;
 }
 
+int amdxdna_get_frame_boundary_preempt_state(struct aie_device *aie,
+					     struct amdxdna_drm_get_info *args)
+{
+	struct amdxdna_drm_attribute_state state = {};
+	u32 buf_sz;
+
+	state.state = aie->frame_boundary_preempt_enabled;
+
+	buf_sz = min(args->buffer_size, sizeof(state));
+	if (copy_to_user(u64_to_user_ptr(args->buffer), &state, buf_sz))
+		return -EFAULT;
+
+	return 0;
+}
+
 struct amdxdna_msg_buf_hdl *amdxdna_alloc_msg_buff(struct amdxdna_dev *xdna, u32 size)
 {
 	struct amdxdna_msg_buf_hdl *hdl;

--- a/drivers/accel/amdxdna/aie.c
+++ b/drivers/accel/amdxdna/aie.c
@@ -546,21 +546,6 @@ int amdxdna_set_force_preempt_state(struct aie_device *aie, struct amdxdna_clien
 	return 0;
 }
 
-void amdxdna_hmm_invalidate(struct amdxdna_gem_obj *abo,
-			    unsigned long cur_seq)
-{
-	struct amdxdna_dev *xdna = to_xdna_dev(to_gobj(abo)->dev);
-	struct drm_gem_object *gobj = to_gobj(abo);
-	long ret;
-
-	ret = dma_resv_wait_timeout(gobj->resv, DMA_RESV_USAGE_BOOKKEEP,
-				    true, MAX_SCHEDULE_TIMEOUT);
-	if (!ret)
-		XDNA_ERR(xdna, "Failed to wait for bo, ret %ld", ret);
-	else if (ret == -ERESTARTSYS)
-		XDNA_DBG(xdna, "Wait for bo interrupted by signal");
-}
-
 struct amdxdna_msg_buf_hdl *amdxdna_alloc_msg_buff(struct amdxdna_dev *xdna, u32 size)
 {
 	struct amdxdna_msg_buf_hdl *hdl;

--- a/drivers/accel/amdxdna/aie.h
+++ b/drivers/accel/amdxdna/aie.h
@@ -39,6 +39,7 @@ struct aie_msg_ops {
 	int  (*fw_log_init)(struct amdxdna_dev *xdna, size_t size, u32 level);
 	int  (*fw_log_config)(struct amdxdna_dev *xdna, u32 level);
 	int  (*fw_log_fini)(struct amdxdna_dev *xdna);
+	void (*fw_log_parse)(struct amdxdna_dev *xdna, char *buf, size_t size);
 
 	int  (*fw_trace_init)(struct amdxdna_dev *xdna, size_t size, u32 categories);
 	int  (*fw_trace_config)(struct amdxdna_dev *xdna, u32 categories);

--- a/drivers/accel/amdxdna/aie.h
+++ b/drivers/accel/amdxdna/aie.h
@@ -181,6 +181,7 @@ int amdxdna_query_ctx_status_by_id(struct aie_device *aie, struct amdxdna_client
 int amdxdna_get_force_preempt_state(struct aie_device *aie, struct amdxdna_drm_get_info *args);
 int amdxdna_set_force_preempt_state(struct aie_device *aie, struct amdxdna_client *client,
 				    struct amdxdna_drm_set_state *args);
+int amdxdna_populate_range(struct amdxdna_gem_obj *abo);
 struct amdxdna_msg_buf_hdl {
 	struct amdxdna_dev	*xdna;
 	void			*vaddr;

--- a/drivers/accel/amdxdna/aie.h
+++ b/drivers/accel/amdxdna/aie.h
@@ -63,6 +63,7 @@ struct aie_device {
 	struct amdxdna_drm_query_aie_metadata metadata;
 	struct aie_msg_ops msg_ops;
 	u32	force_preempt_enabled;
+	u32	frame_boundary_preempt_enabled;
 
 	/* FW hwctx slot count for the telemetry map; 0 if arch has no map. */
 	u32 hwctx_limit;
@@ -183,6 +184,8 @@ int amdxdna_get_force_preempt_state(struct aie_device *aie, struct amdxdna_drm_g
 int amdxdna_set_force_preempt_state(struct aie_device *aie, struct amdxdna_client *client,
 				    struct amdxdna_drm_set_state *args);
 int amdxdna_populate_range(struct amdxdna_gem_obj *abo);
+int amdxdna_get_frame_boundary_preempt_state(struct aie_device *aie,
+					     struct amdxdna_drm_get_info *args);
 struct amdxdna_msg_buf_hdl {
 	struct amdxdna_dev	*xdna;
 	void			*vaddr;

--- a/drivers/accel/amdxdna/aie.h
+++ b/drivers/accel/amdxdna/aie.h
@@ -181,8 +181,6 @@ int amdxdna_query_ctx_status_by_id(struct aie_device *aie, struct amdxdna_client
 int amdxdna_get_force_preempt_state(struct aie_device *aie, struct amdxdna_drm_get_info *args);
 int amdxdna_set_force_preempt_state(struct aie_device *aie, struct amdxdna_client *client,
 				    struct amdxdna_drm_set_state *args);
-void amdxdna_hmm_invalidate(struct amdxdna_gem_obj *abo, unsigned long cur_seq);
-
 struct amdxdna_msg_buf_hdl {
 	struct amdxdna_dev	*xdna;
 	void			*vaddr;

--- a/drivers/accel/amdxdna/aie2_ctx.c
+++ b/drivers/accel/amdxdna/aie2_ctx.c
@@ -858,12 +858,18 @@ static void aie2_hwctx_put_cu_bos(struct amdxdna_hwctx *hwctx)
 {
 	u32 i;
 
-	for (i = 0; i < hwctx->priv->num_cu_bos; i++)
+	if (!hwctx->priv->cu_bos)
+		return;
+
+	/* A partially filled array is left zeroed past the failed lookup. */
+	for (i = 0; i < hwctx->cus->num_cus; i++) {
+		if (!hwctx->priv->cu_bos[i])
+			break;
 		drm_gem_object_put(to_gobj(hwctx->priv->cu_bos[i]));
+	}
 
 	kfree(hwctx->priv->cu_bos);
 	hwctx->priv->cu_bos = NULL;
-	hwctx->priv->num_cu_bos = 0;
 }
 
 void aie2_hwctx_fini(struct amdxdna_hwctx *hwctx)
@@ -922,9 +928,9 @@ static int aie2_config_cu_resp_handler(void *handle, void __iomem *data, size_t 
 /*
  * Resolve each configured CU BO once and keep a reference for the life of the
  * context. hwctx->cus holds userspace GEM handles, which stop resolving as soon
- * as the client drops them -- but aie2_config_cu() runs again on every resume,
- * so a dropped handle turned into a failed hwctx restart and left the device
- * unable to resume at all.
+ * as the client drops them, while aie2_config_cu() runs again on every resume.
+ * A dropped handle would fail the hwctx restart and leave the device unable to
+ * resume at all.
  */
 static int aie2_hwctx_hold_cu_bos(struct amdxdna_hwctx *hwctx)
 {
@@ -944,8 +950,7 @@ static int aie2_hwctx_hold_cu_bos(struct amdxdna_hwctx *hwctx)
 		return -EINVAL;
 	}
 
-	hwctx->priv->cu_bos = kcalloc(num_cus, sizeof(*hwctx->priv->cu_bos),
-				      GFP_KERNEL);
+	hwctx->priv->cu_bos = kzalloc_objs(*hwctx->priv->cu_bos, num_cus);
 	if (!hwctx->priv->cu_bos)
 		return -ENOMEM;
 
@@ -967,7 +972,6 @@ static int aie2_hwctx_hold_cu_bos(struct amdxdna_hwctx *hwctx)
 
 		/* Reference retained; released by aie2_hwctx_put_cu_bos(). */
 		hwctx->priv->cu_bos[i] = abo;
-		hwctx->priv->num_cu_bos = i + 1;
 	}
 
 	return 0;

--- a/drivers/accel/amdxdna/aie2_ctx.c
+++ b/drivers/accel/amdxdna/aie2_ctx.c
@@ -9,7 +9,6 @@
 #include <drm/drm_gem_shmem_helper.h>
 #include <drm/drm_print.h>
 #include <drm/drm_syncobj.h>
-#include <linux/hmm.h>
 #include <linux/limits.h>
 #include <linux/types.h>
 #include <linux/xarray.h>
@@ -1091,71 +1090,6 @@ put_cmd:
 	return ret;
 }
 
-static int aie2_populate_range(struct amdxdna_gem_obj *abo)
-{
-	struct amdxdna_dev *xdna = to_xdna_dev(to_gobj(abo)->dev);
-	struct amdxdna_umap *mapp;
-	struct mm_struct *mm;
-	bool found;
-	int ret;
-
-again:
-	found = false;
-	down_write(&xdna->notifier_lock);
-	list_for_each_entry(mapp, &abo->mem.umap_list, node) {
-		if (mapp->invalid && kref_get_unless_zero(&mapp->refcnt)) {
-			found = true;
-			break;
-		}
-	}
-
-	if (!found) {
-		abo->mem.map_invalid = false;
-		up_write(&xdna->notifier_lock);
-		return 0;
-	}
-
-	up_write(&xdna->notifier_lock);
-
-	mm = mapp->notifier.mm;
-	if (!mmget_not_zero(mm)) {
-		amdxdna_umap_put(mapp);
-		return -EFAULT;
-	}
-
-	mapp->range.notifier_seq = mmu_interval_read_begin(&mapp->notifier);
-	mmap_read_lock(mm);
-	ret = hmm_range_fault(&mapp->range);
-	mmap_read_unlock(mm);
-	if (ret) {
-		if (ret == -EBUSY) {
-			amdxdna_umap_put(mapp);
-			mmput(mm);
-			goto again;
-		}
-
-		goto put_mm;
-	}
-
-	down_write(&xdna->notifier_lock);
-	if (mmu_interval_read_retry(&mapp->notifier, mapp->range.notifier_seq)) {
-		up_write(&xdna->notifier_lock);
-		amdxdna_umap_put(mapp);
-		mmput(mm);
-		goto again;
-	}
-	mapp->invalid = false;
-	up_write(&xdna->notifier_lock);
-	amdxdna_umap_put(mapp);
-	mmput(mm);
-	goto again;
-
-put_mm:
-	amdxdna_umap_put(mapp);
-	mmput(mm);
-	return ret;
-}
-
 int aie2_cmd_submit(struct amdxdna_hwctx *hwctx, struct amdxdna_sched_job *job, u64 *seq)
 {
 	struct amdxdna_dev *xdna = hwctx->client->xdna;
@@ -1210,7 +1144,7 @@ retry:
 		if (abo->mem.map_invalid) {
 			up_read(&xdna->notifier_lock);
 			drm_gem_unlock_reservations(job->bos, job->bo_cnt, &acquire_ctx);
-			ret = aie2_populate_range(abo);
+			ret = amdxdna_populate_range(abo);
 			if (ret)
 				goto cleanup_job;
 			goto retry;

--- a/drivers/accel/amdxdna/aie2_ctx.c
+++ b/drivers/accel/amdxdna/aie2_ctx.c
@@ -1250,21 +1250,6 @@ up_sem:
 	return ret;
 }
 
-void aie2_hmm_invalidate(struct amdxdna_gem_obj *abo,
-			 unsigned long cur_seq)
-{
-	struct amdxdna_dev *xdna = to_xdna_dev(to_gobj(abo)->dev);
-	struct drm_gem_object *gobj = to_gobj(abo);
-	long ret;
-
-	ret = dma_resv_wait_timeout(gobj->resv, DMA_RESV_USAGE_BOOKKEEP,
-				    true, MAX_SCHEDULE_TIMEOUT);
-	if (!ret)
-		XDNA_ERR(xdna, "Failed to wait for bo, ret %ld", ret);
-	else if (ret == -ERESTARTSYS)
-		XDNA_DBG(xdna, "Wait for bo interrupted by signal");
-}
-
 int aie2_hwctx_heap_expand(struct amdxdna_hwctx *hwctx,
 			   struct amdxdna_gem_obj *heap)
 {

--- a/drivers/accel/amdxdna/aie2_ctx.c
+++ b/drivers/accel/amdxdna/aie2_ctx.c
@@ -854,6 +854,18 @@ free_priv:
 	return ret;
 }
 
+static void aie2_hwctx_put_cu_bos(struct amdxdna_hwctx *hwctx)
+{
+	u32 i;
+
+	for (i = 0; i < hwctx->priv->num_cu_bos; i++)
+		drm_gem_object_put(to_gobj(hwctx->priv->cu_bos[i]));
+
+	kfree(hwctx->priv->cu_bos);
+	hwctx->priv->cu_bos = NULL;
+	hwctx->priv->num_cu_bos = 0;
+}
+
 void aie2_hwctx_fini(struct amdxdna_hwctx *hwctx)
 {
 	struct amdxdna_dev *xdna;
@@ -893,6 +905,7 @@ void aie2_hwctx_fini(struct amdxdna_hwctx *hwctx)
 	drm_gem_object_put(to_gobj(hwctx->priv->heap));
 
 	mutex_destroy(&hwctx->priv->io_lock);
+	aie2_hwctx_put_cu_bos(hwctx);
 	kfree(hwctx->col_list);
 	kfree(hwctx->priv);
 	kfree(hwctx->cus);
@@ -904,6 +917,64 @@ static int aie2_config_cu_resp_handler(void *handle, void __iomem *data, size_t 
 
 	amdxdna_pm_suspend_put(hwctx->client->xdna);
 	return 0;
+}
+
+/*
+ * Resolve each configured CU BO once and keep a reference for the life of the
+ * context. hwctx->cus holds userspace GEM handles, which stop resolving as soon
+ * as the client drops them -- but aie2_config_cu() runs again on every resume,
+ * so a dropped handle turned into a failed hwctx restart and left the device
+ * unable to resume at all.
+ */
+static int aie2_hwctx_hold_cu_bos(struct amdxdna_hwctx *hwctx)
+{
+	struct amdxdna_dev *xdna = hwctx->client->xdna;
+	u32 num_cus = hwctx->cus->num_cus;
+	struct drm_gem_object *gobj;
+	struct amdxdna_gem_obj *abo;
+	u32 i;
+
+	/* Bound before the lookup loop, not in aie2_config_cu() afterwards:
+	 * num_cus is only limited by the page-sized config buffer, so an
+	 * over-limit request would otherwise take a reference per CU before
+	 * anything rejected it.
+	 */
+	if (num_cus > MAX_NUM_CUS) {
+		XDNA_DBG(xdna, "Exceed maximum CU %d", MAX_NUM_CUS);
+		return -EINVAL;
+	}
+
+	hwctx->priv->cu_bos = kcalloc(num_cus, sizeof(*hwctx->priv->cu_bos),
+				      GFP_KERNEL);
+	if (!hwctx->priv->cu_bos)
+		return -ENOMEM;
+
+	for (i = 0; i < num_cus; i++) {
+		struct amdxdna_cu_config *cu = &hwctx->cus->cu_configs[i];
+
+		gobj = drm_gem_object_lookup(hwctx->client->filp, cu->cu_bo);
+		if (!gobj) {
+			XDNA_ERR(xdna, "Lookup GEM object failed");
+			goto put_bos;
+		}
+
+		abo = to_xdna_obj(gobj);
+		if (abo->type != AMDXDNA_BO_DEV) {
+			drm_gem_object_put(gobj);
+			XDNA_ERR(xdna, "Invalid BO type");
+			goto put_bos;
+		}
+
+		/* Reference retained; released by aie2_hwctx_put_cu_bos(). */
+		hwctx->priv->cu_bos[i] = abo;
+		hwctx->priv->num_cu_bos = i + 1;
+	}
+
+	return 0;
+
+put_bos:
+	aie2_hwctx_put_cu_bos(hwctx);
+	return -EINVAL;
 }
 
 static int aie2_hwctx_cu_config(struct amdxdna_hwctx *hwctx, void *buf, u32 size)
@@ -937,9 +1008,13 @@ static int aie2_hwctx_cu_config(struct amdxdna_hwctx *hwctx, void *buf, u32 size
 	if (!hwctx->cus)
 		return -ENOMEM;
 
-	ret = amdxdna_pm_resume_get(xdna);
+	ret = aie2_hwctx_hold_cu_bos(hwctx);
 	if (ret)
 		goto free_cus;
+
+	ret = amdxdna_pm_resume_get(xdna);
+	if (ret)
+		goto put_cu_bos;
 
 	ret = aie2_config_cu(hwctx, aie2_config_cu_resp_handler);
 	if (ret) {
@@ -953,6 +1028,8 @@ static int aie2_hwctx_cu_config(struct amdxdna_hwctx *hwctx, void *buf, u32 size
 
 pm_suspend_put:
 	amdxdna_pm_suspend_put(xdna);
+put_cu_bos:
+	aie2_hwctx_put_cu_bos(hwctx);
 free_cus:
 	kfree(hwctx->cus);
 	hwctx->cus = NULL;

--- a/drivers/accel/amdxdna/aie2_message.c
+++ b/drivers/accel/amdxdna/aie2_message.c
@@ -617,11 +617,6 @@ int aie2_config_cu(struct amdxdna_hwctx *hwctx,
 		return -EINVAL;
 	}
 
-	if (hwctx->cus->num_cus != hwctx->priv->num_cu_bos) {
-		XDNA_ERR(xdna, "CU BOs not held for this context");
-		return -EINVAL;
-	}
-
 	for (i = 0; i < hwctx->cus->num_cus; i++) {
 		struct amdxdna_cu_config *cu = &hwctx->cus->cu_configs[i];
 

--- a/drivers/accel/amdxdna/aie2_message.c
+++ b/drivers/accel/amdxdna/aie2_message.c
@@ -1048,6 +1048,7 @@ void aie2_msg_init(struct amdxdna_dev_hdl *ndev)
 		ndev->aie.msg_ops.fw_log_init   = aie2_fw_log_init;
 		ndev->aie.msg_ops.fw_log_config = aie2_fw_log_config;
 		ndev->aie.msg_ops.fw_log_fini   = aie2_fw_log_fini;
+		ndev->aie.msg_ops.fw_log_parse  = aie2_fw_log_parse;
 	}
 
 	if (AIE_FEATURE_ON(&ndev->aie, AIE2_FW_TRACE)) {

--- a/drivers/accel/amdxdna/aie2_message.c
+++ b/drivers/accel/amdxdna/aie2_message.c
@@ -603,7 +603,6 @@ int aie2_config_cu(struct amdxdna_hwctx *hwctx,
 	u32 shift = xdna->dev_info->dev_mem_buf_shift;
 	struct config_cu_req req = { 0 };
 	struct xdna_mailbox_msg msg;
-	struct drm_gem_object *gobj;
 	struct amdxdna_gem_obj *abo;
 	int i;
 
@@ -618,31 +617,29 @@ int aie2_config_cu(struct amdxdna_hwctx *hwctx,
 		return -EINVAL;
 	}
 
+	if (hwctx->cus->num_cus != hwctx->priv->num_cu_bos) {
+		XDNA_ERR(xdna, "CU BOs not held for this context");
+		return -EINVAL;
+	}
+
 	for (i = 0; i < hwctx->cus->num_cus; i++) {
 		struct amdxdna_cu_config *cu = &hwctx->cus->cu_configs[i];
 
 		if (XDNA_MBZ_DBG(xdna, cu->pad, sizeof(cu->pad)))
 			return -EINVAL;
 
-		gobj = drm_gem_object_lookup(hwctx->client->filp, cu->cu_bo);
-		if (!gobj) {
-			XDNA_ERR(xdna, "Lookup GEM object failed");
-			return -EINVAL;
-		}
-		abo = to_xdna_obj(gobj);
-
-		if (abo->type != AMDXDNA_BO_DEV) {
-			drm_gem_object_put(gobj);
-			XDNA_ERR(xdna, "Invalid BO type");
-			return -EINVAL;
-		}
+		/*
+		 * Resolved and referenced once at config time. Looking the
+		 * handle up here instead would fail on resume, once the client
+		 * has dropped it, and take the whole device resume down with it.
+		 */
+		abo = hwctx->priv->cu_bos[i];
 
 		req.cfgs[i] = FIELD_PREP(AIE2_MSG_CFG_CU_PDI_ADDR,
 					 amdxdna_gem_dev_addr(abo) >> shift);
 		req.cfgs[i] |= FIELD_PREP(AIE2_MSG_CFG_CU_FUNC, cu->cu_func);
 		XDNA_DBG(xdna, "CU %d full addr 0x%llx, cfg 0x%x", i,
 			 amdxdna_gem_dev_addr(abo), req.cfgs[i]);
-		drm_gem_object_put(gobj);
 	}
 	req.num_cus = hwctx->cus->num_cus;
 

--- a/drivers/accel/amdxdna/aie2_pci.c
+++ b/drivers/accel/amdxdna/aie2_pci.c
@@ -11,6 +11,7 @@
 #include <drm/drm_managed.h>
 #include <drm/drm_print.h>
 #include <drm/gpu_scheduler.h>
+#include <linux/bitfield.h>
 #include <linux/cleanup.h>
 #include <linux/errno.h>
 #include <linux/firmware.h>
@@ -1085,6 +1086,182 @@ static int aie2_get_dev_rev(struct amdxdna_dev *xdna, u32 *rev)
 		*rev = (u32)aie2_rev;
 
 	return ret;
+}
+
+#define AIE2_MGMT_APP_ID		0xFF
+
+static const char * const aie2_fw_log_level_str[] = {
+	"OFF",
+	"ERR",
+	"WRN",
+	"INF",
+	"DBG",
+	"MAX"
+};
+
+/*
+ * AIE2 firmware log entries are structured (unlike the plain newline-
+ * delimited AIE4 stream): each record is a header, a u64-aligned payload,
+ * and a footer. The header and footer carry a magic byte and a matching
+ * sequence number / word length so a torn or overwritten record in the
+ * wrapping DRAM ring can be detected and skipped.
+ */
+struct aie2_fw_log_header {
+#define AIE2_DPT_ENTRY_MAGIC_HEAD	0xCA
+	u8	magic;
+	u8	data_word_len;
+	__le16	seq_num;
+	u32	reserved;
+} __packed;
+
+/*
+ * The two 32-bit words following the timestamp pack the record metadata.
+ * The kernel avoids C bitfields for wire/DRAM layouts (their bit ordering
+ * and padding are implementation-defined), so the fields are decoded with
+ * explicit masks via FIELD_GET on this little-endian target. Only @level
+ * and @appn (word0) are consumed today; the remaining masks document the
+ * firmware layout.
+ */
+struct aie2_fw_log_data {
+	u64	timestamp;
+	u32	word0;
+	u32	word1;
+} __packed;
+
+/* word0 */
+#define AIE2_FW_LOG_FORMAT	GENMASK(0, 0)
+#define AIE2_FW_LOG_LEVEL	GENMASK(10, 8)
+#define AIE2_FW_LOG_APPN	GENMASK(23, 16)
+#define AIE2_FW_LOG_ARGC	GENMASK(31, 24)
+/* word1 */
+#define AIE2_FW_LOG_LINE	GENMASK(15, 0)
+#define AIE2_FW_LOG_MODULE	GENMASK(31, 16)
+
+struct aie2_fw_log_footer {
+	u32	reserved;
+	__le16	seq_num;
+	u8	data_word_len;
+#define AIE2_DPT_ENTRY_MAGIC_FOOTER	0xBA
+	u8	magic;
+} __packed;
+
+static void aie2_fw_log_print(struct amdxdna_dev *xdna, const char *payload,
+			      size_t size)
+{
+	u32 level, appn, word0;
+	const char *level_str;
+	__le64 raw_timestamp;
+	__le32 raw_word0;
+	char appid[20];
+	u64 timestamp;
+
+	if (size < sizeof(struct aie2_fw_log_data))
+		return;
+
+	/*
+	 * The resync path (aie2_fw_log_parse) advances in 4-byte steps, so a
+	 * valid-looking header can be found at 4-byte alignment and @payload
+	 * may not be 8-byte aligned. Copy the little-endian wire fields into
+	 * aligned locals before converting, instead of dereferencing a
+	 * possibly misaligned struct. This also makes the DRAM layout
+	 * endianness explicit rather than baking in host endianness, and
+	 * avoids depending on <linux/unaligned.h>, which does not exist on
+	 * kernels older than 6.12.
+	 */
+	memcpy(&raw_timestamp, payload, sizeof(raw_timestamp));
+	memcpy(&raw_word0, payload + offsetof(struct aie2_fw_log_data, word0),
+	       sizeof(raw_word0));
+	timestamp = le64_to_cpu(raw_timestamp);
+	word0 = le32_to_cpu(raw_word0);
+
+	level = FIELD_GET(AIE2_FW_LOG_LEVEL, word0);
+	appn = FIELD_GET(AIE2_FW_LOG_APPN, word0);
+
+	if (level < ARRAY_SIZE(aie2_fw_log_level_str))
+		level_str = aie2_fw_log_level_str[level];
+	else
+		level_str = "UNK";
+
+	if (appn == AIE2_MGMT_APP_ID)
+		scnprintf(appid, sizeof(appid), "MGMNT");
+	else
+		scnprintf(appid, sizeof(appid), "APP%2d", appn);
+
+	XDNA_INFO(xdna, "[FW LOG] [%llu] [%s] [%s]: %.*s", timestamp,
+		  level_str, appid, (int)(size - sizeof(struct aie2_fw_log_data)),
+		  payload + sizeof(struct aie2_fw_log_data));
+}
+
+/*
+ * Walk the fetched ring payload record by record, validating each entry's
+ * header/footer magic, sequence continuity and length before emitting it.
+ * On any inconsistency, advance by the minimum alignment (4 bytes) and
+ * resynchronize on the next valid header rather than trusting a possibly
+ * corrupted length.
+ */
+void aie2_fw_log_parse(struct amdxdna_dev *xdna, char *buffer, size_t size)
+{
+	char *end = buffer + size;
+	bool has_prev_seq = false;
+	char *p = buffer;
+	u16 prev_seq = 0;
+
+	if (!buffer || size == 0)
+		return;
+
+	while ((size_t)(end - p) >= sizeof(struct aie2_fw_log_header)) {
+		const struct aie2_fw_log_header *hdr = (const struct aie2_fw_log_header *)p;
+		unsigned int increment_bytes = 4; /* default resync step */
+		bool corrupted = true;
+
+		if (likely(hdr->magic == AIE2_DPT_ENTRY_MAGIC_HEAD)) {
+			size_t payload_bytes = hdr->data_word_len * sizeof(u64);
+			size_t total_entry_size = sizeof(struct aie2_fw_log_header) +
+						  payload_bytes +
+						  sizeof(struct aie2_fw_log_footer);
+			const char *payload = p + sizeof(struct aie2_fw_log_header);
+			const struct aie2_fw_log_footer *ftr;
+			u16 seq = le16_to_cpu(hdr->seq_num);
+			bool valid;
+
+			/* Partial entry at the ring end: stop to avoid overread. */
+			if ((size_t)(end - p) < total_entry_size)
+				break;
+
+			ftr = (const struct aie2_fw_log_footer *)(payload + payload_bytes);
+			valid = (ftr->magic == AIE2_DPT_ENTRY_MAGIC_FOOTER) &&
+				(seq > 0) && (seq == le16_to_cpu(ftr->seq_num)) &&
+				(hdr->data_word_len == ftr->data_word_len);
+
+			if (likely(valid) &&
+			    likely(!has_prev_seq || seq == (u16)(prev_seq + 1))) {
+				has_prev_seq = true;
+				prev_seq = seq;
+				aie2_fw_log_print(xdna, payload, payload_bytes);
+				corrupted = false;
+				increment_bytes = (unsigned int)total_entry_size;
+			}
+
+			if (unlikely(corrupted)) {
+				/*
+				 * Torn/overwritten records are expected at the
+				 * wrap boundary of a continuously overwritten
+				 * ring and the poll worker runs every
+				 * AMDXDNA_DPT_POLL_INTERVAL_MS, so ratelimit to
+				 * avoid drowning the log in the resync path.
+				 */
+				dev_warn_ratelimited(xdna->ddev.dev,
+						     "FW log entry overwritten/corrupted\n");
+				has_prev_seq = false;
+			}
+		}
+
+		if (unlikely(increment_bytes == 0) ||
+		    (size_t)(end - p) < increment_bytes)
+			break;
+
+		p += increment_bytes;
+	}
 }
 
 int aie2_fw_log_init(struct amdxdna_dev *xdna, size_t size, u32 level)

--- a/drivers/accel/amdxdna/aie2_pci.c
+++ b/drivers/accel/amdxdna/aie2_pci.c
@@ -809,22 +809,6 @@ int aie2_fill_hwctx_map(struct aie_device *aie, u32 *map)
 	return 0;
 }
 
-static int aie2_get_frame_boundary_preempt_state(struct amdxdna_client *client,
-						 struct amdxdna_drm_get_info *args)
-{
-	struct amdxdna_drm_attribute_state state = {};
-	struct amdxdna_dev_hdl *ndev = client->xdna->dev_handle;
-	u32 buf_sz;
-
-	state.state = ndev->frame_boundary_preempt;
-
-	buf_sz = min(args->buffer_size, sizeof(state));
-	if (copy_to_user(u64_to_user_ptr(args->buffer), &state, buf_sz))
-		return -EFAULT;
-
-	return 0;
-}
-
 static int aie2_get_info(struct amdxdna_client *client, struct amdxdna_drm_get_info *args)
 {
 	struct amdxdna_dev *xdna = client->xdna;
@@ -873,7 +857,7 @@ static int aie2_get_info(struct amdxdna_client *client, struct amdxdna_drm_get_i
 		ret = amdxdna_get_force_preempt_state(&ndev->aie, args);
 		break;
 	case DRM_AMDXDNA_GET_FRAME_BOUNDARY_PREEMPT_STATE:
-		ret = aie2_get_frame_boundary_preempt_state(client, args);
+		ret = amdxdna_get_frame_boundary_preempt_state(&ndev->aie, args);
 		break;
 	case DRM_AMDXDNA_GET_AUTO_COREDUMP:
 		ret = amdxdna_get_auto_coredump_mode(client, args);
@@ -1020,7 +1004,7 @@ static int aie2_set_frame_boundary_preempt(struct amdxdna_client *client,
 	if (ret)
 		return ret;
 
-	ndev->frame_boundary_preempt = state.state;
+	ndev->aie.frame_boundary_preempt_enabled = state.state;
 
 	return 0;
 }

--- a/drivers/accel/amdxdna/aie2_pci.c
+++ b/drivers/accel/amdxdna/aie2_pci.c
@@ -1251,7 +1251,6 @@ const struct amdxdna_dev_ops aie2_ops = {
 	.hwctx_config = aie2_hwctx_config,
 	.hwctx_sync_debug_bo = aie2_hwctx_sync_debug_bo,
 	.cmd_submit = aie2_cmd_submit,
-	.hmm_invalidate = aie2_hmm_invalidate,
 	.get_array = aie2_get_array,
 	.get_dev_revision = aie2_get_dev_rev,
 	.hwctx_heap_expand = aie2_hwctx_heap_expand,

--- a/drivers/accel/amdxdna/aie2_pci.h
+++ b/drivers/accel/amdxdna/aie2_pci.h
@@ -96,13 +96,13 @@ struct amdxdna_hwctx_priv {
 	struct drm_syncobj		*syncobj;
 
 	/*
-	 * CU BOs resolved once at config time and held for the life of the
-	 * context. hwctx->cus stores userspace GEM *handles*, which are only
-	 * meaningful while the client still holds them; aie2_config_cu() also
-	 * runs on resume, long after the config ioctl returned.
+	 * One entry per hwctx->cus->cu_configs[], resolved at config time and
+	 * held for the life of the context. hwctx->cus stores userspace GEM
+	 * *handles*, which are only meaningful while the client still holds
+	 * them; aie2_config_cu() also runs on resume, long after the config
+	 * ioctl returned.
 	 */
 	struct amdxdna_gem_obj		**cu_bos;
-	u32				num_cu_bos;
 };
 
 enum aie2_dev_status {

--- a/drivers/accel/amdxdna/aie2_pci.h
+++ b/drivers/accel/amdxdna/aie2_pci.h
@@ -267,6 +267,7 @@ int aie2_start_fw_trace(struct amdxdna_dev_hdl *ndev,
 int aie2_fw_log_init(struct amdxdna_dev *xdna, size_t size, u32 level);
 int aie2_fw_log_config(struct amdxdna_dev *xdna, u32 level);
 int aie2_fw_log_fini(struct amdxdna_dev *xdna);
+void aie2_fw_log_parse(struct amdxdna_dev *xdna, char *buffer, size_t size);
 
 int aie2_fw_trace_init(struct amdxdna_dev *xdna, size_t size, u32 categories);
 int aie2_fw_trace_config(struct amdxdna_dev *xdna, u32 categories);

--- a/drivers/accel/amdxdna/aie2_pci.h
+++ b/drivers/accel/amdxdna/aie2_pci.h
@@ -94,6 +94,15 @@ struct amdxdna_hwctx_priv {
 
 	struct amdxdna_gem_obj		*cmd_buf[HWCTX_MAX_CMDS];
 	struct drm_syncobj		*syncobj;
+
+	/*
+	 * CU BOs resolved once at config time and held for the life of the
+	 * context. hwctx->cus stores userspace GEM *handles*, which are only
+	 * meaningful while the client still holds them; aie2_config_cu() also
+	 * runs on resume, long after the config ioctl returned.
+	 */
+	struct amdxdna_gem_obj		**cu_bos;
+	u32				num_cu_bos;
 };
 
 enum aie2_dev_status {

--- a/drivers/accel/amdxdna/aie2_pci.h
+++ b/drivers/accel/amdxdna/aie2_pci.h
@@ -309,7 +309,6 @@ int aie2_hwctx_sync_debug_bo(struct amdxdna_hwctx *hwctx, u32 debug_bo_hdl);
 void aie2_hwctx_suspend(struct amdxdna_client *client);
 int aie2_hwctx_resume(struct amdxdna_client *client);
 int aie2_cmd_submit(struct amdxdna_hwctx *hwctx, struct amdxdna_sched_job *job, u64 *seq);
-void aie2_hmm_invalidate(struct amdxdna_gem_obj *abo, unsigned long cur_seq);
 int aie2_hwctx_heap_expand(struct amdxdna_hwctx *hwctx, struct amdxdna_gem_obj *heap);
 
 /* TDR APIs */

--- a/drivers/accel/amdxdna/aie2_pci.h
+++ b/drivers/accel/amdxdna/aie2_pci.h
@@ -145,7 +145,6 @@ struct amdxdna_dev_hdl {
 	u32				dpm_level;
 	u32				dft_dpm_level;
 	u32				max_dpm_level;
-	u32				frame_boundary_preempt;
 
 	/* Mailbox and the management channel */
 	struct mailbox			*mbox;

--- a/drivers/accel/amdxdna/aie4_ctx.c
+++ b/drivers/accel/amdxdna/aie4_ctx.c
@@ -1491,9 +1491,12 @@ int aie4_cmd_submit(struct amdxdna_hwctx *hwctx, struct amdxdna_sched_job *job, 
 {
 	struct amdxdna_hwctx_priv *priv = hwctx->priv;
 	struct amdxdna_dev *xdna = hwctx->client->xdna;
+	struct ww_acquire_ctx acquire_ctx;
+	struct amdxdna_gem_obj *abo;
 	u32 err_gen;
 	u32 op;
 	int ret;
+	int i;
 
 	XDNA_DBG(xdna, "ctx %s job 0x%llx received", hwctx->name, (u64)job);
 
@@ -1527,6 +1530,42 @@ int aie4_cmd_submit(struct amdxdna_hwctx *hwctx, struct amdxdna_sched_job *job, 
 		return -ESRCH;
 	}
 
+retry:
+	ret = drm_gem_lock_reservations(job->bos, job->bo_cnt, &acquire_ctx);
+	if (ret) {
+		XDNA_WARN(xdna, "Failed to lock BOs, ret %d", ret);
+		goto put_mm;
+	}
+
+	for (i = 0; i < job->bo_cnt; i++) {
+		ret = dma_resv_reserve_fences(job->bos[i]->resv, 1);
+		if (ret) {
+			XDNA_WARN(xdna, "Failed to reserve fences %d", ret);
+			drm_gem_unlock_reservations(job->bos, job->bo_cnt, &acquire_ctx);
+			goto put_mm;
+		}
+	}
+
+	down_read(&xdna->notifier_lock);
+	for (i = 0; i < job->bo_cnt; i++) {
+		abo = to_xdna_obj(job->bos[i]);
+		if (abo->mem.map_invalid) {
+			up_read(&xdna->notifier_lock);
+			drm_gem_unlock_reservations(job->bos, job->bo_cnt, &acquire_ctx);
+			ret = amdxdna_populate_range(abo);
+			if (ret)
+				goto put_mm;
+			goto retry;
+		}
+	}
+
+	job->out_fence = dma_fence_get(job->fence);
+	for (i = 0; i < job->bo_cnt; i++)
+		dma_resv_add_fence(job->bos[i]->resv, job->out_fence, DMA_RESV_USAGE_WRITE);
+
+	up_read(&xdna->notifier_lock);
+	drm_gem_unlock_reservations(job->bos, job->bo_cnt, &acquire_ctx);
+
 	/*
 	 * Wait until this job is at the head of the pending list before touching
 	 * the queue (see enqueue_pending_job).  Freezable so the freezer can
@@ -1543,8 +1582,7 @@ int aie4_cmd_submit(struct amdxdna_hwctx *hwctx, struct amdxdna_sched_job *job, 
 				   READ_ONCE(priv->pending_head) == job);
 	if (ret) {
 		cancel_pending_job(hwctx, job);
-		mmput(job->mm);
-		return ret;
+		goto signal_fence;
 	}
 
 	mutex_lock(&priv->io_lock);
@@ -1569,8 +1607,7 @@ int aie4_cmd_submit(struct amdxdna_hwctx *hwctx, struct amdxdna_sched_job *job, 
 		mutex_unlock(&priv->io_lock);
 		/* Release the next pending submitter. */
 		wake_up_all(&priv->job_list_wq);
-		mmput(job->mm);
-		return ret;
+		goto signal_fence;
 	}
 
 	if (job->aie4_job_state == AIE4_JOB_STATE_SUBMITTING &&
@@ -1617,6 +1654,14 @@ int aie4_cmd_submit(struct amdxdna_hwctx *hwctx, struct amdxdna_sched_job *job, 
 	atomic64_inc(&hwctx->job_submit_cnt);
 	queue_work(priv->job_work_q, &priv->job_work);
 	return 0;
+
+signal_fence:
+	dma_fence_signal(job->fence);
+	dma_fence_put(job->out_fence);
+	job->out_fence = NULL;
+put_mm:
+	mmput(job->mm);
+	return ret;
 }
 
 static int aie4_hwctx_cfg_debug_bo(struct amdxdna_hwctx *hwctx, u32 meta_bo_hdl,

--- a/drivers/accel/amdxdna/aie4_message.c
+++ b/drivers/accel/amdxdna/aie4_message.c
@@ -612,6 +612,7 @@ void aie4_msg_init(struct amdxdna_dev_hdl *ndev)
 		ndev->aie.msg_ops.fw_log_init   = aie4_fw_log_init;
 		ndev->aie.msg_ops.fw_log_config = aie4_fw_log_config;
 		ndev->aie.msg_ops.fw_log_fini   = aie4_fw_log_fini;
+		ndev->aie.msg_ops.fw_log_parse  = aie4_fw_log_parse;
 	}
 
 	if (AIE_FEATURE_ON(&ndev->aie, AIE4_FW_TRACE)) {

--- a/drivers/accel/amdxdna/aie4_pci.c
+++ b/drivers/accel/amdxdna/aie4_pci.c
@@ -357,6 +357,7 @@ static int aie4_query_aie(struct amdxdna_dev_hdl *ndev)
 	 * override is re-applied to firmware by aie4_restore_power_mode().
 	 */
 	ndev->total_col = min(AIE4_TOTAL_COLUMN, ndev->aie.metadata.cols);
+	ndev->aie.frame_boundary_preempt_enabled = 1;
 
 	ret = aie4_init_dpm_freq_table(ndev);
 	if (ret)
@@ -976,6 +977,9 @@ static int aie4_get_info(struct amdxdna_client *client, struct amdxdna_drm_get_i
 		break;
 	case DRM_AMDXDNA_GET_FORCE_PREEMPT_STATE:
 		ret = amdxdna_get_force_preempt_state(&ndev->aie, args);
+		break;
+	case DRM_AMDXDNA_GET_FRAME_BOUNDARY_PREEMPT_STATE:
+		ret = amdxdna_get_frame_boundary_preempt_state(&ndev->aie, args);
 		break;
 	case DRM_AMDXDNA_GET_AUTO_COREDUMP:
 		ret = amdxdna_get_auto_coredump_mode(client, args);

--- a/drivers/accel/amdxdna/aie4_pci.c
+++ b/drivers/accel/amdxdna/aie4_pci.c
@@ -1609,6 +1609,32 @@ int aie4_fw_log_fini(struct amdxdna_dev *xdna)
 	return ret;
 }
 
+/* Max bytes printed per dmesg line; firmware entries are newline-delimited
+ * text, so split on '\n' and cap overly long lines at this chunk size.
+ */
+#define AIE4_FW_LOG_CHUNK	800
+
+void aie4_fw_log_parse(struct amdxdna_dev *xdna, char *buffer, size_t size)
+{
+	size_t offset = 0;
+
+	if (!buffer || size == 0)
+		return;
+
+	while (offset < size) {
+		const char *p = buffer + offset;
+		size_t remaining = size - offset;
+		size_t n = remaining < AIE4_FW_LOG_CHUNK ? remaining : AIE4_FW_LOG_CHUNK;
+		const char *nl = memchr(p, '\n', n);
+
+		if (nl)
+			n = (size_t)(nl - p) + 1;
+
+		XDNA_INFO(xdna, "[FW LOG] %.*s", (int)n, p);
+		offset += n;
+	}
+}
+
 int aie4_fw_trace_init(struct amdxdna_dev *xdna, size_t size, u32 categories)
 {
 	struct amdxdna_dev_hdl *ndev = xdna->dev_handle;

--- a/drivers/accel/amdxdna/aie4_pci.h
+++ b/drivers/accel/amdxdna/aie4_pci.h
@@ -249,6 +249,7 @@ int aie4_start_fw_trace(struct amdxdna_dev_hdl *ndev,
 int aie4_fw_log_init(struct amdxdna_dev *xdna, size_t size, u32 level);
 int aie4_fw_log_config(struct amdxdna_dev *xdna, u32 level);
 int aie4_fw_log_fini(struct amdxdna_dev *xdna);
+void aie4_fw_log_parse(struct amdxdna_dev *xdna, char *buf, size_t size);
 
 int aie4_fw_trace_init(struct amdxdna_dev *xdna, size_t size, u32 categories);
 int aie4_fw_trace_config(struct amdxdna_dev *xdna, u32 categories);

--- a/drivers/accel/amdxdna/amdxdna_ctx.c
+++ b/drivers/accel/amdxdna/amdxdna_ctx.c
@@ -212,8 +212,10 @@ int amdxdna_cmd_set_error(struct amdxdna_gem_obj *abo,
 		if (!abo)
 			return -EINVAL;
 		cmd = amdxdna_gem_vmap(abo);
-		if (!cmd)
+		if (!cmd) {
+			amdxdna_gem_put_obj(abo);
 			return -ENOMEM;
+		}
 	}
 
 	memset(cmd->data, 0xff, abo->mem.size - sizeof(*cmd));

--- a/drivers/accel/amdxdna/amdxdna_ctx.c
+++ b/drivers/accel/amdxdna/amdxdna_ctx.c
@@ -33,7 +33,7 @@
 struct amdxdna_fence {
 	struct dma_fence	base;
 	spinlock_t		lock; /* for base */
-	struct amdxdna_hwctx	*hwctx;
+	struct device		*dev;
 };
 
 static const char *amdxdna_fence_get_driver_name(struct dma_fence *fence)
@@ -47,7 +47,13 @@ static const char *amdxdna_fence_get_timeline_name(struct dma_fence *fence)
 
 	xdna_fence = container_of(fence, struct amdxdna_fence, base);
 
-	return xdna_fence->hwctx->name;
+	/* Use device name rather than hwctx name: the fence is published into
+	 * BO reservation objects via dma_resv_add_fence() and can outlive the
+	 * hwctx (e.g. when a BO is exported as a dma-buf and imported by
+	 * another process). The device outlives any individual context, so
+	 * dev_name() is safe to call at any point during the fence's lifetime.
+	 */
+	return dev_name(xdna_fence->dev);
 }
 
 static const struct dma_fence_ops fence_ops = {
@@ -63,9 +69,13 @@ static struct dma_fence *amdxdna_fence_create(struct amdxdna_hwctx *hwctx)
 	if (!fence)
 		return NULL;
 
-	fence->hwctx = hwctx;
+	fence->dev = hwctx->client->xdna->ddev.dev;
 	spin_lock_init(&fence->lock);
-	dma_fence_init(&fence->base, &fence_ops, &fence->lock, hwctx->id, 0);
+	/* Each job fence needs a unique context so dma_resv_add_fence() does not
+	 * evict a prior job's fence from a shared BO's reservation object when
+	 * two in-flight jobs touch the same BO.
+	 */
+	dma_fence_init(&fence->base, &fence_ops, &fence->lock, dma_fence_context_alloc(1), 0);
 	return &fence->base;
 }
 

--- a/drivers/accel/amdxdna/amdxdna_ctx.c
+++ b/drivers/accel/amdxdna/amdxdna_ctx.c
@@ -669,6 +669,7 @@ void amdxdna_sched_job_cleanup(struct amdxdna_sched_job *job)
 	amdxdna_arg_bos_put(job);
 	amdxdna_gem_put_obj(job->cmd_bo);
 	dma_fence_put(job->fence);
+	mmdrop(job->mm);
 }
 
 int amdxdna_cmd_submit(struct amdxdna_client *client,
@@ -738,6 +739,7 @@ int amdxdna_cmd_submit(struct amdxdna_client *client,
 
 	job->hwctx = hwctx;
 	job->mm = current->mm;
+	mmgrab(job->mm);
 
 	job->fence = amdxdna_fence_create(hwctx);
 	if (!job->fence) {
@@ -772,6 +774,8 @@ put_bos:
 cmd_put:
 	amdxdna_gem_put_obj(job->cmd_bo);
 free_job:
+	if (job->mm)
+		mmdrop(job->mm);
 	kfree(job);
 	return ret;
 }

--- a/drivers/accel/amdxdna/amdxdna_debugfs.c
+++ b/drivers/accel/amdxdna/amdxdna_debugfs.c
@@ -154,7 +154,7 @@ static int fw_log_level_show(struct seq_file *m, void *unused)
 	dpt = amdxdna_dpt_enter_kind(xdna, AMDXDNA_DPT_FW_LOG, &idx);
 	if (dpt) {
 		level = READ_ONCE(dpt->config);
-		srcu_read_unlock(&xdna->dpt_srcu, idx);
+		amdxdna_dpt_exit_kind(xdna, idx);
 	}
 
 	seq_printf(m, "%u\n", level);
@@ -220,7 +220,7 @@ static int fw_log_dump_to_dmesg_show(struct seq_file *m, void *unused)
 	dpt = amdxdna_dpt_enter_kind(xdna, AMDXDNA_DPT_FW_LOG, &idx);
 	if (dpt) {
 		dump = READ_ONCE(dpt->dump_to_dmesg);
-		srcu_read_unlock(&xdna->dpt_srcu, idx);
+		amdxdna_dpt_exit_kind(xdna, idx);
 	}
 
 	seq_printf(m, "%d\n", dump ? 1 : 0);

--- a/drivers/accel/amdxdna/amdxdna_debugfs.c
+++ b/drivers/accel/amdxdna/amdxdna_debugfs.c
@@ -106,6 +106,13 @@ static int amdxdna_carveout_show(struct seq_file *m, void *unused)
 AMDXDNA_DBGFS_FOPS(carveout, amdxdna_carveout_show, amdxdna_carveout_write);
 
 /*
+ * The DPT (fw_log/fw_trace) framework lives in amdxdna_dpt.o, which is only
+ * built for the PCI (aie2/aie4) backends; VE2 (AUX) does not implement it
+ * yet. Keep these nodes out of the AUX build rather than pulling amdxdna_dpt.o
+ * (and its aie.o dependency, which is not AUX-safe) into it.
+ */
+#ifndef AMDXDNA_AUX
+/*
  * fw_log_level: enable/disable firmware logging or change verbosity.
  * Write 0 to disable; 1..AMDXDNA_DPT_FW_LOG_LEVEL_MAX-1 to enable/relevel.
  * Read prints the current level (0 if inactive).
@@ -229,6 +236,7 @@ static int fw_log_dump_to_dmesg_show(struct seq_file *m, void *unused)
 
 AMDXDNA_DBGFS_FOPS(fw_log_dump_to_dmesg, fw_log_dump_to_dmesg_show,
 		   fw_log_dump_to_dmesg_write);
+#endif /* !AMDXDNA_AUX */
 
 static const struct {
 	const char *name;
@@ -236,8 +244,10 @@ static const struct {
 	umode_t mode;
 } amdxdna_dbgfs_files[] = {
 	AMDXDNA_DBGFS_FILE(carveout, 0600),
+#ifndef AMDXDNA_AUX
 	AMDXDNA_DBGFS_FILE(fw_log_level, 0600),
 	AMDXDNA_DBGFS_FILE(fw_log_dump_to_dmesg, 0600),
+#endif
 };
 
 void amdxdna_debugfs_init(struct amdxdna_dev *xdna)

--- a/drivers/accel/amdxdna/amdxdna_debugfs.c
+++ b/drivers/accel/amdxdna/amdxdna_debugfs.c
@@ -5,8 +5,11 @@
 
 #include "amdxdna_cbuf.h"
 #include "amdxdna_debugfs.h"
+#include "amdxdna_dpt.h"
+#include "amdxdna_pm.h"
 
 #include <drm/drm_file.h>
+#include <linux/cleanup.h>
 #include <linux/debugfs.h>
 #include <linux/pm_runtime.h>
 #include <linux/seq_file.h>
@@ -102,12 +105,139 @@ static int amdxdna_carveout_show(struct seq_file *m, void *unused)
  */
 AMDXDNA_DBGFS_FOPS(carveout, amdxdna_carveout_show, amdxdna_carveout_write);
 
+/*
+ * fw_log_level: enable/disable firmware logging or change verbosity.
+ * Write 0 to disable; 1..AMDXDNA_DPT_FW_LOG_LEVEL_MAX-1 to enable/relevel.
+ * Read prints the current level (0 if inactive).
+ */
+static ssize_t fw_log_level_write(struct file *file, const char __user *ptr,
+				  size_t len, loff_t *off)
+{
+	struct amdxdna_dev *xdna = file_to_xdna(file);
+	u32 level;
+	int ret;
+
+	ret = kstrtouint_from_user(ptr, len, 0, &level);
+	if (ret)
+		return ret;
+
+	guard(mutex)(&xdna->dev_lock);
+
+	/*
+	 * (Re)configuring firmware logging exchanges a message with the
+	 * firmware, so the device must be awake. On an idle device runtime PM
+	 * has suspended it (and the DPT), which would otherwise fail the write
+	 * with -EBUSY; resume it for the duration of the config and let it
+	 * autosuspend again afterwards.
+	 */
+	ret = amdxdna_pm_resume_get_locked(xdna);
+	if (ret)
+		return ret;
+
+	ret = amdxdna_fw_log_set_state(xdna, level);
+	amdxdna_pm_suspend_put(xdna);
+	if (ret) {
+		XDNA_ERR(xdna, "Failed to set FW log level %u: %d", level, ret);
+		return ret;
+	}
+
+	return len;
+}
+
+static int fw_log_level_show(struct seq_file *m, void *unused)
+{
+	struct amdxdna_dev *xdna = m->private;
+	struct amdxdna_dpt *dpt;
+	u32 level = 0;
+	int idx;
+
+	dpt = amdxdna_dpt_enter_kind(xdna, AMDXDNA_DPT_FW_LOG, &idx);
+	if (dpt) {
+		level = READ_ONCE(dpt->config);
+		srcu_read_unlock(&xdna->dpt_srcu, idx);
+	}
+
+	seq_printf(m, "%u\n", level);
+	return 0;
+}
+
+AMDXDNA_DBGFS_FOPS(fw_log_level, fw_log_level_show, fw_log_level_write);
+
+/*
+ * fw_log_dump_to_dmesg: toggle kernel-side streaming of FW log entries to
+ * dmesg. Returns -EINVAL if FW logging is not ACTIVE.
+ */
+static ssize_t fw_log_dump_to_dmesg_write(struct file *file, const char __user *ptr,
+					  size_t len, loff_t *off)
+{
+	struct amdxdna_dev *xdna = file_to_xdna(file);
+	struct amdxdna_dpt *dpt;
+	bool dump;
+	int ret;
+
+	ret = kstrtobool_from_user(ptr, len, &dump);
+	if (ret)
+		return ret;
+
+	guard(mutex)(&xdna->dev_lock);
+
+	/*
+	 * Enabling/disabling the dmesg stream touches the DPT poll timer and
+	 * buffer, so the device (and DPT) must be resumed first; an idle
+	 * device is runtime-suspended with the DPT in SUSPENDED state. Resume
+	 * for the operation and let it autosuspend again afterwards.
+	 */
+	ret = amdxdna_pm_resume_get_locked(xdna);
+	if (ret)
+		return ret;
+
+	dpt = rcu_dereference_protected(xdna->fw_log,
+					lockdep_is_held(&xdna->dev_lock));
+	if (!dpt || READ_ONCE(dpt->status) != AMDXDNA_DPT_ACTIVE) {
+		amdxdna_pm_suspend_put(xdna);
+		XDNA_ERR(xdna, "FW logging is not active");
+		return -EINVAL;
+	}
+
+	ret = amdxdna_dpt_dump_to_dmesg(dpt, dump);
+	amdxdna_pm_suspend_put(xdna);
+	if (ret) {
+		XDNA_ERR(xdna, "Failed to %s FW log dmesg: %d",
+			 dump ? "enable" : "disable", ret);
+		return ret;
+	}
+
+	return len;
+}
+
+static int fw_log_dump_to_dmesg_show(struct seq_file *m, void *unused)
+{
+	struct amdxdna_dev *xdna = m->private;
+	struct amdxdna_dpt *dpt;
+	bool dump = false;
+	int idx;
+
+	dpt = amdxdna_dpt_enter_kind(xdna, AMDXDNA_DPT_FW_LOG, &idx);
+	if (dpt) {
+		dump = READ_ONCE(dpt->dump_to_dmesg);
+		srcu_read_unlock(&xdna->dpt_srcu, idx);
+	}
+
+	seq_printf(m, "%d\n", dump ? 1 : 0);
+	return 0;
+}
+
+AMDXDNA_DBGFS_FOPS(fw_log_dump_to_dmesg, fw_log_dump_to_dmesg_show,
+		   fw_log_dump_to_dmesg_write);
+
 static const struct {
 	const char *name;
 	const struct file_operations *fops;
 	umode_t mode;
 } amdxdna_dbgfs_files[] = {
 	AMDXDNA_DBGFS_FILE(carveout, 0600),
+	AMDXDNA_DBGFS_FILE(fw_log_level, 0600),
+	AMDXDNA_DBGFS_FILE(fw_log_dump_to_dmesg, 0600),
 };
 
 void amdxdna_debugfs_init(struct amdxdna_dev *xdna)

--- a/drivers/accel/amdxdna/amdxdna_dpt.c
+++ b/drivers/accel/amdxdna/amdxdna_dpt.c
@@ -23,7 +23,7 @@
 #include "amdxdna_dpt.h"
 #include "amdxdna_pci_drv.h"
 
-const char * const amdxdna_dpt_irq_name[AMDXDNA_DPT_KIND_MAX] = {
+static const char * const amdxdna_dpt_irq_name[AMDXDNA_DPT_KIND_MAX] = {
 	[AMDXDNA_DPT_FW_LOG]   = "xdna_fw_log",
 	[AMDXDNA_DPT_FW_TRACE] = "xdna_fw_trace",
 };
@@ -66,10 +66,15 @@ amdxdna_dpt_enter_kind(struct amdxdna_dev *xdna, enum amdxdna_dpt_kind kind,
 	*idx = srcu_read_lock(&xdna->dpt_srcu);
 	dpt = srcu_dereference(*slot, &xdna->dpt_srcu);
 	if (!dpt || READ_ONCE(dpt->status) != AMDXDNA_DPT_ACTIVE) {
-		srcu_read_unlock(&xdna->dpt_srcu, *idx);
+		amdxdna_dpt_exit_kind(xdna, *idx);
 		return NULL;
 	}
 	return dpt;
+}
+
+void amdxdna_dpt_exit_kind(struct amdxdna_dev *xdna, int idx)
+{
+	srcu_read_unlock(&xdna->dpt_srcu, idx);
 }
 
 /*
@@ -1121,7 +1126,7 @@ int amdxdna_get_fw_log(struct aie_device *aie,
 		return -ESHUTDOWN;
 
 	ret = amdxdna_dpt_get_data(dpt, args);
-	srcu_read_unlock(&xdna->dpt_srcu, idx);
+	amdxdna_dpt_exit_kind(xdna, idx);
 	return ret;
 }
 
@@ -1169,7 +1174,7 @@ int amdxdna_get_fw_log_configs(struct aie_device *aie,
 		config.version = dpt->payload_version;
 		config.status = 1;
 		config.config = READ_ONCE(dpt->config);
-		srcu_read_unlock(&xdna->dpt_srcu, idx);
+		amdxdna_dpt_exit_kind(xdna, idx);
 	}
 
 	if (copy_to_user(buf, &config, sizeof(config)))
@@ -1227,7 +1232,7 @@ int amdxdna_get_fw_trace(struct aie_device *aie,
 		return -ESHUTDOWN;
 
 	ret = amdxdna_dpt_get_data(dpt, args);
-	srcu_read_unlock(&xdna->dpt_srcu, idx);
+	amdxdna_dpt_exit_kind(xdna, idx);
 	return ret;
 }
 
@@ -1275,7 +1280,7 @@ int amdxdna_get_fw_trace_configs(struct aie_device *aie,
 		config.version = dpt->payload_version;
 		config.status = 1;
 		config.config = READ_ONCE(dpt->config);
-		srcu_read_unlock(&xdna->dpt_srcu, idx);
+		amdxdna_dpt_exit_kind(xdna, idx);
 	}
 
 	if (copy_to_user(buf, &config, sizeof(config)))

--- a/drivers/accel/amdxdna/amdxdna_dpt.c
+++ b/drivers/accel/amdxdna/amdxdna_dpt.c
@@ -52,7 +52,7 @@ amdxdna_dpt_slot(struct amdxdna_dev *xdna, enum amdxdna_dpt_kind kind)
 	return NULL;
 }
 
-static struct amdxdna_dpt *
+struct amdxdna_dpt *
 amdxdna_dpt_enter_kind(struct amdxdna_dev *xdna, enum amdxdna_dpt_kind kind,
 		       int *idx)
 {
@@ -82,6 +82,20 @@ static bool amdxdna_dpt_watch_ready(const struct amdxdna_dpt *dpt, u64 offset)
 {
 	return READ_ONCE(dpt->status) != AMDXDNA_DPT_ACTIVE ||
 	       offset != READ_ONCE(dpt->tail);
+}
+
+static int amdxdna_dpt_copy_to_kernel(void *to, const void *from, size_t n)
+{
+	memcpy(to, from, n);
+	return 0;
+}
+
+static void amdxdna_dpt_call_parse(struct amdxdna_dpt *dpt, char *buf, size_t size)
+{
+	struct aie_device *aie = dpt->aie;
+
+	if (dpt->kind == AMDXDNA_DPT_FW_LOG && aie->msg_ops.fw_log_parse)
+		aie->msg_ops.fw_log_parse(dpt->xdna, buf, size);
 }
 
 static int amdxdna_dpt_copy_to_user(void *to, const void *from, size_t n)
@@ -117,49 +131,49 @@ static int amdxdna_dpt_fetch_payload(struct amdxdna_dpt *dpt, u8 *buf,
 		goto exit;
 	}
 
+	/*
+	 * When the reader has fallen more than one full ring behind, the
+	 * oldest in-ring bytes have already been overwritten. Skip forward to
+	 * the start of the still-valid window (tail - log_size) instead of
+	 * repeatedly re-reading (and, in the dmesg path, re-logging) the same
+	 * beginning-of-ring bytes on every fetch until the cursor catches up.
+	 */
+	if (tail - *offset > log_size)
+		*offset = tail - log_size;
+
 	start = *offset % log_size;
 	end = tail % log_size;
 
 	/*
-	 * When the firmware has wrapped past our slot by more than one full
-	 * buffer, re-anchor at the start of the buffer to deliver the most
-	 * recent entries.
+	 * start == end here means the reader is exactly one full ring behind,
+	 * so the entire ring is pending (req_size == log_size). It never means
+	 * "empty" because the tail == *offset case already returned above.
 	 */
-	if (tail - *offset >= log_size + start)
-		start = 0;
-
-	if (end > start) {
+	if (end > start)
 		req_size = end - start;
-		if (req_size > *size) {
-			XDNA_DPT_DBG(dpt, "Insufficient buffer size: 0x%zx", req_size);
-			end = start + *size;
-			req_size = *size;
-		}
-	} else {
+	else
 		req_size = log_size - start + end;
-		if (req_size > *size) {
-			XDNA_DPT_DBG(dpt, "Insufficient buffer size: 0x%zx", req_size);
-			if (start + *size <= log_size)
-				end = start + *size;
-			else
-				end = *size - (log_size - start);
-			req_size = *size;
-		}
+
+	if (req_size > *size) {
+		XDNA_DPT_DBG(dpt, "Insufficient buffer size: 0x%zx", req_size);
+		req_size = *size;
 	}
 
-	if (start > end) {
+	if (start + req_size > log_size) {
+		size_t first = log_size - start;
+
 		/* First chunk: from start to end of log buffer */
-		drm_clflush_virt_range(to_cpu_addr(hdl, start), log_size - start);
-		if (cpy(buf, to_cpu_addr(hdl, start), log_size - start))
+		drm_clflush_virt_range(to_cpu_addr(hdl, start), first);
+		if (cpy(buf, to_cpu_addr(hdl, start), first))
 			return -EFAULT;
 
-		/* Wrap-around chunk: from 0 to end */
-		drm_clflush_virt_range(to_cpu_addr(hdl, 0), end);
-		if (cpy(buf + (log_size - start), to_cpu_addr(hdl, 0), end))
+		/* Wrap-around chunk: from 0 to the remainder */
+		drm_clflush_virt_range(to_cpu_addr(hdl, 0), req_size - first);
+		if (cpy(buf + first, to_cpu_addr(hdl, 0), req_size - first))
 			return -EFAULT;
 	} else {
-		drm_clflush_virt_range(to_cpu_addr(hdl, start), end - start);
-		if (cpy(buf, to_cpu_addr(hdl, start), end - start))
+		drm_clflush_virt_range(to_cpu_addr(hdl, start), req_size);
+		if (cpy(buf, to_cpu_addr(hdl, start), req_size))
 			return -EFAULT;
 	}
 exit:
@@ -294,11 +308,134 @@ static void amdxdna_dpt_timer_put(struct amdxdna_dpt *dpt)
 	mutex_unlock(&dpt->timer_lock);
 }
 
+static void amdxdna_dpt_fetch_and_dump_to_dmesg(struct amdxdna_dpt *dpt)
+{
+	/*
+	 * A single fetch is capped at the local_buffer size and the poll
+	 * worker only re-fetches when the tail advances, so drain the whole
+	 * backlog up to the current tail here. Otherwise a batch larger than
+	 * local_buffer would leave head behind tail and stall until the next
+	 * tail advance. Only amdxdna_dpt_update_tail() moves the tail, so it
+	 * is a fixed snapshot for the duration of this loop and the loop is
+	 * bounded.
+	 */
+	while (dpt->head != READ_ONCE(dpt->tail)) {
+		u32 size = dpt->size;
+		int ret;
+
+		ret = amdxdna_dpt_fetch_payload(dpt, dpt->local_buffer, &dpt->head,
+						&size, amdxdna_dpt_copy_to_kernel);
+		if (ret) {
+			XDNA_DPT_ERR(dpt, "Failed to fetch FW buffer: %d", ret);
+			return;
+		}
+		if (!size)
+			break;
+
+		amdxdna_dpt_call_parse(dpt, dpt->local_buffer, size);
+	}
+}
+
+static void amdxdna_dpt_drain_pending_data(struct amdxdna_dpt *dpt)
+{
+	/*
+	 * Refresh the tail from the firmware footer before draining. At enable
+	 * time (for example right after resume, before the IRQ or poll worker
+	 * has run) the cached tail may lag the ring, so snapshot the latest
+	 * first to avoid leaving already-buffered entries until a later worker
+	 * run.
+	 */
+	amdxdna_dpt_update_tail(dpt);
+	amdxdna_dpt_fetch_and_dump_to_dmesg(dpt);
+}
+
 static void amdxdna_dpt_worker(struct work_struct *w)
 {
 	struct amdxdna_dpt *dpt = container_of(w, struct amdxdna_dpt, work);
 
-	amdxdna_dpt_update_tail(dpt);
+	/*
+	 * The worker is the sole consumer of local_buffer / head once
+	 * dumping is enabled. Pair the acquire load with the store-release
+	 * in amdxdna_dpt_dump_to_dmesg() so that observing dump_to_dmesg
+	 * true guarantees local_buffer has been published.
+	 */
+	if (amdxdna_dpt_update_tail(dpt) && smp_load_acquire(&dpt->dump_to_dmesg))
+		amdxdna_dpt_fetch_and_dump_to_dmesg(dpt);
+}
+
+int amdxdna_dpt_dump_to_dmesg(struct amdxdna_dpt *dpt, bool enable)
+{
+	if (!dpt)
+		return -EINVAL;
+
+	/*
+	 * The poll worker reads dump_to_dmesg with smp_load_acquire() without
+	 * taking dev_lock, so use READ_ONCE() here to keep the compare
+	 * race-free (a plain read is a data race under KCSAN).
+	 */
+	if (READ_ONCE(dpt->dump_to_dmesg) == enable)
+		return 0;
+
+	if (enable) {
+		/*
+		 * dmesg dumping only makes sense when the backend can parse the
+		 * fetched ring payload (see amdxdna_dpt_call_parse). Reject the
+		 * request for any kind or generation that installs no fw_log_parse
+		 * hook, whose fetched batches would otherwise be silently
+		 * discarded, rather than pinning a multi-megabyte buffer and
+		 * running the poll worker for nothing.
+		 */
+		if (dpt->kind != AMDXDNA_DPT_FW_LOG || !dpt->aie->msg_ops.fw_log_parse)
+			return -EOPNOTSUPP;
+
+		/*
+		 * local_buffer is only a CPU memcpy staging area for the ring
+		 * payload (amdxdna_dpt_copy_to_kernel), never a DMA target, so
+		 * a virtually contiguous allocation is sufficient and far more
+		 * robust than a multi-megabyte physically contiguous kmalloc.
+		 */
+		dpt->local_buffer = kvzalloc(dpt->size, GFP_KERNEL);
+		if (!dpt->local_buffer) {
+			XDNA_DPT_ERR(dpt, "Failed to allocate FW fetch buffer");
+			return -ENOMEM;
+		}
+		dpt->head = 0;
+
+		/*
+		 * Drain whatever is already in the ring from this (debugfs)
+		 * context while dump_to_dmesg is still false, so the worker
+		 * skips fetch_and_dump and cannot touch local_buffer / head
+		 * concurrently. Only after the initial drain do we publish the
+		 * buffer and hand ownership of local_buffer / head to the
+		 * worker, which then becomes the sole consumer.
+		 */
+		amdxdna_dpt_drain_pending_data(dpt);
+
+		/*
+		 * Publish local_buffer before dump_to_dmesg becomes visible;
+		 * pairs with the acquire load in amdxdna_dpt_worker().
+		 */
+		smp_store_release(&dpt->dump_to_dmesg, true);
+		amdxdna_dpt_timer_get(dpt);
+	} else {
+		/*
+		 * Stop dumping, then quiesce the host pipeline before freeing:
+		 * a worker queued by the IRQ handler or poll timer reads
+		 * local_buffer, so it must not run past the kvfree. timer_put
+		 * may stop the poll timer, and cancel_work_sync waits for any
+		 * in-flight worker; a worker requeued afterwards observes
+		 * dump_to_dmesg false and skips the dump.
+		 */
+		WRITE_ONCE(dpt->dump_to_dmesg, false);
+		amdxdna_dpt_timer_put(dpt);
+		cancel_work_sync(&dpt->work);
+
+		kvfree(dpt->local_buffer);
+		dpt->local_buffer = NULL;
+		dpt->head = 0;
+	}
+
+	return 0;
 }
 
 static void amdxdna_dpt_timer(struct timer_list *t)
@@ -402,6 +539,7 @@ amdxdna_dpt_publish(struct aie_device *aie, enum amdxdna_dpt_kind kind,
 		return ERR_PTR(ret);
 	}
 	dpt->buf = hdl;
+	dpt->size = to_buf_size(hdl);
 
 	memset(to_cpu_addr(hdl, 0), 0, to_buf_size(hdl));
 	drm_clflush_virt_range(to_cpu_addr(hdl, 0), to_buf_size(hdl));
@@ -628,6 +766,18 @@ static int amdxdna_dpt_fini_kind(struct aie_device *aie, enum amdxdna_dpt_kind k
 	cancel_work_sync(&dpt->work);
 
 	/*
+	 * The dmesg consumer (if enabled) held a timer ref and a local
+	 * buffer. The timer is already shut down, so release the buffer
+	 * directly rather than through amdxdna_dpt_dump_to_dmesg().
+	 */
+	if (dpt->dump_to_dmesg) {
+		dpt->dump_to_dmesg = false;
+		kvfree(dpt->local_buffer);
+		dpt->local_buffer = NULL;
+		dpt->head = 0;
+	}
+
+	/*
 	 * Release any watcher still parked. Required for the steady-state
 	 * "FW idle, no tail advance" case where amdxdna_dpt_update_tail's
 	 * conditional wake_up did not fire; otherwise the watcher would
@@ -758,6 +908,20 @@ static int amdxdna_dpt_resume_kind(struct amdxdna_dev *xdna,
 
 	WRITE_ONCE(dpt->status, AMDXDNA_DPT_ACTIVE);
 
+	/*
+	 * Suspend stopped the poll timer with timer_delete_sync but left
+	 * timer_refs untouched, so a consumer that held a reference across
+	 * suspend (e.g. dmesg dump) can no longer trigger the 0->1 arm in
+	 * amdxdna_dpt_timer_get. Re-arm it here under timer_lock now that
+	 * the device is ACTIVE again, otherwise polling stays dead and, if
+	 * the IRQ is also unavailable, FW-log consumption silently stalls.
+	 */
+	mutex_lock(&dpt->timer_lock);
+	if (refcount_read(&dpt->timer_refs))
+		mod_timer(&dpt->timer,
+			  jiffies + msecs_to_jiffies(AMDXDNA_DPT_POLL_INTERVAL_MS));
+	mutex_unlock(&dpt->timer_lock);
+
 	XDNA_DPT_DBG(dpt, "Resumed");
 	return 0;
 }
@@ -788,6 +952,44 @@ static int amdxdna_fw_log_set_level(struct aie_device *aie, u32 level)
 	WRITE_ONCE(dpt->config, level);
 	XDNA_DBG(xdna, "FW log level changed to %d", level);
 	return 0;
+}
+
+/*
+ * debugfs fw_log_level entry point. Starts logging from INACTIVE, changes
+ * the live level while ACTIVE, or stops logging when @level is NONE. Uses
+ * the xdna->dpt_aie back-pointer so the common debugfs layer need not know
+ * the generation-specific dev_handle layout.
+ */
+int amdxdna_fw_log_set_state(struct amdxdna_dev *xdna, u32 level)
+{
+	struct aie_device *aie = xdna->dpt_aie;
+	enum amdxdna_dpt_status status;
+	struct amdxdna_dpt *dpt;
+
+	drm_WARN_ON(&xdna->ddev, !mutex_is_locked(&xdna->dev_lock));
+
+	if (level >= AMDXDNA_DPT_FW_LOG_LEVEL_MAX)
+		return -EINVAL;
+	if (!aie)
+		return -ENODEV;
+
+	dpt = rcu_dereference_protected(xdna->fw_log,
+					lockdep_is_held(&xdna->dev_lock));
+	status = dpt ? READ_ONCE(dpt->status) : AMDXDNA_DPT_INACTIVE;
+
+	switch (status) {
+	case AMDXDNA_DPT_INACTIVE:
+		if (level == AMDXDNA_DPT_FW_LOG_LEVEL_NONE)
+			return 0;
+		return amdxdna_fw_log_init(aie, level);
+	case AMDXDNA_DPT_ACTIVE:
+		if (level == AMDXDNA_DPT_FW_LOG_LEVEL_NONE)
+			return amdxdna_dpt_fini_kind(aie, AMDXDNA_DPT_FW_LOG);
+		return amdxdna_fw_log_set_level(aie, level);
+	default:
+		XDNA_ERR(xdna, "FW logging not in a stable state, retry");
+		return -EBUSY;
+	}
 }
 
 static int amdxdna_fw_trace_init(struct aie_device *aie, u32 categories)
@@ -843,6 +1045,11 @@ int amdxdna_dpt_init(struct aie_device *aie)
 {
 	int ret;
 
+	/* Record the aie back-pointer so common code (debugfs) can reach
+	 * msg_ops without the generation-specific dev_handle layout.
+	 */
+	aie->xdna->dpt_aie = aie;
+
 	ret = amdxdna_fw_log_init(aie, AMDXDNA_DPT_FW_LOG_LEVEL_DEFAULT);
 	if (ret)
 		XDNA_WARN(aie->xdna, "Failed to enable FW logging: %d", ret);
@@ -853,6 +1060,14 @@ int amdxdna_dpt_init(struct aie_device *aie)
 int amdxdna_dpt_fini(struct aie_device *aie)
 {
 	int ret;
+
+	/*
+	 * Clear the back-pointer before tearing the DPT kinds down so a
+	 * concurrent or in-flight debugfs handler (amdxdna_fw_log_set_state)
+	 * observes a NULL dpt_aie and fails cleanly with -ENODEV instead of
+	 * reaching a DPT that teardown is about to free.
+	 */
+	aie->xdna->dpt_aie = NULL;
 
 	ret = amdxdna_dpt_fini_kind(aie, AMDXDNA_DPT_FW_LOG);
 	if (ret)

--- a/drivers/accel/amdxdna/amdxdna_dpt.h
+++ b/drivers/accel/amdxdna/amdxdna_dpt.h
@@ -125,6 +125,13 @@ struct amdxdna_dpt {
 
 	/* xrt-smi watchers park here */
 	struct wait_queue_head		 wait;
+
+	/* dmesg-dump consumer (head / local_buffer valid only while dump_to_dmesg) */
+	bool				 dump_to_dmesg;
+	u64				 head;
+	u8				*local_buffer;
+	/* ring payload size, set at publish time; valid regardless of dump_to_dmesg */
+	u32				 size;
 };
 
 /*
@@ -140,6 +147,12 @@ int amdxdna_dpt_init(struct aie_device *aie);
 int amdxdna_dpt_fini(struct aie_device *aie);
 int amdxdna_dpt_suspend(struct amdxdna_dev *xdna);
 int amdxdna_dpt_resume(struct amdxdna_dev *xdna);
+
+/* dmesg-dump consumer control (debugfs). */
+int amdxdna_dpt_dump_to_dmesg(struct amdxdna_dpt *dpt, bool enable);
+int amdxdna_fw_log_set_state(struct amdxdna_dev *xdna, u32 level);
+struct amdxdna_dpt *amdxdna_dpt_enter_kind(struct amdxdna_dev *xdna,
+					   enum amdxdna_dpt_kind kind, int *idx);
 
 int amdxdna_get_fw_log(struct aie_device *aie,
 		       struct amdxdna_drm_get_array *args);

--- a/drivers/accel/amdxdna/amdxdna_dpt.h
+++ b/drivers/accel/amdxdna/amdxdna_dpt.h
@@ -62,7 +62,6 @@ enum amdxdna_dpt_kind {
 };
 
 const char *amdxdna_dpt_kind_str(enum amdxdna_dpt_kind kind);
-extern const char * const amdxdna_dpt_irq_name[AMDXDNA_DPT_KIND_MAX];
 
 #define XDNA_DPT_PRINTK(level, dpt, fmt, args...) do {				\
 	const struct amdxdna_dpt *__d = (dpt);					\
@@ -153,6 +152,7 @@ int amdxdna_dpt_dump_to_dmesg(struct amdxdna_dpt *dpt, bool enable);
 int amdxdna_fw_log_set_state(struct amdxdna_dev *xdna, u32 level);
 struct amdxdna_dpt *amdxdna_dpt_enter_kind(struct amdxdna_dev *xdna,
 					   enum amdxdna_dpt_kind kind, int *idx);
+void amdxdna_dpt_exit_kind(struct amdxdna_dev *xdna, int idx);
 
 int amdxdna_get_fw_log(struct aie_device *aie,
 		       struct amdxdna_drm_get_array *args);

--- a/drivers/accel/amdxdna/amdxdna_gem.c
+++ b/drivers/accel/amdxdna/amdxdna_gem.c
@@ -1380,6 +1380,7 @@ int amdxdna_drm_get_bo_info_ioctl(struct drm_device *dev, void *data, struct drm
 
 static int amdxdna_flush_bo(struct amdxdna_gem_obj *abo, u64 offset, u64 size)
 {
+	unsigned long first, nr_pages;
 	u64 end;
 
 	if (offset >= abo->mem.size)
@@ -1389,14 +1390,17 @@ static int amdxdna_flush_bo(struct amdxdna_gem_obj *abo, u64 offset, u64 size)
 		return -EINVAL;
 
 	size = min(abo->mem.size, end) - offset;
-	if (is_import_bo(abo))
-		drm_clflush_sg(abo->base.sgt);
-	else if (amdxdna_gem_vmap(abo))
+	first = offset >> PAGE_SHIFT;
+	nr_pages = (PAGE_ALIGN(offset + size) >> PAGE_SHIFT) - first;
+
+	if (amdxdna_gem_vmap(abo))
 		drm_clflush_virt_range(amdxdna_gem_vmap(abo) + offset, size);
+	else if (is_import_bo(abo))
+		drm_clflush_sg(abo->base.sgt);
 	else if (abo->base.pages)
-		drm_clflush_pages(abo->base.pages, abo->mem.size >> PAGE_SHIFT);
+		drm_clflush_pages(&abo->base.pages[first], nr_pages);
 	else if (abo->mem.pages)
-		drm_clflush_pages(abo->mem.pages, abo->mem.nr_pages);
+		drm_clflush_pages(&abo->mem.pages[first], nr_pages);
 	else
 		return -EINVAL;
 

--- a/drivers/accel/amdxdna/amdxdna_gem.c
+++ b/drivers/accel/amdxdna/amdxdna_gem.c
@@ -271,6 +271,7 @@ static bool amdxdna_hmm_invalidate(struct mmu_interval_notifier *mni,
 	struct amdxdna_umap *mapp = container_of(mni, struct amdxdna_umap, notifier);
 	struct amdxdna_gem_obj *abo = mapp->abo;
 	struct amdxdna_dev *xdna;
+	long ret;
 
 	xdna = to_xdna_dev(to_gobj(abo)->dev);
 	XDNA_DBG(xdna, "Invalidating range 0x%lx, 0x%lx, type %d, evt %d, pending fences %d",
@@ -286,8 +287,12 @@ static bool amdxdna_hmm_invalidate(struct mmu_interval_notifier *mni,
 	mmu_interval_set_seq(&mapp->notifier, cur_seq);
 	up_write(&xdna->notifier_lock);
 
-	if (xdna->dev_info->ops->hmm_invalidate)
-		xdna->dev_info->ops->hmm_invalidate(abo, cur_seq);
+	ret = dma_resv_wait_timeout(to_gobj(abo)->resv, DMA_RESV_USAGE_BOOKKEEP,
+				    true, MAX_SCHEDULE_TIMEOUT);
+	if (!ret)
+		XDNA_ERR(xdna, "Failed to wait for bo, ret %ld", ret);
+	else if (ret == -ERESTARTSYS)
+		XDNA_DBG(xdna, "Wait for bo interrupted by signal");
 
 	if (range->event == MMU_NOTIFY_UNMAP) {
 		down_write(&xdna->notifier_lock);

--- a/drivers/accel/amdxdna/amdxdna_gem.c
+++ b/drivers/accel/amdxdna/amdxdna_gem.c
@@ -456,6 +456,23 @@ static void amdxdna_gem_dev_obj_free(struct drm_gem_object *gobj)
 	amdxdna_gem_destroy_obj(abo);
 }
 
+static void amdxdna_mark_mapp_invalid(struct amdxdna_gem_obj *abo,
+				      struct vm_area_struct *vma)
+{
+	struct amdxdna_dev *xdna = to_xdna_dev(to_gobj(abo)->dev);
+	struct amdxdna_umap *mapp;
+
+	down_write(&xdna->notifier_lock);
+	abo->mem.map_invalid = true;
+	list_for_each_entry(mapp, &abo->mem.umap_list, node) {
+		if (compare_range(mapp, vma->vm_mm, vma->vm_start, vma->vm_end)) {
+			mapp->invalid = true;
+			break;
+		}
+	}
+	up_write(&xdna->notifier_lock);
+}
+
 static int amdxdna_insert_pages(struct amdxdna_gem_obj *abo,
 				struct vm_area_struct *vma)
 {
@@ -470,31 +487,21 @@ static int amdxdna_insert_pages(struct amdxdna_gem_obj *abo,
 			XDNA_ERR(xdna, "Failed shmem mmap %d", ret);
 			return ret;
 		}
-
-		/* The buffer is based on memory pages. Fix the flag. */
-		vm_flags_mod(vma, VM_MIXEDMAP, VM_PFNMAP);
-		ret = vm_insert_pages(vma, vma->vm_start, abo->base.pages,
-				      &num_pages);
+	} else {
+		vma->vm_private_data = NULL;
+		vma->vm_ops = NULL;
+		ret = dma_buf_mmap(abo->dma_buf, vma, 0);
 		if (ret) {
-			XDNA_ERR(xdna, "Failed insert pages %d", ret);
-			drm_gem_object_get(to_gobj(abo));
-			vma->vm_ops->close(vma);
+			XDNA_ERR(xdna, "Failed to mmap dma buf %d", ret);
 			return ret;
 		}
 
-		return 0;
-	}
-
-	vma->vm_private_data = NULL;
-	vma->vm_ops = NULL;
-	ret = dma_buf_mmap(abo->dma_buf, vma, 0);
-	if (ret) {
-		XDNA_ERR(xdna, "Failed to mmap dma buf %d", ret);
-		return ret;
+		/* Drop the reference drm_gem_mmap_obj() acquired.*/
+		drm_gem_object_put(to_gobj(abo));
 	}
 
 	if (!vma->vm_ops)
-		goto put_obj;
+		return 0;
 
 	do {
 		vm_fault_t fault_ret;
@@ -503,17 +510,13 @@ static int amdxdna_insert_pages(struct amdxdna_gem_obj *abo,
 		fault_ret = handle_mm_fault(vma, vma->vm_start + offset,
 					    flags, NULL);
 		if (fault_ret & VM_FAULT_ERROR) {
-			vma->vm_ops->close(vma);
 			XDNA_ERR(xdna, "Fault in page failed");
-			return -EFAULT;
+			amdxdna_mark_mapp_invalid(abo, vma);
+			break;
 		}
 
 		offset += PAGE_SIZE;
 	} while (--num_pages);
-
-put_obj:
-	/* Drop the reference drm_gem_mmap_obj() acquired.*/
-	drm_gem_object_put(to_gobj(abo));
 
 	return 0;
 }

--- a/drivers/accel/amdxdna/amdxdna_gem.c
+++ b/drivers/accel/amdxdna/amdxdna_gem.c
@@ -211,13 +211,11 @@ void amdxdna_gem_destroy_obj(struct amdxdna_gem_obj *abo)
 }
 
 /*
- * Obtains a kernel virtual address on the BO (usually of small size).
- * The mapping is established on the first call and stays valid until
- * amdxdna_gem_vunmap() is called.
+ * Returns the error rather than logging it, for a caller that has a fallback:
+ * an imported BO whose exporter implements no vmap op fails on every call.
  */
-void *amdxdna_gem_vmap(struct amdxdna_gem_obj *abo)
+static void *amdxdna_gem_vmap_try(struct amdxdna_gem_obj *abo)
 {
-	struct amdxdna_dev *xdna = to_xdna_dev(to_gobj(abo)->dev);
 	struct iosys_map map = IOSYS_MAP_INIT_VADDR(NULL);
 	int ret;
 
@@ -230,11 +228,27 @@ void *amdxdna_gem_vmap(struct amdxdna_gem_obj *abo)
 	if (!abo->mem.kva) {
 		ret = drm_gem_vmap(to_gobj(abo), &map);
 		if (ret)
-			XDNA_ERR(xdna, "Vmap bo failed, ret %d", ret);
-		else
-			abo->mem.kva = map.vaddr;
+			return ERR_PTR(ret);
+		abo->mem.kva = map.vaddr;
 	}
 	return abo->mem.kva;
+}
+
+/*
+ * Obtains a kernel virtual address on the BO (usually of small size).
+ * The mapping is established on the first call and stays valid until
+ * amdxdna_gem_vunmap() is called.
+ */
+void *amdxdna_gem_vmap(struct amdxdna_gem_obj *abo)
+{
+	struct amdxdna_dev *xdna = to_xdna_dev(to_gobj(abo)->dev);
+	void *kva = amdxdna_gem_vmap_try(abo);
+
+	if (IS_ERR(kva)) {
+		XDNA_ERR(xdna, "Vmap bo failed, ret %ld", PTR_ERR(kva));
+		return NULL;
+	}
+	return kva;
 }
 
 /*
@@ -1381,6 +1395,7 @@ int amdxdna_drm_get_bo_info_ioctl(struct drm_device *dev, void *data, struct drm
 static int amdxdna_flush_bo(struct amdxdna_gem_obj *abo, u64 offset, u64 size)
 {
 	unsigned long first, nr_pages;
+	void *kva;
 	u64 end;
 
 	if (offset >= abo->mem.size)
@@ -1393,8 +1408,9 @@ static int amdxdna_flush_bo(struct amdxdna_gem_obj *abo, u64 offset, u64 size)
 	first = offset >> PAGE_SHIFT;
 	nr_pages = (PAGE_ALIGN(offset + size) >> PAGE_SHIFT) - first;
 
-	if (amdxdna_gem_vmap(abo))
-		drm_clflush_virt_range(amdxdna_gem_vmap(abo) + offset, size);
+	kva = amdxdna_gem_vmap_try(abo);
+	if (!IS_ERR(kva))
+		drm_clflush_virt_range(kva + offset, size);
 	else if (is_import_bo(abo))
 		drm_clflush_sg(abo->base.sgt);
 	else if (abo->base.pages)

--- a/drivers/accel/amdxdna/amdxdna_pci_drv.c
+++ b/drivers/accel/amdxdna/amdxdna_pci_drv.c
@@ -143,7 +143,18 @@ static int amdxdna_probe(struct pci_dev *pdev, const struct pci_device_id *id)
 	if (ret)
 		return ret;
 
-	drmm_mutex_init(ddev, &xdna->dev_lock);
+	ret = drmm_mutex_init(ddev, &xdna->dev_lock);
+	if (ret)
+		return ret;
+
+	/*
+	 * A VF's dev_lock is acquired in probe() while the PF still holds its
+	 * own dev_lock across pci_enable_sriov(). They are distinct instances
+	 * sharing one lock class, so nest the VF at a deeper subclass to keep
+	 * lockdep from misreporting the hierarchical PF -> VF order.
+	 */
+	lockdep_set_subclass(&xdna->dev_lock,
+			     pdev->is_virtfn ? SINGLE_DEPTH_NESTING : 0);
 	init_rwsem(&xdna->notifier_lock);
 	INIT_LIST_HEAD(&xdna->client_list);
 	ida_init(&xdna->hwctx_ida);

--- a/drivers/accel/amdxdna/amdxdna_pci_drv.h
+++ b/drivers/accel/amdxdna/amdxdna_pci_drv.h
@@ -134,6 +134,7 @@ struct amdxdna_dev_info {
 
 struct amdxdna_carveout;
 struct amdxdna_dpt;
+struct aie_device;
 
 struct amdxdna_dev {
 	struct drm_device		ddev;
@@ -175,6 +176,12 @@ struct amdxdna_dev {
 
 	/* Allow auto core dump for hardware contexts, if true. */
 	bool				auto_coredump;
+
+	/* Back-pointer to the per-generation aie_device, set at DPT init so
+	 * common code (e.g. debugfs) can reach msg_ops without knowing the
+	 * generation-specific struct amdxdna_dev_hdl layout.
+	 */
+	struct aie_device		*dpt_aie;
 };
 
 /*

--- a/drivers/accel/amdxdna/amdxdna_pci_drv.h
+++ b/drivers/accel/amdxdna/amdxdna_pci_drv.h
@@ -76,7 +76,6 @@ struct amdxdna_dev_ops {
 	int (*hwctx_config)(struct amdxdna_hwctx *hwctx, u32 type, u64 value, void *buf, u32 size);
 	int (*hwctx_sync_debug_bo)(struct amdxdna_hwctx *hwctx, u32 debug_bo_hdl);
 	int (*hwctx_heap_expand)(struct amdxdna_hwctx *hwctx, struct amdxdna_gem_obj *heap);
-	void (*hmm_invalidate)(struct amdxdna_gem_obj *abo, unsigned long cur_seq);
 	int (*cmd_submit)(struct amdxdna_hwctx *hwctx, struct amdxdna_sched_job *job, u64 *seq);
 	int (*cmd_wait)(struct amdxdna_hwctx *hwctx, u64 seq, u32 timeout);
 	int (*get_aie_info)(struct amdxdna_client *client, struct amdxdna_drm_get_info *args);


### PR DESCRIPTION
Port a batch of drivers/accel/amdxdna fixes and features from main into ve2_accel, plus two build fixes required to keep the AUX/VE2 backend building cleanly after the port.  
Ported from main: 
- e56ac3c5 fix missing gem put in amdxdna_cmd_set_error 
- 587ca73c annotate PF/VF dev_lock nesting for lockdep 
- 9b744f8d Fix use-after-free of mm_struct in job scheduler 
- 8bd8a050 remove hmm_invalidate ops callback 
- b68b1b41 move populate_range() to common code 
- 2f60210b lock down BOs in aie4_cmd_submit() 
- 7efae89f add firmware-log dmesg-dump, parsers and debugfs nodes 
- 236ce3a1 Sync upstream: amdxdna_insert_pages() fixes 
- f60f8810 add aie4 frame boundary preempt state query 
- fb29f1ed add amdxdna_dpt_exit_kind() to pair with enter_kind 
- 70e5ac83 flush only the requested range in amdxdna_flush_bo 
- 00bd02af do not log a failed vmap probe in amdxdna_flush_bo 
- 5d268cc8 hold CU BO references for the life of the context 
- 1c73d319 fix review comments (fixup for 5d268cc8)  
Build fix (new, not from main): 
- keep DPT (fw_log/fw_trace) debugfs nodes PCI-only: the firmware-log framework added by 7efae89f is tied to the aie2/aie4 firmware protocol and its amdxdna_dpt.o/aie.o dependencies are not AUX-safe (aie.c pulls in hmm_range_fault(), unavailable on the VE2 kernel config), so guard the fw_log_level/fw_log_dump_to_dmesg debugfs nodes with #ifndef AMDXDNA_AUX instead of building DPT for AUX. 