### PR TITLE
Adding missing trace point in aie4 kernel mode submission path and SHIM

### DIFF
--- a/drivers/accel/amdxdna/aie2_ctx.c
+++ b/drivers/accel/amdxdna/aie2_ctx.c
@@ -241,7 +241,7 @@ aie2_sched_notify(struct amdxdna_sched_job *job)
 {
 	struct dma_fence *fence = job->fence;
 
-	trace_xdna_job(&job->base, job->hwctx->name, "signaling fence",
+	trace_xdna_job(&job->base, job->hwctx->name, "job complete",
 		       job->seq, job->drv_cmd ? job->drv_cmd->opcode : DEFAULT_IO);
 
 	aie2_tdr_signal(job->hwctx->client->xdna);

--- a/drivers/accel/amdxdna/aie4_ctx.c
+++ b/drivers/accel/amdxdna/aie4_ctx.c
@@ -44,6 +44,7 @@ static irqreturn_t cert_comp_isr(int irq, void *p)
 {
 	struct cert_comp *cert_comp = p;
 
+	trace_uc_irq_handle("cert", cert_comp->msix_idx);
 	wake_up_all(&cert_comp->waitq);
 	return IRQ_HANDLED;
 }
@@ -1037,6 +1038,7 @@ static int submit_one_cmd(struct amdxdna_hwctx *hwctx,
 					    offsetof(struct amdxdna_cmd, header);
 	*seq = publish_cmd(hwctx);
 	ring_doorbell(hwctx);
+	trace_amdxdna_debug_point(hwctx->name, *seq, "job submitted");
 	XDNA_DBG(xdna, "Submitted one cmd, %s seq %lld", hwctx->name, *seq);
 	return 0;
 }

--- a/src/shim/CMakeLists.txt
+++ b/src/shim/CMakeLists.txt
@@ -29,6 +29,7 @@ target_compile_definitions(${XDNA_TARGET} PRIVATE
   XRT_ENABLE_AIE
   XRT_AIE_BUILD
   XRT_BUILD
+  XRT_ENABLE_USDT
   $<$<CONFIG:Debug>:XDNA_SHIM_DEBUG>
   )
 


### PR DESCRIPTION
@NishadSaraf, with this change, there should be enough trace points to profile SHIM and driver on AIE4 platform.