### PR TITLE
accel/amdxdna: add xdna_job_submitted trace event with outstanding count

### DIFF
--- a/drivers/accel/amdxdna/aie2_ctx.c
+++ b/drivers/accel/amdxdna/aie2_ctx.c
@@ -241,8 +241,9 @@ aie2_sched_notify(struct amdxdna_sched_job *job)
 {
 	struct dma_fence *fence = job->fence;
 
-	trace_xdna_job(&job->base, job->hwctx->name, "job complete",
-		       job->seq, job->drv_cmd ? job->drv_cmd->opcode : DEFAULT_IO);
+	trace_xdna_job_queue(job->hwctx->name, job->seq,
+			     atomic64_read(&job->hwctx->job_submit_cnt) -
+			     atomic64_read(&job->hwctx->job_free_cnt) - 1, "job complete");
 
 	aie2_tdr_signal(job->hwctx->client->xdna);
 	job->hwctx->priv->completed++;
@@ -458,8 +459,9 @@ out:
 		aie2_tdr_signal(hwctx->client->xdna);
 		amdxdna_io_stats_job_start(job->hwctx->client);
 	}
-	trace_xdna_job(sched_job, hwctx->name, "sent to device",
-		       job->seq, job->drv_cmd ? job->drv_cmd->opcode : DEFAULT_IO);
+	trace_xdna_job_queue(hwctx->name, job->seq,
+			     atomic64_read(&hwctx->job_submit_cnt) -
+			     atomic64_read(&hwctx->job_free_cnt) + 1, "sent to device");
 
 	return fence;
 }

--- a/drivers/accel/amdxdna/aie4_ctx.c
+++ b/drivers/accel/amdxdna/aie4_ctx.c
@@ -959,6 +959,7 @@ static int submit_one_cmd(struct amdxdna_hwctx *hwctx,
 	u16 chained;
 	int ret;
 	u32 op;
+	u64 ri;
 
 	op = amdxdna_cmd_get_op(cmd_abo);
 	if (op != ERT_START_DPU) {
@@ -1036,9 +1037,10 @@ static int submit_one_cmd(struct amdxdna_hwctx *hwctx,
 	pkt->pkt_header.common_header.reserved = 0x0;
 	pkt->pkt_header.completion_signal = amdxdna_gem_dev_addr(cmd_abo) +
 					    offsetof(struct amdxdna_cmd, header);
+	ri = get_read_index(hwctx);
 	*seq = publish_cmd(hwctx);
 	ring_doorbell(hwctx);
-	trace_amdxdna_debug_point(hwctx->name, *seq, "job submitted");
+	trace_xdna_job_queue(hwctx->name, *seq, *seq + 1 - ri, "job submitted");
 	XDNA_DBG(xdna, "Submitted one cmd, %s seq %lld", hwctx->name, *seq);
 	return 0;
 }
@@ -1213,8 +1215,9 @@ static void job_worker(struct work_struct *work)
 
 	while ((job = peek_running_job(hwctx))) {
 		wait_till_seq_completed(hwctx, job->seq);
-		trace_amdxdna_debug_point(hwctx->name, job->seq, "job complete");
-
+		trace_xdna_job_queue(hwctx->name, job->seq,
+				     READ_ONCE(hwctx->priv->write_index) -
+				     get_read_index(hwctx), "job complete");
 		if (get_read_index(hwctx) > job->seq) {
 			/*
 			 * The published commands drained.  A chain that was only

--- a/include/trace/events/amdxdna.h
+++ b/include/trace/events/amdxdna.h
@@ -128,6 +128,25 @@ DEFINE_EVENT(xdna_mbox_name_id, mbox_poll_handle,
 	     TP_ARGS(name, irq)
 );
 
+TRACE_EVENT(xdna_job_queue,
+	    TP_PROTO(const char *name, u64 seq, u64 outstanding, const char *str),
+
+	    TP_ARGS(name, seq, outstanding, str),
+
+	    TP_STRUCT__entry(__string(name, name)
+			     __field(u64, seq)
+			     __field(u64, outstanding)
+			     __string(str, str)),
+
+	    TP_fast_assign(__assign_str(name);
+			   __entry->seq = seq;
+			   __entry->outstanding = outstanding;
+			   __assign_str(str);),
+
+	    TP_printk("%s seq#:%llu outstanding:%llu %s", __get_str(name),
+		      __entry->seq, __entry->outstanding, __get_str(str))
+);
+
 #endif /* !defined(_AMDXDNA_TRACE_EVENTS_H_) || defined(TRACE_HEADER_MULTI_READ) */
 
 /* This part must be outside protection */

--- a/test/xrt_test/xrt_test.cpp
+++ b/test/xrt_test/xrt_test.cpp
@@ -298,6 +298,7 @@ execute_batches(xrt::hw_context& hwctx, std::vector<xrt::run>& runs, unsigned r_
     uint64_t submitted = 0;
     uint64_t completed = 0;
     const auto runs_size = runs.size();
+    auto start = std::chrono::high_resolution_clock::now();
     while (submitted < runs_size && submitted < c_rounds) {
       runs[static_cast<size_t>(submitted)].start();
       submitted++;
@@ -315,6 +316,12 @@ execute_batches(xrt::hw_context& hwctx, std::vector<xrt::run>& runs, unsigned r_
         submitted++;
       }
     }
+    auto end = std::chrono::high_resolution_clock::now();
+    auto duration_us = std::chrono::duration_cast<std::chrono::microseconds>(end - start).count();
+    std::cout << "Executed total " << c_rounds << " commands in " << duration_us
+              << "us with max " << o_cmds << " outstanding commands"
+              << ", average latency: " << duration_us * 1.0 / c_rounds << "us"
+              << ", throughput: " << c_rounds * 1000000.0 / duration_us << " OPS\n";
     return;
   }
   std::vector<xrt::runlist> runlists;
@@ -352,7 +359,9 @@ execute_batches(xrt::hw_context& hwctx, std::vector<xrt::run>& runs, unsigned r_
   std::cout << "Executed total " << c_rounds << " runlists in " << duration_us
 	    << "us with max " << o_cmds << " outstanding runlist (" << r_cmds
 	    << " commands per runlist), average latency: "
-	    << duration_us * 1.0 / (static_cast<uint64_t>(r_cmds) * c_rounds) << "us\n";
+	    << duration_us * 1.0 / (static_cast<uint64_t>(r_cmds) * c_rounds) << "us"
+	    << ", throughput: " << c_rounds * 1000000.0 / duration_us << " runlist/s"
+	    << ", " << static_cast<uint64_t>(r_cmds) * c_rounds * 1000000.0 / duration_us << " OPS\n";
 }
 
 void


### PR DESCRIPTION
  - Add new xdna_job_queue trace event recording command sequence number and outstanding queue depth at submission time, and completion time, enabling analysis of device pipeline utilization on both AIE2 and AIE4 platforms
  - Add xrt_test: latency and throughput stats output to execute_batches()
