### PR TITLE
accel/amdxdna/ve2: fix context-switch handoff and HMM invalidate on AUX

### DIFF
--- a/drivers/accel/amdxdna/amdxdna_gem.c
+++ b/drivers/accel/amdxdna/amdxdna_gem.c
@@ -285,7 +285,9 @@ static bool amdxdna_hmm_invalidate(struct mmu_interval_notifier *mni,
 	struct amdxdna_umap *mapp = container_of(mni, struct amdxdna_umap, notifier);
 	struct amdxdna_gem_obj *abo = mapp->abo;
 	struct amdxdna_dev *xdna;
+#ifndef AMDXDNA_AUX
 	long ret;
+#endif
 
 	xdna = to_xdna_dev(to_gobj(abo)->dev);
 	XDNA_DBG(xdna, "Invalidating range 0x%lx, 0x%lx, type %d, evt %d, pending fences %d",
@@ -301,12 +303,22 @@ static bool amdxdna_hmm_invalidate(struct mmu_interval_notifier *mni,
 	mmu_interval_set_seq(&mapp->notifier, cur_seq);
 	up_write(&xdna->notifier_lock);
 
+#ifndef AMDXDNA_AUX
+	/*
+	 * VE2/AUX has no cmd_submit-side BO lockdown that attaches job fences
+	 * to the reservation object (unlike aie2/aie4, see aie4_cmd_submit()),
+	 * so there is nothing queued on abo->resv for this to wait on here.
+	 * Skip it to keep this a fast, non-blocking notifier on AUX, matching
+	 * behavior prior to commit cdd9d5cee72d ("remove hmm_invalidate ops
+	 * callback"), where ve2_ops never installed a .hmm_invalidate hook.
+	 */
 	ret = dma_resv_wait_timeout(to_gobj(abo)->resv, DMA_RESV_USAGE_BOOKKEEP,
 				    true, MAX_SCHEDULE_TIMEOUT);
 	if (!ret)
 		XDNA_ERR(xdna, "Failed to wait for bo, ret %ld", ret);
 	else if (ret == -ERESTARTSYS)
 		XDNA_DBG(xdna, "Wait for bo interrupted by signal");
+#endif /* !AMDXDNA_AUX */
 
 	if (range->event == MMU_NOTIFY_UNMAP) {
 		down_write(&xdna->notifier_lock);

--- a/drivers/accel/amdxdna/ve2_mgmt.c
+++ b/drivers/accel/amdxdna/ve2_mgmt.c
@@ -467,12 +467,24 @@ static int ve2_request_context_switch(struct amdxdna_mgmtctx *mgmtctx)
 }
 
 /*
- * Bring in the context at the head of the command FIFO once the firmware has
- * acknowledged a switch request (is_idle_due_to_context). Reprograms the
- * handshake to point at the incoming context's host queue and, if the entry
- * after the head belongs to yet another context, arms the next switch.
+ * Try to switch the partition over to whichever context is at the head of
+ * the command FIFO.
+ *
+ * Case 1: the partition is idle (either the firmware acked our switch
+ * request, or the active context ran out of work on its own). Reprogram the
+ * handshake for the head context, make it active, and if the entry behind it
+ * belongs to yet another context, get a head start by arming that switch too.
+ *
+ * Case 2: the partition is not (yet) known to be idle, but the head belongs
+ * to some other context. Ask the firmware to yield (arm ctx_switch_req) and
+ * explicitly interrupt it via notify_fw_cmd_ready(), so it is guaranteed to
+ * notice and ack even if it already happens to be sitting idle right now
+ * with nothing else going on to prompt it to check. This mirrors what the
+ * legacy driver does.
+ *
  * Returns the newly scheduled context, or NULL if the FIFO is empty.
  */
+
 static struct amdxdna_hwctx *ve2_response_ctx_switch_req(struct amdxdna_mgmtctx *mgmtctx)
 {
 	struct ve2_ctx_fifo_entry *c_ctx, *t_ctx;
@@ -481,22 +493,28 @@ static struct amdxdna_hwctx *ve2_response_ctx_switch_req(struct amdxdna_mgmtctx 
 	lockdep_assert_held(&mgmtctx->ctx_lock);
 
 	list_for_each_entry_safe(c_ctx, t_ctx, &mgmtctx->ctx_command_fifo_head, list) {
-		if (mgmtctx->is_idle_due_to_context) {
+		if (mgmtctx->is_idle_due_to_context || mgmtctx->is_partition_idle) {
 			hwctx = c_ctx->ctx;
-			mgmtctx->is_partition_idle = 0;
 			/*
-			 * Clear this now that it has been consumed. Otherwise
-			 * every later call to this function (e.g. from the
-			 * async IRQ-driven scheduler_work, which runs once per
-			 * command completion) sees the stale flag still set and
+			 * Clear these now that they have been consumed, from
+			 * here rather than the caller, so a flag set just
+			 * before this function runs is not lost before it can
+			 * be acted upon. Otherwise every later call to this
+			 * function (e.g. from the async IRQ-driven
+			 * scheduler_work, which runs once per command
+			 * completion) sees a stale flag still set and
 			 * redundantly re-runs handshake_init() on the current
 			 * FIFO head even when no real context switch occurred.
 			 */
+			mgmtctx->is_partition_idle = 0;
 			mgmtctx->is_idle_due_to_context = 0;
 			ve2_mgmt_handshake_init(mgmtctx, hwctx);
 			if (mgmtctx->active_ctx == hwctx)
 				break;
 			mgmtctx->active_ctx = hwctx;
+		} else if (c_ctx->ctx != mgmtctx->active_ctx) {
+			ve2_request_context_switch(mgmtctx);
+			notify_fw_cmd_ready(mgmtctx);
 		}
 
 		if (!list_is_last(&c_ctx->list, &mgmtctx->ctx_command_fifo_head) &&
@@ -553,10 +571,23 @@ int ve2_mgmt_schedule_cmd(struct amdxdna_dev *xdna, struct amdxdna_hwctx *hwctx,
 		 * Another context owns the partition. Switch immediately if it
 		 * is idle; otherwise leave the command queued and let the
 		 * IRQ/scheduler switch us in once the active context yields.
+		 *
+		 * @is_partition_idle is set when the active context finished
+		 * all of its own work with nothing yet queued behind it (so
+		 * no switch request was ever armed against it). Leave the
+		 * flag set and let ve2_response_ctx_switch_req() itself check
+		 * and consume it -- clearing it here first, before the flag
+		 * has actually been acted on, would prevent that function
+		 * from ever seeing it set.
 		 */
 		if (mgmtctx->is_partition_idle) {
-			mgmtctx->is_partition_idle = 0;
+			XDNA_DBG(mgmtctx->xdna,
+				 "Context switch: active=%p -> new=%p (partition idle)",
+				 mgmtctx->active_ctx, hwctx);
 			ve2_response_ctx_switch_req(mgmtctx);
+		} else {
+			XDNA_DBG(mgmtctx->xdna, "Command queued: active=%p, pending=%p",
+				 mgmtctx->active_ctx, hwctx);
 		}
 	} else if (mgmtctx->is_idle_due_to_context) {
 		/* We are active again after a firmware-side save; reprogram. */


### PR DESCRIPTION
- ve2_mgmt.c: restore is_partition_idle as a valid idle signal inside ve2_response_ctx_switch_req() instead of clearing it at the call site before the function ever saw it, and restore the legacy driver's arm-and-notify fallback (ve2_request_context_switch() + notify_fw_cmd_ready()) for when the FIFO head belongs to a different context but neither idle flag is set yet. Without this, an already-idle firmware had nothing to prompt it to ack, so a pending context switch could hang until the client-side command timeout.
- amdxdna_gem.c: skip the dma_resv_wait_timeout() call in amdxdna_hmm_invalidate() on VE2/AUX, since AUX has no cmd_submit-side BO lockdown that queues fences on the reservation object, so there is nothing to wait on there.