### PR TITLE
fix(npu): recover wedged AIE2 firmware with a full NPU power-cycle

### DIFF
--- a/drivers/accel/amdxdna/aie2_ctx.c
+++ b/drivers/accel/amdxdna/aie2_ctx.c
@@ -489,6 +489,7 @@ aie2_sched_job_timedout(struct drm_sched_job *sched_job)
 	struct amdxdna_dev *xdna;
 	struct aie_device *aie;
 	bool fw_dead = false;
+	bool fw_fatal = false;
 	int ret;
 
 	xdna = hwctx->client->xdna;
@@ -511,12 +512,11 @@ aie2_sched_job_timedout(struct drm_sched_job *sched_job)
 				fw_dead = true;
 			kfree(report);
 		} else {
-			/* A fatal_type report is NOT a wedge signal by itself: the
-			 * firmware answered the query, so it is alive. dpu_pc ==
-			 * UINT_MAX is the documented idle value (see struct
-			 * app_health_report, aie2_msg_priv.h) and is likewise
-			 * deliberately not used as a wedge signal to avoid false
-			 * positives. */
+			/* fatal_type means the ERT hit a fatal exception. The firmware
+			 * still answers queries, so it is NOT a wedge signal by itself:
+			 * it only escalates when the per-context restart also fails. */
+			if (report->fatal_info.fatal_type)
+				fw_fatal = true;
 			job->aie2_job_health = report;
 		}
 	}
@@ -535,17 +535,22 @@ aie2_sched_job_timedout(struct drm_sched_job *sched_job)
 	aie2_hwctx_stop(xdna, hwctx, sched_job);
 
 	ret = aie2_hwctx_restart(xdna, hwctx);
-	if (ret || fw_dead) {
+	if (fw_dead || (fw_fatal && ret)) {
 		/*
 		 * Per-context recovery goes through the mailbox; it cannot fix a
-		 * dead firmware (an unresponsive health query or a restart the
-		 * firmware rejects). Power-cycle the NPU via SMU to reload the
-		 * firmware. aie2_hw_reset() rate-limits itself to one reset per
-		 * AIE2_HW_RESET_MIN_INTERVAL_MS.
+		 * dead firmware (an unresponsive health query, or a restart the
+		 * firmware rejects after reporting a fatal error). Power-cycle the
+		 * NPU via SMU to reload the firmware. aie2_hw_reset() rate-limits
+		 * itself to one reset per AIE2_HW_RESET_MIN_INTERVAL_MS.
 		 */
 		XDNA_WARN(xdna, "NPU firmware unhealthy (ctx restart ret %d, health %s) - power-cycling NPU",
-			  ret, fw_dead ? "unresponsive" : "ok");
+			  ret, fw_dead ? "unresponsive" : "fatal+rejected");
 		aie2_hw_reset(xdna);
+	} else if (ret) {
+		/* Restart rejected but no fatal report: the firmware is responsive,
+		 * so do not escalate to a device-wide power-cycle; log and let the
+		 * next timeout retry. */
+		XDNA_WARN(xdna, "NPU context restart rejected (ret %d) without fatal report - not power-cycling", ret);
 	}
 
 #ifdef HAVE_drm_gpu_sched_stat_reset

--- a/drivers/accel/amdxdna/aie2_ctx.c
+++ b/drivers/accel/amdxdna/aie2_ctx.c
@@ -512,9 +512,11 @@ aie2_sched_job_timedout(struct drm_sched_job *sched_job)
 				fw_dead = true;
 			kfree(report);
 		} else {
-			/* fatal_type means the ERT hit a fatal exception. The firmware
+			/*
+			 * fatal_type means the ERT hit a fatal exception. The firmware
 			 * still answers queries, so it is NOT a wedge signal by itself:
-			 * it only escalates when the per-context restart also fails. */
+			 * it only escalates when the per-context restart also fails.
+			 */
 			if (report->fatal_info.fatal_type)
 				fw_fatal = true;
 			job->aie2_job_health = report;
@@ -543,14 +545,21 @@ aie2_sched_job_timedout(struct drm_sched_job *sched_job)
 		 * NPU via SMU to reload the firmware. aie2_hw_reset() rate-limits
 		 * itself to one reset per AIE2_HW_RESET_MIN_INTERVAL_MS.
 		 */
-		XDNA_WARN(xdna, "NPU firmware unhealthy (ctx restart ret %d, health %s) - power-cycling NPU",
+		XDNA_WARN(xdna,
+			  "NPU firmware unhealthy (ctx restart ret %d, health %s) "
+			  "- power-cycling NPU",
 			  ret, fw_dead ? "unresponsive" : "fatal+rejected");
 		aie2_hw_reset(xdna);
 	} else if (ret) {
-		/* Restart rejected but no fatal report: the firmware is responsive,
+		/*
+		 * Restart rejected but no fatal report: the firmware is responsive,
 		 * so do not escalate to a device-wide power-cycle; log and let the
-		 * next timeout retry. */
-		XDNA_WARN(xdna, "NPU context restart rejected (ret %d) without fatal report - not power-cycling", ret);
+		 * next timeout retry.
+		 */
+		XDNA_WARN(xdna,
+			  "NPU context restart rejected (ret %d) without fatal report "
+			  "- not power-cycling",
+			  ret);
 	}
 
 #ifdef HAVE_drm_gpu_sched_stat_reset

--- a/drivers/accel/amdxdna/aie2_ctx.c
+++ b/drivers/accel/amdxdna/aie2_ctx.c
@@ -511,13 +511,12 @@ aie2_sched_job_timedout(struct drm_sched_job *sched_job)
 				fw_dead = true;
 			kfree(report);
 		} else {
-			/* fatal_type is set by the firmware when it reports an
-			 * unrecoverable error. Note: dpu_pc == UINT_MAX is the
-			 * documented idle value (see struct app_health_report,
-			 * aie2_msg_priv.h) and is deliberately NOT used as a
-			 * wedge signal to avoid false positives. */
-			if (report->fatal_info.fatal_type)
-				fw_dead = true;
+			/* A fatal_type report is NOT a wedge signal by itself: the
+			 * firmware answered the query, so it is alive. dpu_pc ==
+			 * UINT_MAX is the documented idle value (see struct
+			 * app_health_report, aie2_msg_priv.h) and is likewise
+			 * deliberately not used as a wedge signal to avoid false
+			 * positives. */
 			job->aie2_job_health = report;
 		}
 	}
@@ -539,13 +538,13 @@ aie2_sched_job_timedout(struct drm_sched_job *sched_job)
 	if (ret || fw_dead) {
 		/*
 		 * Per-context recovery goes through the mailbox; it cannot fix a
-		 * dead firmware (unresponsive health query, firmware-reported
-		 * fatal error, or a restart the firmware rejects). Power-cycle
-		 * the NPU via SMU to reload the firmware. aie2_hw_reset()
-		 * rate-limits itself to one reset per AIE2_HW_RESET_MIN_INTERVAL_MS.
+		 * dead firmware (an unresponsive health query or a restart the
+		 * firmware rejects). Power-cycle the NPU via SMU to reload the
+		 * firmware. aie2_hw_reset() rate-limits itself to one reset per
+		 * AIE2_HW_RESET_MIN_INTERVAL_MS.
 		 */
 		XDNA_WARN(xdna, "NPU firmware unhealthy (ctx restart ret %d, health %s) - power-cycling NPU",
-			  ret, fw_dead ? "fatal/absent" : "ok");
+			  ret, fw_dead ? "unresponsive" : "ok");
 		aie2_hw_reset(xdna);
 	}
 

--- a/drivers/accel/amdxdna/aie2_ctx.c
+++ b/drivers/accel/amdxdna/aie2_ctx.c
@@ -488,6 +488,7 @@ aie2_sched_job_timedout(struct drm_sched_job *sched_job)
 	struct amdxdna_dev_hdl *ndev;
 	struct amdxdna_dev *xdna;
 	struct aie_device *aie;
+	bool fw_dead = false;
 	int ret;
 
 	xdna = hwctx->client->xdna;
@@ -504,10 +505,21 @@ aie2_sched_job_timedout(struct drm_sched_job *sched_job)
 	report = kzalloc_obj(*report);
 	if (report) {
 		ret = aie2_query_app_health(ndev, hwctx->fw_ctx_id, report);
-		if (ret)
+		if (ret) {
+			/* Firmware did not answer the health query: it is wedged. */
+			if (ret != -EOPNOTSUPP)
+				fw_dead = true;
 			kfree(report);
-		else
+		} else {
+			/* fatal_type is set by the firmware when it reports an
+			 * unrecoverable error. Note: dpu_pc == UINT_MAX is the
+			 * documented idle value (see struct app_health_report,
+			 * aie2_msg_priv.h) and is deliberately NOT used as a
+			 * wedge signal to avoid false positives. */
+			if (report->fatal_info.fatal_type)
+				fw_dead = true;
 			job->aie2_job_health = report;
+		}
 	}
 
 	if (xdna->auto_coredump) {
@@ -523,7 +535,19 @@ aie2_sched_job_timedout(struct drm_sched_job *sched_job)
 	job->job_timeout = true;
 	aie2_hwctx_stop(xdna, hwctx, sched_job);
 
-	aie2_hwctx_restart(xdna, hwctx);
+	ret = aie2_hwctx_restart(xdna, hwctx);
+	if (ret || fw_dead) {
+		/*
+		 * Per-context recovery goes through the mailbox; it cannot fix a
+		 * dead firmware (unresponsive health query, firmware-reported
+		 * fatal error, or a restart the firmware rejects). Power-cycle
+		 * the NPU via SMU to reload the firmware. aie2_hw_reset()
+		 * rate-limits itself to one reset per AIE2_HW_RESET_MIN_INTERVAL_MS.
+		 */
+		XDNA_WARN(xdna, "NPU firmware unhealthy (ctx restart ret %d, health %s) - power-cycling NPU",
+			  ret, fw_dead ? "fatal/absent" : "ok");
+		aie2_hw_reset(xdna);
+	}
 
 #ifdef HAVE_drm_gpu_sched_stat_reset
 	return DRM_GPU_SCHED_STAT_RESET;

--- a/drivers/accel/amdxdna/aie2_pci.c
+++ b/drivers/accel/amdxdna/aie2_pci.c
@@ -488,6 +488,62 @@ static int aie2_hw_resume(struct amdxdna_dev *xdna)
 	return ret;
 }
 
+/*
+ * aie2_hw_reset - recover a wedged NPU via full hardware power-cycle.
+ *
+ * Suspends every context, tears the device down, powers the NPU off and on
+ * through the SMU (reloading the firmware), then re-creates every context.
+ * The mailbox path cannot recover a dead firmware — only a hardware reset
+ * can. Called from aie2_sched_job_timedout() when per-context recovery
+ * fails or the firmware reports a fatal error. dev_lock must be held
+ * (aie2_hwctx_suspend requires it).
+ *
+ * Rate-limited: if the firmware re-wedges immediately after a reset, a
+ * reset storm must not hammer the SMU power-cycle. One reset per window
+ * is enough; repeated timeouts after that indicate a deeper firmware
+ * problem and are reported to the log instead of resetting in a loop.
+ */
+int aie2_hw_reset(struct amdxdna_dev *xdna)
+{
+	struct amdxdna_dev_hdl *ndev = xdna->dev_handle;
+	struct amdxdna_client *client;
+	int ret, first_ret = 0;
+
+	if (ndev->dev_status <= AIE2_DEV_INIT) {
+		XDNA_DBG(xdna, "device not started, nothing to reset");
+		return 0;
+	}
+
+	if (time_before(jiffies, ndev->last_reset_jiffies +
+				msecs_to_jiffies(AIE2_HW_RESET_MIN_INTERVAL_MS))) {
+		XDNA_WARN(xdna, "NPU reset skipped: last reset %d ms ago",
+			  jiffies_to_msecs(jiffies - ndev->last_reset_jiffies));
+		return -EAGAIN;
+	}
+	ndev->last_reset_jiffies = jiffies;
+
+	XDNA_WARN(xdna, "NPU firmware unhealthy: power-cycling NPU");
+	aie2_hw_suspend(xdna);
+
+	ret = aie2_hw_start(xdna);
+	if (ret) {
+		XDNA_ERR(xdna, "NPU power-cycle start failed: %d", ret);
+		return ret;
+	}
+
+	/* Resume every client even if one fails, so a single broken context
+	 * does not leave the rest of the device suspended. */
+	list_for_each_entry(client, &xdna->client_list, node) {
+		ret = aie2_hwctx_resume(client);
+		if (ret && !first_ret) {
+			XDNA_ERR(xdna, "resume failed after NPU reset: %d", ret);
+			first_ret = ret;
+		}
+	}
+
+	return first_ret;
+}
+
 static int aie2_init(struct amdxdna_dev *xdna)
 {
 	struct pci_dev *pdev = to_pci_dev(xdna->ddev.dev);

--- a/drivers/accel/amdxdna/aie2_pci.c
+++ b/drivers/accel/amdxdna/aie2_pci.c
@@ -520,6 +520,10 @@ int aie2_hw_reset(struct amdxdna_dev *xdna)
 			  jiffies_to_msecs(jiffies - ndev->last_reset_jiffies));
 		return -EAGAIN;
 	}
+
+	/* Stamp before resetting: if the power-cycle itself fails (NPU stays
+	 * wedged), retries stay bounded to one per window instead of storming
+	 * the SMU on every job timeout. */
 	ndev->last_reset_jiffies = jiffies;
 
 	XDNA_WARN(xdna, "NPU firmware unhealthy: power-cycling NPU");

--- a/drivers/accel/amdxdna/aie2_pci.c
+++ b/drivers/accel/amdxdna/aie2_pci.c
@@ -521,9 +521,11 @@ int aie2_hw_reset(struct amdxdna_dev *xdna)
 		return -EAGAIN;
 	}
 
-	/* Stamp before resetting: if the power-cycle itself fails (NPU stays
+	/*
+	 * Stamp before resetting: if the power-cycle itself fails (NPU stays
 	 * wedged), retries stay bounded to one per window instead of storming
-	 * the SMU on every job timeout. */
+	 * the SMU on every job timeout.
+	 */
 	ndev->last_reset_jiffies = jiffies;
 
 	XDNA_WARN(xdna, "NPU firmware unhealthy: power-cycling NPU");
@@ -535,8 +537,10 @@ int aie2_hw_reset(struct amdxdna_dev *xdna)
 		return ret;
 	}
 
-	/* Resume every client even if one fails, so a single broken context
-	 * does not leave the rest of the device suspended. */
+	/*
+	 * Resume every client even if one fails, so a single broken context
+	 * does not leave the rest of the device suspended.
+	 */
 	list_for_each_entry(client, &xdna->client_list, node) {
 		ret = aie2_hwctx_resume(client);
 		if (ret && !first_ret) {

--- a/drivers/accel/amdxdna/aie2_pci.h
+++ b/drivers/accel/amdxdna/aie2_pci.h
@@ -163,6 +163,9 @@ struct amdxdna_dev_hdl {
 
 	enum aie2_tdr_status		tdr_status;
 	struct aie2_tdr			tdr; /* TDR for device recovery */
+
+	/* jiffies of the last full NPU power-cycle (see aie2_hw_reset) */
+	unsigned long			last_reset_jiffies;
 };
 
 enum aie2_fw_feature {
@@ -317,6 +320,8 @@ int aie2_hwctx_config(struct amdxdna_hwctx *hwctx, u32 type, u64 value, void *bu
 int aie2_hwctx_sync_debug_bo(struct amdxdna_hwctx *hwctx, u32 debug_bo_hdl);
 void aie2_hwctx_suspend(struct amdxdna_client *client);
 int aie2_hwctx_resume(struct amdxdna_client *client);
+#define AIE2_HW_RESET_MIN_INTERVAL_MS	60000
+int aie2_hw_reset(struct amdxdna_dev *xdna);
 int aie2_cmd_submit(struct amdxdna_hwctx *hwctx, struct amdxdna_sched_job *job, u64 *seq);
 int aie2_hwctx_heap_expand(struct amdxdna_hwctx *hwctx, struct amdxdna_gem_obj *heap);
 


### PR DESCRIPTION
# NPU firmware wedge recovery — PR to amd/xdna-driver

Branch: `feat/npu-wedge-recovery` (commit 424edeb)
Fork: `bong-water-water-bong/xdna-driver-upstream`
Upstream: `amd/xdna-driver` (current HEAD 5b875dc)

## Problem

On Strix Halo (PCI 0x17f0), the NPU firmware can wedge after ~1h of sustained
MoE decode (the 35B MoE NPU workstream; 1bit-systems issue #1568: "decode
degrades to constant '/' after ~1h"). Symptoms:

- Job scheduler fires a job timeout; the timed-out job never completes.
- Per-context recovery keeps failing: the management mailbox path
  (CREATE_CONTEXT / MAP_HOST_BUF / CONFIG_CU) cannot fix the device because
  the firmware is unresponsive, or its ERT rejects new contexts.
- Firmware ERT returns `AIE2_STATUS_MGMT_ERT_NOAVAIL (0x2000003)` for
  CREATE_CONTEXT once the device has degraded (observed in dmesg on
  7.0.0-29, in-tree amdxdna):

```
amdxdna 0000:c6:00.1: [drm] *ERROR* aie2_send_mgmt_msg_wait: command opcode 0x2 failed, status 0x2000003
amdxdna 0000:c6:00.1: [drm] *ERROR* aie2_hwctx_init: Alloc hw resource failed, ret -22
amdxdna 0000:c6:00.1: [drm] *ERROR* amdxdna_drm_create_hwctx_ioctl: Init hwctx failed, ret -22
```

A per-context restart re-submits to the same dead silicon. Only a full SMU
power-cycle (psp_stop + smu_fini, then smu_init + psp_start + mgmt fw init)
reloads the firmware and resets the ERT.

## Fix

`aie2_hw_reset()` — recover a wedged NPU with a full hardware power-cycle:

1. Suspend every context (existing `aie2_hw_suspend`: wait-for-idle,
   destroy context, stop scheduler).
2. `aie2_hw_stop()` + `aie2_hw_start()` — powers the NPU off/on through the
   SMU, reloading the firmware.
3. Resume every context (existing `aie2_hwctx_resume`: re-create context,
   remap heaps, config CU). Continues past a failed context so one broken
   context does not leave the rest of the device suspended.

Triggered from `aie2_sched_job_timedout()` when any of:

- the app-health query fails with a real error (`ret != -EOPNOTSUPP`), or
- the firmware reports `fatal_info.fatal_type`, or
- the per-context restart fails (covers the ERT-NOAVAIL case, where the
  firmware is alive but rejects new contexts).

`dev_lock` is already held in the timeout path (`guard(mutex)`), which
`aie2_hwctx_suspend` requires.

## Design decisions

- **`dpu_pc == UINT_MAX` is NOT a wedge signal.** `struct app_health_report`
  documents `dpu_pc` as UINT_MAX "before execution begins or after
  successful completion" (aie2_msg_priv.h) — i.e. the idle value. Using it
  as a death signal would false-positive on a healthy device whose DPU
  simply never latched a PC. The health-query failure + fatal_type +
  restart-failure signals are unambiguous.
- **Rate-limited**: one reset per `AIE2_HW_RESET_MIN_INTERVAL_MS` (60s).
  A firmware that re-wedges immediately must not produce a reset storm
  (each reset is a full SMU power-cycle). Repeated timeouts past the window
  indicate a deeper firmware problem and are surfaced in the log instead.
- **Bounded stall**: with a dead firmware, the suspend path's mailbox
  destroy is bounded by the existing TX/RX mailbox timeouts (2s/5s) — the
  same bound the existing TDR per-context recovery already accepts.

## Test status

- Compile-tested against kernel 7.0.0-29 (in-tree amdxdna) — clean build.
- Live wedge reproduction (~1h of MoE decode) and module hot-swap test are
  pending; happy to run them and report dmesg before merge.

## Repro notes

- Hardware: Strix Halo NPU 0x17f0 rev 0x11, firmware amdnpu/17f0_11/npu_7.sbin
- Workload: sustained MoE decode (1bit 35B MoE workstream) until the
  scheduler timeout fires and per-context recovery fails.
