### PR TITLE
accel/amdxdna/ve2: Add named tracepoints for hwctx/partition/cmd latency

### DIFF
--- a/drivers/accel/amdxdna/ve2_hwctx.c
+++ b/drivers/accel/amdxdna/ve2_hwctx.c
@@ -241,8 +241,7 @@ static void hsa_queue_commit_slot(struct amdxdna_hwctx *hwctx, u64 seq)
 	}
 	hsa_queue_sync_write_index_for_write(queue);
 
-	trace_amdxdna_trace_point("XRT_PROFILING_TRACE_UPDATE_WRITE_INDEX",
-				  hwctx->client->pid, hwctx->id, seq, header->write_index);
+	trace_xdna_queue_write_index(hwctx->name, hwctx->id, seq, header->write_index);
 	mutex_unlock(&queue->hq_lock);
 }
 
@@ -740,7 +739,12 @@ int ve2_hwctx_init(struct amdxdna_hwctx *hwctx)
 	struct amdxdna_ctx_priv *vp;
 	int ret;
 
-	trace_amdxdna_trace_point("XRT_PROFILING_TRACE_ENTER", client->pid, 0, hwctx->id, 0);
+	/*
+	 * hwctx->name is not assigned until after this function returns
+	 * successfully (amdxdna_drm_create_hwctx_ioctl()), so key on
+	 * hwctx->id alone rather than the __string(name, ...) used elsewhere.
+	 */
+	trace_xdna_hwctx_init_start(hwctx->id, hwctx->num_tiles);
 
 	hdl = ve2_dev_hdl(xdna);
 	if (!hdl)
@@ -831,8 +835,7 @@ int ve2_hwctx_init(struct amdxdna_hwctx *hwctx)
 		XDNA_DBG(xdna, "hwctx %p: interrupt mode", hwctx);
 	}
 
-	trace_amdxdna_trace_point("XRT_PROFILING_TRACE_EXIT", client->pid, hwctx->start_col,
-				  hwctx->id, 0);
+	trace_xdna_hwctx_init_done(hwctx->id, hwctx->start_col, 0);
 	return 0;
 
 free_hwctx_config:
@@ -869,8 +872,12 @@ void ve2_hwctx_fini(struct amdxdna_hwctx *hwctx)
 
 	vp = priv->hw_priv;
 
-	trace_amdxdna_trace_point("XRT_PROFILING_TRACE_ENTER",
-				  hwctx->client->pid, hwctx->start_col, hwctx->id, 0);
+	/*
+	 * Key on hwctx->id alone: on some hwctx_init() failure cleanup paths
+	 * hwctx_fini() is reached before hwctx->name is assigned, or just
+	 * after it has been freed (amdxdna_drm_create_hwctx_ioctl()).
+	 */
+	trace_xdna_hwctx_fini_start(hwctx->id, hwctx->start_col);
 
 	/* Snapshot per-column CERT firmware status before tearing the partition down. */
 	if (vp && vp->mgmtctx)
@@ -904,8 +911,7 @@ void ve2_hwctx_fini(struct amdxdna_hwctx *hwctx)
 		kfree(vp);
 		priv->hw_priv = NULL;
 
-		trace_amdxdna_trace_point("XRT_PROFILING_TRACE_EXIT",
-					  hwctx->client->pid, hwctx->id, submitted, completed);
+		trace_xdna_hwctx_fini_done(hwctx->id, submitted, completed);
 	}
 
 	kfree(priv);
@@ -997,8 +1003,7 @@ int ve2_cmd_submit(struct amdxdna_hwctx *hwctx, struct amdxdna_sched_job *job, u
 		return -EINVAL;
 	}
 
-	trace_amdxdna_trace_point("XRT_PROFILING_TRACE_ENTER",
-				  hwctx->client->pid, hwctx->start_col, hwctx->id, 0);
+	trace_xdna_cmd_submit_start(hwctx->name, hwctx->id, hwctx->start_col);
 
 	if (op == ERT_CMD_CHAIN)
 		ret = ve2_submit_cmd_chain(hwctx, job, seq);
@@ -1009,6 +1014,13 @@ int ve2_cmd_submit(struct amdxdna_hwctx *hwctx, struct amdxdna_sched_job *job, u
 			return -ERESTARTSYS;
 		return ret;
 	}
+
+	/*
+	 * Command(s) are now committed into the host queue (write_index
+	 * advanced); *seq is the last sub-command's slot, i.e. the one
+	 * ve2_cmd_wait()/xdna_cmd_complete will report completion for.
+	 */
+	trace_xdna_cmd_submit(hwctx->name, hwctx->id, *seq, op);
 
 	if (!vp->mgmtctx) {
 		struct amdxdna_sched_job *pjob;
@@ -1040,8 +1052,6 @@ int ve2_cmd_submit(struct amdxdna_hwctx *hwctx, struct amdxdna_sched_job *job, u
 		return ret;
 	}
 
-	trace_amdxdna_trace_point("XRT_PROFILING_TRACE_EXIT",
-				  hwctx->client->pid, hwctx->start_col, hwctx->id, *seq);
 	return 0;
 }
 
@@ -1060,8 +1070,7 @@ static bool check_read_index(struct amdxdna_hwctx *hwctx, u64 seq)
 	read_index = *(u64 *)((char *)vp->hsa_queue.hsa_queue_p + HSA_QUEUE_READ_INDEX_OFFSET);
 
 	if (read_index > seq) {
-		trace_amdxdna_trace_point("XRT_PROFILING_TRACE_UPDATE_READ_INDEX",
-					  hwctx->client->pid, hwctx->id, seq, read_index);
+		trace_xdna_queue_read_index(hwctx->name, hwctx->id, seq, read_index);
 		return true;
 	}
 
@@ -1299,8 +1308,7 @@ int ve2_cmd_wait(struct amdxdna_hwctx *hwctx, u64 seq, u32 timeout_ms)
 	bool timed_out;
 	long ret = 0;
 
-	trace_amdxdna_trace_point("XRT_PROFILING_TRACE_ENTER",
-				  hwctx->client->pid, hwctx->start_col, hwctx->id, seq);
+	trace_xdna_cmd_wait_start(hwctx->name, hwctx->id, seq);
 
 	if (wait_jifs)
 		ret = wait_event_interruptible_timeout(vp->waitq,
@@ -1312,8 +1320,7 @@ int ve2_cmd_wait(struct amdxdna_hwctx *hwctx, u64 seq, u32 timeout_ms)
 
 	/* Interrupted by a signal; the command stays in flight for retry. */
 	if (ret < 0) {
-		trace_amdxdna_trace_point("XRT_PROFILING_TRACE_EXIT",
-					  hwctx->client->pid, hwctx->start_col, hwctx->id, seq);
+		trace_xdna_cmd_wait_done(hwctx->name, hwctx->id, seq, ret);
 		return ret;
 	}
 
@@ -1331,8 +1338,7 @@ int ve2_cmd_wait(struct amdxdna_hwctx *hwctx, u64 seq, u32 timeout_ms)
 	/* Already completed and released by another waiter. */
 	if (!job) {
 		mutex_unlock(&vp->hsa_queue.hq_lock);
-		trace_amdxdna_trace_point("XRT_PROFILING_TRACE_EXIT",
-					  hwctx->client->pid, hwctx->start_col, hwctx->id, seq);
+		trace_xdna_cmd_wait_done(hwctx->name, hwctx->id, seq, 0);
 		return 0;
 	}
 
@@ -1346,13 +1352,21 @@ int ve2_cmd_wait(struct amdxdna_hwctx *hwctx, u64 seq, u32 timeout_ms)
 	else
 		ve2_process_hqc_completion(hwctx, job, seq);
 
+	/*
+	 * Mirrors aie4_ctx.c's job_worker() trace_amdxdna_debug_point(...,
+	 * "job complete") at the point the final command state is known, plus
+	 * a structured event carrying that state for latency/outcome analysis
+	 * (pairs with xdna_cmd_submit on the same hwctx_id+seq).
+	 */
+	trace_amdxdna_debug_point(hwctx->name, seq, "job complete");
+	trace_xdna_cmd_complete(hwctx->name, hwctx->id, seq, amdxdna_cmd_get_state(job->cmd_bo));
+
 	ve2_hwctx_job_release(hwctx, job);
 	ve2_job_put(job);
 
 	mutex_unlock(&vp->hsa_queue.hq_lock);
 
-	trace_amdxdna_trace_point("XRT_PROFILING_TRACE_EXIT",
-				  hwctx->client->pid, hwctx->start_col, hwctx->id, seq);
+	trace_xdna_cmd_wait_done(hwctx->name, hwctx->id, seq, 0);
 	return 0;
 }
 

--- a/drivers/accel/amdxdna/ve2_mgmt.c
+++ b/drivers/accel/amdxdna/ve2_mgmt.c
@@ -415,23 +415,19 @@ static int ve2_mgmt_handshake_init(struct amdxdna_mgmtctx *mgmtctx,
 				  AIE_PART_INIT_OPT_NMU_CONFIG | AIE_PART_INIT_OPT_DIS_TLAST_ERROR |
 				  AIE_PART_INIT_OPT_ERR_SHIM_INIT | AIE_PART_INIT_OPT_HANDSHAKE);
 
-	trace_amdxdna_trace_point("XRT_PROFILING_TRACE_PARTITION_INIT",
-				  hwctx->client->pid, mgmtctx->start_col, hwctx->id, num_col);
+	trace_xdna_partition_init_start(hwctx->name, hwctx->id, mgmtctx->start_col, num_col);
 	ret = aie_partition_initialize(mgmtctx->aie_dev, &args);
+	trace_xdna_partition_init_done(hwctx->name, hwctx->id, mgmtctx->start_col, num_col, ret);
 	if (ret < 0) {
 		XDNA_ERR(xdna, "aie partition init failed: %d", ret);
 		goto release_hs_data;
 	}
-	trace_amdxdna_trace_point("XRT_PROFILING_TRACE_PARTITION_DONE",
-				  hwctx->client->pid, mgmtctx->start_col, hwctx->id, num_col);
 
 	/*
 	 * Refresh host_time_high/low now that the (slow) partition init has
 	 * completed, so CERT reads an up-to-date value as soon as it wakes up.
 	 */
 	ve2_cert_update_host_time(mgmtctx, num_col);
-	trace_amdxdna_trace_point("XRT_PROFILING_TRACE_HOST_TIME_SETUP",
-				  hwctx->client->pid, mgmtctx->start_col, hwctx->id, num_col);
 
 	/* Wake up the lead UC only */
 	ret = aie_partition_uc_wakeup(mgmtctx->aie_dev, &lead_loc);
@@ -539,18 +535,16 @@ int ve2_mgmt_schedule_cmd(struct amdxdna_dev *xdna, struct amdxdna_hwctx *hwctx,
 
 	mgmtctx = vp->mgmtctx;
 
-	trace_amdxdna_trace_point("XRT_PROFILING_TRACE_ENTER",
-				  hwctx->client->pid, mgmtctx->start_col, hwctx->id,
-				  command_index);
+	trace_xdna_mgmt_schedule_cmd_start(hwctx->name, hwctx->id, mgmtctx->start_col,
+					   command_index);
 
 	mutex_lock(&mgmtctx->ctx_lock);
 
 	ret = ve2_fifo_enqueue(mgmtctx, hwctx, command_index);
 	if (ret) {
 		mutex_unlock(&mgmtctx->ctx_lock);
-		trace_amdxdna_trace_point("XRT_PROFILING_TRACE_EXIT",
-					  hwctx->client->pid, mgmtctx->start_col, hwctx->id,
-					  command_index);
+		trace_xdna_mgmt_schedule_cmd_done(hwctx->name, hwctx->id, mgmtctx->start_col,
+						  command_index, ret);
 		return ret;
 	}
 
@@ -560,9 +554,8 @@ int ve2_mgmt_schedule_cmd(struct amdxdna_dev *xdna, struct amdxdna_hwctx *hwctx,
 		ret = ve2_mgmt_handshake_init(mgmtctx, hwctx);
 		if (ret) {
 			mutex_unlock(&mgmtctx->ctx_lock);
-			trace_amdxdna_trace_point("XRT_PROFILING_TRACE_EXIT",
-						  hwctx->client->pid, mgmtctx->start_col,
-						  hwctx->id, command_index);
+			trace_xdna_mgmt_schedule_cmd_done(hwctx->name, hwctx->id,
+							  mgmtctx->start_col, command_index, ret);
 			return ret;
 		}
 		mgmtctx->active_ctx = hwctx;
@@ -601,9 +594,8 @@ int ve2_mgmt_schedule_cmd(struct amdxdna_dev *xdna, struct amdxdna_hwctx *hwctx,
 
 	mutex_unlock(&mgmtctx->ctx_lock);
 
-	trace_amdxdna_trace_point("XRT_PROFILING_TRACE_EXIT",
-				  hwctx->client->pid, mgmtctx->start_col, hwctx->id,
-				  command_index);
+	trace_xdna_mgmt_schedule_cmd_done(hwctx->name, hwctx->id, mgmtctx->start_col,
+					  command_index, 0);
 	return 0;
 }
 
@@ -723,8 +715,7 @@ static void ve2_scheduler_work(struct work_struct *work)
 	if (!vp)
 		return;
 
-	trace_amdxdna_trace_point("XRT_PROFILING_TRACE_ENTER",
-				  hwctx->client->pid, mgmtctx->start_col, hwctx->id, 0);
+	trace_xdna_sched_work_start(hwctx->name, hwctx->id, mgmtctx->start_col);
 
 	/* If a switch was requested, mark the firmware ready to be reprogrammed. */
 	ve2_check_context_req(mgmtctx);
@@ -747,8 +738,7 @@ static void ve2_scheduler_work(struct work_struct *work)
 			 mgmtctx->active_ctx);
 	}
 
-	trace_amdxdna_trace_point("XRT_PROFILING_TRACE_EXIT",
-				  hwctx->client->pid, mgmtctx->start_col, hwctx->id, 0);
+	trace_xdna_sched_work_done(hwctx->name, hwctx->id, mgmtctx->start_col);
 }
 
 static void pop_from_ctx_command_fifo_till(struct amdxdna_mgmtctx *mgmtctx,
@@ -789,8 +779,7 @@ static void ve2_irq_handler(u32 partition_id, void *priv)
 	if (!active_ctx)
 		return;
 
-	trace_amdxdna_trace_point("XRT_PROFILING_TRACE_ENTER",
-				  active_ctx->client->pid, mgmtctx->start_col, active_ctx->id, 0);
+	trace_xdna_irq_enter(active_ctx->name, mgmtctx->partition_id, active_ctx->id);
 
 	if (get_ctx_read_index(active_ctx, &read_index)) {
 		XDNA_ERR(mgmtctx->xdna, "IRQ: failed to get read index");
@@ -803,9 +792,8 @@ static void ve2_irq_handler(u32 partition_id, void *priv)
 		wake_up_interruptible_all(&vp->waitq);
 
 	get_ctx_write_index(active_ctx, &write_index);
-	trace_amdxdna_trace_point("XRT_PROFILING_TRACE_EXIT",
-				  active_ctx->client->pid, active_ctx->id,
-				  write_index, read_index);
+	trace_xdna_irq_exit(active_ctx->name, mgmtctx->partition_id, active_ctx->id,
+			    read_index, write_index);
 
 	if (mgmtctx->work_queue &&
 	    (ve2_check_idle_or_queue_not_empty(mgmtctx) || ve2_check_misc_interrupt(mgmtctx))) {

--- a/drivers/accel/tools/README.md
+++ b/drivers/accel/tools/README.md
@@ -1,0 +1,150 @@
+# amdxdna perf tracing tools
+
+Two scripts for capturing and analyzing latency of amdxdna driver operations
+using `perf`/ftrace. They work together as a pipeline:
+
+```
+npu_perf_trace.sh  --(capture)-->  perf.converted.out  --(analyze)-->  npu_perf_analyze.sh
+```
+
+Both scripts support `-h`/`--help` and print full usage without requiring
+root:
+
+```bash
+./npu_perf_trace.sh --help
+./npu_perf_analyze.sh --help
+```
+
+These tools are backend-agnostic: the amdxdna driver's tracepoints all live
+under a single `TRACE_SYSTEM amdxdna` (see
+`include/trace/events/amdxdna.h`), shared by the aie2, aie4, and ve2
+backends alike. Everything below applies equally to all three; the VE2
+examples are called out because VE2 has some tracepoints (and usage
+patterns, e.g. multiple hwctx sharing a partition) the PCI backends don't.
+
+## 1. `npu_perf_trace.sh` — capture a trace
+
+```bash
+sudo ./npu_perf_trace.sh [-libdir <path-to-xrt-libs>] <command to run> [args...]
+```
+
+What it does:
+1. Finds the loaded amdxdna accel device under `/sys/kernel/debug/accel`.
+2. Adds XRT's `sdt_xrt:*` USDT probes (from `libxrt_coreutil.so` /
+   `libxrt_driver_xdna.so`, via `perf buildid-cache` + `perf probe`).
+3. Runs `perf record -e amdxdna:* -e sdt_xrt:* -a <command>` — i.e. captures
+   every `amdxdna:*` tracepoint (hwctx init/fini, partition init, IRQ,
+   command submit/wait/complete, scheduler work, mailbox, ...) plus XRT's
+   USDT probes, system-wide, while `<command>` runs.
+4. Converts the result with `perf script --reltime --ns` and substitutes
+   raw IOCTL numbers with their human-readable names (using
+   `/sys/kernel/debug/accel/<dev>/ioctl_id`).
+5. Writes the final text trace to `perf.converted.out` in the current
+   directory (used as the default input for `npu_perf_analyze.sh`).
+
+Must be run as **root** (needed for `perf record`/`perf probe` and to read
+`/sys/kernel/debug/accel` and `/sys/kernel/debug/tracing`).
+
+Example:
+
+```bash
+cd test_files
+sudo /path/to/npu_perf_trace.sh ./host.exe
+```
+
+## 2. `npu_perf_analyze.sh` — measure latency between two events
+
+```bash
+./npu_perf_analyze.sh [-file <perf.converted.out>] [-range <start:end>] [-key <pattern>] \
+    <event1_pattern> <event2_pattern>
+```
+
+Scans `perf.converted.out` (or `-f`/`-file <path>`) for every line matching
+`event1_pattern`, and every line matching `event2_pattern` (plain `egrep`
+patterns matched anywhere in the line), then pairs each `event2` occurrence
+with the closest preceding, not-yet-used `event1` occurrence and reports the
+average/largest/smallest time delta (in nanoseconds) across all pairs.
+
+Options:
+- `-file`/`-f <path>`: input file (default `perf.converted.out`)
+- `-range`/`-r <start:end>`: only consider the `[start, end)` slice of the
+  matched pairs (0-indexed, in the order they were found)
+- `-key`/`-k <pattern>`: only consider lines that *also* match this pattern
+  before pairing. Use this to correlate paired events by an identifying
+  field (e.g. `hwctx=3` or `seq=42`) instead of relying purely on nearest
+  timestamp, which can mis-pair events when multiple contexts are
+  interleaved (e.g. VE2, where several hwctx can share a partition).
+
+### Examples
+
+Time from an XRT wait-cmd ioctl call to its return (generic, all backends):
+
+```bash
+./npu_perf_analyze.sh \
+  "sdt_xrt:ioctl_entry: \(.+\) arg1=DRM_IOCTL_AMDXDNA_WAIT_CMD" \
+  "sdt_xrt:ioctl_exit: \(.+\) arg1=DRM_IOCTL_AMDXDNA_WAIT_CMD"
+```
+
+VE2 partition-init latency for a specific hwctx:
+
+```bash
+./npu_perf_analyze.sh -k "hwctx=3" \
+  "amdxdna:xdna_partition_init_start" "amdxdna:xdna_partition_init_done"
+```
+
+VE2 command submit -> complete latency for a specific sequence number:
+
+```bash
+./npu_perf_analyze.sh -k "seq=42" \
+  "amdxdna:xdna_cmd_submit" "amdxdna:xdna_cmd_complete"
+```
+
+VE2 hwctx init latency (no `name` field available yet at this point in the
+driver, so pair on `hwctx_id` alone — see comment in
+`include/trace/events/amdxdna.h`):
+
+```bash
+./npu_perf_analyze.sh -k "hwctx=3" \
+  "amdxdna:xdna_hwctx_init_start" "amdxdna:xdna_hwctx_init_done"
+```
+
+Only look at pairs 10 through 50 (0-indexed) from a large capture:
+
+```bash
+./npu_perf_analyze.sh -r 10:50 \
+  "amdxdna:xdna_cmd_wait_start" "amdxdna:xdna_cmd_wait_done"
+```
+
+## VE2 tracepoint reference
+
+All of the following are under the single `amdxdna:*` group (see
+`include/trace/events/amdxdna.h` for exact field names/types):
+
+| Stage | Start event | Done/complete event | Key fields |
+|---|---|---|---|
+| hwctx create/destroy | `xdna_hwctx_init_start` / `xdna_hwctx_fini_start` | `xdna_hwctx_init_done` / `xdna_hwctx_fini_done` | `hwctx` |
+| Partition init | `xdna_partition_init_start` | `xdna_partition_init_done` | `hwctx`, `start_col`, `num_col` |
+| Scheduler work | `xdna_sched_work_start` | `xdna_sched_work_done` | `hwctx`, `start_col` |
+| Mgmt schedule cmd | `xdna_mgmt_schedule_cmd_start` | `xdna_mgmt_schedule_cmd_done` | `hwctx` |
+| Command submit | `xdna_cmd_submit_start` | `xdna_cmd_submit` | `hwctx`, `seq`, `op` |
+| Command wait | `xdna_cmd_wait_start` | `xdna_cmd_wait_done` | `hwctx`, `seq` |
+| Command complete | — | `xdna_cmd_complete` | `hwctx`, `seq`, `state` |
+| Queue indices | `xdna_queue_write_index` | `xdna_queue_read_index` | `hwctx`, `seq` |
+| IRQ handling | `xdna_irq_enter` | `xdna_irq_exit` | `partition`, `hwctx` |
+
+For a higher-level, ready-made report covering all of the stages above with
+one command, see `test/*/xrt_profiling` (`xrt_profile --start` / `--stop`)
+instead — it enables/parses these same tracepoints automatically and
+produces a per-command latency breakdown without manually pairing events.
+
+## Troubleshooting
+
+- `No events found for ...`: usually means `perf.converted.out` has no
+  matching lines. Confirm the tracepoint group name matches what's actually
+  registered on your board: `perf list | grep amdxdna` or
+  `ls /sys/kernel/debug/tracing/events/amdxdna/`.
+- `<file> is not found`: run `npu_perf_trace.sh` first, or pass `-file` to
+  point at an existing trace.
+- Getting mis-paired/nonsensical diffs on VE2: add `-key "hwctx=<id>"` or
+  `-key "seq=<n>"` to disambiguate when multiple hw contexts are active
+  concurrently.

--- a/drivers/accel/tools/npu_perf_analyze.sh
+++ b/drivers/accel/tools/npu_perf_analyze.sh
@@ -8,11 +8,19 @@ usage()
   cat << USAGE_END
 Usage: $0 [options] event1_pattern event2_pattern
 Options:
+  -help/-h: Show this help and exit
   -file/-f: Trace log file for parsing
   -range/-r: [entry_index_begin:entry_index_end), e.g.: 100:200
+  -key/-k: Only consider lines also matching this pattern, e.g.: "hwctx=3" or "seq=42".
+           Use this to correlate paired events (e.g. xdna_cmd_submit/xdna_cmd_complete,
+           xdna_partition_init_start/_done) by hwctx_id or seq instead of just nearest
+           timestamp, which can mis-pair events when multiple hw contexts are interleaved
+           (e.g. VE2 with several hwctx sharing a partition).
 Parsing trace log file to find time interval from event1 to event2.
 event pattern examples:
   "sdt_xrt:ioctl_exit: \(.+\) arg1=DRM_IOCTL_AMDXDNA_WAIT_CMD"
+  -k "hwctx=3" "amdxdna:xdna_partition_init_start" "amdxdna:xdna_partition_init_done"
+  -k "seq=42" "amdxdna:xdna_cmd_submit" "amdxdna:xdna_cmd_complete"
 USAGE_END
 }
 
@@ -20,11 +28,17 @@ read_timestamps()
 {
 	timestamps=()
 
+	local matched
+	matched=$(egrep "$1" ${perf_out_file})
+	if [ -n "${key_filter}" ]; then
+		matched=$(echo "${matched}" | egrep "${key_filter}")
+	fi
+
 	while IFS= read -r line; do
 		if [ "$line" != "" ]; then
 			timestamps+=($(("10#${line}")))
 		fi
-	done <<< `egrep "$1" ${perf_out_file} | awk '{print $4}' | tr -d '.' | tr -d ':'`
+	done <<< `echo "${matched}" | awk '{print $4}' | tr -d '.' | tr -d ':'`
 	echo ${timestamps[@]}
 }
 
@@ -37,9 +51,14 @@ range_start=-1
 range_end=-1
 event1=""
 event2=""
+key_filter=""
 perf_out_file="perf.converted.out"
 while [ $# -gt 0 ]; do
 	case "$1" in
+		-h | --help)
+			usage
+			exit 0
+			;;
 		-range | -r)
 			st=$(echo $2 | cut -d':' -f1)
 			end=$(echo $2 | cut -d':' -f2)
@@ -65,6 +84,10 @@ while [ $# -gt 0 ]; do
 			perf_out_file=$2
 			shift
 			;;
+		-key | -k)
+			key_filter=$2
+			shift
+			;;
 		*)
 			break
 			;;
@@ -79,6 +102,9 @@ if [ ! -f ${perf_out_file} ]; then
 	exit 1
 else
 	echo "Parsing ${perf_out_file}..."
+fi
+if [ -n "${key_filter}" ]; then
+	echo "Filtering by key: '${key_filter}'"
 fi
 
 event1_ts=($(read_timestamps "${event1}"))
@@ -97,29 +123,24 @@ if [ ${event2_ts_num} -eq 0 ]; then
 fi
 echo "${event2_ts_num} events for: '${event2}'"
 
-# Calculate time difference between two events
+# Calculate time difference between two events. Pair each event2 occurrence
+# with the closest preceding, not-yet-used event1 occurrence; skip any event2
+# that happens before the first event1. Stop once either array is exhausted.
 diffs_event1=()
 diffs_event2=()
 diffs=()
 i1=0
 i2=0
-while [ 1 ]; do
-	while [[ ${i2} -lt ${event2_ts_num} && ${event2_ts[i2]} -lt ${event1_ts[i1]} ]]; do
+while [[ ${i1} -lt ${event1_ts_num} && ${i2} -lt ${event2_ts_num} ]]; do
+	if [[ ${event2_ts[i2]} -lt ${event1_ts[i1]} ]]; then
 		(( i2++ ))
-	done
-	if [ ${i2} -eq ${event2_ts_num} ]; then
-		break
+		continue
 	fi
 
-	while [[ ${i1} -lt ${event1_ts_num} && ${event1_ts[i1]} -lt ${event2_ts[i2]} ]]; do
+	while [[ $(( i1 + 1 )) -lt ${event1_ts_num} && ${event1_ts[i1+1]} -lt ${event2_ts[i2]} ]]; do
 		(( i1++ ))
 	done
-	if [ ${i1} -eq ${event1_ts_num} ]; then
-		break
-	fi
 
-
-	(( i1-- ))
 	diffs_event1+=( $((event1_ts[i1])) )
 	diffs_event2+=( $((event2_ts[i2])) )
 	diffs+=( $((event2_ts[i2] - event1_ts[i1])) )

--- a/drivers/accel/tools/npu_perf_trace.sh
+++ b/drivers/accel/tools/npu_perf_trace.sh
@@ -30,6 +30,37 @@ trace_error()
 	exit 1
 }
 
+usage()
+{
+	cat << USAGE_END
+Usage: sudo $0 [options] <command to run and trace> [args...]
+
+Captures a perf trace of the amdxdna driver's tracepoints (TRACE_SYSTEM
+"amdxdna", shared by aie2/aie4/ve2) together with XRT's sdt_xrt:* USDT
+probes while <command> runs, then converts the result into
+perf.converted.out (in the current directory) for use with
+npu_perf_analyze.sh.
+
+Options:
+  -help/-h: Show this help and exit
+  -libdir/-l <path>: Path to XRT's lib directory containing
+                      libxrt_coreutil.so and libxrt_driver_xdna.so
+                      (default: /opt/xilinx/xrt/lib)
+
+Must be run as root (needed for "perf record"/"perf probe" and to access
+/sys/kernel/debug/accel and /sys/kernel/debug/tracing).
+
+Examples:
+  sudo $0 ./host.exe
+  sudo $0 -libdir /opt/xilinx/xrt/lib ./host.exe --iters 100
+USAGE_END
+}
+
+if [[ "$1" == "-h" || "$1" == "--help" ]]; then
+	usage
+	exit 0
+fi
+
 add_sdt_xrt()
 {
 	perf list | grep sdt_xrt > /dev/null && sdt_pre_enabled=1
@@ -71,6 +102,10 @@ sdt_pre_enabled=0
 xrt_lib_prefix="/opt/xilinx/xrt/lib"
 while [ $# -gt 0 ]; do
 	case "$1" in
+		-h | --help)
+			usage
+			exit 0
+			;;
 		-libdir | -l)
 			xrt_lib_prefix=$2
 			shift
@@ -83,7 +118,7 @@ while [ $# -gt 0 ]; do
 done
 accel_debugfs="/sys/kernel/debug/accel"
 xrt_libs="${xrt_lib_prefix}/libxrt_coreutil.so,${xrt_lib_prefix}/libxrt_driver_xdna.so"
-perf_record_args="-e amdxdna_trace:* "
+perf_record_args="-e amdxdna:* "
 perf_record_args+="-e sdt_xrt:* "
 exec_cmd=""
 

--- a/include/trace/events/amdxdna.h
+++ b/include/trace/events/amdxdna.h
@@ -129,39 +129,419 @@ DEFINE_EVENT(xdna_mbox_name_id, mbox_poll_handle,
 );
 
 /*
- * Generic profiling tracepoint consumed by the xrt_profile userspace tool/test
- * (xrt_profiling) to build per hardware-context / per-command timing
- * breakdowns. Each call site passes a fixed message string (e.g.
- * XRT_PROFILING_TRACE_ENTER/EXIT) plus up to three numeric arguments whose
- * meaning depends on the calling function; see trace_amdxdna_trace_point()
- * call sites in ve2_hwctx.c / ve2_mgmt.c for the argument layout of each.
+ * Structured, per-operation latency tracepoints.
+ *
+ * These replace the former generic __amdxdna_trace_point probe that the
+ * xrt_profiling userspace test used to consume: a fixed message string
+ * (e.g. XRT_PROFILING_TRACE_ENTER/EXIT/UPDATE_WRITE_INDEX/...) plus up to
+ * three anonymous u64 arguments whose meaning depended on the call site.
+ * That worked for a single fixed consumer, but the events couldn't be
+ * selectively enabled/filtered per operation with standard ftrace/perf
+ * tooling (e.g. `echo 1 > events/amdxdna/xdna_irq_enter/enable`), and their
+ * anonymous fields weren't self-describing.
+ *
+ * The named, typed events below cover every call site the old probe had in
+ * ve2_hwctx.c / ve2_mgmt.c (hwctx create/destroy, partition initialize, IRQ,
+ * command submit/wait/complete, scheduler work, mgmt-scheduler kick, host
+ * queue write/read index), following the same enter/done pairing style
+ * already used by the reference xilinx-ai-engine driver (ai-engine-trace.h:
+ * aie_partition_request/aie_partition_request_done,
+ * aie2ps_interrupt_user_event1/_done, ...) which the VE2 backend sits on top
+ * of. A consumer computes latency by diffing the trace timestamps of the
+ * start/done pair sharing the same correlation key (hwctx_id, and seq where
+ * applicable) - no in-kernel duration math is required, matching how ftrace/
+ * trace-cmd/perf already report per-event timestamps.
+ *
+ * These are backend-agnostic (TRACE_SYSTEM amdxdna) so aie2/aie4 can adopt
+ * them too; only the VE2 backend calls them today.
  */
-TRACE_EVENT(__amdxdna_trace_point,
-	    TP_PROTO(const char *msg, const char *func, u64 pid, u64 arg1, u64 arg2, u64 arg3),
 
-	    TP_ARGS(msg, func, pid, arg1, arg2, arg3),
+DECLARE_EVENT_CLASS(xdna_partition_init,
+		    TP_PROTO(const char *name, u32 hwctx_id, u32 start_col, u32 num_col),
 
-	    TP_STRUCT__entry(__string(msg, msg)
-			     __string(func, func)
-			     __field(u64, pid)
-			     __field(u64, arg1)
-			     __field(u64, arg2)
-			     __field(u64, arg3)),
+		    TP_ARGS(name, hwctx_id, start_col, num_col),
 
-	    TP_fast_assign(__assign_str(msg);
-			   __assign_str(func);
-			   __entry->pid = pid;
-			   __entry->arg1 = arg1;
-			   __entry->arg2 = arg2;
-			   __entry->arg3 = arg3;),
+		    TP_STRUCT__entry(__string(name, name)
+				     __field(u32, hwctx_id)
+				     __field(u32, start_col)
+				     __field(u32, num_col)),
 
-	    TP_printk("%s: %s() pid=%llu [%llu,%llu,%llu]", __get_str(msg), __get_str(func),
-		      __entry->pid, __entry->arg1, __entry->arg2, __entry->arg3)
+		    TP_fast_assign(__assign_str(name);
+				   __entry->hwctx_id = hwctx_id;
+				   __entry->start_col = start_col;
+				   __entry->num_col = num_col;),
+
+		    TP_printk("%s: hwctx=%u start_col=%u num_col=%u",
+			      __get_str(name), __entry->hwctx_id, __entry->start_col,
+			      __entry->num_col)
 );
 
-/* Macro wrapper that automatically captures the function name */
-#define trace_amdxdna_trace_point(msg, pid, arg1, arg2, arg3) \
-	trace___amdxdna_trace_point(msg, __func__, pid, arg1, arg2, arg3)
+DEFINE_EVENT(xdna_partition_init, xdna_partition_init_start,
+	     TP_PROTO(const char *name, u32 hwctx_id, u32 start_col, u32 num_col),
+	     TP_ARGS(name, hwctx_id, start_col, num_col)
+);
+
+TRACE_EVENT(xdna_partition_init_done,
+	    TP_PROTO(const char *name, u32 hwctx_id, u32 start_col, u32 num_col, int ret),
+
+	    TP_ARGS(name, hwctx_id, start_col, num_col, ret),
+
+	    TP_STRUCT__entry(__string(name, name)
+			     __field(u32, hwctx_id)
+			     __field(u32, start_col)
+			     __field(u32, num_col)
+			     __field(int, ret)),
+
+	    TP_fast_assign(__assign_str(name);
+			   __entry->hwctx_id = hwctx_id;
+			   __entry->start_col = start_col;
+			   __entry->num_col = num_col;
+			   __entry->ret = ret;),
+
+	    TP_printk("%s: hwctx=%u start_col=%u num_col=%u ret=%d",
+		      __get_str(name), __entry->hwctx_id, __entry->start_col,
+		      __entry->num_col, __entry->ret)
+);
+
+DECLARE_EVENT_CLASS(xdna_sched_work,
+		    TP_PROTO(const char *name, u32 hwctx_id, u32 start_col),
+
+		    TP_ARGS(name, hwctx_id, start_col),
+
+		    TP_STRUCT__entry(__string(name, name)
+				     __field(u32, hwctx_id)
+				     __field(u32, start_col)),
+
+		    TP_fast_assign(__assign_str(name);
+				   __entry->hwctx_id = hwctx_id;
+				   __entry->start_col = start_col;),
+
+		    TP_printk("%s: hwctx=%u start_col=%u",
+			      __get_str(name), __entry->hwctx_id, __entry->start_col)
+);
+
+DEFINE_EVENT(xdna_sched_work, xdna_sched_work_start,
+	     TP_PROTO(const char *name, u32 hwctx_id, u32 start_col),
+	     TP_ARGS(name, hwctx_id, start_col)
+);
+
+DEFINE_EVENT(xdna_sched_work, xdna_sched_work_done,
+	     TP_PROTO(const char *name, u32 hwctx_id, u32 start_col),
+	     TP_ARGS(name, hwctx_id, start_col)
+);
+
+TRACE_EVENT(xdna_irq_enter,
+	    TP_PROTO(const char *name, u32 partition_id, u32 hwctx_id),
+
+	    TP_ARGS(name, partition_id, hwctx_id),
+
+	    TP_STRUCT__entry(__string(name, name)
+			     __field(u32, partition_id)
+			     __field(u32, hwctx_id)),
+
+	    TP_fast_assign(__assign_str(name);
+			   __entry->partition_id = partition_id;
+			   __entry->hwctx_id = hwctx_id;),
+
+	    TP_printk("%s: partition=0x%x hwctx=%u",
+		      __get_str(name), __entry->partition_id, __entry->hwctx_id)
+);
+
+TRACE_EVENT(xdna_irq_exit,
+	    TP_PROTO(const char *name, u32 partition_id, u32 hwctx_id, u64 read_index,
+		     u64 write_index),
+
+	    TP_ARGS(name, partition_id, hwctx_id, read_index, write_index),
+
+	    TP_STRUCT__entry(__string(name, name)
+			     __field(u32, partition_id)
+			     __field(u32, hwctx_id)
+			     __field(u64, read_index)
+			     __field(u64, write_index)),
+
+	    TP_fast_assign(__assign_str(name);
+			   __entry->partition_id = partition_id;
+			   __entry->hwctx_id = hwctx_id;
+			   __entry->read_index = read_index;
+			   __entry->write_index = write_index;),
+
+	    TP_printk("%s: partition=0x%x hwctx=%u read_index=%llu write_index=%llu",
+		      __get_str(name), __entry->partition_id, __entry->hwctx_id,
+		      __entry->read_index, __entry->write_index)
+);
+
+TRACE_EVENT(xdna_cmd_submit,
+	    TP_PROTO(const char *name, u32 hwctx_id, u64 seq, u32 op),
+
+	    TP_ARGS(name, hwctx_id, seq, op),
+
+	    TP_STRUCT__entry(__string(name, name)
+			     __field(u32, hwctx_id)
+			     __field(u64, seq)
+			     __field(u32, op)),
+
+	    TP_fast_assign(__assign_str(name);
+			   __entry->hwctx_id = hwctx_id;
+			   __entry->seq = seq;
+			   __entry->op = op;),
+
+	    TP_printk("%s: hwctx=%u seq=%llu op=%u",
+		      __get_str(name), __entry->hwctx_id, __entry->seq, __entry->op)
+);
+
+TRACE_EVENT(xdna_cmd_complete,
+	    TP_PROTO(const char *name, u32 hwctx_id, u64 seq, u32 state),
+
+	    TP_ARGS(name, hwctx_id, seq, state),
+
+	    TP_STRUCT__entry(__string(name, name)
+			     __field(u32, hwctx_id)
+			     __field(u64, seq)
+			     __field(u32, state)),
+
+	    TP_fast_assign(__assign_str(name);
+			   __entry->hwctx_id = hwctx_id;
+			   __entry->seq = seq;
+			   __entry->state = state;),
+
+	    TP_printk("%s: hwctx=%u seq=%llu state=%u",
+		      __get_str(name), __entry->hwctx_id, __entry->seq, __entry->state)
+);
+
+/*
+ * hwctx create/destroy latency. hwctx->name is not assigned until after
+ * hwctx_init() returns successfully (see amdxdna_drm_create_hwctx_ioctl()),
+ * and may already be freed on some hwctx_init() failure cleanup paths, so
+ * these two pairs key on hwctx_id alone rather than the __string(name, ...)
+ * used by the other events above.
+ */
+DECLARE_EVENT_CLASS(xdna_hwctx_init,
+		    TP_PROTO(u32 hwctx_id, u32 num_tiles),
+
+		    TP_ARGS(hwctx_id, num_tiles),
+
+		    TP_STRUCT__entry(__field(u32, hwctx_id)
+				     __field(u32, num_tiles)),
+
+		    TP_fast_assign(__entry->hwctx_id = hwctx_id;
+				   __entry->num_tiles = num_tiles;),
+
+		    TP_printk("hwctx=%u num_tiles=%u",
+			      __entry->hwctx_id, __entry->num_tiles)
+);
+
+DEFINE_EVENT(xdna_hwctx_init, xdna_hwctx_init_start,
+	     TP_PROTO(u32 hwctx_id, u32 num_tiles),
+	     TP_ARGS(hwctx_id, num_tiles)
+);
+
+TRACE_EVENT(xdna_hwctx_init_done,
+	    TP_PROTO(u32 hwctx_id, u32 start_col, int ret),
+
+	    TP_ARGS(hwctx_id, start_col, ret),
+
+	    TP_STRUCT__entry(__field(u32, hwctx_id)
+			     __field(u32, start_col)
+			     __field(int, ret)),
+
+	    TP_fast_assign(__entry->hwctx_id = hwctx_id;
+			   __entry->start_col = start_col;
+			   __entry->ret = ret;),
+
+	    TP_printk("hwctx=%u start_col=%u ret=%d",
+		      __entry->hwctx_id, __entry->start_col, __entry->ret)
+);
+
+TRACE_EVENT(xdna_hwctx_fini_start,
+	    TP_PROTO(u32 hwctx_id, u32 start_col),
+
+	    TP_ARGS(hwctx_id, start_col),
+
+	    TP_STRUCT__entry(__field(u32, hwctx_id)
+			     __field(u32, start_col)),
+
+	    TP_fast_assign(__entry->hwctx_id = hwctx_id;
+			   __entry->start_col = start_col;),
+
+	    TP_printk("hwctx=%u start_col=%u", __entry->hwctx_id, __entry->start_col)
+);
+
+TRACE_EVENT(xdna_hwctx_fini_done,
+	    TP_PROTO(u32 hwctx_id, u32 submitted, u32 completed),
+
+	    TP_ARGS(hwctx_id, submitted, completed),
+
+	    TP_STRUCT__entry(__field(u32, hwctx_id)
+			     __field(u32, submitted)
+			     __field(u32, completed)),
+
+	    TP_fast_assign(__entry->hwctx_id = hwctx_id;
+			   __entry->submitted = submitted;
+			   __entry->completed = completed;),
+
+	    TP_printk("hwctx=%u submitted=%u completed=%u",
+		      __entry->hwctx_id, __entry->submitted, __entry->completed)
+);
+
+/*
+ * ve2_mgmt_schedule_cmd() latency: from a newly-submitted command handed to
+ * the partition scheduler to it being enqueued/kicked off (context activated
+ * or switch armed). Complements xdna_sched_work_start/_done, which covers
+ * the deferred workqueue side of the same scheduler.
+ */
+DECLARE_EVENT_CLASS(xdna_mgmt_schedule_cmd,
+		    TP_PROTO(const char *name, u32 hwctx_id, u32 start_col, u64 command_index),
+
+		    TP_ARGS(name, hwctx_id, start_col, command_index),
+
+		    TP_STRUCT__entry(__string(name, name)
+				     __field(u32, hwctx_id)
+				     __field(u32, start_col)
+				     __field(u64, command_index)),
+
+		    TP_fast_assign(__assign_str(name);
+				   __entry->hwctx_id = hwctx_id;
+				   __entry->start_col = start_col;
+				   __entry->command_index = command_index;),
+
+		    TP_printk("%s: hwctx=%u start_col=%u command_index=%llu",
+			      __get_str(name), __entry->hwctx_id, __entry->start_col,
+			      __entry->command_index)
+);
+
+DEFINE_EVENT(xdna_mgmt_schedule_cmd, xdna_mgmt_schedule_cmd_start,
+	     TP_PROTO(const char *name, u32 hwctx_id, u32 start_col, u64 command_index),
+	     TP_ARGS(name, hwctx_id, start_col, command_index)
+);
+
+TRACE_EVENT(xdna_mgmt_schedule_cmd_done,
+	    TP_PROTO(const char *name, u32 hwctx_id, u32 start_col, u64 command_index, int ret),
+
+	    TP_ARGS(name, hwctx_id, start_col, command_index, ret),
+
+	    TP_STRUCT__entry(__string(name, name)
+			     __field(u32, hwctx_id)
+			     __field(u32, start_col)
+			     __field(u64, command_index)
+			     __field(int, ret)),
+
+	    TP_fast_assign(__assign_str(name);
+			   __entry->hwctx_id = hwctx_id;
+			   __entry->start_col = start_col;
+			   __entry->command_index = command_index;
+			   __entry->ret = ret;),
+
+	    TP_printk("%s: hwctx=%u start_col=%u command_index=%llu ret=%d",
+		      __get_str(name), __entry->hwctx_id, __entry->start_col,
+		      __entry->command_index, __entry->ret)
+);
+
+/*
+ * Host queue write_index (host -> CERT, command committed) / read_index
+ * (CERT -> host, command consumed) crossing @seq. Diffing the timestamps of
+ * an xdna_queue_write_index and the xdna_queue_read_index that first reports
+ * read_index > that same seq gives firmware execution time for that command.
+ */
+TRACE_EVENT(xdna_queue_write_index,
+	    TP_PROTO(const char *name, u32 hwctx_id, u64 seq, u64 write_index),
+
+	    TP_ARGS(name, hwctx_id, seq, write_index),
+
+	    TP_STRUCT__entry(__string(name, name)
+			     __field(u32, hwctx_id)
+			     __field(u64, seq)
+			     __field(u64, write_index)),
+
+	    TP_fast_assign(__assign_str(name);
+			   __entry->hwctx_id = hwctx_id;
+			   __entry->seq = seq;
+			   __entry->write_index = write_index;),
+
+	    TP_printk("%s: hwctx=%u seq=%llu write_index=%llu",
+		      __get_str(name), __entry->hwctx_id, __entry->seq, __entry->write_index)
+);
+
+TRACE_EVENT(xdna_queue_read_index,
+	    TP_PROTO(const char *name, u32 hwctx_id, u64 seq, u64 read_index),
+
+	    TP_ARGS(name, hwctx_id, seq, read_index),
+
+	    TP_STRUCT__entry(__string(name, name)
+			     __field(u32, hwctx_id)
+			     __field(u64, seq)
+			     __field(u64, read_index)),
+
+	    TP_fast_assign(__assign_str(name);
+			   __entry->hwctx_id = hwctx_id;
+			   __entry->seq = seq;
+			   __entry->read_index = read_index;),
+
+	    TP_printk("%s: hwctx=%u seq=%llu read_index=%llu",
+		      __get_str(name), __entry->hwctx_id, __entry->seq, __entry->read_index)
+);
+
+/*
+ * ve2_cmd_submit() function-entry marker. Diffing against xdna_cmd_submit
+ * (same hwctx_id, emitted once the command is actually committed to the
+ * host queue) gives the submit-path latency ("Submit" column).
+ */
+TRACE_EVENT(xdna_cmd_submit_start,
+	    TP_PROTO(const char *name, u32 hwctx_id, u32 start_col),
+
+	    TP_ARGS(name, hwctx_id, start_col),
+
+	    TP_STRUCT__entry(__string(name, name)
+			     __field(u32, hwctx_id)
+			     __field(u32, start_col)),
+
+	    TP_fast_assign(__assign_str(name);
+			   __entry->hwctx_id = hwctx_id;
+			   __entry->start_col = start_col;),
+
+	    TP_printk("%s: hwctx=%u start_col=%u",
+		      __get_str(name), __entry->hwctx_id, __entry->start_col)
+);
+
+/*
+ * ve2_cmd_wait() latency: from a waiter blocking on a command's completion
+ * to it observing (or giving up on) that completion. @ret mirrors the
+ * function's return value (e.g. -ERESTARTSYS if interrupted by a signal).
+ */
+TRACE_EVENT(xdna_cmd_wait_start,
+	    TP_PROTO(const char *name, u32 hwctx_id, u64 seq),
+
+	    TP_ARGS(name, hwctx_id, seq),
+
+	    TP_STRUCT__entry(__string(name, name)
+			     __field(u32, hwctx_id)
+			     __field(u64, seq)),
+
+	    TP_fast_assign(__assign_str(name);
+			   __entry->hwctx_id = hwctx_id;
+			   __entry->seq = seq;),
+
+	    TP_printk("%s: hwctx=%u seq=%llu",
+		      __get_str(name), __entry->hwctx_id, __entry->seq)
+);
+
+TRACE_EVENT(xdna_cmd_wait_done,
+	    TP_PROTO(const char *name, u32 hwctx_id, u64 seq, int ret),
+
+	    TP_ARGS(name, hwctx_id, seq, ret),
+
+	    TP_STRUCT__entry(__string(name, name)
+			     __field(u32, hwctx_id)
+			     __field(u64, seq)
+			     __field(int, ret)),
+
+	    TP_fast_assign(__assign_str(name);
+			   __entry->hwctx_id = hwctx_id;
+			   __entry->seq = seq;
+			   __entry->ret = ret;),
+
+	    TP_printk("%s: hwctx=%u seq=%llu ret=%d",
+		      __get_str(name), __entry->hwctx_id, __entry->seq, __entry->ret)
+);
 
 #endif /* !defined(_AMDXDNA_TRACE_EVENTS_H_) || defined(TRACE_HEADER_MULTI_READ) */
 


### PR DESCRIPTION
Replace the generic __amdxdna_trace_point probe (three anonymous u64 args whose meaning varied per call site) with 17 named, structured TRACE_EVENTs covering the VE2 command/context lifecycle:
 - hwctx init/fini:        xdna_hwctx_init_{start,done}, xdna_hwctx_fini_{start,done}
 - partition init:         xdna_partition_init_{start,done}
 - IRQ handling:           xdna_irq_{enter,exit}
 - command submit/wait:    xdna_cmd_submit_start, xdna_cmd_submit, xdna_cmd_wait_{start,done}, xdna_cmd_complete
 - queue indices:          xdna_queue_{write,read}_index
 - scheduler work:         xdna_mgmt_schedule_cmd_{start,done}, xdna_sched_work_{start,done}

Each event carries typed, self-documenting fields (hwctx_id, seq, start_col, state, etc.) instead of positional arguments, so per-stage latency (init, partition bring-up, submit, wait, fw exec, scheduler) can be derived directly from ftrace/perf timestamps without decoding call-site-specific argument layouts.

accel/amdxdna/tools: 
-Fix stale trace group, add -h/--help and READMEs npu_perf_trace.sh recorded perf events with "-e amdxdna_trace:*", but the driver's TRACE_SYSTEM was renamed to "amdxdna" a while back (see xrt_profile's matching fix in #781), so it was silently capturing zero amdxdna tracepoints. 
-Update it to "-e amdxdna:*", and fix the same stale "amdxdna_trace:" prefix in npu_perf_analyze.sh's usage examples. This group is shared by aie2/aie4/ve2 alike, so the fix benefits all backends, not just VE2. 
-Add -h/--help to both scripts (npu_perf_trace.sh had no usage() at all; npu_perf_analyze.sh only printed usage on zero args). --help works without requiring root. 
-Add README.md documenting the capture -> analyze pipeline, all options (including the new -key/-k correlation filter), a VE2 tracepoint reference table, and troubleshooting tips.