### PR TITLE
shim: fix UMQ BO use-after-free in hwctx destructor

### DIFF
--- a/src/shim/hwctx.cpp
+++ b/src/shim/hwctx.cpp
@@ -132,9 +132,9 @@ get_cu_pdi(int idx) const
 hwctx::
 hwctx(const device& dev, const qos_type& qos, const xrt::xclbin& xclbin,
   std::unique_ptr<hwq> queue)
-  : m_ctx(dev)
-  , m_device(dev)
+  : m_device(dev)
   , m_q(std::move(queue))
+  , m_ctx(dev)
 {
   xclbin_parser xp(xclbin);
 
@@ -150,9 +150,9 @@ hwctx(const device& dev, const qos_type& qos, const xrt::xclbin& xclbin,
 hwctx::
 hwctx(const device& dev, const qos_type& qos, uint32_t partition_size,
   std::unique_ptr<hwq> queue)
-  : m_ctx(dev)
-  , m_device(dev)
+  : m_device(dev)
   , m_q(std::move(queue))
+  , m_ctx(dev)
 {
   m_col_cnt = partition_size;
   m_ops_per_cycle = 0;

--- a/src/shim/hwctx.h
+++ b/src/shim/hwctx.h
@@ -111,7 +111,7 @@ private:
     const device& m_device;
     slot_id m_handle = AMDXDNA_INVALID_CTX_HANDLE;
     uint32_t m_syncobj = AMDXDNA_INVALID_FENCE_HANDLE;
-  } m_ctx;
+  };
 
   const device& m_device;
   slot_id m_handle = AMDXDNA_INVALID_CTX_HANDLE;
@@ -122,6 +122,9 @@ private:
   uint32_t m_ops_per_cycle = 0;
   std::unique_ptr<hwq> m_q;
   amdxdna_qos_info m_qos = {};
+  // Must be the last member: destroyed first, ensuring destroy_ctx ioctl fires
+  // before any other member (e.g. the UMQ BO owned by m_q) is freed.
+  ctx m_ctx;
 
   void
   create_ctx_on_device(const qos_type& qos);


### PR DESCRIPTION
Move m_ctx to be the last member of hwctx so it is destroyed first, ensuring the destroy_ctx ioctl tears down the hw context on device before the UMQ BO (owned by m_q) is freed.