### PR TITLE
shim_test: add debug info when poll_command is stuck

### DIFF
--- a/src/shim/hwq.h
+++ b/src/shim/hwq.h
@@ -47,6 +47,9 @@ public:
   virtual bo_id
   get_queue_bo() const = 0;
 
+  virtual void
+  dump() const {}
+
 protected:
   const pdev& m_pdev;
   const hwctx* m_ctx = nullptr;

--- a/src/shim/umq/hwq.cpp
+++ b/src/shim/umq/hwq.cpp
@@ -90,28 +90,28 @@ hwq_umq::
 dump() const
 {
   auto h = m_umq_hdr;
-  shim_debug("Dumping UMQ queue header @%p:", h);
-  shim_debug("\tRead Index:\t0x%lx", h->read_index);
-  shim_debug("\tWrite Index:\t0x%lx", h->write_index);
-  shim_debug("\tCapacity:\t%d", h->capacity);
-  shim_debug("\tData Addr:\t%p", h->data_address);
+  shim_info("Dumping UMQ queue header @%p:", h);
+  shim_info("\tRead Index:\t0x%lx", h->read_index);
+  shim_info("\tWrite Index:\t0x%lx", h->write_index);
+  shim_info("\tCapacity:\t%d", h->capacity);
+  shim_info("\tData Addr:\t0x%lx", h->data_address);
 
-  shim_debug("Dumping UMQ queue slot @%p:", m_umq_pkt);
+  shim_info("Dumping UMQ queue slot @%p:", m_umq_pkt);
   for (uint32_t i = 0; i < h->capacity; i++) {
     auto pkt = &m_umq_pkt[i];
-    shim_debug("==========slot %u==========", i);
-    shim_debug("\ttype:\t\t%u", static_cast<uint8_t>(pkt->xrt_header.common_header.type));
-    shim_debug("\topcode:\t\t%u", pkt->xrt_header.common_header.opcode);
-    shim_debug("\tchain_flag:\t\t%u", pkt->xrt_header.common_header.chain_flag);
-    shim_debug("\tcount:\t\t%u", pkt->xrt_header.common_header.count);
-    shim_debug("\tdistribute:\t%u", pkt->xrt_header.common_header.distribute);
-    shim_debug("\tindirect:\t%u", pkt->xrt_header.common_header.indirect);
-    shim_debug("\tcomplete addr:\t%p", pkt->xrt_header.completion_signal);
+    shim_info("==========slot %u==========", i);
+    shim_info("\ttype:\t\t%u", static_cast<uint8_t>(pkt->xrt_header.common_header.type));
+    shim_info("\topcode:\t\t%u", pkt->xrt_header.common_header.opcode);
+    shim_info("\tchain_flag:\t%u", pkt->xrt_header.common_header.chain_flag);
+    shim_info("\tcount:\t\t%u", pkt->xrt_header.common_header.count);
+    shim_info("\tdistribute:\t%u", pkt->xrt_header.common_header.distribute);
+    shim_info("\tindirect:\t%u", pkt->xrt_header.common_header.indirect);
+    shim_info("\tcomplete addr:\t0x%lx", pkt->xrt_header.completion_signal);
     if (pkt->xrt_header.common_header.indirect == 0) {
       volatile struct exec_buf *ebp =
         reinterpret_cast<volatile struct exec_buf *>(pkt->data);
 
-      shim_debug("\tdpu: [0x%x 0x%x]",
+      shim_info("\tdpu:\t\t[0x%x 0x%x]",
         ebp->dpu_control_code_host_addr_high,
         ebp->dpu_control_code_host_addr_low);
     } else {
@@ -121,19 +121,19 @@ dump() const
       for (int i = 0; i < HSA_MAX_LEVEL1_INDIRECT_ENTRIES; i++, hp++) {
         uint32_t hi = hp->host_addr_high;
         uint32_t lo = hp->host_addr_low;
-        shim_debug("\thost addr: [0x%x 0x%x]", hi, lo);
+        shim_info("\thost addr: [0x%x 0x%x]", hi, lo);
 
         volatile struct host_indirect_data *data =
         reinterpret_cast<volatile struct host_indirect_data *>(m_umq_indirect_buf);
-        shim_debug("\t\th:distribute:\t%d", data[i].header.distribute);
-        shim_debug("\t\th:indirect:\t%d", data[i].header.indirect);
-        shim_debug("\t\tp:dpu: [0x%x 0x%x]",
+        shim_info("\t\th:distribute:\t%d", data[i].header.distribute);
+        shim_info("\t\th:indirect:\t%d", data[i].header.indirect);
+        shim_info("\t\tp:dpu: [0x%x 0x%x]",
           data[i].payload.dpu_control_code_host_addr_high,
           data[i].payload.dpu_control_code_host_addr_low);
       }
     }
   }
-  shim_debug("Finished dumping UMQ\r\n");
+  shim_info("Finished dumping UMQ\r\n");
 }
 
 void

--- a/src/shim/umq/hwq.h
+++ b/src/shim/umq/hwq.h
@@ -30,6 +30,9 @@ public:
   int
   poll_command(xrt_core::buffer_handle *) const override;
 
+  void
+  dump() const override;
+
 private:
   std::unique_ptr<buffer> m_umq_bo;
   void *m_umq_bo_buf;
@@ -41,9 +44,6 @@ private:
 
   uint64_t
   issue_command(const cmd_buffer *cmd_bo) override;
-
-  void
-  dump() const;
 
   void
   dump_raw() const;

--- a/test/shim_test/CMakeLists.txt
+++ b/test/shim_test/CMakeLists.txt
@@ -17,6 +17,8 @@ target_compile_definitions(${XDNA_SHIM_TEST} PRIVATE
 
 target_link_libraries(${XDNA_SHIM_TEST} PRIVATE
   xrt_coreutil # for xclbin parser and some other helpers
+  xrt_driver_xdna # HACK: linked directly to access shim internals for debug
+  xrt_core        # HACK: transitive dep of xrt_driver_xdna
   aiebu_static
   dl
   )
@@ -35,6 +37,9 @@ target_include_directories(${XDNA_SHIM_TEST} PRIVATE
   ${XRT_SUBMOD_SOURCE_DIR}/src/runtime_src/core/include
   ${XRT_SUBMOD_SOURCE_DIR}/src/runtime_src/core/common/elf
   ${XRT_SUBMOD_BINARY_DIR}/src/gen
+  # HACK: include shim headers directly for debug casts
+  ${CMAKE_SOURCE_DIR}/src/shim
+  ${CMAKE_SOURCE_DIR}/src/include/uapi
   )
 
 target_compile_options(${XDNA_SHIM_TEST} PRIVATE -O3)

--- a/test/shim_test/io_test.cpp
+++ b/test/shim_test/io_test.cpp
@@ -13,6 +13,7 @@
 #include "core/common/query_requests.h"
 #include "core/include/ert.h"
 #include "xrt/detail/xclbin.h"
+#include "hwq.h"
 #include <fstream>
 #include <sstream>
 #include <string>
@@ -30,7 +31,7 @@
 #include <sys/types.h>
 
 // FIXME
-#include "../../src/include/uapi/drm_local/amdxdna_accel.h"
+#include "drm_local/amdxdna_accel.h"
 // end of FIXME
 
 using namespace xrt_core;
@@ -129,7 +130,19 @@ io_test_init_runlist_cmd(bo* cmd_bo, std::vector<bo*>& cmd_bos)
 void io_test_cmd_wait(hwqueue_handle *hwq, std::shared_ptr<bo> bo)
 {
     if (io_test_parameters.wait == IO_TEST_POLL_WAIT) {
-      while(!hwq->poll_command(bo->get()));
+      auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(2);
+      bool printed = false;
+      while (!hwq->poll_command(bo->get())) {
+        if (!printed && std::chrono::steady_clock::now() > deadline) {
+          printed = true;
+          auto seq = static_cast<shim_xdna::cmd_buffer *>(bo->get())->wait_for_submitted();
+          std::cout << "poll_command stuck for more than 2 seconds, seq=" << seq << std::endl;
+          static_cast<shim_xdna::hwq *>(hwq)->dump();
+          auto ret = hwq->wait_command(bo->get(), 1000 /* ms */);
+          std::cout << "driver wait_command returned: " << ret
+                    << (ret > 0 ? " (completed)" : " (timed out)") << std::endl;
+        }
+      }
     } else {
       hwq->wait_command(bo->get(), 0);
     }


### PR DESCRIPTION
This is a temporary change for debugging shim_test #49 hang issue. Change should be reverted once issue is fixed.

Print queue state (read_index, write_index, slot info) and driver wait_command result when poll_command spins for too long. The timeout is currently set to to 2s.