### PR TITLE
accel/amdxdna/ve2: fix pinned-column partition sharing and stale handshake on teardown

### DIFF
--- a/drivers/accel/amdxdna/amdxdna_solver.c
+++ b/drivers/accel/amdxdna/amdxdna_solver.c
@@ -214,6 +214,7 @@ static int allocate_partition(struct solver_state *xrs,
 			      struct solver_node *snode,
 			      struct alloc_requests *req)
 {
+	u32 user_col = req->rqos.user_start_col;
 	struct partition_node *pt_node, *rpt_node = NULL;
 	int idx, ret;
 
@@ -233,11 +234,26 @@ static int allocate_partition(struct solver_state *xrs,
 		if (rpt_node && pt_node->nshared >= rpt_node->nshared)
 			continue;
 
-		for (idx = 0; idx < snode->cols_len; idx++) {
-			if (snode->start_cols[idx] != pt_node->start_col)
+		if (req->cdo.ncols != pt_node->ncols)
+			continue;
+
+		/*
+		 * A caller that pinned a specific start column must only ever
+		 * reuse a partition at that exact column -- never silently
+		 * redirect it to share a different one. Fail with -ENODEV
+		 * below if no such partition exists, matching the strict
+		 * behaviour of get_free_partition() above.
+		 */
+		if (user_col != USER_START_COL_NOT_REQUESTED) {
+			if (pt_node->start_col != user_col)
 				continue;
 
-			if (req->cdo.ncols != pt_node->ncols)
+			rpt_node = pt_node;
+			continue;
+		}
+
+		for (idx = 0; idx < snode->cols_len; idx++) {
+			if (snode->start_cols[idx] != pt_node->start_col)
 				continue;
 
 			rpt_node = pt_node;

--- a/drivers/accel/amdxdna/ve2_mgmt.c
+++ b/drivers/accel/amdxdna/ve2_mgmt.c
@@ -259,7 +259,24 @@ static int ve2_xrs_col_list(struct amdxdna_hwctx *hwctx, u32 total_col)
 				 user_col, num_col, total_col);
 			return -ERANGE;
 		}
-		first_col = user_col;
+
+		/*
+		 * A pinned start column is a hard requirement, not merely a
+		 * preferred starting point: the resource solver must place
+		 * (or share) the partition at exactly this column, or fail.
+		 * Offer only this single candidate so it can never end up
+		 * silently placed/shared elsewhere.
+		 */
+		hwctx->col_list = kmalloc(sizeof(*hwctx->col_list), GFP_KERNEL);
+		if (!hwctx->col_list)
+			return -ENOMEM;
+
+		hwctx->col_list_len = 1;
+		hwctx->col_list[0] = user_col;
+
+		print_hex_dump_debug("col_list: ", DUMP_PREFIX_OFFSET, 16, 4, hwctx->col_list,
+				     sizeof(*hwctx->col_list), false);
+		return 0;
 	} else if (start_col > 0) {
 		/*
 		 * Test-only override: force the lead column to @start_col (and
@@ -1267,6 +1284,34 @@ static void ve2_fifo_remove_ctx(struct amdxdna_mgmtctx *mgmtctx, struct amdxdna_
 	}
 }
 
+/*
+ * Zero out the CERT handshake memory for every column of a partition that is
+ * about to be torn down (last sharer releasing it). Mirrors the legacy
+ * driver's cert_clear_partition(): without this, stale handshake state
+ * (ctx_switch_req, hsa addr, debug/trace buffer pointers, etc. from the
+ * previous occupant) can persist in AIE memory across a partition
+ * teardown/re-request cycle on the same columns.
+ */
+static void ve2_clear_partition_handshake(struct amdxdna_mgmtctx *mgmtctx,
+					  struct amdxdna_hwctx *hwctx)
+{
+	struct amdxdna_dev *xdna = mgmtctx->xdna;
+	struct aie_op_handshake_data *hs_data;
+	int ret;
+
+	hs_data = ve2_prepare_hs_data(mgmtctx, hwctx, false);
+	if (!hs_data) {
+		XDNA_ERR(xdna, "No memory for hs_data while clearing partition handshake");
+		return;
+	}
+
+	ret = aie_partition_handshake_update(mgmtctx->aie_dev, hs_data, mgmtctx->num_col);
+	if (ret < 0)
+		XDNA_ERR(xdna, "aie partition handshake update failed, ret: %d", ret);
+
+	ve2_free_hs_data(hs_data, mgmtctx->num_col);
+}
+
 int ve2_mgmt_destroy_partition(struct amdxdna_hwctx *hwctx)
 {
 	struct amdxdna_ctx_priv *vp = hwctx ? ve2_hw_priv(hwctx) : NULL;
@@ -1311,6 +1356,8 @@ int ve2_mgmt_destroy_partition(struct amdxdna_hwctx *hwctx)
 
 	if (release_aie_part) {
 		struct workqueue_struct *wq;
+
+		ve2_clear_partition_handshake(mgmtctx, hwctx);
 
 		aie_unregister_error_notification(mgmtctx->aie_dev);
 


### PR DESCRIPTION
-Honor user_start_col exactly when reusing a shared AIE partition instead of silently redirecting to a different column.
-Clear CERT handshake state before releasing a partition so stale data can't leak into its next occupant.