### PR TITLE
vxdna: add version API for QEMU to query vxdna version

### DIFF
--- a/src/vxdna/include/vaccel.h
+++ b/src/vxdna/include/vaccel.h
@@ -20,6 +20,33 @@
 extern "C" {
 #endif
 
+/*
+ * vxdna host backend version, queried by QEMU via vaccel_get_version().
+ *
+ * In every release, we bump up the major number if the interface (the
+ * guest<->host ccmd protocol or the vaccel API/ABI) is not compatible with
+ * the previous version, else the minor number is bumped up.
+ *
+ * version history
+ * v1.0
+ *   start to track version
+ */
+
+#define VXDNA_MAJOR_VERSION 1
+#define VXDNA_MINOR_VERSION 0
+
+/**
+ * @brief vxdna version information
+ *
+ * Passed by the caller to vaccel_get_version(). The struct may gain new
+ * fields at the end in future versions; callers pass sizeof(this struct)
+ * so the backend can tell which fields the caller understands.
+ */
+struct vaccel_version {
+    uint32_t major; /**< Major version */
+    uint32_t minor; /**< Minor version */
+};
+
 struct iovec; // from Linux, iovec is defined in <linux/fs.h>
 
 struct vaccel_create_resource_blob_args
@@ -135,6 +162,23 @@ int vaccel_create(void *cookie, uint32_t capset_id, const struct vaccel_callback
  * @param cookie Device cookie
  */
 void vaccel_destroy(void *cookie);
+
+/**
+ * @brief Get the vxdna host backend version
+ *
+ * Fills the caller-provided vaccel_version struct with the major and minor
+ * version of the vxdna host backend. This allows QEMU to enquire the vxdna
+ * version at runtime for compatibility checks. Does not require a device to
+ * have been created.
+ *
+ * The caller passes the size of its vaccel_version struct. Today the size
+ * must match sizeof(struct vaccel_version) exactly.
+ *
+ * @param[out] version Version struct to fill
+ * @param size Size of the version struct, in bytes
+ * @return 0 on success, negative errno on failure
+ */
+int vaccel_get_version(struct vaccel_version *version, uint32_t size);
 
 /**
  * @brief Get virtio vaccel capset information

--- a/src/vxdna/src/vaccel_manager.cpp
+++ b/src/vxdna/src/vaccel_manager.cpp
@@ -473,6 +473,22 @@ int vaccel_submit_ccmd(void *cookie, uint32_t ctx_id, const void *ccmd, uint32_t
 }
 
 int
+vaccel_get_version(struct vaccel_version *version, uint32_t size)
+{
+    if (!version)
+        return -EINVAL;
+
+    if (size != sizeof(struct vaccel_version))
+        return -EINVAL;
+
+    version->major = VXDNA_MAJOR_VERSION;
+    version->minor = VXDNA_MINOR_VERSION;
+
+    vxdna_info("vxdna version %u.%u", VXDNA_MAJOR_VERSION, VXDNA_MINOR_VERSION);
+    return 0;
+}
+
+int
 vaccel_get_capset_info(void *cookie,
                        uint32_t *max_version, uint32_t *max_size)
 {

--- a/src/vxdna/tests/test_vaccel.cpp
+++ b/src/vxdna/tests/test_vaccel.cpp
@@ -8,6 +8,7 @@
  * Tests all public APIs exposed in vaccel.h including:
  * - vaccel_create()
  * - vaccel_destroy()
+ * - vaccel_get_version()
  * - vaccel_get_capset_info()
  * - vaccel_fill_capset()
  */
@@ -279,6 +280,38 @@ TEST_F(VaccelRendererTest, GetCapsetInfoPartialOutputs) {
     ret = vaccel_get_capset_info(cookie_, nullptr, &max_size);
     EXPECT_EQ(ret, 0);
     EXPECT_GT(max_size, 0);
+}
+
+// =============================================================================
+// vaccel_get_version() Tests
+// =============================================================================
+
+TEST(VaccelVersionTest, GetVersionSuccess) {
+    struct vaccel_version version = {};
+
+    int ret = vaccel_get_version(&version, sizeof(version));
+    EXPECT_EQ(ret, 0) << "vaccel_get_version() should succeed with matching size";
+    EXPECT_EQ(version.major, VXDNA_MAJOR_VERSION);
+    EXPECT_EQ(version.minor, VXDNA_MINOR_VERSION);
+}
+
+TEST(VaccelVersionTest, GetVersionNullVersion) {
+    int ret = vaccel_get_version(nullptr, sizeof(struct vaccel_version));
+    EXPECT_EQ(ret, -EINVAL) << "vaccel_get_version() should fail with NULL version";
+}
+
+TEST(VaccelVersionTest, GetVersionSizeTooSmall) {
+    struct vaccel_version version = {};
+
+    int ret = vaccel_get_version(&version, sizeof(version) - 1);
+    EXPECT_EQ(ret, -EINVAL) << "vaccel_get_version() should fail with too-small size";
+}
+
+TEST(VaccelVersionTest, GetVersionSizeTooLarge) {
+    struct vaccel_version version = {};
+
+    int ret = vaccel_get_version(&version, sizeof(version) + 1);
+    EXPECT_EQ(ret, -EINVAL) << "vaccel_get_version() should fail with mismatched size";
 }
 
 // =============================================================================


### PR DESCRIPTION
Add VXDNA_MAJOR_VERSION/VXDNA_MINOR_VERSION and a size-versioned vaccel_get_version() so QEMU can enquire the vxdna host backend version at runtime for compatibility checks.