### PR TITLE
Cherry-pick : AIESW-41368 : Fix full ELF rejecting runs with more than 64 args

### DIFF
--- a/src/shim_ve2/xdna_bo.cpp
+++ b/src/shim_ve2/xdna_bo.cpp
@@ -410,37 +410,31 @@ bind_at(size_t pos, const xrt_core::buffer_handle* bh, size_t offset, size_t siz
 
   if (boh->get_type() != AMDXDNA_BO_CMD) {
     auto h = boh->get_drm_bo_handle();
-    m_args_map[pos] = h;
+    m_args_map[pos] = { h };
     shim_debug("Added arg BO %d to cmd BO %d", h, get_drm_bo_handle());
   } else {
-    const size_t max_args_order = 6;
-    const size_t max_args = 1 << max_args_order;
-    size_t key = pos << max_args_order;
-    uint32_t hs[max_args];
-    auto arg_cnt = boh->get_arg_bo_handles(hs, max_args);
+    // For a nested CMD BO, collect all its arg handles and store them under pos.
+    std::vector<uint32_t> hs;
+    for (const auto& [k, v] : boh->m_args_map)
+      hs.insert(hs.end(), v.begin(), v.end());
     std::string bohs;
-    for (int i = 0; i < arg_cnt; i++) {
-	m_args_map[key + i] = hs[i];
-	bohs += std::to_string(hs[i]) + " ";
-    }
+    for (auto h : hs)
+      bohs += std::to_string(h) + " ";
+    m_args_map[pos] = std::move(hs);
     shim_debug("Added arg BO %s to cmd BO %d", bohs.c_str(), get_drm_bo_handle());
   }
 }
 
-uint32_t
+std::vector<uint32_t>
 xdna_bo::
-get_arg_bo_handles(uint32_t *handles, size_t num) const
+get_arg_bo_handles() const
 {
   std::lock_guard<std::mutex> lg(m_args_map_lock);
 
-  auto sz = m_args_map.size();
-  if (sz > num)
-    shim_err(E2BIG, "There are %ld BO args, provided buffer can hold only %ld", sz, num);
-
-  for (auto m : m_args_map)
-    *(handles++) = m.second;
-
-  return sz;
+  std::vector<uint32_t> handles;
+  for (const auto& [k, v] : m_args_map)
+    handles.insert(handles.end(), v.begin(), v.end());
+  return handles;
 }
 
 uint32_t

--- a/src/shim_ve2/xdna_bo.cpp
+++ b/src/shim_ve2/xdna_bo.cpp
@@ -413,15 +413,15 @@ bind_at(size_t pos, const xrt_core::buffer_handle* bh, size_t offset, size_t siz
     m_args_map[pos] = { h };
     shim_debug("Added arg BO %d to cmd BO %d", h, get_drm_bo_handle());
   } else {
-    // For a nested CMD BO, collect all its arg handles and store them under pos.
-    std::vector<uint32_t> hs;
-    for (const auto& [k, v] : boh->m_args_map)
-      hs.insert(hs.end(), v.begin(), v.end());
+    // For a nested CMD BO, use get_arg_bo_handles() to get a thread-safe snapshot.
+    auto hs = boh->get_arg_bo_handles();
+#ifdef XDNA_SHIM_DEBUG
     std::string bohs;
     for (auto h : hs)
       bohs += std::to_string(h) + " ";
-    m_args_map[pos] = std::move(hs);
     shim_debug("Added arg BO %s to cmd BO %d", bohs.c_str(), get_drm_bo_handle());
+#endif
+    m_args_map[pos] = std::move(hs);
   }
 }
 

--- a/src/shim_ve2/xdna_bo.h
+++ b/src/shim_ve2/xdna_bo.h
@@ -7,6 +7,7 @@
 #include <atomic>
 #include <string>
 #include <unistd.h>
+#include <vector>
 
 #include "drm_local/amdxdna_accel.h"
 #include "core/common/shim/buffer_handle.h"
@@ -162,10 +163,10 @@ public:
   xrt_core::hwctx_handle::slot_id m_owner_ctx_id = AMDXDNA_INVALID_CTX_HANDLE;
 
   // Only for AMDXDNA_BO_CMD type
-  uint32_t
-  get_arg_bo_handles(uint32_t *handles, size_t num) const;
+  std::vector<uint32_t>
+  get_arg_bo_handles() const;
 
-  std::map<size_t, uint32_t> m_args_map;
+  std::map<size_t, std::vector<uint32_t>> m_args_map;
   mutable std::mutex m_args_map_lock;
 
 };

--- a/src/shim_ve2/xdna_hwq.cpp
+++ b/src/shim_ve2/xdna_hwq.cpp
@@ -49,9 +49,6 @@ void
 xdna_hwq::
 submit_command(xrt_core::buffer_handle *cmd_bo)
 {
-  const size_t max_arg_bos = 1024;
-  uint32_t arg_bo_hdls[max_arg_bos];
-
   if (!cmd_bo)
     shim_err(EINVAL, "submit_command: cmd_bo is NULL");
 
@@ -62,7 +59,8 @@ submit_command(xrt_core::buffer_handle *cmd_bo)
     shim_err(EINVAL, "submit_command: No hwctx bound to HW queue");
 
   auto hwctx_id = m_hwctx->get_slotidx();
-  auto arg_count = static_cast<uint32_t>(boh->get_arg_bo_handles(arg_bo_hdls, max_arg_bos));
+  auto arg_bo_hdls = boh->get_arg_bo_handles();
+  auto arg_count = static_cast<uint32_t>(arg_bo_hdls.size());
 
   shim_debug("Submitting command: hwctx=%u, cmd_bo_hdl=%u, arg_count=%u",
              hwctx_id, cmd_bo_hdl, arg_count);
@@ -70,7 +68,7 @@ submit_command(xrt_core::buffer_handle *cmd_bo)
   amdxdna_drm_exec_cmd ecmd = {
     .hwctx = hwctx_id,
     .cmd_handles = cmd_bo_hdl,
-    .args = reinterpret_cast<uintptr_t>(arg_bo_hdls),
+    .args = reinterpret_cast<uintptr_t>(arg_bo_hdls.data()),
     .cmd_count = 1,
     .arg_count = arg_count,
   };


### PR DESCRIPTION
cherry picked from commit 122cb64dd57ab8ed2a619d9aab01d15f5af0e6a7

- Full-ELF runs in VE2 flow were limited to 64 argument BOs per nested CMD BO. The limit originated from a flat-map encoding scheme in xdna_bo::bind_at(), nested CMD BO args were flattened into the parent's m_args_map using a positional key encoding of key = pos << max_args_order (with max_args_order = 6, giving 64 sub-slots per position)
- This PR fixes the max arg limit of 64 by removing hardcoded BO argument limits in bind_at and submit_command
- It does it by replacing the flat map<size_t, uint32_t> with map<size_t, vector<uint32_t>> so each argument position owns a list of handles directly, eliminating the need for any key encoding trick.
