### PR TITLE
Fix dma-buf fd leak in VE2 shim shared_handle destructor

### DIFF
--- a/src/shim_ve2/xdna_bo.cpp
+++ b/src/shim_ve2/xdna_bo.cpp
@@ -131,7 +131,6 @@ xdna_bo(const device_xdna& device, xrt_core::hwctx_handle::slot_id ctx_id,
   , m_aligned_size(size)
   , m_flags(flags)
   , m_type(type)
-  , m_import(-1)
   , m_owner_ctx_id(ctx_id)
   , m_map_offset(0)
 {
@@ -161,7 +160,6 @@ xdna_bo(const device_xdna& device, xrt_core::hwctx_handle::slot_id ctx_id,
   , m_edev(device.get_edev())
   , m_aligned_size(size)
   , m_type(AMDXDNA_BO_SHARE)
-  , m_import(-1)
   , m_owner_ctx_id(ctx_id)
   , m_map_offset(0)
   , m_uptr(uptr)
@@ -184,11 +182,10 @@ xdna_bo(const device_xdna& device, xrt_core::hwctx_handle::slot_id ctx_id,
 xdna_bo::
 xdna_bo(const device_xdna& device, xrt_core::shared_handle::export_handle ehdl)
   : m_edev(device.get_edev())
-  , m_import(ehdl)
 {
-  uint32_t boh = shim_xdna_edge::xdna_bo::import_drm_bo(m_import, &m_type, &m_aligned_size);
+  uint32_t boh = import_drm_bo(ehdl, &m_type, &m_aligned_size);
   m_edev->bo_handle_ref_inc(boh);
-  shim_xdna_edge::xdna_bo::get_drm_bo_info(boh);
+  get_drm_bo_info(boh);
 }
 
 xdna_bo::
@@ -584,9 +581,8 @@ export_drm_bo(uint32_t boh) const
 
 uint32_t
 xdna_bo::
-import_drm_bo(const shim_xdna_edge::shared& share,uint32_t *type, size_t *size) const
+import_drm_bo(xrt_core::shared_handle::export_handle fd, uint32_t *type, size_t *size) const
 {
-  xrt_core::shared_handle::export_handle fd = share.get_export_handle();
   drm_prime_handle imp_bo = {AMDXDNA_INVALID_BO_HANDLE, 0, fd};
   m_edev->ioctl(DRM_IOCTL_PRIME_FD_TO_HANDLE, &imp_bo);
   *type = AMDXDNA_BO_SHARE;

--- a/src/shim_ve2/xdna_bo.h
+++ b/src/shim_ve2/xdna_bo.h
@@ -28,6 +28,10 @@ public:
 
   ~shared() override
   {
+    if (m_fd != -1) {
+      shim_debug("Closing exported fd %d", m_fd);
+      close(m_fd);
+    }
   }
 
   export_handle
@@ -64,7 +68,7 @@ public:
   export_drm_bo(uint32_t boh) const;
   
   uint32_t
-  import_drm_bo(const shim_xdna_edge::shared&, uint32_t*, size_t*) const;
+  import_drm_bo(xrt_core::shared_handle::export_handle fd, uint32_t*, size_t*) const;
 public:
   xdna_bo(const device_xdna& device, xrt_core::hwctx_handle::slot_id ctx_id,
      size_t size, uint64_t flags, uint32_t type, uint32_t mem_bitmap=0);
@@ -90,10 +94,6 @@ public:
   // Sync the BO
   void
   sync_bo(direction dir, size_t size, size_t offset);
-
-  // Import DRM BO from m_import shared object
-  void
-  import_bo();
 
   void
   bind_at(size_t pos, const xrt_core::buffer_handle* bh, size_t offset, size_t size) override;
@@ -151,8 +151,6 @@ public:
   uint64_t m_xdna_addr = AMDXDNA_INVALID_ADDR;
   uint64_t m_vaddr = AMDXDNA_INVALID_ADDR;
   void *m_uptr = nullptr;
-
-  const shared m_import;
 
   // Command ID in the queue after command submission.
   // Only valid for cmd BO.

--- a/src/shim_ve2/xdna_device.cpp
+++ b/src/shim_ve2/xdna_device.cpp
@@ -1354,6 +1354,7 @@ import_bo(pid_t pid, xrt_core::shared_handle::export_handle ehdl)
   auto bofd = syscall(SYS_pidfd_getfd, pidfd, ehdl, 0);
   if (bofd < 0) {
     int saved_errno = errno;
+    close(pidfd);
     throw xrt_core::system_error
       (saved_errno, std::string("pidfd_getfd failed (err=") + std::to_string(saved_errno) + ": " +
        errno_to_str(saved_errno) + "). Check that ptrace access mode "
@@ -1361,7 +1362,12 @@ import_bo(pid_t pid, xrt_core::shared_handle::export_handle ehdl)
        "check /etc/sysctl.d/10-ptrace.conf");
   }
 
-  return std::make_unique<xdna_bo>(*this, bofd);
+  // bofd is a duplicated fd owned by this import path; xdna_bo uses it only
+  // for PRIME_FD_TO_HANDLE in the constructor (same as zocl xclImportBO).
+  auto bo = std::make_unique<xdna_bo>(*this, bofd);
+  close(bofd);
+  close(pidfd);
+  return bo;
 #else
   throw xrt_core::system_error
     (std::errc::not_supported,


### PR DESCRIPTION
Close the exported dma-buf fd when the shared_handle is destroyed in shim_ve2/xdna_bo.h, matching the existing behavior in shim/shared.h.

Each xrt::bo::export_buffer() call on device 0 (XDNA) leaked a file descriptor until RLIMIT_NOFILE was exhausted (~980 frames). The fd lifetime is owned by the exporting BO per XRT API contract.

Fixes: AIESW-41721