### PR TITLE
Fix dma-buf fd leak in VE2 shim shared_handle destructor

### DIFF
--- a/src/shim_ve2/xdna_bo.h
+++ b/src/shim_ve2/xdna_bo.h
@@ -27,6 +27,10 @@ public:
 
   ~shared() override
   {
+    if (m_fd != -1) {
+      shim_debug("Closing exported fd %d", m_fd);
+      close(m_fd);
+    }
   }
 
   export_handle


### PR DESCRIPTION
Close the exported dma-buf fd when the shared_handle is destroyed in shim_ve2/xdna_bo.h, matching the existing behavior in shim/shared.h.

Each xrt::bo::export_buffer() call on device 0 (XDNA) leaked a file descriptor until RLIMIT_NOFILE was exhausted (~980 frames). The fd lifetime is owned by the exporting BO per XRT API contract.

Fixes: AIESW-41721