### PR TITLE
Do not close caller-owned fd on imported BO destruction

### DIFF
--- a/src/shim_ve2/xdna_bo.cpp
+++ b/src/shim_ve2/xdna_bo.cpp
@@ -131,7 +131,6 @@ xdna_bo(const device_xdna& device, xrt_core::hwctx_handle::slot_id ctx_id,
   , m_aligned_size(size)
   , m_flags(flags)
   , m_type(type)
-  , m_import(-1)
   , m_owner_ctx_id(ctx_id)
   , m_map_offset(0)
 {
@@ -161,7 +160,6 @@ xdna_bo(const device_xdna& device, xrt_core::hwctx_handle::slot_id ctx_id,
   , m_edev(device.get_edev())
   , m_aligned_size(size)
   , m_type(AMDXDNA_BO_SHARE)
-  , m_import(-1)
   , m_owner_ctx_id(ctx_id)
   , m_map_offset(0)
   , m_uptr(uptr)
@@ -184,11 +182,10 @@ xdna_bo(const device_xdna& device, xrt_core::hwctx_handle::slot_id ctx_id,
 xdna_bo::
 xdna_bo(const device_xdna& device, xrt_core::shared_handle::export_handle ehdl)
   : m_edev(device.get_edev())
-  , m_import(ehdl)
 {
-  uint32_t boh = shim_xdna_edge::xdna_bo::import_drm_bo(m_import, &m_type, &m_aligned_size);
+  uint32_t boh = import_drm_bo(ehdl, &m_type, &m_aligned_size);
   m_edev->bo_handle_ref_inc(boh);
-  shim_xdna_edge::xdna_bo::get_drm_bo_info(boh);
+  get_drm_bo_info(boh);
 }
 
 xdna_bo::
@@ -584,9 +581,8 @@ export_drm_bo(uint32_t boh) const
 
 uint32_t
 xdna_bo::
-import_drm_bo(const shim_xdna_edge::shared& share,uint32_t *type, size_t *size) const
+import_drm_bo(xrt_core::shared_handle::export_handle fd, uint32_t *type, size_t *size) const
 {
-  xrt_core::shared_handle::export_handle fd = share.get_export_handle();
   drm_prime_handle imp_bo = {AMDXDNA_INVALID_BO_HANDLE, 0, fd};
   m_edev->ioctl(DRM_IOCTL_PRIME_FD_TO_HANDLE, &imp_bo);
   *type = AMDXDNA_BO_SHARE;

--- a/src/shim_ve2/xdna_bo.h
+++ b/src/shim_ve2/xdna_bo.h
@@ -68,7 +68,7 @@ public:
   export_drm_bo(uint32_t boh) const;
   
   uint32_t
-  import_drm_bo(const shim_xdna_edge::shared&, uint32_t*, size_t*) const;
+  import_drm_bo(xrt_core::shared_handle::export_handle fd, uint32_t*, size_t*) const;
 public:
   xdna_bo(const device_xdna& device, xrt_core::hwctx_handle::slot_id ctx_id,
      size_t size, uint64_t flags, uint32_t type, uint32_t mem_bitmap=0);
@@ -94,10 +94,6 @@ public:
   // Sync the BO
   void
   sync_bo(direction dir, size_t size, size_t offset);
-
-  // Import DRM BO from m_import shared object
-  void
-  import_bo();
 
   void
   bind_at(size_t pos, const xrt_core::buffer_handle* bh, size_t offset, size_t size) override;
@@ -155,8 +151,6 @@ public:
   uint64_t m_xdna_addr = AMDXDNA_INVALID_ADDR;
   uint64_t m_vaddr = AMDXDNA_INVALID_ADDR;
   void *m_uptr = nullptr;
-
-  const shared m_import;
 
   // Command ID in the queue after command submission.
   // Only valid for cmd BO.

--- a/src/shim_ve2/xdna_device.cpp
+++ b/src/shim_ve2/xdna_device.cpp
@@ -1372,6 +1372,7 @@ import_bo(pid_t pid, xrt_core::shared_handle::export_handle ehdl)
   auto bofd = syscall(SYS_pidfd_getfd, pidfd, ehdl, 0);
   if (bofd < 0) {
     int saved_errno = errno;
+    close(pidfd);
     throw xrt_core::system_error
       (saved_errno, std::string("pidfd_getfd failed (err=") + std::to_string(saved_errno) + ": " +
        errno_to_str(saved_errno) + "). Check that ptrace access mode "
@@ -1379,7 +1380,12 @@ import_bo(pid_t pid, xrt_core::shared_handle::export_handle ehdl)
        "check /etc/sysctl.d/10-ptrace.conf");
   }
 
-  return std::make_unique<xdna_bo>(*this, bofd);
+  // bofd is a duplicated fd owned by this import path; xdna_bo uses it only
+  // for PRIME_FD_TO_HANDLE in the constructor.
+  auto bo = std::make_unique<xdna_bo>(*this, bofd);
+  close(bofd);
+  close(pidfd);
+  return bo;
 #else
   throw xrt_core::system_error
     (std::errc::not_supported,


### PR DESCRIPTION
The merged AIESW-41721 fix closes dma-buf fds in shared::~shared(), but the same class wraps m_import on imported xdna_bo objects. Closing that fd when an imported BO is destroyed breaks multi-import loops that reuse the same export fd (PRIME_FD_TO_HANDLE err=9).

Add an own_fd flag to shared: export-side handles (share()) keep own_fd=true and close on destroy; import-side m_import uses own_fd=false and leaves the fd lifetime to the exporter/app.

Fixes: AIESW-41721 (follow-up)