### PR TITLE
shim_test: consolidate ve2 duplicate test cases using new filters

### DIFF
--- a/test/shim_test/shim_test.cpp
+++ b/test/shim_test/shim_test.cpp
@@ -318,9 +318,21 @@ dev_filter_npu_ve2(device::id_type id, device* dev)
 
 // xdna tests that must not run on VE2 edge (unsupported BO types / fencing).
 bool
-dev_filter_xdna_not_npu_ve2(device::id_type id, device* dev)
+dev_filter_xdna_not_ve2(device::id_type id, device* dev)
 {
   return dev_filter_xdna(id, dev) && !dev_filter_npu_ve2(id, dev);
+}
+
+bool
+dev_filter_is_aie_or_ve2(device::id_type id, device* dev)
+{
+  return dev_filter_is_aie(id, dev) || dev_filter_npu_ve2(id, dev);
+}
+
+bool
+dev_filter_is_aie4_or_ve2(device::id_type id, device* dev)
+{
+  return dev_filter_is_aie4(id, dev) || dev_filter_npu_ve2(id, dev);
 }
 
 static void TEST_async_error_io_any(device::id_type id, std::shared_ptr<device>& sdev, arg_type& arg)
@@ -1544,13 +1556,13 @@ std::vector<test_case> test_list {
   // get async error in multi thread before running any other tests
   // there may or may not be async error.
   test_case{ "get async error in multithread - INITIAL", {},
-    TEST_POSITIVE, dev_filter_is_aie, TEST_async_error_multi, {false}
+    TEST_POSITIVE, dev_filter_is_aie_or_ve2, TEST_async_error_multi, {false}
   },
   //test_case{ "non_xdna_userpf: query(rom_vbnv)", {},
   //  TEST_POSITIVE, dev_filter_not_xdna, TEST_query_userpf<query::rom_vbnv>, {}
   //},
   test_case{ "create_destroy_hw_context", {},
-    TEST_POSITIVE, dev_filter_is_aie, TEST_create_destroy_hw_context, {}
+    TEST_POSITIVE, dev_filter_is_aie_or_ve2, TEST_create_destroy_hw_context, {}
   },
   test_case{ "create_invalid_bo", {},
     TEST_NEGATIVE, dev_filter_xdna, TEST_create_free_bo, {XCL_BO_FLAGS_P2P, 0, 128}
@@ -1573,7 +1585,7 @@ std::vector<test_case> test_list {
     {XCL_BO_FLAGS_HOST_ONLY, 0, 0x10000, 0x23000, 0x2000}
   },
   test_case{ "create_and_free_input_output_bo huge pages", {},
-    TEST_POSITIVE, dev_filter_is_aie, TEST_create_free_bo,
+    TEST_POSITIVE, dev_filter_is_aie_or_ve2, TEST_create_free_bo,
     {XCL_BO_FLAGS_HOST_ONLY, 0, 0x140000000}
   },
   test_case{ "sync_bo for dpu sequence bo", {},
@@ -1589,7 +1601,7 @@ std::vector<test_case> test_list {
     TEST_POSITIVE, dev_filter_xdna, TEST_map_bo, {XCL_BO_FLAGS_HOST_ONLY, 0, 361264}
   },
   test_case{ "map bo for read only", {},
-    TEST_NEGATIVE, dev_filter_xdna_not_npu_ve2, TEST_map_read_bo, {0x1000}
+    TEST_NEGATIVE, dev_filter_xdna_not_ve2, TEST_map_read_bo, {0x1000}
   },
   test_case{ "map exec_buf_bo and test perf", {},
     TEST_POSITIVE, dev_filter_xdna, TEST_create_free_bo, {XCL_BO_FLAGS_EXECBUF, 0, 0x1000}
@@ -1620,28 +1632,28 @@ std::vector<test_case> test_list {
     TEST_POSITIVE, dev_filter_is_aie4_or_npu4, TEST_instr_invalid_addr_io, {}
   },
   test_case{ "measure no-op kernel latency", {},
-    TEST_POSITIVE, dev_filter_is_aie, TEST_io_latency, { IO_TEST_NOOP_RUN, IO_TEST_IOCTL_WAIT, NUM_STRESS_IO }
+    TEST_POSITIVE, dev_filter_is_aie_or_ve2, TEST_io_latency, { IO_TEST_NOOP_RUN, IO_TEST_IOCTL_WAIT, NUM_STRESS_IO }
   },
   test_case{ "measure real kernel latency", {},
-    TEST_POSITIVE, dev_filter_is_aie, TEST_io_latency, { IO_TEST_NORMAL_RUN, IO_TEST_IOCTL_WAIT, NUM_STRESS_IO }
+    TEST_POSITIVE, dev_filter_is_aie_or_ve2, TEST_io_latency, { IO_TEST_NORMAL_RUN, IO_TEST_IOCTL_WAIT, NUM_STRESS_IO }
   },
   test_case{ "create and free debug bo", {},
-    TEST_POSITIVE, dev_filter_xdna_not_npu_ve2, TEST_create_free_debug_bo, { 0x1000 }
+    TEST_POSITIVE, dev_filter_xdna_not_ve2, TEST_create_free_debug_bo, { 0x1000 }
   },
   test_case{ "create and free large debug bo", {},
-    TEST_POSITIVE, dev_filter_xdna_not_npu_ve2, TEST_create_free_debug_bo, { 0x100000 }
+    TEST_POSITIVE, dev_filter_xdna_not_ve2, TEST_create_free_debug_bo, { 0x100000 }
   },
   test_case{ "create and free uc_log bo", {},
-    TEST_POSITIVE, dev_filter_is_aie4, TEST_create_free_uc_log_bo, { 0x10000 }
+    TEST_POSITIVE, dev_filter_is_aie4_or_ve2, TEST_create_free_uc_log_bo, { 0x10000 }
   },
   test_case{ "create and free large uc_log bo", {},
-    TEST_POSITIVE, dev_filter_is_aie4, TEST_create_free_uc_log_bo, { 0x100000 }
+    TEST_POSITIVE, dev_filter_is_aie4_or_ve2, TEST_create_free_uc_log_bo, { 0x100000 }
   },
   test_case{ "multi-command io test real kernel good run", {},
     TEST_POSITIVE, dev_filter_xdna, TEST_io, { IO_TEST_NORMAL_RUN, 3 }
   },
   test_case{ "measure no-op kernel throughput command", {},
-    TEST_POSITIVE, dev_filter_is_aie, TEST_io_throughput, { IO_TEST_NOOP_RUN, IO_TEST_IOCTL_WAIT, NUM_STRESS_IO }
+    TEST_POSITIVE, dev_filter_is_aie_or_ve2, TEST_io_throughput, { IO_TEST_NOOP_RUN, IO_TEST_IOCTL_WAIT, NUM_STRESS_IO }
   },
   test_case{ "export import BO", {},
     TEST_POSITIVE, dev_filter_xdna, TEST_export_import_bo, {}
@@ -1650,13 +1662,13 @@ std::vector<test_case> test_list {
     TEST_POSITIVE, dev_filter_is_aie2, TEST_elf_io, { IO_TEST_NORMAL_RUN, 1 }
   },
   test_case{ "Cmd fencing (user space side)", {},
-    TEST_POSITIVE, dev_filter_xdna_not_npu_ve2, TEST_cmd_fence_host, {}
+    TEST_POSITIVE, dev_filter_xdna_not_ve2, TEST_cmd_fence_host, {}
   },
   test_case{ "io test no op with duplicated BOs", {},
     TEST_POSITIVE, dev_filter_xdna, TEST_noop_io_with_dup_bo, {}
   },
   test_case{ "measure no-op kernel latency chained command", {},
-    TEST_POSITIVE, dev_filter_is_aie, TEST_io_runlist_latency, { IO_TEST_NOOP_RUN, IO_TEST_IOCTL_WAIT, NUM_STRESS_IO }
+    TEST_POSITIVE, dev_filter_is_aie_or_ve2, TEST_io_runlist_latency, { IO_TEST_NOOP_RUN, IO_TEST_IOCTL_WAIT, NUM_STRESS_IO }
   },
   test_case{ "measure no-op kernel throughput chained command", {},
     TEST_POSITIVE, dev_filter_is_aie, TEST_io_runlist_throughput, { IO_TEST_NOOP_RUN, IO_TEST_IOCTL_WAIT, NUM_STRESS_IO }
@@ -1674,7 +1686,7 @@ std::vector<test_case> test_list {
     TEST_POSITIVE, dev_filter_is_aie, TEST_io_runlist_throughput, { IO_TEST_NOOP_RUN, IO_TEST_POLL_WAIT, NUM_STRESS_IO }
   },
   test_case{ "Cmd fencing (driver side)", {},
-    TEST_POSITIVE, dev_filter_xdna_not_npu_ve2, TEST_cmd_fence_device, {}
+    TEST_POSITIVE, dev_filter_xdna_not_ve2, TEST_cmd_fence_device, {}
   },
   test_case{ "sync_bo for input_output 1MiB BO", {},
     TEST_POSITIVE, dev_filter_xdna, TEST_sync_bo, {XCL_BO_FLAGS_HOST_ONLY, 0, 0x100000}
@@ -1689,19 +1701,19 @@ std::vector<test_case> test_list {
     TEST_POSITIVE, dev_filter_is_aie2, TEST_elf_io, { IO_TEST_NORMAL_RUN, 3 }
   },
   test_case{ "max context test", {},
-    TEST_POSITIVE, dev_filter_is_aie, TEST_create_destroy_max_context, { 0 }
+    TEST_POSITIVE, dev_filter_is_aie_or_ve2, TEST_create_destroy_max_context, { 0 }
   },
   test_case{ "max context bad test", {},
-    TEST_NEGATIVE, dev_filter_is_aie, TEST_create_destroy_max_context, { 1 }
+    TEST_NEGATIVE, dev_filter_is_aie_or_ve2, TEST_create_destroy_max_context, { 1 }
   },
   test_case{ "Multi context IO test 1", {},
-    TEST_POSITIVE, dev_filter_is_aie, TEST_multi_context_io_test, { 0 }
+    TEST_POSITIVE, dev_filter_is_aie_or_ve2, TEST_multi_context_io_test, { 0 }
   },
   test_case{ "Multi context IO test 2", {},
-    TEST_POSITIVE, dev_filter_is_aie, TEST_multi_context_io_test, { 1 }
+    TEST_POSITIVE, dev_filter_is_aie_or_ve2, TEST_multi_context_io_test, { 1 }
   },
   test_case{ "Multi context IO test 3", {},
-    TEST_POSITIVE, dev_filter_is_aie, TEST_multi_context_io_test, { 2 }
+    TEST_POSITIVE, dev_filter_is_aie_or_ve2, TEST_multi_context_io_test, { 2 }
   },
   test_case{ "Create and destroy devices", {},
     TEST_POSITIVE, dev_filter_xdna, TEST_create_destroy_device, {}
@@ -1719,7 +1731,7 @@ std::vector<test_case> test_list {
     TEST_POSITIVE, dev_filter_is_aie4_or_npu4_and_amdxdna_drv, TEST_preempt_full_elf_io, { IO_TEST_FORCE_PREEMPTION, 8 }
   },
   test_case{ "Real kernel delay run for auto-suspend/resume", {},
-    TEST_POSITIVE, dev_filter_is_aie, TEST_io_suspend_resume, {}
+    TEST_POSITIVE, dev_filter_is_aie_or_ve2, TEST_io_suspend_resume, {}
   },
   test_case{ "io test timeout run for context health report", {},
     TEST_POSITIVE, dev_filter_is_aie4_or_npu4, TEST_io_timeout, {}
@@ -1764,91 +1776,25 @@ std::vector<test_case> test_list {
   // and still passes. Filter on device type only (not the amdxdna driver) so
   // these also run on the QEMU guest where the NPU is a virtio-gpu device.
   test_case{ "dev BO crossing two heap chunks (128MB)", {},
-    TEST_POSITIVE, dev_filter_is_aie, TEST_dev_bo_cross_heap, { 128ul * 1024 * 1024 }
+    TEST_POSITIVE, dev_filter_is_aie_or_ve2, TEST_dev_bo_cross_heap, { 128ul * 1024 * 1024 }
   },
   test_case{ "dev BO spanning the whole heap (512MB)", {},
-    TEST_POSITIVE, dev_filter_is_aie, TEST_dev_bo_cross_heap, { 512ul * 1024 * 1024 }
+    TEST_POSITIVE, dev_filter_is_aie_or_ve2, TEST_dev_bo_cross_heap, { 512ul * 1024 * 1024 }
   },
   test_case{ "dev BO cross-heap alloc/free stress", {},
-    TEST_POSITIVE, dev_filter_is_aie, TEST_dev_bo_cross_heap_stress,
+    TEST_POSITIVE, dev_filter_is_aie_or_ve2, TEST_dev_bo_cross_heap_stress,
     { 128ul * 1024 * 1024, 100 }
   },
   // npu4 caps the dev heap at 512MB, so a larger BO must be rejected.
   test_case{ "dev BO larger than max heap rejected (npu4)", {},
     TEST_NEGATIVE, dev_filter_is_npu4, TEST_dev_bo_over_max, { 576ul * 1024 * 1024 }
   },
-  // aie4 has no 512MB heap cap, so the same over-512MB BO must allocate fine.
+  // aie4 and ve2 have no 512MB heap cap, so the same over-512MB BO must allocate fine.
   test_case{ "dev BO larger than 512MB accepted (aie4)", {},
-    TEST_POSITIVE, dev_filter_is_aie4, TEST_dev_bo_cross_heap, { 576ul * 1024 * 1024 }
+    TEST_POSITIVE, dev_filter_is_aie4_or_ve2, TEST_dev_bo_cross_heap, { 576ul * 1024 * 1024 }
   },
   test_case{ "export BO then close device", {},
     TEST_POSITIVE, dev_filter_xdna, TEST_export_bo_then_close_device, {}
-  },
-  // --- VE2: board-verified tests (dev_filter_npu_ve2 opt-in) ---
-  // Phase 1: hw_context, 3GB huge BO, noop latency/throughput, multi-ctx x3, suspend/resume
-  // Phase 2: async initial, real kernel latency, uc_log x2, runlist latency, max ctx x2, dev heap x4
-  test_case{ "create_destroy_hw_context (npu_ve2)", {},
-    TEST_POSITIVE, dev_filter_npu_ve2, TEST_create_destroy_hw_context, {}
-  },
-  test_case{ "create_and_free_input_output_bo huge pages (npu_ve2)", {},
-    TEST_POSITIVE, dev_filter_npu_ve2, TEST_create_free_bo,
-    {XCL_BO_FLAGS_HOST_ONLY, 0, 0xC0000000}
-  },
-  test_case{ "measure no-op kernel latency (npu_ve2)", {},
-    TEST_POSITIVE, dev_filter_npu_ve2, TEST_io_latency,
-    { IO_TEST_NOOP_RUN, IO_TEST_IOCTL_WAIT, NUM_STRESS_IO }
-  },
-  test_case{ "measure no-op kernel throughput command (npu_ve2)", {},
-    TEST_POSITIVE, dev_filter_npu_ve2, TEST_io_throughput,
-    { IO_TEST_NOOP_RUN, IO_TEST_IOCTL_WAIT, NUM_STRESS_IO }
-  },
-  test_case{ "Multi context IO test 1 (npu_ve2)", {},
-    TEST_POSITIVE, dev_filter_npu_ve2, TEST_multi_context_io_test, { 0 }
-  },
-  test_case{ "Multi context IO test 2 (npu_ve2)", {},
-    TEST_POSITIVE, dev_filter_npu_ve2, TEST_multi_context_io_test, { 1 }
-  },
-  test_case{ "Multi context IO test 3 (npu_ve2)", {},
-    TEST_POSITIVE, dev_filter_npu_ve2, TEST_multi_context_io_test, { 2 }
-  },
-  test_case{ "Real kernel delay run for auto-suspend/resume (npu_ve2)", {},
-    TEST_POSITIVE, dev_filter_npu_ve2, TEST_io_suspend_resume, {}
-  },
-  test_case{ "get async error in multithread - INITIAL (npu_ve2)", {},
-    TEST_POSITIVE, dev_filter_npu_ve2, TEST_async_error_multi, {false}
-  },
-  test_case{ "measure real kernel latency (npu_ve2)", {},
-    TEST_POSITIVE, dev_filter_npu_ve2, TEST_io_latency,
-    { IO_TEST_NORMAL_RUN, IO_TEST_IOCTL_WAIT, NUM_STRESS_IO }
-  },
-  test_case{ "create and free uc_log bo (npu_ve2)", {},
-    TEST_POSITIVE, dev_filter_npu_ve2, TEST_create_free_uc_log_bo, { 0x10000 }
-  },
-  test_case{ "create and free large uc_log bo (npu_ve2)", {},
-    TEST_POSITIVE, dev_filter_npu_ve2, TEST_create_free_uc_log_bo, { 0x100000 }
-  },
-  test_case{ "measure no-op kernel latency chained command (npu_ve2)", {},
-    TEST_POSITIVE, dev_filter_npu_ve2, TEST_io_runlist_latency,
-    { IO_TEST_NOOP_RUN, IO_TEST_IOCTL_WAIT, NUM_STRESS_IO }
-  },
-  test_case{ "max context test (npu_ve2)", {},
-    TEST_POSITIVE, dev_filter_npu_ve2, TEST_create_destroy_max_context, { 0 }
-  },
-  test_case{ "max context bad test (npu_ve2)", {},
-    TEST_NEGATIVE, dev_filter_npu_ve2, TEST_create_destroy_max_context, { 1 }
-  },
-  test_case{ "dev BO crossing two heap chunks 128MB (npu_ve2)", {},
-    TEST_POSITIVE, dev_filter_npu_ve2, TEST_dev_bo_cross_heap, { 128ul * 1024 * 1024 }
-  },
-  test_case{ "dev BO spanning the whole heap 512MB (npu_ve2)", {},
-    TEST_POSITIVE, dev_filter_npu_ve2, TEST_dev_bo_cross_heap, { 512ul * 1024 * 1024 }
-  },
-  test_case{ "dev BO cross-heap alloc/free stress (npu_ve2)", {},
-    TEST_POSITIVE, dev_filter_npu_ve2, TEST_dev_bo_cross_heap_stress,
-    { 128ul * 1024 * 1024, 100 }
-  },
-  test_case{ "dev BO larger than 512MB accepted (npu_ve2)", {},
-    TEST_POSITIVE, dev_filter_npu_ve2, TEST_dev_bo_cross_heap, { 576ul * 1024 * 1024 }
   },
   test_case{ "get AIE coredump and check registers", {},
     TEST_POSITIVE, dev_filter_is_npu4_and_amdxdna_drv, TEST_io_coredump, {}


### PR DESCRIPTION
Instead of maintaining duplicate test_case entries with "(npu_ve2)" suffix, add two new filter functions that include ve2 alongside the existing aie/aie4 devices:

  dev_filter_is_aie_or_ve2  — replaces dev_filter_is_aie + ve2 duplicate
  dev_filter_is_aie4_or_ve2 — replaces dev_filter_is_aie4 + ve2 duplicate

Also rename dev_filter_xdna_not_npu_ve2 to dev_filter_xdna_not_ve2 for consistency with the new naming convention.