### PR TITLE
Report AIE4 per-context preemption telemetry

### DIFF
--- a/drivers/accel/amdxdna/aie.c
+++ b/drivers/accel/amdxdna/aie.c
@@ -292,6 +292,59 @@ out_free:
 	return ret;
 }
 
+/*
+ * The telemetry map is indexed by firmware context id and sized by
+ * aie->hwctx_limit, so the walk has to carry both the map and that bound:
+ * the per-generation struct amdxdna_dev_hdl that holds the limit is not
+ * visible from here.
+ */
+struct amdxdna_hwctx_map_ctx {
+	u32	*map;
+	u32	limit;
+};
+
+static int amdxdna_fill_hwctx_map_cb(struct amdxdna_hwctx *hwctx, void *arg)
+{
+	struct amdxdna_dev *xdna = hwctx->client->xdna;
+	struct amdxdna_hwctx_map_ctx *ctx = arg;
+
+	if (hwctx->fw_ctx_id >= ctx->limit) {
+		XDNA_ERR(xdna, "Invalid fw ctx id %d/%d", hwctx->fw_ctx_id,
+			 ctx->limit);
+		return -EINVAL;
+	}
+
+	/* Map firmware allocated context id (key) to driver context id (value). */
+	ctx->map[hwctx->fw_ctx_id] = hwctx->id;
+	return 0;
+}
+
+/*
+ * Fill the firmware-context-id to driver-context-id translation for every
+ * context the caller may see. amdxdna_get_telemetry() places the result at
+ * the head of the telemetry buffer, so a consumer can resolve the firmware
+ * context id (the key the firmware indexes its per-context telemetry by) to
+ * the driver context id.
+ */
+static int amdxdna_fill_hwctx_map(struct aie_device *aie, u32 *map)
+{
+	struct amdxdna_hwctx_map_ctx ctx = { .map = map, .limit = aie->hwctx_limit };
+	struct amdxdna_dev *xdna = aie->xdna;
+	struct amdxdna_client *tmp_client;
+	int ret;
+
+	amdxdna_for_each_client(xdna, tmp_client) {
+		if (!amdxdna_client_visible(tmp_client))
+			continue;
+		ret = amdxdna_hwctx_walk(tmp_client, &ctx, NULL,
+					 amdxdna_fill_hwctx_map_cb);
+		if (ret)
+			return ret;
+	}
+
+	return 0;
+}
+
 int amdxdna_get_telemetry(struct aie_device *aie,
 			  struct amdxdna_client *client,
 			  struct amdxdna_drm_get_info *args)
@@ -329,8 +382,8 @@ int amdxdna_get_telemetry(struct aie_device *aie,
 	}
 
 	header->map_num_elements = elem_num;
-	if (elem_num && aie->msg_ops.fill_hwctx_map) {
-		ret = aie->msg_ops.fill_hwctx_map(aie, header->map);
+	if (elem_num) {
+		ret = amdxdna_fill_hwctx_map(aie, header->map);
 		if (ret)
 			return ret;
 	}

--- a/drivers/accel/amdxdna/aie.c
+++ b/drivers/accel/amdxdna/aie.c
@@ -440,6 +440,7 @@ static int amdxdna_fill_hwctx_status_entry(struct aie_device *aie,
 	tmp->pid = hwctx->client->pid;
 	strscpy(tmp->name, hwctx->client->name, sizeof(tmp->name));
 	tmp->context_id = hwctx->id;
+	tmp->hwctx_id = hwctx->fw_ctx_id;
 	tmp->start_col = hwctx->start_col;
 	tmp->num_col = hwctx->num_col;
 	tmp->command_submissions = atomic64_read(&hwctx->job_submit_cnt);

--- a/drivers/accel/amdxdna/aie.h
+++ b/drivers/accel/amdxdna/aie.h
@@ -34,11 +34,10 @@ struct aie_msg_ops {
 
 	int (*query_telemetry)(struct aie_device *aie, char __user *buf, u32 size,
 			       struct amdxdna_drm_query_telemetry_header *header);
-	/* Optional per-arch FW health/map hooks; leave NULL when unsupported. */
+	/* Optional per-arch FW health hook; leave NULL when unsupported. */
 	int (*fill_hwctx_health)(struct aie_device *aie,
 				 struct amdxdna_hwctx *hwctx,
 				 struct amdxdna_drm_hwctx_entry *entry);
-	int (*fill_hwctx_map)(struct aie_device *aie, u32 *map);
 
 	int  (*fw_log_init)(struct amdxdna_dev *xdna, size_t size, u32 level);
 	int  (*fw_log_config)(struct amdxdna_dev *xdna, u32 level);

--- a/drivers/accel/amdxdna/aie2_message.c
+++ b/drivers/accel/amdxdna/aie2_message.c
@@ -1002,7 +1002,6 @@ void aie2_msg_init(struct amdxdna_dev_hdl *ndev)
 	ndev->aie.hwctx_limit = ndev->priv->hwctx_limit;
 	ndev->aie.msg_ops.query_status = aie2_query_status;
 	ndev->aie.msg_ops.query_telemetry = aie2_query_telemetry_cb;
-	ndev->aie.msg_ops.fill_hwctx_map = aie2_fill_hwctx_map;
 	ndev->aie.msg_ops.fill_hwctx_health = aie2_fill_hwctx_health;
 
 	if (AIE_FEATURE_ON(&ndev->aie, AIE2_GET_COREDUMP))

--- a/drivers/accel/amdxdna/aie2_pci.c
+++ b/drivers/accel/amdxdna/aie2_pci.c
@@ -809,39 +809,6 @@ static int aie2_query_resource_info(struct amdxdna_client *client,
 	return 0;
 }
 
-static int aie2_fill_hwctx_map_cb(struct amdxdna_hwctx *hwctx, void *arg)
-{
-	struct amdxdna_dev *xdna = hwctx->client->xdna;
-	u32 *map = arg;
-
-	if (hwctx->fw_ctx_id >= xdna->dev_handle->priv->hwctx_limit) {
-		XDNA_ERR(xdna, "Invalid fw ctx id %d/%d ", hwctx->fw_ctx_id,
-			 xdna->dev_handle->priv->hwctx_limit);
-		return -EINVAL;
-	}
-
-	map[hwctx->fw_ctx_id] = hwctx->id;
-	return 0;
-}
-
-int aie2_fill_hwctx_map(struct aie_device *aie, u32 *map)
-{
-	struct amdxdna_dev *xdna = aie->xdna;
-	struct amdxdna_client *tmp_client;
-	int ret;
-
-	amdxdna_for_each_client(xdna, tmp_client) {
-		if (!amdxdna_client_visible(tmp_client))
-			continue;
-		ret = amdxdna_hwctx_walk(tmp_client, map, NULL,
-					 aie2_fill_hwctx_map_cb);
-		if (ret)
-			return ret;
-	}
-
-	return 0;
-}
-
 static int aie2_get_info(struct amdxdna_client *client, struct amdxdna_drm_get_info *args)
 {
 	struct amdxdna_dev *xdna = client->xdna;

--- a/drivers/accel/amdxdna/aie2_pci.h
+++ b/drivers/accel/amdxdna/aie2_pci.h
@@ -295,7 +295,6 @@ int aie2_query_telemetry(struct amdxdna_dev_hdl *ndev,
 			 struct amdxdna_drm_query_telemetry_header *header);
 int aie2_fill_hwctx_health(struct aie_device *aie, struct amdxdna_hwctx *hwctx,
 			   struct amdxdna_drm_hwctx_entry *entry);
-int aie2_fill_hwctx_map(struct aie_device *aie, u32 *map);
 int aie2_register_asyn_event_msg(struct amdxdna_dev_hdl *ndev, dma_addr_t addr, u32 size,
 				 void *handle, int (*cb)(void*, void __iomem *, size_t));
 int aie2_config_cu(struct amdxdna_hwctx *hwctx,

--- a/drivers/accel/amdxdna/aie4_ctx.c
+++ b/drivers/accel/amdxdna/aie4_ctx.c
@@ -273,6 +273,19 @@ int aie4_hwctx_create(struct amdxdna_hwctx *hwctx)
 
 	priv->hw_ctx_id = resp.hw_context_id;
 
+	/*
+	 * Mirror the firmware hardware context id onto the common hwctx so the
+	 * shared status/telemetry paths can key on it. Unlike AIE2, firmware
+	 * does not hand back a per-context column range; every context runs in
+	 * the single device-wide partition (aie4_partition_init: col_start 0,
+	 * AIE4_TOTAL_COLUMN wide) which the firmware time-shares, so report that
+	 * partition span. This gives amdxdna_drm_hwctx_entry a real hwctx_id and
+	 * a non-empty column list for the aie-partitions view.
+	 */
+	hwctx->fw_ctx_id = resp.hw_context_id;
+	hwctx->start_col = 0;
+	hwctx->num_col = ndev->total_col;
+
 	if (priv->kernel_submit) {
 		/*
 		 * Kernel-mode submission: point at this context's doorbell within

--- a/drivers/accel/amdxdna/aie4_message.c
+++ b/drivers/accel/amdxdna/aie4_message.c
@@ -628,8 +628,16 @@ void aie4_msg_init(struct amdxdna_dev_hdl *ndev)
 
 	ndev->aie.msg_ops.query_status = aie4_query_status;
 	ndev->aie.msg_ops.query_telemetry = aie4_query_telemetry;
-	/* aie4 has no fw_ctx_id <-> hwctx_id map and no per-ctx FW health. */
-	ndev->aie.hwctx_limit = 0;
+	/*
+	 * A non-zero limit makes amdxdna_get_telemetry() emit a
+	 * firmware-context-id to driver-context-id map at the head of the
+	 * telemetry buffer (like aie2), so the shim can label per-context
+	 * telemetry with the driver context id. The firmware assigns each
+	 * context an id in the range [0, MAX_HWCTX_ID) and indexes its
+	 * per-context telemetry (preemption counters) by that id, so the
+	 * telemetry map needs one entry per possible id.
+	 */
+	ndev->aie.hwctx_limit = MAX_HWCTX_ID;
 
 	/*
 	 * FW logging is owned by the PF; a VF must not start its own log

--- a/drivers/accel/amdxdna/amdxdna_ctx.c
+++ b/drivers/accel/amdxdna/amdxdna_ctx.c
@@ -19,7 +19,6 @@
 #include "amdxdna_pci_drv.h"
 #include "amdxdna_pm.h"
 
-#define MAX_HWCTX_ID		1024
 #define MAX_ARG_COUNT		4095
 
 struct amdxdna_fence {

--- a/drivers/accel/amdxdna/amdxdna_ctx.h
+++ b/drivers/accel/amdxdna/amdxdna_ctx.h
@@ -13,6 +13,9 @@
 
 struct amdxdna_hwctx_priv;
 
+/* Driver-wide maximum hardware context id / count. */
+#define MAX_HWCTX_ID		1024
+
 enum ert_cmd_opcode {
 	ERT_START_CU = 0,
 	ERT_START_DPU = 18,

--- a/src/shim/device.cpp
+++ b/src/shim/device.cpp
@@ -19,6 +19,7 @@
 
 #include <algorithm>
 #include <climits>
+#include <cstddef>
 #include <cstdio>
 #include <cstring>
 #include <map>
@@ -1188,13 +1189,23 @@ struct telemetry
   static constexpr uint32_t AIE4_TRACE_COUNT = 16;
   static constexpr size_t AIE4_TELEMETRY_BUFFER_SIZE = 128 * 1024;  // 128KB minimum required by firmware
 
+  // The firmware header (mpnpu-api aie4/npu_msg_priv.h, mirrored in
+  // src/driver/amdxdna/aie4_msg_priv.h) wraps its whole message ABI in
+  // #pragma pack(push, 4), so every uint64_t below is only 4-byte aligned and
+  // the two pads a natural layout would insert - one before l1_interrupt and
+  // one before the frame counter array - do not exist. Declaring these structs
+  // without the pragma puts both counter arrays 8 bytes late, which reads every
+  // per-context counter one index high. The static_assert after
+  // aie4_fw_telemetry pins the resulting offset against the firmware layout.
+#pragma pack(push, 4)
   struct aie4_clk_deep_slp {
     uint8_t ipuaie;
     uint8_t ipuhclk;
     uint8_t nbif;
     uint8_t axi2sdp;
     uint8_t mpipu;
-    uint8_t reserved[3];
+    uint8_t sram;
+    uint8_t reserved[2];
   };
 
   struct aie4_telemetry_opcodes {
@@ -1222,6 +1233,17 @@ struct telemetry
     uint64_t preemption_frame_boundary_counter[AIE4_TOTAL_NUM_UC];
     uint64_t preemption_checkpoint_event_counter[AIE4_TOTAL_NUM_UC];
   };
+#pragma pack(pop)
+
+  // The firmware DMA telemetry buffer is reinterpret_cast onto this struct, so
+  // its byte layout is a hard ABI. Lock the offset of the first preemption
+  // counter array to the value the firmware npu_telemetry ABI dictates (472),
+  // which pins every field ahead of it and so the effect of the pack pragma
+  // above. If the layout drifts - a dropped pragma, a changed field - this
+  // fails to compile rather than silently reading the counters from the wrong
+  // offset.
+  static_assert(offsetof(aie4_fw_telemetry, preemption_frame_boundary_counter) == 472,
+                "AIE4 frame preemption counter offset must match firmware telemetry layout");
 
   struct amdxdna_drm_query_telemetry {
     uint32_t major;
@@ -1382,21 +1404,65 @@ struct telemetry
 
   // AIE4 telemetry handler
   class aie4_telemetry_handler : public telemetry_handler {
-  public:
-    xrt_core::query::aie_telemetry::result_type
-    query_aie_telemetry(const shim_xdna::pdev& pci_dev) const override {
-      xrt_core::query::aie_telemetry::result_type output;
-      std::vector<uint8_t> telemetry_buffer(AIE4_TELEMETRY_BUFFER_SIZE, 0);
+    // The driver (amdxdna_get_telemetry) lays the QUERY_TELEMETRY buffer out as:
+    //   [ header: major,minor,type,map_num_elements (4 x u32 = 16 bytes) ]
+    //   [ map: map_num_elements x u32 ]   -- map[fw_ctx_id] = driver ctx id
+    //   [ aie4_fw_telemetry ]             -- the firmware npu_telemetry payload
+    // The map (mirroring AIE2p) translates a firmware-assigned context id (the
+    // key the firmware uses to index its per-context preemption counters) to
+    // the driver-assigned context id shown to the user. Fixed header size is
+    // the four u32 fields that precede the flexible map[].
+    static constexpr size_t TELEMETRY_HEADER_FIXED = 4 * sizeof(uint32_t);
+    static constexpr size_t TELEMETRY_MAP_COUNT_OFFSET = 3 * sizeof(uint32_t);
 
+    // Run the QUERY_TELEMETRY ioctl and return the raw buffer. The buffer holds
+    // the header + map + firmware telemetry described above.
+    static std::vector<uint8_t>
+    query_buffer(const shim_xdna::pdev& pci_dev) {
+      std::vector<uint8_t> telemetry_buffer(AIE4_TELEMETRY_BUFFER_SIZE, 0);
       amdxdna_drm_get_info query_telemetry = {
         .param = DRM_AMDXDNA_QUERY_TELEMETRY,
         .buffer_size = AIE4_TELEMETRY_BUFFER_SIZE,
         .buffer = reinterpret_cast<uintptr_t>(telemetry_buffer.data())
       };
-
       pci_dev.drv_ioctl(shim_xdna::drv_ioctl_cmd::get_info, &query_telemetry);
+      return telemetry_buffer;
+    }
 
-      auto* fw_telemetry = reinterpret_cast<aie4_fw_telemetry*>(telemetry_buffer.data());
+    // map_count() below derives its clamp by subtracting the header and payload
+    // sizes from the buffer size, so the buffer must be large enough to hold
+    // both; a smaller buffer would wrap that unsigned subtraction and defeat
+    // the clamp instead of tightening it.
+    static_assert(AIE4_TELEMETRY_BUFFER_SIZE >
+                  TELEMETRY_HEADER_FIXED + sizeof(aie4_fw_telemetry),
+                  "AIE4 telemetry buffer must hold the header and the firmware payload");
+
+    // Number of entries in the firmware-context-id to driver-context-id map,
+    // clamped so the trailing firmware telemetry struct always fits in the
+    // buffer (defensive against a malformed header).
+    static uint32_t
+    map_count(const std::vector<uint8_t>& buf) {
+      uint32_t n = 0;
+      std::memcpy(&n, buf.data() + TELEMETRY_MAP_COUNT_OFFSET, sizeof(n));
+      const size_t max_n = (buf.size() - TELEMETRY_HEADER_FIXED -
+                            sizeof(aie4_fw_telemetry)) / sizeof(uint32_t);
+      return static_cast<uint32_t>(std::min<size_t>(n, max_n));
+    }
+
+    // Pointer to the firmware telemetry payload, past the header and the map.
+    static const aie4_fw_telemetry*
+    fw_data(const std::vector<uint8_t>& buf) {
+      const size_t off = TELEMETRY_HEADER_FIXED +
+                         static_cast<size_t>(map_count(buf)) * sizeof(uint32_t);
+      return reinterpret_cast<const aie4_fw_telemetry*>(buf.data() + off);
+    }
+
+  public:
+    xrt_core::query::aie_telemetry::result_type
+    query_aie_telemetry(const shim_xdna::pdev& pci_dev) const override {
+      xrt_core::query::aie_telemetry::result_type output;
+      const auto telemetry_buffer = query_buffer(pci_dev);
+      const auto* fw_telemetry = fw_data(telemetry_buffer);
 
       // AIE4: Map clock domain deep sleep modes (5 domains)
       const uint8_t* clock_domains[] = {
@@ -1418,17 +1484,8 @@ struct telemetry
     xrt_core::query::misc_telemetry::result_type
     query_misc_telemetry(const shim_xdna::pdev& pci_dev) const override {
       xrt_core::query::misc_telemetry::result_type output;
-      std::vector<uint8_t> telemetry_buffer(AIE4_TELEMETRY_BUFFER_SIZE, 0);
-
-      amdxdna_drm_get_info query_telemetry = {
-        .param = DRM_AMDXDNA_QUERY_TELEMETRY,
-        .buffer_size = AIE4_TELEMETRY_BUFFER_SIZE,
-        .buffer = reinterpret_cast<uintptr_t>(telemetry_buffer.data())
-      };
-
-      pci_dev.drv_ioctl(shim_xdna::drv_ioctl_cmd::get_info, &query_telemetry);
-
-      auto* fw_telemetry = reinterpret_cast<aie4_fw_telemetry*>(telemetry_buffer.data());
+      const auto telemetry_buffer = query_buffer(pci_dev);
+      const auto* fw_telemetry = fw_data(telemetry_buffer);
       output.l1_interrupts = fw_telemetry->l1_interrupt;
       return output;
     }
@@ -1436,17 +1493,8 @@ struct telemetry
     xrt_core::query::opcode_telemetry::result_type
     query_opcode_telemetry(const shim_xdna::pdev& pci_dev) const override {
       xrt_core::query::opcode_telemetry::result_type output;
-      std::vector<uint8_t> telemetry_buffer(AIE4_TELEMETRY_BUFFER_SIZE, 0);
-
-      amdxdna_drm_get_info query_telemetry = {
-        .param = DRM_AMDXDNA_QUERY_TELEMETRY,
-        .buffer_size = AIE4_TELEMETRY_BUFFER_SIZE,
-        .buffer = reinterpret_cast<uintptr_t>(telemetry_buffer.data())
-      };
-
-      pci_dev.drv_ioctl(shim_xdna::drv_ioctl_cmd::get_info, &query_telemetry);
-
-      auto* fw_telemetry = reinterpret_cast<aie4_fw_telemetry*>(telemetry_buffer.data());
+      const auto telemetry_buffer = query_buffer(pci_dev);
+      const auto* fw_telemetry = fw_data(telemetry_buffer);
 
       // Flatten hypervisor + supervisor opcode arrays
       for (uint32_t i = 0; i < AIE4_TRACE_COUNT; i++) {
@@ -1469,17 +1517,8 @@ struct telemetry
     xrt_core::query::rtos_telemetry::result_type
     query_rtos_telemetry(const shim_xdna::pdev& pci_dev) const override {
       xrt_core::query::rtos_telemetry::result_type output;
-      std::vector<uint8_t> telemetry_buffer(AIE4_TELEMETRY_BUFFER_SIZE, 0);
-
-      amdxdna_drm_get_info query_telemetry = {
-        .param = DRM_AMDXDNA_QUERY_TELEMETRY,
-        .buffer_size = AIE4_TELEMETRY_BUFFER_SIZE,
-        .buffer = reinterpret_cast<uintptr_t>(telemetry_buffer.data())
-      };
-
-      pci_dev.drv_ioctl(shim_xdna::drv_ioctl_cmd::get_info, &query_telemetry);
-
-      auto* fw_telemetry = reinterpret_cast<aie4_fw_telemetry*>(telemetry_buffer.data());
+      const auto telemetry_buffer = query_buffer(pci_dev);
+      const auto* fw_telemetry = fw_data(telemetry_buffer);
 
       // One full task per supervisor slot (hypervisor + supervisors)
       for (uint32_t i = 0; i < AIE4_MAX_NUM_SUPERVISORS + 1; i++) {

--- a/src/shim/device.cpp
+++ b/src/shim/device.cpp
@@ -22,6 +22,7 @@
 #include <cstddef>
 #include <cstdio>
 #include <cstring>
+#include <limits>
 #include <map>
 #include <optional>
 #include <sstream>
@@ -322,15 +323,13 @@ struct preemption_events
 // boundary event counters.
 //
 // The counters live in the RTOS telemetry payload (already parsed by the
-// rtos_telemetry query handler) and are keyed there by slot_index. On AIE2
-// the driver populates slot_index with the hardware context id from the
-// amdxdna ctx_map, which matches amdxdna_drm_hwctx_entry::context_id. On AIE4
-// there is no such mapping and slot_index is the firmware micro-controller
-// slot, which lines up with amdxdna_drm_hwctx_entry::hwctx_id instead. Callers
-// therefore select the lookup key by device generation (hwctx_id on AIE4,
-// context_id otherwise); probing context_id unconditionally could false-match
-// an unrelated AIE4 telemetry slot since context_id is allocated cyclically
-// from a small value.
+// rtos_telemetry query handler) and are keyed there by slot_index, which on
+// both AIE2p and AIE4 is the driver-assigned context id. On AIE2p the driver
+// populates slot_index from its ctx_map; on AIE4 the rtos_telemetry handler
+// resolves the firmware context id to the driver context id via the ctx_map
+// the driver now places at the head of the telemetry buffer. Either way
+// slot_index matches amdxdna_drm_hwctx_entry::context_id, so callers join on
+// context_id uniformly.
 //
 // Reusing the rtos_telemetry query keeps the telemetry parsing in a single
 // place so both the aie-partitions report and the preemption report share the
@@ -402,18 +401,17 @@ struct partition_info
     if (key != key_type::aie_partition_info)
       throw xrt_core::query::no_such_key(key, "Not implemented");
 
-    // The RTOS telemetry preemption counters are keyed differently per
-    // device generation: on AIE4 by the firmware micro-controller slot
-    // (amdxdna_drm_hwctx_entry::hwctx_id) and on AIE2 by the hardware context
-    // id (amdxdna_drm_hwctx_entry::context_id). Select the join key by
-    // generation rather than probing both, because context_id is allocated
-    // cyclically from a small value and could otherwise false-match an
-    // unrelated telemetry slot on AIE4.
+    // The RTOS telemetry preemption counters are keyed by the driver context
+    // id on every generation (see get_preemption_events above), so the modern
+    // DRM_AMDXDNA_HW_CONTEXT_ALL path below joins on
+    // amdxdna_drm_hwctx_entry::context_id unconditionally. Only the legacy
+    // DRM_AMDXDNA_QUERY_HW_CONTEXTS fallback needs the device generation,
+    // because that ioctl predates AIE4 and is only reached on AIE2.
     //
     // Reading the PCI device id can throw. Preemption enrichment is best
     // effort, so if the generation cannot be determined leave the optional
-    // unset and skip enrichment (counters stay zero) rather than guessing a
-    // key that could attach wrong counts, or failing the whole query.
+    // unset and skip enrichment on that legacy path (counters stay zero)
+    // rather than failing the whole query.
     std::optional<bool> is_aie4_dev;
     try {
       is_aie4_dev = is_aie4(xrt_core::device_query<query::pcie_id>(device).device_id);
@@ -483,15 +481,11 @@ struct partition_info
           new_entry.command_completions = entry.command_completions;
           new_entry.migrations = entry.migrations;
           new_entry.preemptions = entry.preemptions;
-          // The legacy amdxdna_drm_query_hwctx struct only exposes context_id,
-          // not hwctx_id, so the generation-based key selection used on the
-          // modern path is not possible here. This legacy ioctl is the AIE2-era
-          // path where the telemetry slot_index is the hardware context id, so
-          // the join by context_id is correct; AIE4 (keyed by hwctx_id) always
-          // supports the modern DRM_AMDXDNA_HW_CONTEXT_ALL ioctl below, so it
-          // never reaches this path. Only enrich when the device is known to be
-          // non-AIE4 so an unknown generation does not attach a context_id keyed
-          // count that could be wrong; otherwise the counters stay at zero.
+          // This legacy ioctl is the AIE2-era path; AIE4 always supports the
+          // modern DRM_AMDXDNA_HW_CONTEXT_ALL ioctl below and so never reaches
+          // it. Enrich only when the device is known to be non-AIE4, so an
+          // unknown generation leaves the counters at zero instead of joining
+          // telemetry that was never meant to reach this path.
           if (is_aie4_dev && !*is_aie4_dev) {
             const auto preempt_it = legacy_preemption_event_map.find(entry.context_id);
             if (preempt_it != legacy_preemption_event_map.end()) {
@@ -567,15 +561,15 @@ struct partition_info
       new_entry.command_completions = entry.command_completions;
       new_entry.migrations = entry.migrations;
       new_entry.preemptions = entry.preemptions;
-      // Only enrich when the device generation is known; guessing a key could
-      // attach wrong counters (see is_aie4_dev above).
-      if (is_aie4_dev) {
-        const auto preempt_key = *is_aie4_dev ? entry.hwctx_id : entry.context_id;
-        const auto preempt_it = preemption_event_map.find(preempt_key);
-        if (preempt_it != preemption_event_map.end()) {
-          new_entry.preemption_frame_event = preempt_it->second.frame_events;
-          new_entry.preemption_layer_event = preempt_it->second.layer_events;
-        }
+      // Preemption events are keyed by the driver context id on both AIE2p and
+      // AIE4: the rtos_telemetry handler resolves the firmware context id to the
+      // driver context id (via the telemetry ctx_map on AIE4, the ctx_map on
+      // AIE2p) and stores it in slot_index, which matches
+      // amdxdna_drm_hwctx_entry::context_id here.
+      const auto preempt_it = preemption_event_map.find(entry.context_id);
+      if (preempt_it != preemption_event_map.end()) {
+        new_entry.preemption_frame_event = preempt_it->second.frame_events;
+        new_entry.preemption_layer_event = preempt_it->second.layer_events;
       }
       new_entry.errors = entry.errors;
       new_entry.qos.priority = entry.priority;
@@ -1185,8 +1179,26 @@ struct telemetry
   static constexpr uint32_t NPU_MAX_DTLB_COUNT = 12;
   // AIE4 firmware telemetry constants and structs
   static constexpr uint32_t AIE4_MAX_NUM_SUPERVISORS = 4;
-  static constexpr uint32_t AIE4_TOTAL_NUM_UC = 6;
   static constexpr uint32_t AIE4_TRACE_COUNT = 16;
+  // Firmware records preemption counters per hardware context id, not per
+  // micro-controller. The raw firmware buffer is reinterpret_cast onto
+  // aie4_fw_telemetry, so this count must equal the firmware npu_telemetry ABI
+  // (MAX_NUM_HW_CTX_API) exactly: it sets the stride between the two counter
+  // arrays and the extent of the second, so any other value puts the checkpoint
+  // (layer) array at the wrong offset. It is also the hard ceiling on how many
+  // contexts can be reported at all, since the firmware carries no counters
+  // beyond it and truncates its copy-out at that size.
+  static constexpr uint32_t AIE4_MAX_NUM_HW_CTX = 1024;
+  // Smallest number of firmware context slots published through the
+  // rtos_telemetry query. The row count grows past this to cover any higher
+  // slot that carries information (see query_rtos_telemetry() in
+  // aie4_telemetry_handler); this is only the floor, which keeps idle and
+  // typical output a stable size, matches the AIE2p handler's fixed 16 ctx_map
+  // entries, and covers the micro-controller rows the rtos_tasks report
+  // expects.
+  static constexpr uint32_t AIE4_REPORT_MIN_SLOTS = 16;
+  static_assert(AIE4_REPORT_MIN_SLOTS <= AIE4_MAX_NUM_HW_CTX,
+                "AIE4 reported slot floor must stay within the firmware counter arrays");
   static constexpr size_t AIE4_TELEMETRY_BUFFER_SIZE = 128 * 1024;  // 128KB minimum required by firmware
 
   // The firmware header (mpnpu-api aie4/npu_msg_priv.h, mirrored in
@@ -1195,8 +1207,9 @@ struct telemetry
   // the two pads a natural layout would insert - one before l1_interrupt and
   // one before the frame counter array - do not exist. Declaring these structs
   // without the pragma puts both counter arrays 8 bytes late, which reads every
-  // per-context counter one index high. The static_assert after
-  // aie4_fw_telemetry pins the resulting offset against the firmware layout.
+  // per-context counter one index high. The static_asserts after
+  // aie4_fw_telemetry pin the offsets and the total size against the firmware
+  // layout.
 #pragma pack(push, 4)
   struct aie4_clk_deep_slp {
     uint8_t ipuaie;
@@ -1230,20 +1243,37 @@ struct telemetry
     uint64_t did_dma;
     uint64_t resource_acquired[AIE4_MAX_NUM_SUPERVISORS];
     struct aie4_telemetry_opcodes opcodes;
-    uint64_t preemption_frame_boundary_counter[AIE4_TOTAL_NUM_UC];
-    uint64_t preemption_checkpoint_event_counter[AIE4_TOTAL_NUM_UC];
+    uint64_t preemption_frame_boundary_counter[AIE4_MAX_NUM_HW_CTX];
+    uint64_t preemption_checkpoint_event_counter[AIE4_MAX_NUM_HW_CTX];
   };
 #pragma pack(pop)
 
   // The firmware DMA telemetry buffer is reinterpret_cast onto this struct, so
-  // its byte layout is a hard ABI. Lock the offset of the first preemption
-  // counter array to the value the firmware npu_telemetry ABI dictates (472),
-  // which pins every field ahead of it and so the effect of the pack pragma
-  // above. If the layout drifts - a dropped pragma, a changed field - this
-  // fails to compile rather than silently reading the counters from the wrong
-  // offset.
+  // its byte layout is a hard ABI. Lock the two preemption counter array
+  // offsets and the total size to the values the firmware npu_telemetry ABI
+  // dictates: frame at 472, checkpoint/layer at 472 + 1024*8 = 8664, and
+  // sizeof 8664 + 1024*8 = 16856. The size assertion matters on its own, since
+  // the offsets alone do not pin how far the trailing array extends. If the
+  // layout drifts - a dropped pack pragma, a changed field, a reduced
+  // AIE4_MAX_NUM_HW_CTX - this fails to compile rather than silently reading
+  // the counters from the wrong offset.
   static_assert(offsetof(aie4_fw_telemetry, preemption_frame_boundary_counter) == 472,
                 "AIE4 frame preemption counter offset must match firmware telemetry layout");
+  static_assert(offsetof(aie4_fw_telemetry, preemption_checkpoint_event_counter) == 8664,
+                "AIE4 layer preemption counter offset must match firmware telemetry layout");
+  static_assert(sizeof(aie4_fw_telemetry) == 16856,
+                "AIE4 telemetry struct size must match firmware telemetry layout");
+
+  // AIE4_MAX_NUM_HW_CTX is also the hard ceiling on the number of rows
+  // query_rtos_telemetry() can publish, so tie it to the actual extent of the
+  // counter arrays it indexes. The ceiling is exact rather than merely safe:
+  // the firmware API carries only this many counters and the firmware copy-out
+  // truncates at that size, so no slot beyond it can ever be surfaced.
+  static_assert(AIE4_MAX_NUM_HW_CTX ==
+                  sizeof(aie4_fw_telemetry::preemption_frame_boundary_counter) / sizeof(uint64_t) &&
+                AIE4_MAX_NUM_HW_CTX ==
+                  sizeof(aie4_fw_telemetry::preemption_checkpoint_event_counter) / sizeof(uint64_t),
+                "AIE4 context count must match the firmware preemption counter array extent");
 
   struct amdxdna_drm_query_telemetry {
     uint32_t major;
@@ -1348,6 +1378,9 @@ struct telemetry
       for (uint32_t i = 0; i < std::min(telemetry.ctx_map_num_elements, NPU_RTOS_MAX_USER_ID_COUNT); i++) {
         xrt_core::query::rtos_telemetry::data task;
 
+        // FW TID is the firmware-assigned context id, which for AIE2p is the
+        // ctx_map index i; Ctx ID (slot_index) is the driver context id.
+        task.user_task = i;
         task.context_starts = telemetry.context_started_count[i];
         task.schedules = telemetry.scheduled_count[i];
         task.syscalls = telemetry.syscall_count[i];
@@ -1457,6 +1490,19 @@ struct telemetry
       return reinterpret_cast<const aie4_fw_telemetry*>(buf.data() + off);
     }
 
+    // Look up the driver-assigned context id for a firmware context id, or 0
+    // when the slot has no live context. The map lives immediately after the
+    // fixed header.
+    static uint32_t
+    map_driver_ctx_id(const std::vector<uint8_t>& buf, uint32_t fw_ctx_id) {
+      if (fw_ctx_id >= map_count(buf))
+        return 0;
+      uint32_t v = 0;
+      std::memcpy(&v, buf.data() + TELEMETRY_HEADER_FIXED +
+                  static_cast<size_t>(fw_ctx_id) * sizeof(uint32_t), sizeof(v));
+      return v;
+    }
+
   public:
     xrt_core::query::aie_telemetry::result_type
     query_aie_telemetry(const shim_xdna::pdev& pci_dev) const override {
@@ -1520,46 +1566,113 @@ struct telemetry
       const auto telemetry_buffer = query_buffer(pci_dev);
       const auto* fw_telemetry = fw_data(telemetry_buffer);
 
-      // One full task per supervisor slot (hypervisor + supervisors)
-      for (uint32_t i = 0; i < AIE4_MAX_NUM_SUPERVISORS + 1; i++) {
+      // Sentinel Ctx ID for a firmware slot that no live context owns. The
+      // reports render it as "N/A" in the Ctx ID column.
+      constexpr uint64_t NO_CONTEXT = (std::numeric_limits<uint64_t>::max)();
+
+      // Both consumers of this collection identify a row by its position in the
+      // vector rather than by any id field set here: the preemption report
+      // prints FW TID as a running row counter (aie2_preemption_info) and the
+      // telemetry report prints RTOS Task the same way (ReportTelemetry
+      // generate_rtos_string). Neither one filters rows.
+      //
+      // The rows below are therefore one contiguous run of firmware context ids
+      // starting at zero, emitted unconditionally: row i describes firmware
+      // context id i, which is what makes the FW TID column read as the
+      // firmware context id. Skipping an empty slot, or prefixing rows that are
+      // not context slots, shifts every row after it and silently corrupts that
+      // column. The AIE2p handler above depends on the same property, walking
+      // its ctx_map indices unconditionally.
+      //
+      // What that requires is contiguity, not a constant row count. Row i must
+      // describe firmware context id i with no gaps; how many rows follow is
+      // free. So the window below varies in size while staying contiguous from
+      // zero - row i is still id i either way - and it is only a `continue`
+      // that would break the correspondence. Do not be tempted to pin the count
+      // to a fixed size to make it look more predictable: firmware may hand out
+      // any id below AIE4_MAX_NUM_HW_CTX, and a fixed window smaller than that
+      // silently drops a live context from both this report and the
+      // aie-partitions view, which is built from this same collection (see
+      // get_preemption_events above).
+      //
+      // Grow the window to the last slot carrying information, floored at
+      // AIE4_REPORT_MIN_SLOTS and ceilinged at AIE4_MAX_NUM_HW_CTX. A slot
+      // counts when a live context owns it, or when it still holds counters
+      // from a context that has since gone away - including the counters is
+      // what makes the preemption report a persistent view of the residue
+      // rather than a snapshot of live contexts only. Scanning from the floor
+      // suffices, since everything below it is published regardless. In
+      // practice this stays tiny: ctx_acquire() claims the lowest free slot and
+      // ctx_release() frees in place, so the ids in use are dense and the
+      // highest is (live count - 1).
+      uint32_t rows = AIE4_REPORT_MIN_SLOTS;
+      for (uint32_t id = AIE4_REPORT_MIN_SLOTS; id < AIE4_MAX_NUM_HW_CTX; id++) {
+        if (map_driver_ctx_id(telemetry_buffer, id) != AMDXDNA_INVALID_CTX_HANDLE ||
+            fw_telemetry->preemption_frame_boundary_counter[id] != 0 ||
+            fw_telemetry->preemption_checkpoint_event_counter[id] != 0)
+          rows = id + 1;
+      }
+
+      for (uint32_t id = 0; id < rows; id++) {
         xrt_core::query::rtos_telemetry::data task;
 
-        task.context_starts = fw_telemetry->context_starting[i];
-        task.schedules = fw_telemetry->scheduler_scheduled[i];
+        // AIE4 records the scheduler counters per micro-controller (index 0 is
+        // the hypervisor, 1..N the supervisors) but the preemption counters per
+        // hardware context id, so it has two index spaces where AIE2p has one.
+        // A single shared collection can only express one of them, so the low
+        // rows do double duty: the rtos_tasks report reads their scheduler
+        // fields and the preemption report reads their per-context fields. Rows
+        // past the micro-controllers have no scheduler data and must not index
+        // the micro-controller arrays, which hold AIE4_MAX_NUM_SUPERVISORS + 1
+        // entries at most.
+        const bool is_uc = id < AIE4_MAX_NUM_SUPERVISORS + 1;
+
+        task.context_starts = is_uc ? fw_telemetry->context_starting[id] : 0;
+        task.schedules = is_uc ? fw_telemetry->scheduler_scheduled[id] : 0;
         task.syscalls = 0;  // Not available in AIE4
 
         // DMA access only available for hypervisor (index 0)
-        task.dma_access = (i == 0) ? fw_telemetry->did_dma : 0;
+        task.dma_access = (id == 0) ? fw_telemetry->did_dma : 0;
 
         // Resource acquisition only for supervisors (not hypervisor)
-        task.resource_acquisition = (i > 0 && i <= AIE4_MAX_NUM_SUPERVISORS) ?
-                                     fw_telemetry->resource_acquired[i - 1] : 0;
+        task.resource_acquisition = (id > 0 && is_uc) ?
+                                     fw_telemetry->resource_acquired[id - 1] : 0;
 
         // DTLB data not available in AIE4
         task.dtlbs = std::vector<xrt_core::query::rtos_telemetry::dtlb_data>();
-        task.preemption_data.slot_index = i;
-        task.preemption_data.preemption_checkpoint_event =
-          fw_telemetry->preemption_checkpoint_event_counter[i];
-        task.preemption_data.preemption_frame_boundary_events =
-          fw_telemetry->preemption_frame_boundary_counter[i];
 
-        output.push_back(std::move(task));
-      }
+        // The reports display the row ordinal and ignore this field, and the
+        // ordinal equals id because the rows are contiguous from zero. Set it
+        // regardless to record what the column is meant to convey, so a
+        // consumer that does read the field arrives at the same answer.
+        task.user_task = id;
 
-      // Add preemption-only entries for remaining UCs
-      for (auto i = AIE4_MAX_NUM_SUPERVISORS + 1; i < AIE4_TOTAL_NUM_UC; i++) {
-        xrt_core::query::rtos_telemetry::data task;
-        task.context_starts = 0;
-        task.schedules = 0;
-        task.syscalls = 0;
-        task.dma_access = 0;
-        task.resource_acquisition = 0;
-        task.dtlbs = std::vector<xrt_core::query::rtos_telemetry::dtlb_data>();
-        task.preemption_data.slot_index = i;
+        // Preemption counters are indexed by the firmware-assigned hardware
+        // context id, confirmed against the firmware source: cert.c calls
+        // telemetry_preemption_{frame_boundary,checkpoint_event}(ctx_id) with
+        // ctx_id == hw_ctx_id (the id the firmware returns to the driver and
+        // the driver stores as hwctx->fw_ctx_id), and telemetry.c increments
+        // counter[ctx_id] directly - there is no reserved slot and no +1
+        // offset. The driver publishes a fw_ctx_id -> driver_ctx_id map at the
+        // head of the buffer (mirroring AIE2p) to name the owning context.
+        //
+        // The preemption report is the persistent view: the firmware counters
+        // outlive the context that generated them, within a single firmware
+        // lifetime, so a slot that has recorded events is still reported once
+        // no live context owns it. An unowned slot reads back as
+        // AMDXDNA_INVALID_CTX_HANDLE from the map and is reported as
+        // NO_CONTEXT, which is honest about there being no owner and keeps the
+        // slot out of the aie-partitions view, since that joins on the driver
+        // context id (see get_preemption_events above) and so only ever matches
+        // a live context.
+        const uint32_t driver_ctx_id = map_driver_ctx_id(telemetry_buffer, id);
+        task.preemption_data.slot_index =
+          (driver_ctx_id == AMDXDNA_INVALID_CTX_HANDLE) ? NO_CONTEXT : driver_ctx_id;
         task.preemption_data.preemption_checkpoint_event =
-          fw_telemetry->preemption_checkpoint_event_counter[i];
+          fw_telemetry->preemption_checkpoint_event_counter[id];
         task.preemption_data.preemption_frame_boundary_events =
-          fw_telemetry->preemption_frame_boundary_counter[i];
+          fw_telemetry->preemption_frame_boundary_counter[id];
+
         output.push_back(std::move(task));
       }
       return output;

--- a/test/shim_test/io.cpp
+++ b/test/shim_test/io.cpp
@@ -277,6 +277,49 @@ get_fine_preemption_checkpoints(const std::string& ml_txn)
   return count;
 }
 
+// Raw ISA opcode value, OPCODE_PREEMPT in the aiebu ISA specification
+// (specification/aie2ps/isa.h), which aie4 control code shares.
+const uint8_t aie4_opcode_preempt = 25;
+
+// The aie4 data set ships a full ELF and no transaction blob, so the checkpoint
+// count comes from the control code itself: one aie4 'preempt' instruction is
+// one fine preemption checkpoint. The assembler records every occurrence in the
+// ELF .dump debug section, grouped by kernel instance and AIE column.
+//
+// A checkpoint is a partition wide rendezvous and firmware acknowledges one
+// preemption per context, so the number of checkpoints is the count seen by a
+// single column, not the sum over columns. Every column and instance must
+// therefore agree; disagreement means this derivation no longer models the
+// control code and is worth failing on rather than papering over.
+unsigned long
+get_aie4_fine_preemption_checkpoints(const std::string& elf, const std::string& kernel_name)
+{
+  unsigned long count = 0;
+  bool seen = false;
+
+  // dev_info spells the kernel as "kernel:instance", the query takes the kernel.
+  auto kernel = kernel_name.substr(0, kernel_name.find(':'));
+
+  aiebu::aiebu_assembler asp(elf);
+  for (const auto& loc : asp.get_op_locations(aie4_opcode_preempt, kernel).get_line_info()) {
+    for (const auto& per_col : loc.line_info) {
+      auto checkpoints = static_cast<unsigned long>(per_col.entries.size());
+
+      if (seen && checkpoints != count) {
+        throw std::runtime_error("Preemption checkpoints are not uniform across the "
+          "control code of " + elf);
+      }
+      count = checkpoints;
+      seen = true;
+    }
+  }
+
+  if (!count)
+    throw std::runtime_error("Preemptible kernel must have atleast 1 preemption checkpoint");
+
+  return count;
+}
+
 uint32_t
 get_column_size(const xrt::xclbin& xclbin)
 {
@@ -589,8 +632,14 @@ elf_preempt_io_test_bo_set(device* dev, const std::string& tag, const flow_type*
     m_kernel_index = elf_int::no_ctrl_code_id;
   }
 
-  if (!m_is_aie4)
-    m_total_fine_preemption_checkpoints = get_fine_preemption_checkpoints(m_local_data_path + "ml_txn.bin");
+  if (m_is_aie4) {
+    m_total_fine_preemption_checkpoints =
+      get_aie4_fine_preemption_checkpoints(get_binary_path(dev, tag_c, m_flow),
+                                           get_kernel_name(dev, tag_c, m_flow));
+  } else {
+    m_total_fine_preemption_checkpoints =
+      get_fine_preemption_checkpoints(m_local_data_path + "ml_txn.bin");
+  }
 
   for (int i = 0; i < IO_TEST_BO_MAX_TYPES; i++) {
     auto& ibo = m_bo_array[i];

--- a/test/shim_test/shim_test.cpp
+++ b/test/shim_test/shim_test.cpp
@@ -1418,7 +1418,12 @@ TEST_query_memory_usage(device::id_type id, std::shared_ptr<device>& sdev, arg_t
 }
 
 constexpr uint32_t TELEMETRY_DATA_SIZE = 256 * 1024;
-constexpr uint32_t TELEMETRY_MAP_CAPACITY = 256;
+// Upper bound on the firmware-context-id to driver-context-id map the driver
+// places at the head of the telemetry buffer. AIE4 sizes this map to
+// MAX_NUM_HW_CTX (1024, one slot per possible firmware context id); AIE2p uses
+// a smaller map. Keep this at the largest supported map so the probe buffer is
+// big enough and the capacity check does not false-fail on AIE4.
+constexpr uint32_t TELEMETRY_MAP_CAPACITY = 1024;
 // aie4 selects a telemetry category via the type field; older NPUs require 0.
 constexpr uint32_t AIE4_TELEMETRY_PERF_COUNTER = 1;
 


### PR DESCRIPTION
On AIE4 preemption counters could not be attributed to a hardware
context: FW TID showed a plain row counter and Ctx ID was always zero.
Unlike AIE2p, AIE4 published no mapping between the context id firmware
assigns, which is what indexes the counters, and the id the driver reports
to userspace.