### PR TITLE
tools: pin VTD archives on main to fix validation CI

### DIFF
--- a/CMake/version.cmake
+++ b/CMake/version.cmake
@@ -115,9 +115,9 @@ endif()
 # version.json records it at configure time without downloading any archive.
 #
 #   * A committed tools/WHENCE snapshot pins the commit in a "# vtd-commit:"
-#     line (release branches), so read it directly.
-#   * Otherwise (main/link) resolve the Xilinx/VTD HEAD via git ls-remote, which
-#     is metadata only and downloads no archive.
+#     line (release branches and main's VTD-only manifest), so read it directly.
+#   * Otherwise resolve the Xilinx/VTD HEAD via git ls-remote, which is
+#     metadata only and downloads no archive.
 #
 # Resolution is best-effort and never fails the configure when offline.
 set(XDNA_VTD_COMMIT "")

--- a/build/build.sh
+++ b/build/build.sh
@@ -100,9 +100,10 @@ sync_npufws()
   local commit_file=${firmware_dir}/.whence_commit
 
   mkdir -p "${firmware_dir}"
-  # Release branches pin firmware with a committed tools/WHENCE snapshot; main
-  # has no snapshot and always fetches the latest amd-ipu-staging manifest.
-  if [ -f "${whence_snapshot}" ]; then
+  # Release branches pin firmware with "# whence-commit:" in tools/WHENCE. main
+  # may carry a VTD-only WHENCE (no whence-commit), so always fetch firmware
+  # live from amd-ipu-staging unless that pin is present.
+  if [ -f "${whence_snapshot}" ] && grep -q '^# whence-commit:' "${whence_snapshot}"; then
     echo "Sync NPUFW from pinned snapshot ${whence_snapshot}"
     python3 "${sync_script}" firmware --whence "${whence_snapshot}" \
       --out "${firmware_dir}" --commit-file "${commit_file}"
@@ -124,10 +125,10 @@ sync_vtd_archives()
 
   mkdir -p "${vtd_dir}" "$(dirname "${commit_file}")"
 
-  # Release branches pin the VTD archives with a "# vtd-commit:" line in the
-  # committed tools/WHENCE. main has no snapshot, so synthesize a minimal
-  # manifest holding the default "Repo: VTD" File: list (and no pin), which
-  # makes the sync resolve and fetch the latest Xilinx/VTD commit.
+  # Release branches and main both use tools/WHENCE for VTD. When "# vtd-commit:"
+  # is absent the sync resolves the latest Xilinx/VTD commit; when present the
+  # fetch is pinned. main carries a VTD-only WHENCE; release snapshots add the
+  # firmware section and both pins.
   local vtd_whence="${whence_manifest}"
   local tmp_whence=""
   if [ ! -f "${whence_manifest}" ]; then
@@ -143,7 +144,7 @@ File: archive/phx/xrt_smi_phx.a
 File: archive/npu3/xrt_smi_npu3.a
 EOF
     vtd_whence="${tmp_whence}"
-    echo "Sync VTD archives from latest Xilinx/VTD (no committed WHENCE snapshot)"
+    echo "Sync VTD archives from latest Xilinx/VTD (no committed WHENCE)"
   else
     echo "Sync VTD archives from ${whence_manifest}"
   fi

--- a/tools/WHENCE
+++ b/tools/WHENCE
@@ -1,0 +1,13 @@
+# VTD-only manifest for main. Firmware still tracks amd-ipu-staging live
+# (no "# whence-commit:" pin). Release branches replace this with a full
+# snapshot from tools/update_whence_snapshot.sh (firmware + VTD).
+#
+# VTD (validation test data) archive manifest, fetched from Xilinx/VTD.
+# The archives are packaged into the plugin as the xrt-smi validation binaries.
+# vtd-commit: 8ed67e05d2be88aa9841d9758c770a1127b75314
+
+Repo: VTD - xrt-smi validation archives fetched from github.com/Xilinx/VTD
+
+File: archive/strx/xrt_smi_strx.a
+File: archive/phx/xrt_smi_phx.a
+File: archive/npu3/xrt_smi_npu3.a

--- a/tools/update_whence_snapshot.sh
+++ b/tools/update_whence_snapshot.sh
@@ -2,9 +2,9 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
 #
-# Generate tools/WHENCE, the pinned firmware manifest snapshot used by release
-# branches. main does not carry tools/WHENCE and always fetches the latest
-# manifest live from the drm-firmware amd-ipu-staging branch.
+# Generate tools/WHENCE, the pinned firmware+VTD manifest snapshot used by
+# release branches. main may carry a VTD-only WHENCE; run this script when
+# cutting a release to replace it with a full pinned snapshot.
 #
 # The snapshot records, for every device directory, the versioned real file and
 # the stable "npu.dev.sbin" / "cert.dev.sbin" symlink that points at it, e.g.


### PR DESCRIPTION
Latest Xilinx/VTD HEAD breaks runlist-throughput with null JSON fields. Restore a VTD-only tools/WHENCE pinned to 8ed67e05 and teach build.sh to fetch firmware live from amd-ipu-staging unless whence-commit is present.