### PR TITLE
Added debug queue feature

### DIFF
--- a/drivers/accel/amdxdna/ve2_debug.c
+++ b/drivers/accel/amdxdna/ve2_debug.c
@@ -9,6 +9,7 @@
 #include <drm/drm_drv.h>
 #include <linux/cleanup.h>
 #include <linux/completion.h>
+#include <linux/dma-mapping.h>
 #include <linux/errno.h>
 #include <linux/fdtable.h>
 #include <linux/jiffies.h>
@@ -137,6 +138,53 @@ static int ve2_get_hwctx_mem_bitmap(struct amdxdna_client *client,
 	return 0;
 }
 
+static int ve2_dbg_queue_data_rw(struct amdxdna_dev *xdna, struct amdxdna_hwctx *hwctx,
+				 u32 col, u32 row, u32 addr, void *data, size_t size,
+				 int cmd_type)
+{
+	dma_addr_t dma_handle;
+	void *virt_ptr = NULL;
+	int ret = 0;
+
+	if (size % 4 != 0) {
+		XDNA_ERR(xdna, "Size (%zu) must be a multiple of 4 bytes", size);
+		return -EINVAL;
+	}
+
+	virt_ptr = dma_alloc_coherent(xdna->ddev.dev, size, &dma_handle, GFP_KERNEL);
+	if (!virt_ptr) {
+		XDNA_ERR(xdna, "Failed to allocate DMA buffer");
+		return -ENOMEM;
+	}
+
+	addr = addr + ((col << VE2_COL_SHIFT) + (row << VE2_ROW_SHIFT));
+
+	switch (cmd_type) {
+	case DBG_CMD_WRITE:
+		memcpy(virt_ptr, data, size);
+		ret = submit_command_to_dbg_queue(hwctx, DBG_CMD_WRITE, addr, (u64)dma_handle,
+						  size / 4);
+		break;
+	case DBG_CMD_READ:
+		ret = submit_command_to_dbg_queue(hwctx, DBG_CMD_READ, addr, (u64)dma_handle,
+						  size / 4);
+		if (ret == 0)
+			memcpy(data, virt_ptr, size);
+		break;
+	case DBG_CMD_EXIT:
+		ret = submit_command_to_dbg_queue(hwctx, DBG_CMD_EXIT, addr, (u64)dma_handle,
+						  size / 4);
+		break;
+	default:
+		XDNA_ERR(xdna, "CMD_TYPE is not supported");
+		ret = -EINVAL;
+		break;
+	}
+
+	dma_free_coherent(xdna->ddev.dev, size, virt_ptr, dma_handle);
+	return ret;
+}
+
 static int ve2_aie_tile_read(struct amdxdna_client *client, struct amdxdna_drm_get_array *args)
 {
 	struct amdxdna_drm_aie_tile_access footer = {};
@@ -228,7 +276,13 @@ static int ve2_aie_tile_read(struct amdxdna_client *client, struct amdxdna_drm_g
 
 	loc.col = footer.col;
 	loc.row = footer.row;
-	ret = aie_partition_read(mgmtctx->aie_dev, loc, footer.addr, footer.size, local_buf);
+	if (enable_debug_queue) {
+		ret = ve2_dbg_queue_data_rw(xdna, hwctx, footer.col, footer.row,
+					    footer.addr, local_buf, footer.size, DBG_CMD_READ);
+	} else {
+		ret = aie_partition_read(mgmtctx->aie_dev, loc, footer.addr,
+					 footer.size, local_buf);
+	}
 	mutex_unlock(&mgmtctx->ctx_lock);
 	mutex_lock(&xdna->dev_lock);
 
@@ -893,7 +947,21 @@ static int ve2_aie_tile_write(struct amdxdna_client *client, struct amdxdna_drm_
 
 	loc.col = footer.col;
 	loc.row = footer.row;
-	ret = aie_partition_write(mgmtctx->aie_dev, loc, footer.addr, footer.size, local_buf, 0);
+	if (enable_debug_queue) {
+		/* TODO: temporary fix to exit the debug queue. */
+		if (footer.col == 3) {
+			ret = ve2_dbg_queue_data_rw(xdna, hwctx, footer.col, footer.row,
+						    footer.addr, local_buf, footer.size,
+						    DBG_CMD_EXIT);
+		} else {
+			ret = ve2_dbg_queue_data_rw(xdna, hwctx, footer.col, footer.row,
+						    footer.addr, local_buf, footer.size,
+						    DBG_CMD_WRITE);
+		}
+	} else {
+		ret = aie_partition_write(mgmtctx->aie_dev, loc, footer.addr, footer.size,
+					  local_buf, 0);
+	}
 	mutex_unlock(&mgmtctx->ctx_lock);
 	mutex_lock(&xdna->dev_lock);
 

--- a/drivers/accel/amdxdna/ve2_host_queue.h
+++ b/drivers/accel/amdxdna/ve2_host_queue.h
@@ -148,6 +148,11 @@ struct ve2_dbg_queue {
 	struct mutex			hq_lock;/* protect dbg queue submit and wait */
 	u64				reserved_write_index;
 	struct device			*alloc_dev;
+	/*
+	 * Driver-local slot readiness for ordered write_index advance.
+	 * hqc_mem is owned by CERT (firmware writes DBG_PKT_* completion there).
+	 */
+	DECLARE_BITMAP(slot_ready, HOST_QUEUE_ENTRY);
 };
 
 static inline void dbg_queue_sync_read_index_for_read(struct ve2_dbg_queue *queue)

--- a/drivers/accel/amdxdna/ve2_host_queue.h
+++ b/drivers/accel/amdxdna/ve2_host_queue.h
@@ -123,6 +123,65 @@ struct ve2_hsa_queue {
 	DECLARE_BITMAP(slot_ready, HOST_QUEUE_ENTRY);
 };
 
+enum dbg_cmd_type {
+	DBG_CMD_EXIT = 11,
+	DBG_CMD_READ = 12,
+	DBG_CMD_WRITE = 13,
+};
+
+struct rw_mem {
+	u32	aie_addr;
+	u32	length;
+	u32	host_addr_high;
+	u32	host_addr_low;
+};
+
+struct dbg_queue {
+	struct host_queue_header		hq_header;
+	struct host_queue_packet		hq_entry[HOST_QUEUE_ENTRY];
+};
+
+struct ve2_dbg_queue {
+	struct dbg_queue		*dbg_queue_p;
+	dma_addr_t			dbg_queue_dma_addr;
+	struct ve2_hq_complete		hq_complete;
+	struct mutex			hq_lock;/* protect dbg queue submit and wait */
+	u64				reserved_write_index;
+	struct device			*alloc_dev;
+};
+
+static inline void dbg_queue_sync_read_index_for_read(struct ve2_dbg_queue *queue)
+{
+	dma_addr_t read_idx_addr = queue->dbg_queue_dma_addr +
+		offsetof(struct dbg_queue, hq_header) +
+		offsetof(struct host_queue_header, read_index);
+
+	dma_sync_single_for_cpu(queue->alloc_dev, read_idx_addr,
+				sizeof(queue->dbg_queue_p->hq_header.read_index),
+				DMA_FROM_DEVICE);
+}
+
+static inline void dbg_queue_sync_write_index_for_write(struct ve2_dbg_queue *queue)
+{
+	dma_addr_t write_idx_addr = queue->dbg_queue_dma_addr +
+		offsetof(struct dbg_queue, hq_header) +
+		offsetof(struct host_queue_header, write_index);
+
+	dma_sync_single_for_device(queue->alloc_dev, write_idx_addr,
+				   sizeof(queue->dbg_queue_p->hq_header.write_index),
+				   DMA_TO_DEVICE);
+}
+
+static inline void dbg_queue_sync_packet_for_write(struct ve2_dbg_queue *queue, u32 slot_idx)
+{
+	dma_addr_t pkt_dma_addr = queue->dbg_queue_dma_addr +
+		offsetof(struct dbg_queue, hq_entry) +
+		slot_idx * sizeof(struct host_queue_packet);
+
+	dma_sync_single_for_device(queue->alloc_dev, pkt_dma_addr,
+				   sizeof(struct host_queue_packet), DMA_TO_DEVICE);
+}
+
 static inline void hsa_queue_sync_read_index_for_read(struct ve2_hsa_queue *queue)
 {
 	dma_addr_t read_idx_addr = queue->hsa_queue_dma_addr +

--- a/drivers/accel/amdxdna/ve2_hwctx.c
+++ b/drivers/accel/amdxdna/ve2_hwctx.c
@@ -58,6 +58,10 @@ int max_col;
 module_param(max_col, int, 0644);
 MODULE_PARM_DESC(max_col, "Max column supported by this driver");
 
+int enable_debug_queue;
+module_param(enable_debug_queue, int, 0644);
+MODULE_PARM_DESC(enable_debug_queue, "Enable debug queue. It is disabled by default.");
+
 #define CTX_TIMER		(msecs_to_jiffies(1))	/* 1ms */
 #define VE2_RETRY_TIMEOUT_MS	5000	/* max wait for a free host-queue slot */
 
@@ -719,6 +723,276 @@ static void ve2_free_hsa_queue(struct amdxdna_hwctx *hwctx)
 	mutex_destroy(&queue->hq_lock);
 }
 
+static void dbg_q_timeout_cb(struct timer_list *t)
+{
+	struct amdxdna_ctx_priv *vp = timer_container_of(vp, t, dbg_q_timer);
+
+	if (!vp || !vp->dbg_queue.dbg_queue_p)
+		return;
+
+	wake_up_interruptible(&vp->dbg_q_waitq);
+	mod_timer(&vp->dbg_q_timer, jiffies + CTX_TIMER);
+}
+
+static inline struct host_queue_packet *dbg_queue_get_pkt(struct dbg_queue *queue, u64 slot)
+{
+	return &queue->hq_entry[slot & (queue->hq_header.capacity - 1)];
+}
+
+static inline void dbg_queue_pkt_set_invalid(struct host_queue_packet *pkt)
+{
+	pkt->xrt_header.common_header.type = HOST_QUEUE_PACKET_TYPE_INVALID;
+}
+
+static void ve2_free_dbg_queue(struct amdxdna_hwctx *hwctx)
+{
+	struct amdxdna_dev *xdna = hwctx->client->xdna;
+	struct amdxdna_ctx_priv *vp = ve2_hw_priv(hwctx);
+	struct ve2_dbg_queue *queue;
+	size_t alloc_size;
+
+	if (!vp)
+		return;
+
+	queue = &vp->dbg_queue;
+	if (!queue->dbg_queue_p)
+		return;
+
+	XDNA_DBG(xdna, "DBG queue free: hwctx=%u dma_addr=0x%llx",
+		 hwctx->id, (u64)queue->dbg_queue_dma_addr);
+
+	alloc_size = sizeof(struct dbg_queue) + sizeof(u64) * HOST_QUEUE_ENTRY;
+	dma_free_coherent(queue->alloc_dev, alloc_size, queue->dbg_queue_p,
+			  queue->dbg_queue_dma_addr);
+	queue->dbg_queue_p = NULL;
+	mutex_destroy(&queue->hq_lock);
+}
+
+static struct host_queue_packet *
+dbg_queue_reserve_slot(struct amdxdna_dev *xdna, struct ve2_dbg_queue *queue, u64 *slot)
+{
+	struct host_queue_header *header = &queue->dbg_queue_p->hq_header;
+	struct ve2_hq_complete *hq_complete = &queue->hq_complete;
+	struct host_queue_packet *hq_entry = queue->dbg_queue_p->hq_entry;
+	enum ert_cmd_state state;
+	u64 outstanding;
+	u32 slot_idx;
+	u64 read_index;
+
+	mutex_lock(&queue->hq_lock);
+	dbg_queue_sync_read_index_for_read(queue);
+
+	read_index = header->read_index;
+	if (queue->reserved_write_index < read_index) {
+		XDNA_ERR(xdna, "DBG Queue: reserved_write_index(%llu) < read_index(%llu)",
+			 queue->reserved_write_index, read_index);
+		mutex_unlock(&queue->hq_lock);
+		return ERR_PTR(-EINVAL);
+	}
+
+	outstanding = queue->reserved_write_index - read_index;
+	if (outstanding >= header->capacity) {
+		XDNA_DBG(xdna, "DBG Queue full: outstanding=%llu >= capacity=%u",
+			 outstanding, header->capacity);
+		mutex_unlock(&queue->hq_lock);
+		return ERR_PTR(-EBUSY);
+	}
+
+	slot_idx = queue->reserved_write_index % header->capacity;
+	state = (enum ert_cmd_state)hq_complete->hqc_mem[slot_idx];
+	if (state != ERT_CMD_STATE_INVALID) {
+		XDNA_DBG(xdna, "Slot %u is still in use with state %u", slot_idx, state);
+		mutex_unlock(&queue->hq_lock);
+		return ERR_PTR(-EBUSY);
+	}
+
+	*slot = queue->reserved_write_index++;
+	hq_complete->hqc_mem[slot_idx] = ERT_CMD_STATE_NEW;
+	mutex_unlock(&queue->hq_lock);
+
+	return &hq_entry[slot_idx];
+}
+
+static void dbg_queue_commit_slot(struct ve2_dbg_queue *queue, u64 slot)
+{
+	struct host_queue_header *header = &queue->dbg_queue_p->hq_header;
+	struct ve2_hq_complete *hq_complete = &queue->hq_complete;
+	struct host_queue_packet *hq_entry = queue->dbg_queue_p->hq_entry;
+	u32 capacity = header->capacity;
+	u32 slot_idx = slot % capacity;
+	struct host_queue_packet *pkt = &hq_entry[slot_idx];
+
+	mutex_lock(&queue->hq_lock);
+	pkt->xrt_header.common_header.type = HOST_QUEUE_PACKET_TYPE_VENDOR_SPECIFIC;
+	dbg_queue_sync_packet_for_write(queue, slot_idx);
+	hq_complete->hqc_mem[slot_idx] = ERT_CMD_STATE_SUBMITTED;
+
+	while (header->write_index < queue->reserved_write_index) {
+		u32 next_idx = header->write_index % capacity;
+		enum ert_cmd_state st = hq_complete->hqc_mem[next_idx];
+
+		if (st != ERT_CMD_STATE_SUBMITTED)
+			break;
+		header->write_index++;
+	}
+	dbg_queue_sync_write_index_for_write(queue);
+	mutex_unlock(&queue->hq_lock);
+}
+
+static bool dbg_queue_commands_done(struct ve2_dbg_queue *queue)
+{
+	dbg_queue_sync_read_index_for_read(queue);
+	return queue->dbg_queue_p->hq_header.read_index ==
+	       queue->dbg_queue_p->hq_header.write_index;
+}
+
+static struct host_queue_packet *get_dbg_queue_pkt(struct amdxdna_hwctx *hwctx, u64 *seq,
+						   int *err)
+{
+	struct amdxdna_dev *xdna = hwctx->client->xdna;
+	struct amdxdna_ctx_priv *vp = ve2_hw_priv(hwctx);
+	struct ve2_dbg_queue *dbg_queue = &vp->dbg_queue;
+	struct host_queue_packet *pkt;
+
+	pkt = dbg_queue_reserve_slot(xdna, dbg_queue, seq);
+	if (IS_ERR(pkt)) {
+		*err = PTR_ERR(pkt);
+		XDNA_DBG(xdna, "DBG Queue: No slot available (err=%d)", *err);
+		return NULL;
+	}
+
+	*err = 0;
+	return pkt;
+}
+
+static int ve2_create_dbg_queue(struct amdxdna_hwctx *hwctx)
+{
+	struct amdxdna_dev *xdna = hwctx->client->xdna;
+	struct amdxdna_ctx_priv *vp = ve2_hw_priv(hwctx);
+	struct ve2_dbg_queue *queue;
+	dma_addr_t dma_handle;
+	size_t alloc_size;
+	int slot;
+
+	if (!vp)
+		return -EINVAL;
+
+	queue = &vp->dbg_queue;
+	alloc_size = sizeof(struct dbg_queue) + sizeof(u64) * HOST_QUEUE_ENTRY;
+
+	queue->dbg_queue_p = dma_alloc_coherent(xdna->ddev.dev, alloc_size,
+						&dma_handle, GFP_KERNEL);
+	if (!queue->dbg_queue_p) {
+		XDNA_ERR(xdna, "DBG queue alloc failed: hwctx=%u ret=%d",
+			 hwctx->id, -ENOMEM);
+		return -ENOMEM;
+	}
+	queue->alloc_dev = xdna->ddev.dev;
+
+	mutex_init(&queue->hq_lock);
+	queue->reserved_write_index = 0;
+	queue->dbg_queue_dma_addr = dma_handle;
+	queue->hq_complete.hqc_mem =
+		(u64 *)((char *)queue->dbg_queue_p + sizeof(struct dbg_queue));
+	queue->hq_complete.hqc_dma_addr = dma_handle + sizeof(struct dbg_queue);
+	memset(queue->hq_complete.hqc_mem, 0, sizeof(u64) * HOST_QUEUE_ENTRY);
+	queue->dbg_queue_p->hq_header.data_address =
+		dma_handle + sizeof(struct host_queue_header);
+	WARN_ON(!is_power_of_2(HOST_QUEUE_ENTRY));
+	queue->dbg_queue_p->hq_header.capacity = HOST_QUEUE_ENTRY;
+	queue->dbg_queue_p->hq_header.version.major = HOST_QUEUE_MAJOR_VERSION;
+	queue->dbg_queue_p->hq_header.version.minor = HOST_QUEUE_MINOR_VERSION;
+
+	for (slot = 0; slot < HOST_QUEUE_ENTRY; slot++)
+		dbg_queue_pkt_set_invalid(dbg_queue_get_pkt(queue->dbg_queue_p, slot));
+
+	dma_sync_single_for_device(queue->alloc_dev, dma_handle, alloc_size, DMA_TO_DEVICE);
+
+	XDNA_DBG(xdna, "DBG queue alloc: hwctx=%u dma_addr=0x%llx capacity=%u",
+		 hwctx->id, (u64)dma_handle, HOST_QUEUE_ENTRY);
+
+	return 0;
+}
+
+int submit_command_to_dbg_queue(struct amdxdna_hwctx *hwctx, u32 opcode, u32 aie_addr,
+				u64 paddr, u32 length)
+{
+	struct amdxdna_ctx_priv *vp = ve2_hw_priv(hwctx);
+	struct amdxdna_dev *xdna = hwctx->client->xdna;
+	struct ve2_dbg_queue *dbg_queue;
+	struct xrt_packet_header *hdr;
+	struct host_queue_packet *pkt;
+	struct rw_mem *ebp;
+	long wait_ret;
+	u64 seq = 0;
+	u32 slot_idx;
+	int err;
+
+	if (!vp || !vp->dbg_queue.dbg_queue_p) {
+		XDNA_ERR(xdna, "Debug queue is not initialized");
+		return -EINVAL;
+	}
+
+	dbg_queue = &vp->dbg_queue;
+	pkt = get_dbg_queue_pkt(hwctx, &seq, &err);
+	if (!pkt)
+		return err;
+
+	slot_idx = seq & (dbg_queue->dbg_queue_p->hq_header.capacity - 1);
+
+	XDNA_DBG(xdna,
+		 "DBG queue submit start: hwctx=%u opcode=%u aie_addr=0x%x seq=%llu paddr=0x%llx length=%u",
+		 hwctx->id, opcode, aie_addr, seq, paddr, length);
+
+	hdr = &pkt->xrt_header;
+	hdr->common_header.opcode = opcode;
+	hdr->completion_signal =
+		(u64)(dbg_queue->hq_complete.hqc_dma_addr + slot_idx * sizeof(u64));
+	hdr->common_header.count = sizeof(struct rw_mem);
+	hdr->common_header.distribute = 0;
+	hdr->common_header.indirect = 0;
+
+	ebp = (struct rw_mem *)pkt->data;
+	ebp->aie_addr = aie_addr;
+	ebp->host_addr_high = upper_32_bits(paddr);
+	ebp->host_addr_low = lower_32_bits(paddr);
+	ebp->length = length;
+
+	dbg_queue_commit_slot(dbg_queue, seq);
+	XDNA_DBG(xdna, "DBG queue write_index: hwctx=%u seq=%llu write_index=%llu",
+		 hwctx->id, seq, dbg_queue->dbg_queue_p->hq_header.write_index);
+
+	wait_ret = wait_event_interruptible_timeout(vp->dbg_q_waitq,
+						    dbg_queue_commands_done(dbg_queue),
+						    msecs_to_jiffies(5000));
+
+	if (wait_ret == 0) {
+		XDNA_ERR(xdna, "DBG Queue command wait timeout");
+		err = -ETIMEDOUT;
+		goto cleanup_slot;
+	} else if (wait_ret < 0) {
+		XDNA_ERR(xdna, "DBG Queue command wait interrupted");
+		err = (int)wait_ret;
+		goto cleanup_slot;
+	}
+
+	err = 0;
+
+cleanup_slot:
+	XDNA_DBG(xdna,
+		 "DBG queue submit done: hwctx=%u opcode=%u seq=%llu ret=%d read_index=%llu write_index=%llu",
+		 hwctx->id, opcode, seq, err,
+		 dbg_queue->dbg_queue_p->hq_header.read_index,
+		 dbg_queue->dbg_queue_p->hq_header.write_index);
+	mutex_lock(&dbg_queue->hq_lock);
+	dbg_queue->hq_complete.hqc_mem[slot_idx] = ERT_CMD_STATE_INVALID;
+	dbg_queue_pkt_set_invalid(pkt);
+	dbg_queue_sync_packet_for_write(dbg_queue, slot_idx);
+	mutex_unlock(&dbg_queue->hq_lock);
+
+	return err;
+}
+
 static void ve2_hwctx_poll_timer(struct timer_list *t)
 {
 	struct amdxdna_ctx_priv *vp = timer_container_of(vp, t, event_timer);
@@ -824,6 +1098,17 @@ int ve2_hwctx_init(struct amdxdna_hwctx *hwctx)
 		goto free_hwctx_config;
 	}
 
+	if (enable_debug_queue) {
+		ret = ve2_create_dbg_queue(hwctx);
+		if (ret) {
+			XDNA_ERR(xdna, "Debug queue alloc failed, ret %d", ret);
+			goto free_hsa_queue;
+		}
+		init_waitqueue_head(&vp->dbg_q_waitq);
+		timer_setup(&vp->dbg_q_timer, dbg_q_timeout_cb, 0);
+		mod_timer(&vp->dbg_q_timer, jiffies + CTX_TIMER);
+	}
+
 	if (!hwctx->max_opc)	/* default to max number of commands */
 		hwctx->max_opc = HWCTX_MAX_CMDS;
 
@@ -838,6 +1123,8 @@ int ve2_hwctx_init(struct amdxdna_hwctx *hwctx)
 	trace_xdna_hwctx_init_done(hwctx->id, hwctx->start_col, 0);
 	return 0;
 
+free_hsa_queue:
+	ve2_free_hsa_queue(hwctx);
 free_hwctx_config:
 	kfree(vp->hwctx_config);
 	vp->hwctx_config = NULL;
@@ -896,11 +1183,15 @@ void ve2_hwctx_fini(struct amdxdna_hwctx *hwctx)
 
 	ve2_mgmt_destroy_partition(hwctx);
 	ve2_free_hsa_queue(hwctx);
+	if (enable_debug_queue)
+		ve2_free_dbg_queue(hwctx);
 
 	if (vp) {
 		u32 submitted = vp->submitted;
 		u32 completed = vp->completed;
 
+		if (enable_debug_queue)
+			timer_delete_sync(&vp->dbg_q_timer);
 		if (enable_polling)
 			timer_delete_sync(&vp->event_timer);
 		kfree(vp->hwctx_config);

--- a/drivers/accel/amdxdna/ve2_hwctx.c
+++ b/drivers/accel/amdxdna/ve2_hwctx.c
@@ -59,8 +59,8 @@ module_param(max_col, int, 0644);
 MODULE_PARM_DESC(max_col, "Max column supported by this driver");
 
 int enable_debug_queue;
-module_param(enable_debug_queue, int, 0644);
-MODULE_PARM_DESC(enable_debug_queue, "Enable debug queue. It is disabled by default.");
+module_param(enable_debug_queue, int, 0444);
+MODULE_PARM_DESC(enable_debug_queue, "Enable debug queue (must be set before hwctx creation)");
 
 #define CTX_TIMER		(msecs_to_jiffies(1))	/* 1ms */
 #define VE2_RETRY_TIMEOUT_MS	5000	/* max wait for a free host-queue slot */
@@ -772,9 +772,7 @@ static struct host_queue_packet *
 dbg_queue_reserve_slot(struct amdxdna_dev *xdna, struct ve2_dbg_queue *queue, u64 *slot)
 {
 	struct host_queue_header *header = &queue->dbg_queue_p->hq_header;
-	struct ve2_hq_complete *hq_complete = &queue->hq_complete;
 	struct host_queue_packet *hq_entry = queue->dbg_queue_p->hq_entry;
-	enum ert_cmd_state state;
 	u64 outstanding;
 	u32 slot_idx;
 	u64 read_index;
@@ -799,15 +797,13 @@ dbg_queue_reserve_slot(struct amdxdna_dev *xdna, struct ve2_dbg_queue *queue, u6
 	}
 
 	slot_idx = queue->reserved_write_index % header->capacity;
-	state = (enum ert_cmd_state)hq_complete->hqc_mem[slot_idx];
-	if (state != ERT_CMD_STATE_INVALID) {
-		XDNA_DBG(xdna, "Slot %u is still in use with state %u", slot_idx, state);
-		mutex_unlock(&queue->hq_lock);
-		return ERR_PTR(-EBUSY);
-	}
 
+	/*
+	 * Slot availability is determined by read_index (ring math above).
+	 * CERT owns hqc_mem; track readiness in driver-local slot_ready.
+	 */
 	*slot = queue->reserved_write_index++;
-	hq_complete->hqc_mem[slot_idx] = ERT_CMD_STATE_NEW;
+	clear_bit(slot_idx, queue->slot_ready);
 	mutex_unlock(&queue->hq_lock);
 
 	return &hq_entry[slot_idx];
@@ -816,7 +812,6 @@ dbg_queue_reserve_slot(struct amdxdna_dev *xdna, struct ve2_dbg_queue *queue, u6
 static void dbg_queue_commit_slot(struct ve2_dbg_queue *queue, u64 slot)
 {
 	struct host_queue_header *header = &queue->dbg_queue_p->hq_header;
-	struct ve2_hq_complete *hq_complete = &queue->hq_complete;
 	struct host_queue_packet *hq_entry = queue->dbg_queue_p->hq_entry;
 	u32 capacity = header->capacity;
 	u32 slot_idx = slot % capacity;
@@ -825,13 +820,14 @@ static void dbg_queue_commit_slot(struct ve2_dbg_queue *queue, u64 slot)
 	mutex_lock(&queue->hq_lock);
 	pkt->xrt_header.common_header.type = HOST_QUEUE_PACKET_TYPE_VENDOR_SPECIFIC;
 	dbg_queue_sync_packet_for_write(queue, slot_idx);
-	hq_complete->hqc_mem[slot_idx] = ERT_CMD_STATE_SUBMITTED;
+
+	/* Mark slot ready in driver-local tracking (cert owns hqc_mem) */
+	set_bit(slot_idx, queue->slot_ready);
 
 	while (header->write_index < queue->reserved_write_index) {
 		u32 next_idx = header->write_index % capacity;
-		enum ert_cmd_state st = hq_complete->hqc_mem[next_idx];
 
-		if (st != ERT_CMD_STATE_SUBMITTED)
+		if (!test_bit(next_idx, queue->slot_ready))
 			break;
 		header->write_index++;
 	}
@@ -891,10 +887,12 @@ static int ve2_create_dbg_queue(struct amdxdna_hwctx *hwctx)
 
 	mutex_init(&queue->hq_lock);
 	queue->reserved_write_index = 0;
+	bitmap_zero(queue->slot_ready, HOST_QUEUE_ENTRY);
 	queue->dbg_queue_dma_addr = dma_handle;
 	queue->hq_complete.hqc_mem =
 		(u64 *)((char *)queue->dbg_queue_p + sizeof(struct dbg_queue));
 	queue->hq_complete.hqc_dma_addr = dma_handle + sizeof(struct dbg_queue);
+	/* Zero hqc_mem so it starts clean for cert's completion writes. */
 	memset(queue->hq_complete.hqc_mem, 0, sizeof(u64) * HOST_QUEUE_ENTRY);
 	queue->dbg_queue_p->hq_header.data_address =
 		dma_handle + sizeof(struct host_queue_header);
@@ -985,7 +983,6 @@ cleanup_slot:
 		 dbg_queue->dbg_queue_p->hq_header.read_index,
 		 dbg_queue->dbg_queue_p->hq_header.write_index);
 	mutex_lock(&dbg_queue->hq_lock);
-	dbg_queue->hq_complete.hqc_mem[slot_idx] = ERT_CMD_STATE_INVALID;
 	dbg_queue_pkt_set_invalid(pkt);
 	dbg_queue_sync_packet_for_write(dbg_queue, slot_idx);
 	mutex_unlock(&dbg_queue->hq_lock);
@@ -1183,15 +1180,16 @@ void ve2_hwctx_fini(struct amdxdna_hwctx *hwctx)
 
 	ve2_mgmt_destroy_partition(hwctx);
 	ve2_free_hsa_queue(hwctx);
-	if (enable_debug_queue)
+
+	if (enable_debug_queue && vp && vp->dbg_queue.dbg_queue_p) {
+		timer_delete_sync(&vp->dbg_q_timer);
 		ve2_free_dbg_queue(hwctx);
+	}	
 
 	if (vp) {
 		u32 submitted = vp->submitted;
 		u32 completed = vp->completed;
 
-		if (enable_debug_queue)
-			timer_delete_sync(&vp->dbg_q_timer);
 		if (enable_polling)
 			timer_delete_sync(&vp->event_timer);
 		kfree(vp->hwctx_config);

--- a/drivers/accel/amdxdna/ve2_hwctx.c
+++ b/drivers/accel/amdxdna/ve2_hwctx.c
@@ -944,6 +944,7 @@ int submit_command_to_dbg_queue(struct amdxdna_hwctx *hwctx, u32 opcode, u32 aie
 
 	hdr = &pkt->xrt_header;
 	hdr->common_header.opcode = opcode;
+	hdr->common_header.chain_flag = LAST_CMD;
 	hdr->completion_signal =
 		(u64)(dbg_queue->hq_complete.hqc_dma_addr + slot_idx * sizeof(u64));
 	hdr->common_header.count = sizeof(struct rw_mem);

--- a/drivers/accel/amdxdna/ve2_hwctx.h
+++ b/drivers/accel/amdxdna/ve2_hwctx.h
@@ -82,6 +82,9 @@ struct amdxdna_ctx_priv {
 
 	/* Host queue and completion wait. */
 	struct ve2_hsa_queue		hsa_queue;
+	struct ve2_dbg_queue		dbg_queue;
+	struct timer_list		dbg_q_timer;
+	wait_queue_head_t		dbg_q_waitq;
 	wait_queue_head_t		waitq;
 	struct timer_list		event_timer;
 
@@ -125,6 +128,7 @@ int ve2_cmd_wait(struct amdxdna_hwctx *hwctx, u64 seq, u32 timeout_ms);
 #define VERBOSITY_LEVEL_DBG	2
 
 extern int enable_polling;
+extern int enable_debug_queue;
 extern int ve2_perf_optimization;
 extern int verbosity;
 extern int partition_size;

--- a/drivers/accel/amdxdna/ve2_mgmt.c
+++ b/drivers/accel/amdxdna/ve2_mgmt.c
@@ -92,9 +92,12 @@ static void cert_setup_partition(struct amdxdna_mgmtctx *mgmtctx,
 	struct amdxdna_ctx_priv *vp = ve2_hw_priv(hwctx);
 	struct ve2_config_hwctx *cfg = NULL;
 	u64 hsa_addr = U64_MAX;
+	u64 dbg_addr = U64_MAX;
 
 	if (col == 0 && vp && vp->hsa_queue.hsa_queue_dma_addr)
 		hsa_addr = vp->hsa_queue.hsa_queue_dma_addr;
+	if (col == 0 && enable_debug_queue && vp && vp->dbg_queue.dbg_queue_dma_addr)
+		dbg_addr = vp->dbg_queue.dbg_queue_dma_addr;
 
 	if (vp && vp->hwctx_config && col < hwctx->num_col)
 		cfg = &vp->hwctx_config[col];
@@ -103,10 +106,14 @@ static void cert_setup_partition(struct amdxdna_mgmtctx *mgmtctx,
 	cert_hs->aie_info.partition_size = mgmtctx->num_col;
 	cert_hs->hsa_addr_high = upper_32_bits(hsa_addr);
 	cert_hs->hsa_addr_low = lower_32_bits(hsa_addr);
-
-	/* No debug HSA queue: mark the debug HSA address explicitly invalid. */
-	cert_hs->dbg.hsa_addr_high = 0xFFFFFFFF;
-	cert_hs->dbg.hsa_addr_low = 0xFFFFFFFF;
+	if (enable_debug_queue) {
+		cert_hs->dbg.hsa_addr_high = upper_32_bits(dbg_addr);
+		cert_hs->dbg.hsa_addr_low = lower_32_bits(dbg_addr);
+	} else {
+		/* No debug HSA queue: mark the debug HSA address explicitly invalid. */
+		cert_hs->dbg.hsa_addr_high = 0xFFFFFFFF;
+		cert_hs->dbg.hsa_addr_low = 0xFFFFFFFF;
+	}
 
 	if (cfg) {
 		cert_hs->log_addr_high = upper_32_bits(cfg->log_buf_addr);
@@ -125,6 +132,12 @@ static void cert_setup_partition(struct amdxdna_mgmtctx *mgmtctx,
 	cert_hs->ctx_switch_req = 0;
 	cert_hs->hsa_location = 0;
 	cert_hs->mpaie_alive = ALIVE_MAGIC;
+
+	XDNA_DBG(mgmtctx->xdna,
+		 "DBG queue handshake: hwctx=%u col=%u enable=%u dbg_dma=0x%llx hs_dbg=0x%x%08x",
+		 hwctx->id, col, enable_debug_queue,
+		 vp ? (u64)vp->dbg_queue.dbg_queue_dma_addr : 0ULL,
+		 cert_hs->dbg.hsa_addr_high, cert_hs->dbg.hsa_addr_low);
 }
 
 static void ve2_cert_update_host_time(struct amdxdna_mgmtctx *mgmtctx, u32 num_col)

--- a/drivers/accel/amdxdna/ve2_mgmt.h
+++ b/drivers/accel/amdxdna/ve2_mgmt.h
@@ -61,6 +61,11 @@ struct amdxdna_mgmtctx {
 	u32				is_idle_due_to_context;/* fw acked the switch req */
 };
 
+extern int enable_debug_queue;
+
+int submit_command_to_dbg_queue(struct amdxdna_hwctx *hwctx, u32 opcode,
+				u32 aie_addr, u64 paddr, u32 length);
+
 /* Helper functions for reading privileged memory. */
 static inline int ve2_partition_read_privileged_mem(struct amdxdna_mgmtctx *mgmtctx,
 						    size_t field_off, size_t size, void *buf)


### PR DESCRIPTION
**Description**
This PR adds a dedicated debug host queue to the VE2 (AUX) driver so register read/write from the host can reach CERT while the UC is blocked at break() in control code. Instead of using aie_partition_read/write (direct privileged mem), the driver submits DBG_CMD_READ, DBG_CMD_WRITE, and DBG_CMD_EXIT packets on a separate DMA-coherent queue that CERT consumes via dedicated APIs.

The feature is gated by a new module parameter, **enable_debug_queue**, which must be set before hwctx creation.

**Limitations**
EXIT via col == 3 write — temporary hack in ve2_debug.c; needs a proper EXIT IOCTL or opcode path
