### PR TITLE
Add query without device handle check

### DIFF
--- a/src/shim/device.cpp
+++ b/src/shim/device.cpp
@@ -2321,6 +2321,17 @@ struct function1_get : function0_get<QueryRequestType, Getter>
   }
 };
 
+template <typename QueryRequestType, typename Getter>
+struct function4_get : virtual QueryRequestType
+{
+  std::any
+  get(const xrt_core::device* device, const std::any& param) const
+  {
+    auto k = QueryRequestType::key;
+    return Getter::get(device, k, param);
+  }
+};
+
 template <typename QueryRequestType, typename Putter>
 struct function_putter : virtual QueryRequestType
 {
@@ -2362,6 +2373,14 @@ emplace_func1_request()
 {
   auto k = QueryRequestType::key;
   query_tbl.emplace(k, std::make_unique<function1_get<QueryRequestType, Getter>>());
+}
+
+template <typename QueryRequestType, typename Getter>
+static void
+emplace_func4_request()
+{
+  auto k = QueryRequestType::key;
+  query_tbl.emplace(k, std::make_unique<function4_get<QueryRequestType, Getter>>());
 }
 
 template <typename QueryRequestType, typename GetPut>
@@ -2424,8 +2443,8 @@ initialize_query_table()
   emplace_func0_request<query::rom_ddr_bank_size_gb,           default_value>();
   emplace_sysfs_get<query::rom_vbnv>                           ("", "vbnv");
   emplace_func1_request<query::sdm_sensor_info,                sensor_info>();
-  emplace_func1_request<query::xrt_smi_config,                 xrt_smi_config>();
-  emplace_func1_request<query::xrt_smi_lists,                  xrt_smi_lists>();
+  emplace_func4_request<query::xrt_smi_config,                 xrt_smi_config>();
+  emplace_func4_request<query::xrt_smi_lists,                  xrt_smi_lists>();
   emplace_func1_request<query::firmware_version,               firmware_version>();
   emplace_func0_request<query::cert_firmware_version,          cert_firmware_version>();
   emplace_func1_request<query::sub_device_path,                sub_device_path>();


### PR DESCRIPTION
When a single PF is available, xrt-smi fails with following error :
```
aktondak@***:/proj/rdi/staff/aktondak/xdna/xdna-driver/build$ xrt-smi examine
XRT build version: 2.26.0
Build hash: fc972f70181ca2be96e0f7572ab849a58f96a126
Build hash date: Mon, 10 Aug 2026 11:24:59 -0700
Git branch: sriov_handling
PID: 75692
UID: 50084377
[Thu Aug 20 21:55:42 2026 GMT]
HOST: ***-14
EXE: /opt/xilinx/xrt/bin/unwrapped/xrt-smi
[xrt-smi] ERROR: No device handle
```
The reason is that PF devices do not have a device handle for them. Thus all queries done on PFs should bypass the userhandle check. 
This PR adds a new function to query table without a userhandle check, similar to alveo and ve2 shims and routes xrt-smi related queries through them. It should be allowed to get xrt-smi related artifacts from shim even without a user handle. 
After fix : 
```
xrt-smi examine
System Configuration
  OS Name              : Linux
  Release              : 7.2.0-rc3-20260713t172825.fed378f
  Machine              : x86_64
  CPU Cores            : 20
  Memory               : 31359 MB
  Distribution         : Ubuntu 24.04.3 LTS
  GLIBC                : 2.39
  Model                : Plum-MDS1
  BIOS Vendor          : AMD
  BIOS Version         : WMP66603N_239
  Processor            : AMD Eng Sample: 100-000001713-33_N

XRT
  Version              : 2.26.0
  Branch               : sriov_handling
  Hash                 : fc972f70181ca2be96e0f7572ab849a58f96a126
  Hash Date            : Mon, 10 Aug 2026 11:24:59 -0700
  amdxdna Version      : 2.26.0_20260820, 6d32e07e7cb2726b85e5dc691613c8e6ce6581c5
  virtio-pci Version   : 7.2.0-rc3-20260713t172825.fed378f

Device(s) Present
|BDF             |Name             |Architecture  |Topology  |
|----------------|-----------------|--------------|----------|
|[0000:c5:00.1]  |RyzenAI-npu9-pf  |aie4          |N/A       |
```
