### PR TITLE
accel/amdxdna: fix DPT watch-path log flooding and deprecated workqueue use

### DIFF
--- a/drivers/accel/amdxdna/amdxdna_dpt.c
+++ b/drivers/accel/amdxdna/amdxdna_dpt.c
@@ -240,7 +240,7 @@ static irqreturn_t amdxdna_dpt_irq_handler(int irq, void *data)
 	if (dpt->io_base)
 		writel(0, dpt->io_base + dpt->msi_address);
 
-	queue_work(system_wq, &dpt->work);
+	queue_work(system_percpu_wq, &dpt->work);
 	return IRQ_HANDLED;
 }
 
@@ -447,7 +447,7 @@ static void amdxdna_dpt_timer(struct timer_list *t)
 {
 	struct amdxdna_dpt *dpt = container_of(t, struct amdxdna_dpt, timer);
 
-	queue_work(system_wq, &dpt->work);
+	queue_work(system_percpu_wq, &dpt->work);
 	mod_timer(&dpt->timer,
 		  jiffies + msecs_to_jiffies(AMDXDNA_DPT_POLL_INTERVAL_MS));
 }

--- a/drivers/accel/amdxdna/amdxdna_dpt.c
+++ b/drivers/accel/amdxdna/amdxdna_dpt.c
@@ -126,8 +126,17 @@ static int amdxdna_dpt_fetch_payload(struct amdxdna_dpt *dpt, u8 *buf,
 
 	tail = READ_ONCE(dpt->tail);
 
+	/*
+	 * A reader whose offset is ahead of the tail is holding a cursor from
+	 * a ring that no longer exists: every publish starts a fresh handle at
+	 * tail 0, so an offset saved before a disable/enable cycle can never be
+	 * satisfied. The caller gets -EINVAL and is expected to restart from
+	 * offset 0; rate-limit the message because a consumer that retries in a
+	 * loop instead would otherwise flood the kernel log.
+	 */
 	if (tail < *offset) {
-		XDNA_DPT_ERR(dpt, "Invalid fetch offset: 0x%llx", *offset);
+		XDNA_DPT_ERR_RATELIMITED(dpt, "Invalid fetch offset: 0x%llx",
+					 *offset);
 		return -EINVAL;
 	}
 
@@ -303,7 +312,7 @@ static void amdxdna_dpt_timer_get(struct amdxdna_dpt *dpt)
 static void amdxdna_dpt_timer_put(struct amdxdna_dpt *dpt)
 {
 	mutex_lock(&dpt->timer_lock);
-	if (WARN_ON(!refcount_read(&dpt->timer_refs))) {
+	if (drm_WARN_ON_ONCE(&dpt->xdna->ddev, !refcount_read(&dpt->timer_refs))) {
 		mutex_unlock(&dpt->timer_lock);
 		return;
 	}
@@ -331,7 +340,8 @@ static void amdxdna_dpt_fetch_and_dump_to_dmesg(struct amdxdna_dpt *dpt)
 		ret = amdxdna_dpt_fetch_payload(dpt, dpt->local_buffer, &dpt->head,
 						&size, amdxdna_dpt_copy_to_kernel);
 		if (ret) {
-			XDNA_DPT_ERR(dpt, "Failed to fetch FW buffer: %d", ret);
+			XDNA_DPT_ERR_RATELIMITED(dpt, "Failed to fetch FW buffer: %d",
+						 ret);
 			return;
 		}
 		if (!size)
@@ -599,8 +609,9 @@ static int amdxdna_dpt_get_data(struct amdxdna_dpt *dpt,
 	buf_size = args->element_size;
 	buf = u64_to_user_ptr(args->buffer);
 	if (!access_ok(buf, buf_size)) {
-		XDNA_DPT_ERR(dpt, "Failed to access buffer, element num %d size 0x%x",
-			     args->num_element, args->element_size);
+		XDNA_DPT_ERR_RATELIMITED(dpt,
+					 "Failed to access buffer, element num %d size 0x%x",
+					 args->num_element, args->element_size);
 		return -EFAULT;
 	}
 
@@ -652,7 +663,7 @@ static int amdxdna_dpt_get_data(struct amdxdna_dpt *dpt,
 	ret = amdxdna_dpt_fetch_payload(dpt, buf, &footer.offset, &footer.size,
 					amdxdna_dpt_copy_to_user);
 	if (ret) {
-		XDNA_DPT_ERR(dpt, "Failed to fetch FW buffer: %d", ret);
+		XDNA_DPT_ERR_RATELIMITED(dpt, "Failed to fetch FW buffer: %d", ret);
 		footer.offset = 0;
 		footer.size = 0;
 		ret = -EINVAL;

--- a/drivers/accel/amdxdna/amdxdna_dpt.h
+++ b/drivers/accel/amdxdna/amdxdna_dpt.h
@@ -73,6 +73,8 @@ const char *amdxdna_dpt_kind_str(enum amdxdna_dpt_kind kind);
 #define XDNA_DPT_WARN(dpt, fmt, args...) XDNA_DPT_PRINTK(WARN, dpt, fmt, ##args)
 #define XDNA_DPT_INFO(dpt, fmt, args...) XDNA_DPT_PRINTK(INFO, dpt, fmt, ##args)
 #define XDNA_DPT_DBG(dpt,  fmt, args...) XDNA_DPT_PRINTK(DBG,  dpt, fmt, ##args)
+#define XDNA_DPT_ERR_RATELIMITED(dpt, fmt, args...) \
+	XDNA_DPT_PRINTK(ERR_RATELIMITED, dpt, fmt, ##args)
 
 #define XDNA_DPT_MBZ_DBG(dpt, ptr, sz)	XDNA_MBZ_DBG((dpt)->xdna, ptr, sz)
 

--- a/drivers/accel/amdxdna/amdxdna_pci_drv.h
+++ b/drivers/accel/amdxdna/amdxdna_pci_drv.h
@@ -26,6 +26,8 @@
 #define XDNA_ERR(xdna, fmt, args...)	drm_err(&(xdna)->ddev, "%s: "fmt, __func__, ##args)
 #define XDNA_DBG(xdna, fmt, args...)	drm_dbg(&(xdna)->ddev, fmt, ##args)
 #define XDNA_INFO_ONCE(xdna, fmt, args...) drm_info_once(&(xdna)->ddev, fmt, ##args)
+#define XDNA_ERR_RATELIMITED(xdna, fmt, args...) \
+	drm_err_ratelimited(&(xdna)->ddev, "%s: "fmt, __func__, ##args)
 
 #define XDNA_MBZ_DBG(xdna, ptr, sz)					\
 	({								\

--- a/drivers/accel/tools/configure_kernel.sh
+++ b/drivers/accel/tools/configure_kernel.sh
@@ -260,6 +260,11 @@ int main(void)
 	return 0;
 }
 EOF
+cat >> "$OUT" <<'EOF'
+#ifndef HAVE_system_percpu_wq
+#define system_percpu_wq	system_wq
+#endif
+EOF
 
 # Test MODULE_IMPORT_NS signature in 6.13+:
 # #define MODULE_IMPORT_NS(ns)


### PR DESCRIPTION
Two independent fixes to the firmware debug/profile/trace (DPT) path,
both of which show up as kernel log noise.

## Summary

**Deprecated workqueue.** 6.17 renamed `system_wq` to `system_percpu_wq`
and left the old name as a deprecated alias that warns on every enqueue,
so each DPT IRQ and poll tick logged `work func amdxdna_dpt_worker
[amdxdna] enqueued on deprecated workqueue`. `configure_kernel.sh`
already probed for `system_percpu_wq` but never emitted a fallback, so
nothing could act on the result. This adds one in the same style as the
existing `drm_gem_vmap`, `kzalloc_obj` and `BIT_U64` shims, mapping the
new name onto `system_wq` when the probe fails, so the driver can call
`queue_work(system_percpu_wq, ...)` unconditionally with no `#ifdef`.

**Watch-path log flooding.** A reader that carries a fetch offset across
a DPT disable/enable cycle can never be satisfied, because the new
handle starts at tail 0. `amdxdna_dpt_get_data()` cannot resync it
either, since the footer writeback is gated on
`ret == 0 || ret == -ESHUTDOWN`. A CI firmware log run on aie4 turned
that into thousands of lines per second of `Invalid fetch offset: 0x20c5`
and `Failed to fetch FW buffer: -22`. Every error a watcher can drive in
a loop is now rate limited: the three fetch failures plus the
`access_ok()` rejection, all decided by user-supplied arguments.
`amdxdna_dpt_timer_put()` runs once per watch iteration too, so its bare
`WARN_ON` became `drm_WARN_ON_ONCE` rather than a stack trace per poll.

The underlying resync gap is not addressed here; it needs a matching
shim change, since today the shim throws on the errno without reading
the footer back. Rate limiting bounds the log damage in the meantime.

## Test plan

- [x] checkpatch clean on both patches (`--strict`)
- [x] Builds warning-free on 7.2 against `drivers/accel/amdxdna`
- [x] Both probe outcomes verified: with `HAVE_system_percpu_wq` the
      module links `system_percpu_wq`; with the probe result removed the
      new fallback engages and it links `system_wq`. The generated
      `config_kernel.h` emits the `#define` before the `#ifndef` guard,
      so the fallback is correctly skipped on 6.17+
- [x] Loaded on Strix/npu4 with a kprobe on `amdxdna_dpt_worker`; the
      worker fires, no deprecation warning, no DPT fetch errors
- [x] shim_test on Strix gives identical results to the board's own
      module (same executed/passed counts, same pre-existing failures),
      so no regression
- [x] Not re-run on aie4, where the original flood was reported
