### PR TITLE
accel/amdxdna: Report hwctx as idle|active accurately instead of alwa…

### DIFF
--- a/drivers/accel/amdxdna/aie.c
+++ b/drivers/accel/amdxdna/aie.c
@@ -423,6 +423,7 @@ static int amdxdna_fill_hwctx_status_entry(struct aie_device *aie,
 {
 	struct amdxdna_drm_hwctx_entry *tmp __free(kfree) = NULL;
 	struct amdxdna_drm_hwctx_entry __user *buf;
+	u64 submitted, completed;
 	u32 size;
 
 	/*
@@ -443,8 +444,10 @@ static int amdxdna_fill_hwctx_status_entry(struct aie_device *aie,
 	tmp->hwctx_id = hwctx->fw_ctx_id;
 	tmp->start_col = hwctx->start_col;
 	tmp->num_col = hwctx->num_col;
-	tmp->command_submissions = atomic64_read(&hwctx->job_submit_cnt);
-	tmp->command_completions = atomic64_read(&hwctx->job_free_cnt);
+	amdxdna_hwctx_snapshot_counts(hwctx, &submitted, &completed);
+	tmp->command_submissions = submitted;
+	tmp->command_completions = completed;
+	tmp->state = amdxdna_hwctx_report_state(hwctx, submitted, completed);
 	tmp->pasid = hwctx->client->pasid;
 	tmp->heap_usage = hwctx->client->heap_usage;
 	tmp->priority = hwctx->qos.priority;
@@ -453,7 +456,6 @@ static int amdxdna_fill_hwctx_status_entry(struct aie_device *aie,
 	tmp->dma_bandwidth = hwctx->qos.dma_bandwidth;
 	tmp->latency = hwctx->qos.latency;
 	tmp->frame_exec_time = hwctx->qos.frame_exec_time;
-	tmp->state = AMDXDNA_HWCTX_STATE_ACTIVE;
 
 	/* Optional FW health is best-effort; ignore errors. */
 	if (aie->msg_ops.fill_hwctx_health)

--- a/drivers/accel/amdxdna/aie4_ctx.c
+++ b/drivers/accel/amdxdna/aie4_ctx.c
@@ -350,6 +350,7 @@ void aie4_hwctx_destroy(struct amdxdna_hwctx *hwctx)
 		XDNA_WARN(xdna, "destroy ctx id %d failed %d", priv->hw_ctx_id, ret);
 
 	priv->hw_ctx_id = CTX_INVALID_ID;
+	hwctx->fw_ctx_id = -1;
 	hwctx->doorbell_offset = CTX_INVALID_DOORBELL;
 	aie4_unlink_cert_comp(hwctx);
 

--- a/drivers/accel/amdxdna/aie4_pci.c
+++ b/drivers/accel/amdxdna/aie4_pci.c
@@ -923,9 +923,9 @@ static int aie4_query_clock_metadata(struct amdxdna_client *client,
 
 	aie_update_counters(ndev);
 	snprintf(clock->mp_npu_clock.name, sizeof(clock->mp_npu_clock.name),
-		 "MP-NPU Clock");
+		 "NPU H Clock");
 	clock->mp_npu_clock.freq_mhz = ndev->aie.npuclk_freq;
-	snprintf(clock->h_clock.name, sizeof(clock->h_clock.name), "H Clock");
+	snprintf(clock->h_clock.name, sizeof(clock->h_clock.name), "AIE Clock");
 	clock->h_clock.freq_mhz = ndev->aie.hclk_freq;
 
 	buf_sz = min(args->buffer_size, sizeof(*clock));

--- a/drivers/accel/amdxdna/amdxdna_ctx.h
+++ b/drivers/accel/amdxdna/amdxdna_ctx.h
@@ -10,6 +10,7 @@
 #include <linux/bitfield.h>
 
 #include "amdxdna_gem.h"
+#include "drm/amdxdna_accel.h"
 
 struct amdxdna_hwctx_priv;
 
@@ -200,6 +201,23 @@ struct amdxdna_hwctx {
 	/* Saved core dump, captured automatically on timeout if device auto_coredump is set. */
 	char				*coredump;
 };
+
+static inline void
+amdxdna_hwctx_snapshot_counts(struct amdxdna_hwctx *hwctx,
+			      u64 *submitted, u64 *completed)
+{
+	/* Read completions first: avoid stale-submit false idle on concurrent submit. */
+	*completed = atomic64_read(&hwctx->job_free_cnt);
+	*submitted = atomic64_read(&hwctx->job_submit_cnt);
+}
+
+static inline u32
+amdxdna_hwctx_report_state(struct amdxdna_hwctx *hwctx,
+			   u64 submitted, u64 completed)
+{
+	return (hwctx->fw_ctx_id == (u32)-1 || submitted == completed) ?
+		AMDXDNA_HWCTX_STATE_IDLE : AMDXDNA_HWCTX_STATE_ACTIVE;
+}
 
 #define drm_job_to_xdna_job(j) \
 	container_of(j, struct amdxdna_sched_job, base)


### PR DESCRIPTION
…ys active

Fixes [AIESW-42563](https://jira.xilinx.com/browse/AIESW-42563)