### PR TITLE
accel/amdxdna: fix cross-kind DPT teardown deadlock and keep DPT alive across an FLR

### DIFF
--- a/drivers/accel/amdxdna/aie2_pci.c
+++ b/drivers/accel/amdxdna/aie2_pci.c
@@ -1287,7 +1287,7 @@ int aie2_fw_log_init(struct amdxdna_dev *xdna, size_t size, u32 level)
 		return -EINVAL;
 	}
 
-	dpt = rcu_dereference_protected(xdna->fw_log,
+	dpt = rcu_dereference_protected(xdna->fw_log.data,
 					lockdep_is_held(&xdna->dev_lock));
 	if (!dpt) {
 		XDNA_ERR(xdna, "FW log handle not allocated");
@@ -1346,7 +1346,7 @@ int aie2_fw_log_fini(struct amdxdna_dev *xdna)
 	struct amdxdna_dpt *dpt;
 	int ret;
 
-	dpt = rcu_dereference_protected(xdna->fw_log,
+	dpt = rcu_dereference_protected(xdna->fw_log.data,
 					lockdep_is_held(&xdna->dev_lock));
 	if (!dpt)
 		return 0;
@@ -1373,7 +1373,7 @@ int aie2_fw_trace_init(struct amdxdna_dev *xdna, size_t size, u32 categories)
 	struct amdxdna_dpt *dpt;
 	int ret;
 
-	dpt = rcu_dereference_protected(xdna->fw_trace,
+	dpt = rcu_dereference_protected(xdna->fw_trace.data,
 					lockdep_is_held(&xdna->dev_lock));
 	if (!dpt) {
 		XDNA_ERR(xdna, "FW trace handle not allocated");

--- a/drivers/accel/amdxdna/aie4_pci.c
+++ b/drivers/accel/amdxdna/aie4_pci.c
@@ -1786,7 +1786,7 @@ int aie4_fw_log_init(struct amdxdna_dev *xdna, size_t size, u32 level)
 		return -EINVAL;
 	}
 
-	dpt = rcu_dereference_protected(xdna->fw_log,
+	dpt = rcu_dereference_protected(xdna->fw_log.data,
 					lockdep_is_held(&xdna->dev_lock));
 	if (!dpt) {
 		XDNA_ERR(xdna, "FW log handle not allocated");
@@ -1866,7 +1866,7 @@ int aie4_fw_trace_init(struct amdxdna_dev *xdna, size_t size, u32 categories)
 	struct amdxdna_dpt *dpt;
 	int ret;
 
-	dpt = rcu_dereference_protected(xdna->fw_trace,
+	dpt = rcu_dereference_protected(xdna->fw_trace.data,
 					lockdep_is_held(&xdna->dev_lock));
 	if (!dpt) {
 		XDNA_ERR(xdna, "FW trace handle not allocated");

--- a/drivers/accel/amdxdna/aie4_pci.c
+++ b/drivers/accel/amdxdna/aie4_pci.c
@@ -1509,6 +1509,7 @@ pci_disable:
  *
  *                              | PF  | VF  | Classic
  * -----------------------------|-----|-----|--------
+ * -> dpt_reset_prepare         |  Y  |  Y  |   Y
  * -> hwctx_disconnect_all      |  -  |  Y  |   Y
  * -> mailbox_fini              |  Y  |  Y  |   Y
  * -> async_events_free         |  -  |  Y  |   Y
@@ -1527,6 +1528,19 @@ pci_disable:
  *      <- async_events_alloc   |  -  |  Y  |   Y
  * <- restore_sriov             |  Y  |  -  |   -
  * <- hwctx_reconnect_all       |  -  |  Y  |   Y
+ * <- dpt_reset_done            |  Y  |  Y  |   Y
+ *
+ * dpt_reset_prepare runs first: it sends no firmware messages, so it is
+ * safe even when the firmware is unresponsive, and it releases any parked
+ * watcher and stops the DPT poll timer before the rest of the teardown
+ * runs. Anything the firmware logs after that snapshot is lost, but no
+ * step below it sends a command, so there is nothing left to report. It
+ * mirrors dpt_reset_done, which cannot move earlier because
+ * amdxdna_dpt_resume_chan() re-attaches the ring over the mailbox.
+ *
+ * dpt_reset_done runs last and only when everything before it succeeded,
+ * so a failed reset leaves the DPT channels suspended rather than active
+ * on firmware that is not running.
  *
  * (*) fw_load is required but currently skipped for PF and Classic due to a
  *     firmware bug where reloading FW after FLR causes a hang; see
@@ -1538,6 +1552,9 @@ static void aie4_pf_reset_prepare(struct amdxdna_dev *xdna)
 	struct amdxdna_dev_hdl *ndev = xdna->dev_handle;
 
 	drm_WARN_ON(&xdna->ddev, !mutex_is_locked(&xdna->dev_lock));
+
+	/* Release parked DPT watchers and stop the poll timer; see above. */
+	amdxdna_dpt_reset_prepare(xdna);
 
 	/*
 	 * PF has no hwctx. Just tear down the mailbox so no firmware
@@ -1565,6 +1582,15 @@ static void aie4_pf_reset_done(struct amdxdna_dev *xdna)
 	if (ret)
 		goto hw_stop;
 
+	/*
+	 * Restart DPT last and only here: on any failure above the channels
+	 * stay SUSPENDED, which turns a would-be watcher away with
+	 * -ESHUTDOWN rather than parking it on firmware that is not running.
+	 */
+	ret = amdxdna_dpt_reset_done(xdna);
+	if (ret)
+		XDNA_WARN(xdna, "DPT restart after reset failed: %d", ret);
+
 	XDNA_INFO(xdna, "reset done, service online");
 	return;
 
@@ -1579,6 +1605,9 @@ static void aie4_vf_reset_prepare(struct amdxdna_dev *xdna)
 	struct amdxdna_dev_hdl *ndev = xdna->dev_handle;
 
 	drm_WARN_ON(&xdna->ddev, !mutex_is_locked(&xdna->dev_lock));
+
+	/* Release parked DPT watchers and stop the poll timer; see above. */
+	amdxdna_dpt_reset_prepare(xdna);
 
 	aie4_hwctx_disconnect_all(ndev);
 	aie4_mailbox_fini(ndev);
@@ -1607,6 +1636,15 @@ static void aie4_vf_reset_done(struct amdxdna_dev *xdna)
 	if (ret)
 		goto hw_clear;
 
+	/*
+	 * Restart DPT last and only here: on any failure above the channels
+	 * stay SUSPENDED, which turns a would-be watcher away with
+	 * -ESHUTDOWN rather than parking it on firmware that is not running.
+	 */
+	ret = amdxdna_dpt_reset_done(xdna);
+	if (ret)
+		XDNA_WARN(xdna, "DPT restart after reset failed: %d", ret);
+
 	XDNA_INFO(xdna, "reset done, service online");
 	return;
 
@@ -1622,6 +1660,9 @@ static void aie4_classic_reset_prepare(struct amdxdna_dev *xdna)
 	struct amdxdna_dev_hdl *ndev = xdna->dev_handle;
 
 	drm_WARN_ON(&xdna->ddev, !mutex_is_locked(&xdna->dev_lock));
+
+	/* Release parked DPT watchers and stop the poll timer; see above. */
+	amdxdna_dpt_reset_prepare(xdna);
 
 	/*
 	 * In this situation, the firmware might be not responsive, thus
@@ -1657,6 +1698,15 @@ static void aie4_classic_reset_done(struct amdxdna_dev *xdna)
 	ret = aie4_hwctx_reconnect_all(ndev);
 	if (ret)
 		goto hw_clear;
+
+	/*
+	 * Restart DPT last and only here: on any failure above the channels
+	 * stay SUSPENDED, which turns a would-be watcher away with
+	 * -ESHUTDOWN rather than parking it on firmware that is not running.
+	 */
+	ret = amdxdna_dpt_reset_done(xdna);
+	if (ret)
+		XDNA_WARN(xdna, "DPT restart after reset failed: %d", ret);
 
 	XDNA_INFO(xdna, "reset done, service online");
 	return;

--- a/drivers/accel/amdxdna/aie4_pci.c
+++ b/drivers/accel/amdxdna/aie4_pci.c
@@ -4,6 +4,7 @@
  */
 
 #include "drm/amdxdna_accel.h"
+#include <drm/drm_cache.h>
 #include <drm/drm_drv.h>
 #include <drm/drm_managed.h>
 #include <drm/drm_print.h>
@@ -1005,6 +1006,26 @@ dev_exit:
 	return ret;
 }
 
+/*
+ * Hand firmware a defined work buffer instead of relying on it to clear its own
+ * partitions. Four of the five partition init callbacks memset on attach, but
+ * the telemetry one only records the pointer, so its counters would otherwise
+ * start from whatever the page allocator left behind.
+ */
+static void aie4_zero_work_buffer(struct amdxdna_dev_hdl *ndev)
+{
+	void *vaddr;
+	u32 size;
+
+	if (!ndev->work_buf_hdl)
+		return;
+
+	vaddr = to_cpu_addr(ndev->work_buf_hdl, 0);
+	size = to_buf_size(ndev->work_buf_hdl);
+	memset(vaddr, 0, size);
+	drm_clflush_virt_range(vaddr, size);
+}
+
 static int aie4_alloc_work_buffer(struct amdxdna_dev_hdl *ndev)
 {
 	struct amdxdna_dev *xdna = ndev->aie.xdna;
@@ -1018,6 +1039,9 @@ static int aie4_alloc_work_buffer(struct amdxdna_dev_hdl *ndev)
 		ndev->work_buf_hdl = NULL;
 		return ret;
 	}
+
+	/* amdxdna_alloc_msg_buff() does not zero, and firmware attaches this. */
+	aie4_zero_work_buffer(ndev);
 
 	XDNA_DBG(xdna, "Work buffer allocated: size 0x%x",
 		 to_buf_size(ndev->work_buf_hdl));
@@ -1515,6 +1539,7 @@ pci_disable:
  * -> async_events_free         |  -  |  Y  |   Y
  * -> fw_clear_alive            |  Y  |  Y  |   Y
  *    ---- FLR boundary ----
+ * <- zero_work_buffer          |  Y  |  -  |   Y
  * <- fw_load(*)                |  Y  |  -  |   Y
  * <- mailbox_init              |  Y  |  Y  |   Y
  * <- query_fw                  |  Y  |  Y  |   Y
@@ -1572,6 +1597,14 @@ static void aie4_pf_reset_done(struct amdxdna_dev *xdna)
 	int ret;
 
 	drm_WARN_ON(&xdna->ddev, !mutex_is_locked(&xdna->dev_lock));
+
+	/*
+	 * FLR only: suspend asks firmware to release the work buffer, so what it
+	 * leaves behind is retained state. An FLR gives it no such chance - PMFW
+	 * resets the NPU underneath it, possibly mid-DMA - so the contents are
+	 * indeterminate and are cleared before firmware attaches them again.
+	 */
+	aie4_zero_work_buffer(ndev);
 
 	/* PF owns firmware: must do full fw_load cycle after FLR. */
 	ret = aie4_pf_hw_restart(ndev);
@@ -1690,6 +1723,9 @@ static void aie4_classic_reset_done(struct amdxdna_dev *xdna)
 	int ret;
 
 	drm_WARN_ON(&xdna->ddev, !mutex_is_locked(&xdna->dev_lock));
+
+	/* FLR only, for the reason in aie4_pf_reset_done(). */
+	aie4_zero_work_buffer(ndev);
 
 	ret = aie4_classic_hw_restart(ndev);
 	if (ret)

--- a/drivers/accel/amdxdna/amdxdna_debugfs.c
+++ b/drivers/accel/amdxdna/amdxdna_debugfs.c
@@ -151,10 +151,10 @@ static int fw_log_level_show(struct seq_file *m, void *unused)
 	u32 level = 0;
 	int idx;
 
-	dpt = amdxdna_dpt_enter_kind(xdna, AMDXDNA_DPT_FW_LOG, &idx);
+	dpt = amdxdna_dpt_enter(&xdna->fw_log, &idx);
 	if (dpt) {
 		level = READ_ONCE(dpt->config);
-		amdxdna_dpt_exit_kind(xdna, idx);
+		amdxdna_dpt_exit(&xdna->fw_log, idx);
 	}
 
 	seq_printf(m, "%u\n", level);
@@ -191,7 +191,7 @@ static ssize_t fw_log_dump_to_dmesg_write(struct file *file, const char __user *
 	if (ret)
 		return ret;
 
-	dpt = rcu_dereference_protected(xdna->fw_log,
+	dpt = rcu_dereference_protected(xdna->fw_log.data,
 					lockdep_is_held(&xdna->dev_lock));
 	if (!dpt || READ_ONCE(dpt->status) != AMDXDNA_DPT_ACTIVE) {
 		amdxdna_pm_suspend_put(xdna);
@@ -217,10 +217,10 @@ static int fw_log_dump_to_dmesg_show(struct seq_file *m, void *unused)
 	bool dump = false;
 	int idx;
 
-	dpt = amdxdna_dpt_enter_kind(xdna, AMDXDNA_DPT_FW_LOG, &idx);
+	dpt = amdxdna_dpt_enter(&xdna->fw_log, &idx);
 	if (dpt) {
 		dump = READ_ONCE(dpt->dump_to_dmesg);
-		amdxdna_dpt_exit_kind(xdna, idx);
+		amdxdna_dpt_exit(&xdna->fw_log, idx);
 	}
 
 	seq_printf(m, "%d\n", dump ? 1 : 0);

--- a/drivers/accel/amdxdna/amdxdna_dpt.c
+++ b/drivers/accel/amdxdna/amdxdna_dpt.c
@@ -210,14 +210,17 @@ static int amdxdna_dpt_fetch_payload(struct amdxdna_dpt *dpt, u8 *buf,
 	 * A reader whose offset is ahead of the tail is holding a cursor from
 	 * a ring that no longer exists: every publish starts a fresh handle at
 	 * tail 0, so an offset saved before a disable/enable cycle can never be
-	 * satisfied. The caller gets -EINVAL and is expected to restart from
-	 * offset 0; rate-limit the message because a consumer that retries in a
-	 * loop instead would otherwise flood the kernel log.
+	 * satisfied. -ESTALE tells the consumer to drop that cursor and restart
+	 * from offset 0, and unlike a silent reset it also tells it that it
+	 * lost its place, so a gap can be recorded rather than a fresh ring
+	 * being indistinguishable from missed data. Rate-limit the message: a
+	 * consumer that ignores the resync and retries in a loop would
+	 * otherwise flood the kernel log.
 	 */
 	if (tail < *offset) {
-		XDNA_DPT_ERR_RATELIMITED(dpt, "Invalid fetch offset: 0x%llx",
+		XDNA_DPT_ERR_RATELIMITED(dpt, "Stale fetch offset: 0x%llx",
 					 *offset);
-		return -EINVAL;
+		return -ESTALE;
 	}
 
 	if (tail == *offset) {
@@ -724,23 +727,37 @@ static int amdxdna_dpt_get_data(struct amdxdna_dpt *dpt,
 	footer.size = offset;
 	ret = amdxdna_dpt_fetch_payload(dpt, buf, &footer.offset, &footer.size,
 					amdxdna_dpt_copy_to_user);
-	if (ret) {
-		XDNA_DPT_ERR_RATELIMITED(dpt, "Failed to fetch FW buffer: %d", ret);
+	if (ret == -ESTALE) {
+		/*
+		 * Hand back the resync point along with the error. The error
+		 * is what tells the consumer its cursor died and that the
+		 * data published before the restart is gone; the offset
+		 * saves it from having to know that 0 is the only value that
+		 * can work. fetch_payload has already reported the condition,
+		 * so do not log it a second time.
+		 */
 		footer.offset = 0;
 		footer.size = 0;
-		ret = -EINVAL;
+	} else if (ret) {
+		XDNA_DPT_ERR_RATELIMITED(dpt, "Failed to fetch FW buffer: %d", ret);
+		footer.size = 0;
 	}
 
 exit:
-	if (ret == 0 || ret == -ESHUTDOWN) {
+	/*
+	 * -ESHUTDOWN and -ESTALE are reported with metadata, not instead of
+	 * it: the first carries a zero-size sentinel, the second the offset
+	 * to resume from. A fetch that failed any other way leaves the
+	 * caller's buffer untouched, since there is nothing useful to say.
+	 */
+	if (ret == 0 || ret == -ESHUTDOWN || ret == -ESTALE) {
 		if (copy_to_user(buf + offset, &footer, sizeof(footer))) {
 			/*
-			 * On -ESHUTDOWN preserve the original error: user
-			 * space still gets the zero-size sentinel via the
-			 * footer.size = 0 already set on the shutdown
-			 * branch above, and even if the writeback fails
-			 * the disabled-channel status code must reach the
-			 * caller intact.
+			 * Preserve the original error: the caller needs to
+			 * know the channel is gone, or that its cursor is,
+			 * more than it needs to know the writeback failed,
+			 * and it can tell either way because the metadata it
+			 * would have read is unchanged.
 			 */
 			if (ret == 0)
 				ret = -EFAULT;

--- a/drivers/accel/amdxdna/amdxdna_dpt.c
+++ b/drivers/accel/amdxdna/amdxdna_dpt.c
@@ -23,58 +23,137 @@
 #include "amdxdna_dpt.h"
 #include "amdxdna_pci_drv.h"
 
-static const char * const amdxdna_dpt_irq_name[AMDXDNA_DPT_KIND_MAX] = {
-	[AMDXDNA_DPT_FW_LOG]   = "xdna_fw_log",
-	[AMDXDNA_DPT_FW_TRACE] = "xdna_fw_trace",
+/*
+ * Everything that distinguishes one DPT channel from another. The firmware
+ * hooks are thunks over aie->msg_ops rather than cached copies of its
+ * members, because msg_ops is populated at DPT init while the channels are
+ * wired up at probe.
+ */
+struct amdxdna_dpt_desc {
+	const char	*name;
+	const char	*irq_name;
+	size_t		 buf_size;
+	/* Start/stop the firmware producer for this channel. */
+	int		(*fw_init)(struct aie_device *aie, size_t size, u32 config);
+	int		(*fw_fini)(struct aie_device *aie);
+	/*
+	 * Render one fetched batch into dmesg, and NULL for a channel whose
+	 * payload nothing renders. A NULL @buf is a query rather than a
+	 * batch, which is how the dmesg dump gate asks before any payload
+	 * exists; either form reports -EOPNOTSUPP when the backend installed
+	 * no renderer of its own, so the gate refuses the channel instead of
+	 * arming a dump whose batches would be discarded.
+	 */
+	int		(*parse)(struct aie_device *aie, char *buf, size_t size);
 };
 
-const char *amdxdna_dpt_kind_str(enum amdxdna_dpt_kind kind)
+static int amdxdna_dpt_log_fw_init(struct aie_device *aie, size_t size, u32 config)
 {
-	static const char * const names[AMDXDNA_DPT_KIND_MAX] = {
-		[AMDXDNA_DPT_FW_LOG]   = "fw_log",
-		[AMDXDNA_DPT_FW_TRACE] = "fw_trace",
-	};
-
-	return (kind < AMDXDNA_DPT_KIND_MAX) ? names[kind] : "fw_???";
+	if (!aie->msg_ops.fw_log_init)
+		return -EOPNOTSUPP;
+	return aie->msg_ops.fw_log_init(aie->xdna, size, config);
 }
 
-static struct amdxdna_dpt __rcu **
-amdxdna_dpt_slot(struct amdxdna_dev *xdna, enum amdxdna_dpt_kind kind)
+static int amdxdna_dpt_log_fw_fini(struct aie_device *aie)
 {
-	switch (kind) {
-	case AMDXDNA_DPT_FW_LOG:
-		return &xdna->fw_log;
-	case AMDXDNA_DPT_FW_TRACE:
-		return &xdna->fw_trace;
-	case AMDXDNA_DPT_KIND_MAX:
-		break;
+	if (!aie->msg_ops.fw_log_fini)
+		return 0;
+	return aie->msg_ops.fw_log_fini(aie->xdna);
+}
+
+static int amdxdna_dpt_log_parse(struct aie_device *aie, char *buf, size_t size)
+{
+	if (!aie->msg_ops.fw_log_parse)
+		return -EOPNOTSUPP;
+	if (!buf)
+		return 0;
+	aie->msg_ops.fw_log_parse(aie->xdna, buf, size);
+	return 0;
+}
+
+static int amdxdna_dpt_trace_fw_init(struct aie_device *aie, size_t size, u32 config)
+{
+	if (!aie->msg_ops.fw_trace_init)
+		return -EOPNOTSUPP;
+	return aie->msg_ops.fw_trace_init(aie->xdna, size, config);
+}
+
+static int amdxdna_dpt_trace_fw_fini(struct aie_device *aie)
+{
+	if (!aie->msg_ops.fw_trace_fini)
+		return 0;
+	return aie->msg_ops.fw_trace_fini(aie->xdna);
+}
+
+static const struct amdxdna_dpt_desc amdxdna_dpt_fw_log_desc = {
+	.name		= "fw_log",
+	.irq_name	= "xdna_fw_log",
+	.buf_size	= AMDXDNA_DPT_FW_LOG_SIZE,
+	.fw_init	= amdxdna_dpt_log_fw_init,
+	.fw_fini	= amdxdna_dpt_log_fw_fini,
+	.parse		= amdxdna_dpt_log_parse,
+};
+
+static const struct amdxdna_dpt_desc amdxdna_dpt_fw_trace_desc = {
+	.name		= "fw_trace",
+	.irq_name	= "xdna_fw_trace",
+	.buf_size	= AMDXDNA_DPT_FW_TRACE_SIZE,
+	.fw_init	= amdxdna_dpt_trace_fw_init,
+	.fw_fini	= amdxdna_dpt_trace_fw_fini,
+};
+
+const char *amdxdna_dpt_name(const struct amdxdna_dpt *dpt)
+{
+	return dpt->chan->desc->name;
+}
+
+/*
+ * Wire up both channels. Called from probe, before any handle can be
+ * published, and torn down from the drm release action.
+ */
+int amdxdna_dpt_chan_init(struct amdxdna_dev *xdna)
+{
+	int ret;
+
+	xdna->fw_log.desc = &amdxdna_dpt_fw_log_desc;
+	xdna->fw_trace.desc = &amdxdna_dpt_fw_trace_desc;
+
+	ret = init_srcu_struct(&xdna->fw_log.srcu);
+	if (ret)
+		return ret;
+
+	ret = init_srcu_struct(&xdna->fw_trace.srcu);
+	if (ret) {
+		cleanup_srcu_struct(&xdna->fw_log.srcu);
+		return ret;
 	}
-	return NULL;
+
+	return 0;
+}
+
+void amdxdna_dpt_chan_fini(struct amdxdna_dev *xdna)
+{
+	cleanup_srcu_struct(&xdna->fw_trace.srcu);
+	cleanup_srcu_struct(&xdna->fw_log.srcu);
 }
 
 struct amdxdna_dpt *
-amdxdna_dpt_enter_kind(struct amdxdna_dev *xdna, enum amdxdna_dpt_kind kind,
-		       int *idx)
+amdxdna_dpt_enter(struct amdxdna_dpt_chan *chan, int *idx)
 {
-	struct amdxdna_dpt __rcu **slot;
 	struct amdxdna_dpt *dpt;
 
-	slot = amdxdna_dpt_slot(xdna, kind);
-	if (!slot)
-		return NULL;
-
-	*idx = srcu_read_lock(&xdna->dpt_srcu);
-	dpt = srcu_dereference(*slot, &xdna->dpt_srcu);
+	*idx = srcu_read_lock(&chan->srcu);
+	dpt = srcu_dereference(chan->data, &chan->srcu);
 	if (!dpt || READ_ONCE(dpt->status) != AMDXDNA_DPT_ACTIVE) {
-		amdxdna_dpt_exit_kind(xdna, *idx);
+		amdxdna_dpt_exit(chan, *idx);
 		return NULL;
 	}
 	return dpt;
 }
 
-void amdxdna_dpt_exit_kind(struct amdxdna_dev *xdna, int idx)
+void amdxdna_dpt_exit(struct amdxdna_dpt_chan *chan, int idx)
 {
-	srcu_read_unlock(&xdna->dpt_srcu, idx);
+	srcu_read_unlock(&chan->srcu, idx);
 }
 
 /*
@@ -95,12 +174,13 @@ static int amdxdna_dpt_copy_to_kernel(void *to, const void *from, size_t n)
 	return 0;
 }
 
-static void amdxdna_dpt_call_parse(struct amdxdna_dpt *dpt, char *buf, size_t size)
+static int amdxdna_dpt_call_parse(struct amdxdna_dpt *dpt, char *buf, size_t size)
 {
-	struct aie_device *aie = dpt->aie;
+	const struct amdxdna_dpt_desc *desc = dpt->chan->desc;
 
-	if (dpt->kind == AMDXDNA_DPT_FW_LOG && aie->msg_ops.fw_log_parse)
-		aie->msg_ops.fw_log_parse(dpt->xdna, buf, size);
+	if (!desc->parse)
+		return -EOPNOTSUPP;
+	return desc->parse(dpt->aie, buf, size);
 }
 
 static int amdxdna_dpt_copy_to_user(void *to, const void *from, size_t n)
@@ -269,7 +349,7 @@ static int amdxdna_dpt_irq_init(struct amdxdna_dpt *dpt)
 	dpt->irq = ret;
 
 	ret = request_irq(dpt->irq, amdxdna_dpt_irq_handler, 0,
-			  amdxdna_dpt_irq_name[dpt->kind], dpt);
+			  dpt->chan->desc->irq_name, dpt);
 	if (ret) {
 		dpt->irq = 0;
 		return ret;
@@ -347,7 +427,12 @@ static void amdxdna_dpt_fetch_and_dump_to_dmesg(struct amdxdna_dpt *dpt)
 		if (!size)
 			break;
 
-		amdxdna_dpt_call_parse(dpt, dpt->local_buffer, size);
+		ret = amdxdna_dpt_call_parse(dpt, dpt->local_buffer, size);
+		if (ret) {
+			XDNA_DPT_ERR_RATELIMITED(dpt, "Failed to parse FW buffer: %d",
+						 ret);
+			return;
+		}
 	}
 }
 
@@ -392,15 +477,18 @@ int amdxdna_dpt_dump_to_dmesg(struct amdxdna_dpt *dpt, bool enable)
 		return 0;
 
 	if (enable) {
+		const struct amdxdna_dpt_desc *desc = dpt->chan->desc;
+
 		/*
-		 * dmesg dumping only makes sense when the backend can parse the
-		 * fetched ring payload (see amdxdna_dpt_call_parse). Reject the
-		 * request for any kind or generation that installs no fw_log_parse
-		 * hook, whose fetched batches would otherwise be silently
-		 * discarded, rather than pinning a multi-megabyte buffer and
-		 * running the poll worker for nothing.
+		 * dmesg dumping only makes sense when the fetched ring payload
+		 * gets rendered, so ask with a query call (a NULL batch) before
+		 * committing anything. That reports -EOPNOTSUPP both for a
+		 * channel with no parse hook and for one whose backend installed
+		 * no renderer, either of which would leave fetched batches
+		 * silently discarded, and refusing beats pinning a
+		 * multi-megabyte buffer and running the poll worker for nothing.
 		 */
-		if (dpt->kind != AMDXDNA_DPT_FW_LOG || !dpt->aie->msg_ops.fw_log_parse)
+		if (!desc->parse || desc->parse(dpt->aie, NULL, 0))
 			return -EOPNOTSUPP;
 
 		/*
@@ -463,32 +551,14 @@ static void amdxdna_dpt_timer(struct timer_list *t)
 }
 
 /*
- * Tell the firmware to start emitting entries into the @dpt buffer
- * for the consumer of @dpt->kind. Returns -EOPNOTSUPP when the backend
- * does not implement this kind so the caller can decide whether that is
- * fatal.
+ * Tell the firmware to start emitting entries into the @dpt buffer.
+ * Returns -EOPNOTSUPP when the backend does not implement this channel
+ * so the caller can decide whether that is fatal.
  */
 static int amdxdna_dpt_msg_init(struct amdxdna_dpt *dpt)
 {
-	struct aie_device *aie = dpt->aie;
-
-	switch (dpt->kind) {
-	case AMDXDNA_DPT_FW_LOG:
-		if (!aie->msg_ops.fw_log_init)
-			return -EOPNOTSUPP;
-		return aie->msg_ops.fw_log_init(dpt->xdna,
-						to_buf_size(dpt->buf),
-						dpt->config);
-	case AMDXDNA_DPT_FW_TRACE:
-		if (!aie->msg_ops.fw_trace_init)
-			return -EOPNOTSUPP;
-		return aie->msg_ops.fw_trace_init(dpt->xdna,
-						  to_buf_size(dpt->buf),
-						  dpt->config);
-	case AMDXDNA_DPT_KIND_MAX:
-		break;
-	}
-	return -EINVAL;
+	return dpt->chan->desc->fw_init(dpt->aie, to_buf_size(dpt->buf),
+					dpt->config);
 }
 
 /*
@@ -498,13 +568,10 @@ static int amdxdna_dpt_msg_init(struct amdxdna_dpt *dpt)
  */
 static void amdxdna_dpt_unpublish(struct amdxdna_dpt *dpt)
 {
-	struct amdxdna_dev *xdna = dpt->xdna;
-	struct amdxdna_dpt __rcu **slot;
+	struct amdxdna_dpt_chan *chan = dpt->chan;
 
-	slot = amdxdna_dpt_slot(xdna, dpt->kind);
-	if (slot)
-		rcu_assign_pointer(*slot, NULL);
-	synchronize_srcu(&xdna->dpt_srcu);
+	rcu_assign_pointer(chan->data, NULL);
+	synchronize_srcu(&chan->srcu);
 
 	mutex_destroy(&dpt->timer_lock);
 	amdxdna_free_msg_buff(dpt->buf);
@@ -512,28 +579,23 @@ static void amdxdna_dpt_unpublish(struct amdxdna_dpt *dpt)
 }
 
 /*
- * Allocate a fresh dpt handle, plant it in the slot for @kind in INACTIVE
- * state, DMA-alloc its ring buffer, then ask the backend to start emitting
+ * Allocate a fresh dpt handle, plant it in @chan in INACTIVE state,
+ * DMA-alloc its ring buffer, then ask the backend to start emitting
  * via amdxdna_dpt_msg_init. On success the handle is fully active: IRQ has
  * been wired (best-effort), metadata has been read, and status is ACTIVE.
  * On failure the handle has already been unpublished and an ERR_PTR is
  * returned.
  */
 static struct amdxdna_dpt *
-amdxdna_dpt_publish(struct aie_device *aie, enum amdxdna_dpt_kind kind,
-		    size_t buf_size, u32 config)
+amdxdna_dpt_publish(struct aie_device *aie, struct amdxdna_dpt_chan *chan,
+		    u32 config)
 {
 	struct amdxdna_dev *xdna = aie->xdna;
 	struct amdxdna_msg_buf_hdl *hdl;
-	struct amdxdna_dpt __rcu **slot;
 	struct amdxdna_dpt *dpt;
 	int ret;
 
-	slot = amdxdna_dpt_slot(xdna, kind);
-	if (!slot)
-		return ERR_PTR(-EINVAL);
-
-	if (rcu_access_pointer(*slot))
+	if (rcu_access_pointer(chan->data))
 		return ERR_PTR(-EBUSY);
 
 	dpt = kzalloc_obj(*dpt);
@@ -542,11 +604,11 @@ amdxdna_dpt_publish(struct aie_device *aie, enum amdxdna_dpt_kind kind,
 
 	dpt->xdna = xdna;
 	dpt->aie = aie;
-	dpt->kind = kind;
+	dpt->chan = chan;
 	dpt->status = AMDXDNA_DPT_INACTIVE;
 	dpt->config = config;
 
-	hdl = amdxdna_alloc_msg_buff(xdna, buf_size);
+	hdl = amdxdna_alloc_msg_buff(xdna, chan->desc->buf_size);
 	if (IS_ERR(hdl)) {
 		ret = PTR_ERR(hdl);
 		XDNA_DPT_ERR(dpt, "Failed to allocate buffer: %d", ret);
@@ -567,9 +629,9 @@ amdxdna_dpt_publish(struct aie_device *aie, enum amdxdna_dpt_kind kind,
 
 	/* Plant the handle in INACTIVE state so the backend's msg_ops init
 	 * can reach the DMA buffer + msi-info slots through xdna->fw_*.
-	 * Readers see status != ACTIVE in amdxdna_dpt_enter_kind and bail out.
+	 * Readers see status != ACTIVE in amdxdna_dpt_enter and bail out.
 	 */
-	rcu_assign_pointer(*slot, dpt);
+	rcu_assign_pointer(chan->data, dpt);
 
 	ret = amdxdna_dpt_msg_init(dpt);
 	if (ret) {
@@ -677,7 +739,7 @@ exit:
 			 * space still gets the zero-size sentinel via the
 			 * footer.size = 0 already set on the shutdown
 			 * branch above, and even if the writeback fails
-			 * the disabled-kind status code must reach the
+			 * the disabled-channel status code must reach the
 			 * caller intact.
 			 */
 			if (ret == 0)
@@ -698,8 +760,7 @@ static int amdxdna_fw_log_init(struct aie_device *aie, u32 level)
 
 	drm_WARN_ON(&xdna->ddev, !mutex_is_locked(&xdna->dev_lock));
 
-	dpt = amdxdna_dpt_publish(aie, AMDXDNA_DPT_FW_LOG,
-				  AMDXDNA_DPT_FW_LOG_SIZE, level);
+	dpt = amdxdna_dpt_publish(aie, &xdna->fw_log, level);
 	if (IS_ERR(dpt)) {
 		ret = PTR_ERR(dpt);
 		return ret == -EOPNOTSUPP ? 0 : ret;
@@ -708,28 +769,13 @@ static int amdxdna_fw_log_init(struct aie_device *aie, u32 level)
 }
 
 /*
- * Tell the firmware to stop emitting entries into the @dpt buffer
- * for the consumer of @dpt->kind. Best-effort: returns the backend
- * error but it is the caller's responsibility to continue tearing the
- * handle down regardless.
+ * Tell the firmware to stop emitting entries into the @dpt buffer.
+ * Best-effort: returns the backend error but it is the caller's
+ * responsibility to continue tearing the handle down regardless.
  */
 static int amdxdna_dpt_msg_fini(struct amdxdna_dpt *dpt)
 {
-	struct aie_device *aie = dpt->aie;
-
-	switch (dpt->kind) {
-	case AMDXDNA_DPT_FW_LOG:
-		if (aie->msg_ops.fw_log_fini)
-			return aie->msg_ops.fw_log_fini(dpt->xdna);
-		return 0;
-	case AMDXDNA_DPT_FW_TRACE:
-		if (aie->msg_ops.fw_trace_fini)
-			return aie->msg_ops.fw_trace_fini(dpt->xdna);
-		return 0;
-	case AMDXDNA_DPT_KIND_MAX:
-		break;
-	}
-	return -EINVAL;
+	return dpt->chan->desc->fw_fini(dpt->aie);
 }
 
 /*
@@ -737,19 +783,15 @@ static int amdxdna_dpt_msg_fini(struct amdxdna_dpt *dpt)
  * waits for them to exit via synchronize_srcu, and only then frees the
  * handle.
  */
-static int amdxdna_dpt_fini_kind(struct aie_device *aie, enum amdxdna_dpt_kind kind)
+static int amdxdna_dpt_fini_chan(struct aie_device *aie,
+				 struct amdxdna_dpt_chan *chan)
 {
 	struct amdxdna_dev *xdna = aie->xdna;
-	struct amdxdna_dpt __rcu **slot;
 	struct amdxdna_dpt *dpt;
 
 	drm_WARN_ON(&xdna->ddev, !mutex_is_locked(&xdna->dev_lock));
 
-	slot = amdxdna_dpt_slot(xdna, kind);
-	if (!slot)
-		return -EINVAL;
-
-	dpt = rcu_dereference_protected(*slot,
+	dpt = rcu_dereference_protected(chan->data,
 					lockdep_is_held(&xdna->dev_lock));
 	if (!dpt)
 		return 0;
@@ -763,13 +805,13 @@ static int amdxdna_dpt_fini_kind(struct aie_device *aie, enum amdxdna_dpt_kind k
 	amdxdna_dpt_msg_fini(dpt);
 
 	/*
-	 * Close the publish gate (mirrors enter_kind's ptr-then-status read
-	 * order), then mark in-flight readers to bail. After this no new
+	 * Close the publish gate (mirrors amdxdna_dpt_enter's ptr-then-status
+	 * read order), then mark in-flight readers to bail. After this no new
 	 * srcu_dereference can return this handle, and any reader that
 	 * already loaded the pointer will observe SHUTTING_DOWN on its
 	 * post-wait status check.
 	 */
-	rcu_assign_pointer(*slot, NULL);
+	rcu_assign_pointer(chan->data, NULL);
 	WRITE_ONCE(dpt->status, AMDXDNA_DPT_SHUTTING_DOWN);
 
 	/*
@@ -794,22 +836,25 @@ static int amdxdna_dpt_fini_kind(struct aie_device *aie, enum amdxdna_dpt_kind k
 	}
 
 	/*
-	 * Release any watcher still parked. Required for the steady-state
-	 * "FW idle, no tail advance" case where amdxdna_dpt_update_tail's
-	 * conditional wake_up did not fire; otherwise the watcher would
-	 * never observe SHUTTING_DOWN and synchronize_srcu would deadlock.
-	 * The flip-before-wake invariant is preserved: status is already
-	 * SHUTTING_DOWN here, so any watcher woken now re-evaluates
-	 * watch_ready, returns true, and exits with -ESHUTDOWN.
+	 * Release every watcher still parked on this channel. Required for
+	 * the steady-state "FW idle, no tail advance" case where
+	 * amdxdna_dpt_update_tail's conditional wake_up did not fire;
+	 * otherwise the watcher would never observe SHUTTING_DOWN and
+	 * synchronize_srcu would deadlock. The flip-before-wake invariant is
+	 * preserved: status is already SHUTTING_DOWN here, so any watcher
+	 * woken now re-evaluates watch_ready, returns true, and exits with
+	 * -ESHUTDOWN.
 	 */
 	wake_up_all(&dpt->wait);
 
 	/*
-	 * Wait for every reader currently inside a dpt_* helper
-	 * (including any one we just woke) to drop the SRCU read lock
-	 * before freeing the handle.
+	 * Wait for every reader of this channel (including any one we just
+	 * woke) to drop the SRCU read lock before freeing the handle. This
+	 * uses the channel's own domain, so it is bounded by the wake_up_all
+	 * above: a watcher parked on the other channel is neither woken nor
+	 * waited for, and cannot stall this teardown.
 	 */
-	synchronize_srcu(&xdna->dpt_srcu);
+	synchronize_srcu(&chan->srcu);
 
 	mutex_destroy(&dpt->timer_lock);
 	amdxdna_free_msg_buff(dpt->buf);
@@ -818,19 +863,14 @@ static int amdxdna_dpt_fini_kind(struct aie_device *aie, enum amdxdna_dpt_kind k
 	return 0;
 }
 
-static int amdxdna_dpt_suspend_kind(struct amdxdna_dev *xdna,
-				    enum amdxdna_dpt_kind kind)
+static int amdxdna_dpt_suspend_chan(struct amdxdna_dev *xdna,
+				    struct amdxdna_dpt_chan *chan)
 {
-	struct amdxdna_dpt __rcu **slot;
 	struct amdxdna_dpt *dpt;
 
 	drm_WARN_ON(&xdna->ddev, !mutex_is_locked(&xdna->dev_lock));
 
-	slot = amdxdna_dpt_slot(xdna, kind);
-	if (!slot)
-		return -EINVAL;
-
-	dpt = rcu_dereference_protected(*slot,
+	dpt = rcu_dereference_protected(chan->data,
 					lockdep_is_held(&xdna->dev_lock));
 	if (!dpt || READ_ONCE(dpt->status) != AMDXDNA_DPT_ACTIVE)
 		return 0;
@@ -862,16 +902,18 @@ static int amdxdna_dpt_suspend_kind(struct amdxdna_dev *xdna,
 	cancel_work_sync(&dpt->work);
 
 	/*
-	 * Capture FW's final tail and wake sleeping watchers. They wake
-	 * under the SRCU read lock with status SUSPENDING, exit
+	 * Capture FW's final tail and wake this channel's sleeping watchers.
+	 * They wake under the SRCU read lock with status SUSPENDING, exit
 	 * wait_event, and run fetch_payload to copy the final batch to
-	 * user space; synchronize_srcu below waits for those reads to
-	 * finish before we flip status to SUSPENDED.
+	 * user space; the channel's own synchronize_srcu below waits for
+	 * those reads to finish before we flip status to SUSPENDED, and
+	 * ignores readers of the other channel, which this wake_up_all
+	 * cannot release.
 	 */
 	amdxdna_dpt_update_tail(dpt);
 	wake_up_all(&dpt->wait);
 
-	synchronize_srcu(&xdna->dpt_srcu);
+	synchronize_srcu(&chan->srcu);
 
 	WRITE_ONCE(dpt->status, AMDXDNA_DPT_SUSPENDED);
 
@@ -879,20 +921,15 @@ static int amdxdna_dpt_suspend_kind(struct amdxdna_dev *xdna,
 	return 0;
 }
 
-static int amdxdna_dpt_resume_kind(struct amdxdna_dev *xdna,
-				   enum amdxdna_dpt_kind kind)
+static int amdxdna_dpt_resume_chan(struct amdxdna_dev *xdna,
+				   struct amdxdna_dpt_chan *chan)
 {
-	struct amdxdna_dpt __rcu **slot;
 	struct amdxdna_dpt *dpt;
 	int ret;
 
 	drm_WARN_ON(&xdna->ddev, !mutex_is_locked(&xdna->dev_lock));
 
-	slot = amdxdna_dpt_slot(xdna, kind);
-	if (!slot)
-		return -EINVAL;
-
-	dpt = rcu_dereference_protected(*slot,
+	dpt = rcu_dereference_protected(chan->data,
 					lockdep_is_held(&xdna->dev_lock));
 	if (!dpt || READ_ONCE(dpt->status) != AMDXDNA_DPT_SUSPENDED)
 		return 0;
@@ -950,7 +987,7 @@ static int amdxdna_fw_log_set_level(struct aie_device *aie, u32 level)
 
 	drm_WARN_ON(&xdna->ddev, !mutex_is_locked(&xdna->dev_lock));
 
-	dpt = rcu_dereference_protected(xdna->fw_log,
+	dpt = rcu_dereference_protected(xdna->fw_log.data,
 					lockdep_is_held(&xdna->dev_lock));
 	if (!dpt || READ_ONCE(dpt->status) != AMDXDNA_DPT_ACTIVE)
 		return -EINVAL;
@@ -989,7 +1026,7 @@ int amdxdna_fw_log_set_state(struct amdxdna_dev *xdna, u32 level)
 	if (!aie)
 		return -ENODEV;
 
-	dpt = rcu_dereference_protected(xdna->fw_log,
+	dpt = rcu_dereference_protected(xdna->fw_log.data,
 					lockdep_is_held(&xdna->dev_lock));
 	status = dpt ? READ_ONCE(dpt->status) : AMDXDNA_DPT_INACTIVE;
 
@@ -1000,7 +1037,7 @@ int amdxdna_fw_log_set_state(struct amdxdna_dev *xdna, u32 level)
 		return amdxdna_fw_log_init(aie, level);
 	case AMDXDNA_DPT_ACTIVE:
 		if (level == AMDXDNA_DPT_FW_LOG_LEVEL_NONE)
-			return amdxdna_dpt_fini_kind(aie, AMDXDNA_DPT_FW_LOG);
+			return amdxdna_dpt_fini_chan(aie, &xdna->fw_log);
 		return amdxdna_fw_log_set_level(aie, level);
 	default:
 		XDNA_ERR(xdna, "FW logging not in a stable state, retry");
@@ -1015,8 +1052,7 @@ static int amdxdna_fw_trace_init(struct aie_device *aie, u32 categories)
 
 	drm_WARN_ON(&xdna->ddev, !mutex_is_locked(&xdna->dev_lock));
 
-	dpt = amdxdna_dpt_publish(aie, AMDXDNA_DPT_FW_TRACE,
-				  AMDXDNA_DPT_FW_TRACE_SIZE, categories);
+	dpt = amdxdna_dpt_publish(aie, &xdna->fw_trace, categories);
 	if (IS_ERR(dpt))
 		return PTR_ERR(dpt);
 	return 0;
@@ -1030,7 +1066,7 @@ static int amdxdna_fw_trace_set_categories(struct aie_device *aie, u32 categorie
 
 	drm_WARN_ON(&xdna->ddev, !mutex_is_locked(&xdna->dev_lock));
 
-	dpt = rcu_dereference_protected(xdna->fw_trace,
+	dpt = rcu_dereference_protected(xdna->fw_trace.data,
 					lockdep_is_held(&xdna->dev_lock));
 	if (!dpt || READ_ONCE(dpt->status) != AMDXDNA_DPT_ACTIVE)
 		return -EINVAL;
@@ -1051,11 +1087,11 @@ static int amdxdna_fw_trace_set_categories(struct aie_device *aie, u32 categorie
 }
 
 /*
- * Probe-time entry: auto-starts FW_LOG only. FW_TRACE is opt-in via
- * DRM_AMDXDNA_SET_FW_TRACE_STATE to avoid generating large trace payloads
- * unconditionally. Best-effort: per-kind failures surface via XDNA_WARN
- * but the wrapper always returns 0 so callers (per-generation probe paths)
- * cannot abort device bring-up on a logging failure.
+ * Probe-time entry: auto-starts the log channel only. The trace channel is
+ * opt-in via DRM_AMDXDNA_SET_FW_TRACE_STATE to avoid generating large trace
+ * payloads unconditionally. Best-effort: per-channel failures surface via
+ * XDNA_WARN but the wrapper always returns 0 so callers (per-generation
+ * probe paths) cannot abort device bring-up on a logging failure.
  */
 int amdxdna_dpt_init(struct aie_device *aie)
 {
@@ -1078,18 +1114,18 @@ int amdxdna_dpt_fini(struct aie_device *aie)
 	int ret;
 
 	/*
-	 * Clear the back-pointer before tearing the DPT kinds down so a
+	 * Clear the back-pointer before tearing the DPT channels down so a
 	 * concurrent or in-flight debugfs handler (amdxdna_fw_log_set_state)
 	 * observes a NULL dpt_aie and fails cleanly with -ENODEV instead of
 	 * reaching a DPT that teardown is about to free.
 	 */
 	aie->xdna->dpt_aie = NULL;
 
-	ret = amdxdna_dpt_fini_kind(aie, AMDXDNA_DPT_FW_LOG);
+	ret = amdxdna_dpt_fini_chan(aie, &aie->xdna->fw_log);
 	if (ret)
 		return ret;
 
-	return amdxdna_dpt_fini_kind(aie, AMDXDNA_DPT_FW_TRACE);
+	return amdxdna_dpt_fini_chan(aie, &aie->xdna->fw_trace);
 }
 
 int amdxdna_dpt_suspend(struct amdxdna_dev *xdna)
@@ -1097,12 +1133,12 @@ int amdxdna_dpt_suspend(struct amdxdna_dev *xdna)
 	int ret, ret2;
 
 	/*
-	 * FW_LOG and FW_TRACE are independent DPT kinds. Suspend every kind
-	 * and aggregate the result so a failure on one does not skip the
-	 * other; each kind is a safe no-op when it is not active.
+	 * The log and trace channels are independent. Suspend both and
+	 * aggregate the result so a failure on one does not skip the other;
+	 * each channel is a safe no-op when it is not active.
 	 */
-	ret = amdxdna_dpt_suspend_kind(xdna, AMDXDNA_DPT_FW_LOG);
-	ret2 = amdxdna_dpt_suspend_kind(xdna, AMDXDNA_DPT_FW_TRACE);
+	ret = amdxdna_dpt_suspend_chan(xdna, &xdna->fw_log);
+	ret2 = amdxdna_dpt_suspend_chan(xdna, &xdna->fw_trace);
 
 	return ret ? ret : ret2;
 }
@@ -1112,12 +1148,12 @@ int amdxdna_dpt_resume(struct amdxdna_dev *xdna)
 	int ret, ret2;
 
 	/*
-	 * FW_LOG and FW_TRACE are independent DPT kinds. Resume every kind
-	 * and aggregate the result so a failure on one does not skip the
-	 * other; each kind is a safe no-op when it is not active.
+	 * The log and trace channels are independent. Resume both and
+	 * aggregate the result so a failure on one does not skip the other;
+	 * each channel is a safe no-op when it is not active.
 	 */
-	ret = amdxdna_dpt_resume_kind(xdna, AMDXDNA_DPT_FW_LOG);
-	ret2 = amdxdna_dpt_resume_kind(xdna, AMDXDNA_DPT_FW_TRACE);
+	ret = amdxdna_dpt_resume_chan(xdna, &xdna->fw_log);
+	ret2 = amdxdna_dpt_resume_chan(xdna, &xdna->fw_trace);
 
 	return ret ? ret : ret2;
 }
@@ -1132,12 +1168,12 @@ int amdxdna_get_fw_log(struct aie_device *aie,
 	if (!capable(CAP_SYS_ADMIN))
 		return -EPERM;
 
-	dpt = amdxdna_dpt_enter_kind(xdna, AMDXDNA_DPT_FW_LOG, &idx);
+	dpt = amdxdna_dpt_enter(&xdna->fw_log, &idx);
 	if (!dpt)
 		return -ESHUTDOWN;
 
 	ret = amdxdna_dpt_get_data(dpt, args);
-	amdxdna_dpt_exit_kind(xdna, idx);
+	amdxdna_dpt_exit(&xdna->fw_log, idx);
 	return ret;
 }
 
@@ -1180,12 +1216,12 @@ int amdxdna_get_fw_log_configs(struct aie_device *aie,
 		return -ENOSPC;
 	}
 
-	dpt = amdxdna_dpt_enter_kind(xdna, AMDXDNA_DPT_FW_LOG, &idx);
+	dpt = amdxdna_dpt_enter(&xdna->fw_log, &idx);
 	if (dpt) {
 		config.version = dpt->payload_version;
 		config.status = 1;
 		config.config = READ_ONCE(dpt->config);
-		amdxdna_dpt_exit_kind(xdna, idx);
+		amdxdna_dpt_exit(&xdna->fw_log, idx);
 	}
 
 	if (copy_to_user(buf, &config, sizeof(config)))
@@ -1217,12 +1253,12 @@ int amdxdna_set_fw_log_state(struct aie_device *aie,
 		return -EINVAL;
 
 	if (!fw_log.action)
-		return amdxdna_dpt_fini_kind(aie, AMDXDNA_DPT_FW_LOG);
+		return amdxdna_dpt_fini_chan(aie, &xdna->fw_log);
 
 	if (!fw_log.config || fw_log.config >= AMDXDNA_DPT_FW_LOG_LEVEL_MAX)
 		return -EINVAL;
 
-	if (!rcu_access_pointer(xdna->fw_log))
+	if (!rcu_access_pointer(xdna->fw_log.data))
 		return amdxdna_fw_log_init(aie, fw_log.config);
 
 	return amdxdna_fw_log_set_level(aie, fw_log.config);
@@ -1238,12 +1274,12 @@ int amdxdna_get_fw_trace(struct aie_device *aie,
 	if (!capable(CAP_SYS_ADMIN))
 		return -EPERM;
 
-	dpt = amdxdna_dpt_enter_kind(xdna, AMDXDNA_DPT_FW_TRACE, &idx);
+	dpt = amdxdna_dpt_enter(&xdna->fw_trace, &idx);
 	if (!dpt)
 		return -ESHUTDOWN;
 
 	ret = amdxdna_dpt_get_data(dpt, args);
-	amdxdna_dpt_exit_kind(xdna, idx);
+	amdxdna_dpt_exit(&xdna->fw_trace, idx);
 	return ret;
 }
 
@@ -1286,12 +1322,12 @@ int amdxdna_get_fw_trace_configs(struct aie_device *aie,
 		return -ENOSPC;
 	}
 
-	dpt = amdxdna_dpt_enter_kind(xdna, AMDXDNA_DPT_FW_TRACE, &idx);
+	dpt = amdxdna_dpt_enter(&xdna->fw_trace, &idx);
 	if (dpt) {
 		config.version = dpt->payload_version;
 		config.status = 1;
 		config.config = READ_ONCE(dpt->config);
-		amdxdna_dpt_exit_kind(xdna, idx);
+		amdxdna_dpt_exit(&xdna->fw_trace, idx);
 	}
 
 	if (copy_to_user(buf, &config, sizeof(config)))
@@ -1324,12 +1360,12 @@ int amdxdna_set_fw_trace_state(struct aie_device *aie,
 		return -EINVAL;
 
 	if (!fw_trace.action)
-		return amdxdna_dpt_fini_kind(aie, AMDXDNA_DPT_FW_TRACE);
+		return amdxdna_dpt_fini_chan(aie, &xdna->fw_trace);
 
 	if (!fw_trace.config)
 		return -EINVAL;
 
-	if (!rcu_access_pointer(xdna->fw_trace))
+	if (!rcu_access_pointer(xdna->fw_trace.data))
 		return amdxdna_fw_trace_init(aie, fw_trace.config);
 
 	return amdxdna_fw_trace_set_categories(aie, fw_trace.config);

--- a/drivers/accel/amdxdna/amdxdna_dpt.c
+++ b/drivers/accel/amdxdna/amdxdna_dpt.c
@@ -938,8 +938,16 @@ static int amdxdna_dpt_suspend_chan(struct amdxdna_dev *xdna,
 	return 0;
 }
 
+/*
+ * Re-arm a SUSPENDED channel. @fresh selects which side of the firmware
+ * contract applies: PM suspend leaves the firmware ring state intact and
+ * resumes from the persisted offsets (@fresh false), whereas an FLR
+ * wipes only the firmware's in-SRAM state -- the footer cursors survive
+ * it and would still be resumed from -- so the ring is restarted from
+ * scratch (@fresh true).
+ */
 static int amdxdna_dpt_resume_chan(struct amdxdna_dev *xdna,
-				   struct amdxdna_dpt_chan *chan)
+				   struct amdxdna_dpt_chan *chan, bool fresh)
 {
 	struct amdxdna_dpt *dpt;
 	int ret;
@@ -962,9 +970,33 @@ static int amdxdna_dpt_resume_chan(struct amdxdna_dev *xdna,
 	mutex_unlock(&dpt->timer_lock);
 
 	/*
-	 * Resubmit the same buffer without clearing it. The handle is
-	 * already reachable through xdna->fw_*, so the backend's init
-	 * hook can reach it for msi/io_base storage.
+	 * Restart the ring the way amdxdna_dpt_publish() does at enable
+	 * time: zero the buffer, which also clears the footer state the
+	 * firmware would otherwise resume from (see amdxdna_dpt_suspend_chan),
+	 * and drop the host cursors with it. Doing this while the channel is
+	 * still SUSPENDED is what makes it safe: no reader can be admitted,
+	 * suspend already drained the ones that were, and both the poll
+	 * timer and the worker are stopped, so nothing else is looking at
+	 * the buffer or at tail / head right now.
+	 *
+	 * PMFW resets the firmware during an FLR with no driver message, so
+	 * the firmware that comes back has no record of the attachment, yet
+	 * the cursors it persisted in the footer survive and it resumes
+	 * incrementing them. The driver cannot vouch for ring contents
+	 * behind an inherited cursor, so a re-attached buffer starts zeroed.
+	 */
+	if (fresh) {
+		memset(to_cpu_addr(dpt->buf, 0), 0, to_buf_size(dpt->buf));
+		drm_clflush_virt_range(to_cpu_addr(dpt->buf, 0),
+				       to_buf_size(dpt->buf));
+		WRITE_ONCE(dpt->tail, 0);
+		dpt->head = 0;
+	}
+
+	/*
+	 * Resubmit the same buffer. The handle is already reachable through
+	 * xdna->fw_*, so the backend's init hook can reach it for msi/io_base
+	 * storage.
 	 */
 	ret = amdxdna_dpt_msg_init(dpt);
 	if (ret) {
@@ -1169,8 +1201,50 @@ int amdxdna_dpt_resume(struct amdxdna_dev *xdna)
 	 * aggregate the result so a failure on one does not skip the other;
 	 * each channel is a safe no-op when it is not active.
 	 */
-	ret = amdxdna_dpt_resume_chan(xdna, &xdna->fw_log);
-	ret2 = amdxdna_dpt_resume_chan(xdna, &xdna->fw_trace);
+	ret = amdxdna_dpt_resume_chan(xdna, &xdna->fw_log, false);
+	ret2 = amdxdna_dpt_resume_chan(xdna, &xdna->fw_trace, false);
+
+	return ret ? ret : ret2;
+}
+
+/*
+ * Quiesce both DPT channels for the duration of an FLR.
+ *
+ * Nothing in the reset path re-issues the per-channel firmware attach
+ * (amdxdna_dpt_msg_init), so once the reset firmware comes up it has no
+ * record of the rings and stops advancing their tails. A watcher parked
+ * in amdxdna_dpt_get_data() is woken only by amdxdna_dpt_update_tail()
+ * seeing that tail move, or by a status flip out of ACTIVE, and a reset
+ * performs neither: it sleeps until it is killed, pinning a runtime PM
+ * reference the whole time.
+ *
+ * Reuse the PM suspend path, which sends no mailbox traffic and so is
+ * safe even when the firmware is already unresponsive. It flips status
+ * before waking, so every watcher it releases re-evaluates
+ * amdxdna_dpt_watch_ready() and leaves; the synchronize_srcu() inside it
+ * waits only for readers its own wake_up_all() can release.
+ */
+int amdxdna_dpt_reset_prepare(struct amdxdna_dev *xdna)
+{
+	return amdxdna_dpt_suspend(xdna);
+}
+
+/*
+ * Bring the DPT channels back after an FLR, restarting each ring rather
+ * than resuming it.
+ *
+ * Callers must invoke this only once the reset has otherwise succeeded.
+ * Leaving a channel SUSPENDED is the safe outcome: amdxdna_dpt_enter()
+ * rejects that state, so a watcher gets -ESHUTDOWN instead of parking on
+ * firmware that is not running, which is the very failure this is meant
+ * to prevent. The same holds when the firmware attach itself fails.
+ */
+int amdxdna_dpt_reset_done(struct amdxdna_dev *xdna)
+{
+	int ret, ret2;
+
+	ret = amdxdna_dpt_resume_chan(xdna, &xdna->fw_log, true);
+	ret2 = amdxdna_dpt_resume_chan(xdna, &xdna->fw_trace, true);
 
 	return ret ? ret : ret2;
 }

--- a/drivers/accel/amdxdna/amdxdna_dpt.h
+++ b/drivers/accel/amdxdna/amdxdna_dpt.h
@@ -21,10 +21,22 @@
  *
  * A single struct amdxdna_dpt and one set of amdxdna_dpt_* helpers serve
  * firmware logging (xdna->fw_log) and firmware tracing (xdna->fw_trace).
- * Each handle's lifetime is guarded by xdna->dpt_srcu so that disabling
- * a kind while N watchers are sleeping inside amdxdna_dpt_get_data
- * delivers -ESHUTDOWN to every one of them and tears down the handle
- * without UAF.
+ * Each is a struct amdxdna_dpt_chan holding everything that channel needs,
+ * so the helpers take a channel pointer and never switch on which channel
+ * they were handed.
+ *
+ * A channel's handle lifetime is guarded by the channel's own SRCU domain,
+ * so that disabling one while N watchers are sleeping inside
+ * amdxdna_dpt_get_data delivers -ESHUTDOWN to every one of them and tears
+ * down the handle without UAF, while leaving watchers parked on the other
+ * channel untouched.
+ *
+ * The domains must be per-channel, not device-wide: a watcher parks in
+ * wait_event_interruptible() while still inside its read-side critical
+ * section, and only its own channel's teardown wakes it. A shared domain
+ * would make disabling one channel wait for a watcher parked on the other,
+ * which nothing wakes, so the teardown would block forever holding
+ * dev_lock.
  */
 
 #define AMDXDNA_DPT_FOOTER_SIZE		SZ_4K
@@ -55,18 +67,12 @@ enum amdxdna_dpt_status {
 	AMDXDNA_DPT_SHUTTING_DOWN,	/* fini in progress; between status write and kfree */
 };
 
-enum amdxdna_dpt_kind {
-	AMDXDNA_DPT_FW_LOG,
-	AMDXDNA_DPT_FW_TRACE,
-	AMDXDNA_DPT_KIND_MAX,
-};
-
-const char *amdxdna_dpt_kind_str(enum amdxdna_dpt_kind kind);
+const char *amdxdna_dpt_name(const struct amdxdna_dpt *dpt);
 
 #define XDNA_DPT_PRINTK(level, dpt, fmt, args...) do {				\
 	const struct amdxdna_dpt *__d = (dpt);					\
 	XDNA_##level(__d->xdna, "%s: " fmt,					\
-		     amdxdna_dpt_kind_str(__d->kind), ##args);			\
+		     amdxdna_dpt_name(__d), ##args);				\
 } while (0)
 
 #define XDNA_DPT_ERR(dpt,  fmt, args...) XDNA_DPT_PRINTK(ERR,  dpt, fmt, ##args)
@@ -95,11 +101,12 @@ struct amdxdna_dpt_footer {
 struct amdxdna_dpt {
 	struct amdxdna_dev		*xdna;
 	struct aie_device		*aie;
-	enum amdxdna_dpt_kind		 kind;
+	/* Channel this handle is published in; also names it for logging. */
+	struct amdxdna_dpt_chan		*chan;
 	enum amdxdna_dpt_status		 status;
 	/*
-	 * Kind-specific configuration: log level for FW_LOG,
-	 * category bitmask for FW_TRACE.
+	 * Per-channel configuration: log level for the log channel,
+	 * category bitmask for the trace channel.
 	 */
 	u32				 config;
 
@@ -136,13 +143,21 @@ struct amdxdna_dpt {
 };
 
 /*
+ * Channel setup, called from probe before any handle can be published and
+ * torn down from the drm release action.
+ */
+int amdxdna_dpt_chan_init(struct amdxdna_dev *xdna);
+void amdxdna_dpt_chan_fini(struct amdxdna_dev *xdna);
+
+/*
  * Top-level DPT lifecycle. amdxdna_dpt_init/fini are called from
  * per-generation init/fini after aie->msg_ops has been populated;
  * amdxdna_dpt_suspend/resume are driven from the common PM layer
  * (amdxdna_pm.c) and take struct amdxdna_dev *.
- * amdxdna_dpt_init auto-starts FW_LOG only; FW_TRACE remains inactive
- * at probe and is opt-in via the DRM_AMDXDNA_SET_FW_TRACE_STATE ioctl
- * to avoid generating large trace payloads unconditionally.
+ * amdxdna_dpt_init auto-starts the log channel only; the trace channel
+ * remains inactive at probe and is opt-in via the
+ * DRM_AMDXDNA_SET_FW_TRACE_STATE ioctl to avoid generating large trace
+ * payloads unconditionally.
  */
 int amdxdna_dpt_init(struct aie_device *aie);
 int amdxdna_dpt_fini(struct aie_device *aie);
@@ -152,9 +167,8 @@ int amdxdna_dpt_resume(struct amdxdna_dev *xdna);
 /* dmesg-dump consumer control (debugfs). */
 int amdxdna_dpt_dump_to_dmesg(struct amdxdna_dpt *dpt, bool enable);
 int amdxdna_fw_log_set_state(struct amdxdna_dev *xdna, u32 level);
-struct amdxdna_dpt *amdxdna_dpt_enter_kind(struct amdxdna_dev *xdna,
-					   enum amdxdna_dpt_kind kind, int *idx);
-void amdxdna_dpt_exit_kind(struct amdxdna_dev *xdna, int idx);
+struct amdxdna_dpt *amdxdna_dpt_enter(struct amdxdna_dpt_chan *chan, int *idx);
+void amdxdna_dpt_exit(struct amdxdna_dpt_chan *chan, int idx);
 
 int amdxdna_get_fw_log(struct aie_device *aie,
 		       struct amdxdna_drm_get_array *args);

--- a/drivers/accel/amdxdna/amdxdna_dpt.h
+++ b/drivers/accel/amdxdna/amdxdna_dpt.h
@@ -164,6 +164,15 @@ int amdxdna_dpt_fini(struct aie_device *aie);
 int amdxdna_dpt_suspend(struct amdxdna_dev *xdna);
 int amdxdna_dpt_resume(struct amdxdna_dev *xdna);
 
+/*
+ * FLR counterparts of suspend/resume, driven from the per-generation
+ * reset_prepare / reset_done handlers. Unlike PM suspend, PMFW resets
+ * the firmware with no driver message, so reset_done restarts each ring
+ * from a zeroed buffer instead of resuming it.
+ */
+int amdxdna_dpt_reset_prepare(struct amdxdna_dev *xdna);
+int amdxdna_dpt_reset_done(struct amdxdna_dev *xdna);
+
 /* dmesg-dump consumer control (debugfs). */
 int amdxdna_dpt_dump_to_dmesg(struct amdxdna_dpt *dpt, bool enable);
 int amdxdna_fw_log_set_state(struct amdxdna_dev *xdna, u32 level);

--- a/drivers/accel/amdxdna/amdxdna_error.c
+++ b/drivers/accel/amdxdna/amdxdna_error.c
@@ -425,6 +425,15 @@ int amdxdna_async_events_alloc(struct aie_device *aie,
 		e->events = events;
 		e->aie = aie;
 
+		/*
+		 * amdxdna_alloc_msg_buff() does not zero. The decode path trusts
+		 * err_cnt and the payload it bounds, so a firmware write shorter
+		 * than the report would otherwise leave page contents to be
+		 * decoded into the cached error userspace reads back. The send
+		 * below flushes this range before arming firmware.
+		 */
+		memset(e->buf, 0, e->size);
+
 		ret = amdxdna_async_event_send(e);
 		if (ret) {
 			amdxdna_free_msg_buff(e->hdl);

--- a/drivers/accel/amdxdna/amdxdna_pci_drv.c
+++ b/drivers/accel/amdxdna/amdxdna_pci_drv.c
@@ -76,9 +76,11 @@ MODULE_FIRMWARE("amdnpu/1b0b_00/cert.dev.sbin");
  *       struct amdxdna_dpt_metadata, _set_dpt_state, _get_dpt_state
  * 0.15: Expose firmware trace GET/GET_CONFIG/SET_STATE ioctls
  * 0.16: Expose auto core dump SET_STATE/GET_INFO ioctls
+ * 0.17: Firmware log and trace reads report -ESTALE when the caller's
+ *       cursor predates a ring restart
  */
 #define AMDXDNA_DRIVER_MAJOR		0
-#define AMDXDNA_DRIVER_MINOR		16
+#define AMDXDNA_DRIVER_MINOR		17
 
 /*
  * Bind the driver base on (vendor_id, device_id) pair and later use the

--- a/drivers/accel/amdxdna/amdxdna_pci_drv.c
+++ b/drivers/accel/amdxdna/amdxdna_pci_drv.c
@@ -19,6 +19,7 @@
 #include "amdxdna_cbuf.h"
 #include "amdxdna_ctx.h"
 #include "amdxdna_debugfs.h"
+#include "amdxdna_dpt.h"
 #include "amdxdna_gem.h"
 #include "amdxdna_pci_drv.h"
 #include "amdxdna_pm.h"
@@ -434,7 +435,7 @@ static void amdxdna_xdna_drm_release(struct drm_device *drm, void *res)
 	struct amdxdna_dev *xdna = res;
 
 	amdxdna_carveout_fini(xdna);
-	cleanup_srcu_struct(&xdna->dpt_srcu);
+	amdxdna_dpt_chan_fini(xdna);
 	ida_destroy(&xdna->hwctx_ida);
 }
 
@@ -475,13 +476,13 @@ static int amdxdna_probe(struct pci_dev *pdev, const struct pci_device_id *id)
 	ida_init(&xdna->hwctx_ida);
 	pci_set_drvdata(pdev, xdna);
 
-	ret = init_srcu_struct(&xdna->dpt_srcu);
+	ret = amdxdna_dpt_chan_init(xdna);
 	if (ret)
 		return ret;
 
 	ret = drmm_add_action(ddev, amdxdna_xdna_drm_release, xdna);
 	if (ret) {
-		cleanup_srcu_struct(&xdna->dpt_srcu);
+		amdxdna_dpt_chan_fini(xdna);
 		return ret;
 	}
 

--- a/drivers/accel/amdxdna/amdxdna_pci_drv.h
+++ b/drivers/accel/amdxdna/amdxdna_pci_drv.h
@@ -138,7 +138,22 @@ struct amdxdna_dev_info {
 
 struct amdxdna_carveout;
 struct amdxdna_dpt;
+struct amdxdna_dpt_desc;
 struct aie_device;
+
+/*
+ * One firmware Debug/Profile/Trace channel, holding everything needed to
+ * work with it: @srcu guards the lifetime of @data, and @desc carries the
+ * channel's constants and firmware hooks. Callers pass a channel pointer
+ * around rather than a handle plus a discriminator, so the two channels
+ * share one set of helpers without any of them switching on which is which.
+ * struct amdxdna_dpt_desc is private to amdxdna_dpt.c.
+ */
+struct amdxdna_dpt_chan {
+	struct srcu_struct		srcu;
+	struct amdxdna_dpt __rcu	*data;
+	const struct amdxdna_dpt_desc	*desc;
+};
 
 struct amdxdna_dev {
 	struct drm_device		ddev;
@@ -169,14 +184,13 @@ struct amdxdna_dev {
 
 	struct amdxdna_carveout		*carveout;
 
-	/* Firmware Debug/Profile/Trace (DPT) framework. dpt_srcu guards the
-	 * lifetime of every dpt handle hung off this device; on disable we
-	 * synchronize_srcu so kfree of the handle is provably ordered after
-	 * any watcher's srcu_read_unlock.
+	/* Firmware Debug/Profile/Trace (DPT) framework. Each channel owns the
+	 * SRCU domain guarding its own handle; on disable we synchronize_srcu
+	 * so kfree of the handle is provably ordered after any watcher's
+	 * srcu_read_unlock.
 	 */
-	struct srcu_struct		dpt_srcu;
-	struct amdxdna_dpt __rcu	*fw_log;
-	struct amdxdna_dpt __rcu	*fw_trace;
+	struct amdxdna_dpt_chan		fw_log;
+	struct amdxdna_dpt_chan		fw_trace;
 
 	/* Allow auto core dump for hardware contexts, if true. */
 	bool				auto_coredump;

--- a/drivers/accel/amdxdna/amdxdna_pm.c
+++ b/drivers/accel/amdxdna/amdxdna_pm.c
@@ -24,7 +24,7 @@ int amdxdna_pm_suspend(struct device *dev)
 	/*
 	 * Drain and pause firmware DPT (log/trace) after the device has
 	 * quiesced. Common to every generation/config; a safe no-op when no
-	 * DPT kind is active. A drain/pause failure must not change the
+	 * DPT channel is active. A drain/pause failure must not change the
 	 * device suspend result (logging/tracing is auxiliary), but surface
 	 * it so it is visible rather than silently swallowed.
 	 */

--- a/include/uapi/drm/amdxdna_accel.h
+++ b/include/uapi/drm/amdxdna_accel.h
@@ -895,6 +895,15 @@ struct amdxdna_drm_get_array {
 	 * call sleeps in the kernel until new data is available, logging is
 	 * disabled, or a signal arrives.
 	 *
+	 * Returns -ESTALE if @offset predates a disable/enable cycle that
+	 * restarted the ring: that cursor can never be satisfied, and the
+	 * data emitted before the restart is lost. The metadata is still
+	 * written back, with @offset reset to the start of the live ring and
+	 * @size 0, so a caller resumes by storing it and reissuing the call.
+	 * Returns -ESHUTDOWN if logging is not enabled, or was disabled while
+	 * the call waited; that is terminal for the session, so a caller must
+	 * not retry it in a loop. Any other error leaves @buffer untouched.
+	 *
 	 * Access: requires CAP_SYS_ADMIN.
 	 *
 	 * %DRM_AMDXDNA_FW_LOG_CONFIG:
@@ -916,6 +925,15 @@ struct amdxdna_drm_get_array {
 	 * watch); the remainder receives the payload. When @watch is set the
 	 * call sleeps in the kernel until new data is available, tracing is
 	 * disabled, or a signal arrives.
+	 *
+	 * Returns -ESTALE if @offset predates a disable/enable cycle that
+	 * restarted the ring: that cursor can never be satisfied, and the
+	 * events emitted before the restart are lost. The metadata is still
+	 * written back, with @offset reset to the start of the live ring and
+	 * @size 0, so a caller resumes by storing it and reissuing the call.
+	 * Returns -ESHUTDOWN if tracing is not enabled, or was disabled while
+	 * the call waited; that is terminal for the session, so a caller must
+	 * not retry it in a loop. Any other error leaves @buffer untouched.
 	 *
 	 * Access: requires CAP_SYS_ADMIN.
 	 *

--- a/src/shim/device.cpp
+++ b/src/shim/device.cpp
@@ -926,6 +926,8 @@ struct event_trace
             throw xrt_core::system_error(EINTR, "Query interrupted by user");
           else if (e.get_code() == ESHUTDOWN)
             throw xrt_core::system_error(ESHUTDOWN, "Event trace disabled during query");
+          else if (e.get_code() == ESTALE)
+            throw xrt_core::system_error(ESTALE, "Event trace ring restarted during query");
           else if (e.get_code() == EPERM)
             throw xrt_core::system_error(EPERM, "Must be root to access event trace");
           throw std::runtime_error("Failed to get event_trace");
@@ -1055,6 +1057,8 @@ struct firmware_log
             throw xrt_core::system_error(EINTR, "Query interrupted by user");
           else if (e.get_code() == ESHUTDOWN)
             throw xrt_core::system_error(ESHUTDOWN, "Firmware log disabled during query");
+          else if (e.get_code() == ESTALE)
+            throw xrt_core::system_error(ESTALE, "Firmware log ring restarted during query");
           else if (e.get_code() == EPERM)
             throw xrt_core::system_error(EPERM, "Must be root to access firmware log");
           throw std::runtime_error("Failed to get firmware log");

--- a/test/scripts/test_fw_dpt_xrt_smi.sh
+++ b/test/scripts/test_fw_dpt_xrt_smi.sh
@@ -35,6 +35,14 @@
 # sufficient. Pass --xrt-smi <path> only when testing a
 # newer-than-installed in-tree build.
 #
+# One group -- "fw_dpt: cross-channel teardown" -- needs BOTH channels active at
+# the same time, so it runs only in the default (both) mode and is skipped
+# by -log and -trace. It is the regression test for the cross-channel SRCU
+# deadlock, and on a driver that still carries that bug it will briefly
+# wedge the device before recovering it by killing the readers parked in
+# the DPT watch path. See the block comment above
+# test_fw_dpt_cross_channel_teardown.
+#
 # The event-trace groups need a workload to make the firmware emit trace
 # events; they run the shim_test case selected by SHIM_TEST_CASE
 # ("multi-command preempt full ELF io test real kernel good run",
@@ -164,6 +172,64 @@ ORIG_LOG_LEVEL=""
 ORIG_TRACE_CAPTURED=0
 ORIG_TRACE_STATE=""
 ORIG_TRACE_CATS=""
+
+# ---------------------------------------------------------------------------
+# Cross-channel teardown group state
+# ---------------------------------------------------------------------------
+
+# Pid this script launched a deliberately-parked watcher under. This is
+# the ROOT of the watcher's process tree, which is not necessarily the
+# process that blocks inside the driver's wait_event_interruptible -- see
+# dpt_watcher_tree. On a driver with the cross-channel SRCU bug that parked
+# reader is the ONLY thing whose death lets a blocked
+# amdxdna_dpt_fini_chan() finish, so the EXIT/INT/TERM trap must always
+# release it: an interrupted run that leaves it behind leaves the device
+# wedged until somebody kills that reader by hand.
+DPT_PARKED_WATCHER_PID=""
+
+# Pid of the backgrounded, timed "configure --disable" under measurement.
+DPT_DISABLE_PID=""
+
+# Set to 1 once a teardown has been seen NOT to return even after every
+# reader found parked in the DPT watch path was released. It records an
+# observation, not a verdict on the host: teardown() re-checks whether the
+# device answers once its own cleanup has run, and only skips the DPT
+# state restore if it does not, because the configure ioctls that replay
+# the captured state would block on the dev_lock a still-blocked teardown
+# holds.
+DPT_DEVICE_WEDGED=0
+
+# Wall-clock budget for a DPT disable issued while a watcher is parked.
+# The verified-good figures on aie4 are ~200ms cross-channel and ~201ms
+# same-channel; 5000ms is deliberately generous headroom for a loaded CI host
+# while staying orders of magnitude below the "never returns" failure this
+# group exists to catch.
+DPT_TEARDOWN_BUDGET_MS=5000
+
+# Hard bound on how long an outstanding disable is tolerated before it is
+# declared wedged and the parked watcher is killed to recover the device.
+DPT_TEARDOWN_WEDGE_MS=15000
+
+# A park must hold across this many consecutive 250ms samples before it
+# counts as stable. A single snapshot is not enough: a watcher that is
+# merely between poll iterations can momentarily look parked, and firing
+# the teardown at that instant yields a meaningless "fast" measurement.
+DPT_PARK_STABLE_SAMPLES=8
+
+# Wall-clock budget for a watcher to reach a stable park, sampled every
+# 250ms. It has to cover draining whatever the ring already held before
+# the cursor reaches the tail, plus DPT_PARK_STABLE_SAMPLES of holding
+# still. Measured on npu4 the watcher was already parked at the first
+# sample and stable 2s later, so this is roughly 4x the observed
+# time-to-stable -- enough slack for a chattier ring or a loaded host
+# without making a genuine "never parks" failure slow to report.
+DPT_PARK_BUDGET_MS=10000
+
+# Wall-clock budget for the post-cleanup "does the device still answer"
+# probe. Generous because it only runs on a path that has already failed,
+# and an examine on a busy but healthy device is worth waiting out rather
+# than misreporting as wedged.
+DPT_PROBE_BUDGET_MS=20000
 
 # ---------------------------------------------------------------------------
 # Pretty-print helpers
@@ -806,14 +872,55 @@ teardown() {
     local rc=$?
     info "Cleaning up..."
 
+    # Release a deliberately-parked DPT watcher FIRST. If the cross-channel
+    # group was interrupted mid-measurement, a teardown may be blocked in
+    # synchronize_srcu holding dev_lock, and nothing else below can make
+    # progress until that reader drops its SRCU read lock.
+    dpt_release_parked_watcher
+
     local pat
     pat=$(dpt_consumer_pattern)
     pkill -TERM -f "${pat}" 2>/dev/null || true
     sleep 0.3
     pkill -KILL -f "${pat}" 2>/dev/null || true
 
-    # Best-effort: only meaningful once xrt-smi has been resolved.
-    if [[ -n "${XRT_SMI_BIN}" && -n "${BDF}" ]]; then
+    # The restore runs after BOTH kills above, and that order is
+    # load-bearing twice over. A reader left parked would have its channel
+    # woken and re-read behind the replay; and the replay's own configure
+    # invocations match the BDF-scoped consumer pattern pkilled just above,
+    # so a restore started any earlier would be killed by this very
+    # cleanup.
+    #
+    # Restoring is only meaningful once xrt-smi has been resolved, and only
+    # safe while the device still answers. restore_dpt_state() replays the
+    # captured configuration with configure ioctls, and those take the same
+    # xdna->dev_lock that a teardown blocked in synchronize_srcu is still
+    # holding. On a wedged device the replay would therefore block forever
+    # -- turning a reported failure into a trap that never returns, with no
+    # summary and no exit code, on shared lab hardware.
+    #
+    # When the cross-channel group could not get a teardown to return, the
+    # readers that were pinning it have just been killed above, so whether
+    # the device recovered is now a question with a cheap answer. Answer it
+    # instead of guessing: on hardware this cleanup did recover the device
+    # every time, and a reboot demanded wrongly on a shared lab host gets
+    # acted on and destroys somebody else's session.
+    if (( DPT_DEVICE_WEDGED )); then
+        info "cross-channel group reported an unfinished teardown; checking whether the" \
+             "device responds now that the parked readers are gone"
+        if dpt_device_responds; then
+            info "device RESPONDS after cleanup (xrt-smi examine returned 0):" \
+                 "killing the readers recovered it, and no reboot is indicated"
+            restore_dpt_state
+        else
+            info "device did NOT respond to a bounded xrt-smi examine after cleanup:" \
+                 "a blocked teardown is most likely still holding dev_lock"
+            info "skipping the DPT state restore: its configure ioctls would block on" \
+                 "that lock rather than put anything back, and the trap would never return"
+            info "the device is left as the tests left it; this host may need a reboot to" \
+                 "clear it, and nothing else here can"
+        fi
+    elif [[ -n "${XRT_SMI_BIN}" && -n "${BDF}" ]]; then
         restore_dpt_state
     fi
 
@@ -1759,6 +1866,685 @@ test_fw_trace_multi_watcher() {
 }
 
 # ---------------------------------------------------------------------------
+# Cross-channel teardown (SRCU domain split regression)
+#
+# fw_log and fw_trace used to share ONE device-wide dpt_srcu domain. A
+# watcher parks inside its SRCU read-side critical section --
+# amdxdna_dpt_enter() takes srcu_read_lock, then
+# amdxdna_dpt_get_data() sleeps in wait_event_interruptible() and only
+# amdxdna_dpt_exit() drops the lock, after the wait returns. Teardown
+# via amdxdna_dpt_fini_chan() wake_up_all()s only ITS OWN channel's waitqueue
+# and then calls synchronize_srcu(). On a shared domain that
+# synchronize_srcu also waited for the other channel's parked watcher, which
+# nothing in that path wakes, so disabling one channel never returned -- while
+# holding xdna->dev_lock, so every later ioctl piled up behind it.
+#
+# The assertion is a wall-clock one, because that is the only thing that
+# distinguishes the two behaviours: with per-channel domains the teardown
+# returns in ~200ms, and without them it does not return at all. Being
+# fast is necessary but not sufficient, though -- the disable must also
+# have exited 0. A command that errors out returns every bit as fast as
+# one that did the work, so on timing alone a broken teardown path would
+# be recorded as a pass having measured nothing about teardown at all.
+#
+# Both cases park a fw_trace watcher, because an idle trace ring is the
+# most reliable way to keep a watcher parked: with no workload the tail
+# stops advancing, so the watcher's cursor reaches the tail and it sleeps
+# instead of returning data. A chatty ring is the enemy here -- the
+# firmware writing wakes the watcher, it briefly drops the SRCU lock, and
+# a teardown can slip through, turning a real deadlock into a spurious
+# pass. fw_log is therefore held at level 1 (ERR) for the same reason.
+#
+# DANGER: on an unfixed driver this wedges the device. The blocked teardown
+# sits in uninterruptible D state inside synchronize_srcu() holding
+# dev_lock, and the only thing that frees it is killing every reader parked
+# in the domain -- not merely the one this group parked, since on a shared
+# domain readers left behind by earlier groups hold it open just as
+# effectively. Readers do sleep in wait_event_INTERRUPTIBLE, so a signal
+# reaches them.
+# Everything below is therefore bounded -- no unbounded wait anywhere, not
+# even in timeout(1), which would itself block reaping a D-state child.
+# The bare wait(1) calls are not an exception: each one only collects the
+# exit status of a pid that dpt_wait_pid_ms has already watched exit, so
+# there is nothing left for it to wait for. DPT_PARKED_WATCHER_PID is
+# tracked globally so the EXIT/INT/TERM trap releases the watcher's whole
+# process tree, reader included, even if this script is killed
+# mid-measurement.
+# ---------------------------------------------------------------------------
+
+# Bounded wait for pid $1 to exit, up to $2 milliseconds, polling at 50ms.
+# Returns 0 as soon as the pid is gone, 1 if it is still alive at the
+# deadline. Deliberately never waits indefinitely: this is what keeps the
+# wedge scenario recoverable.
+dpt_wait_pid_ms() {
+    local pid="$1" limit="$2" waited=0
+    while :; do
+        kill -0 "${pid}" 2>/dev/null || return 0
+        (( waited >= limit )) && return 1
+        sleep 0.05
+        waited=$((waited + 50))
+    done
+}
+
+# Whether /proc/<tid>/stack can be read at all on this kernel (needs
+# CONFIG_STACKTRACE, plus root). Without it there is no way to prove a
+# watcher really parked, and this group skips rather than assert on timing
+# it cannot attribute.
+#
+# The read has to be attempted, and nothing but the read decides: the mode
+# bits on /proc/self/stack say 0400 to its owner, but the open is gated on
+# CAP_SYS_ADMIN and is refused outright under kernel lockdown, so [[ -r ]]
+# answers yes where the read fails and the group would report "never
+# parked" on a kernel that simply cannot answer the question. It also
+# answers no where the read would succeed, because it tests the real uid
+# while the open uses the effective one, and the group would skip a check
+# the host could have run.
+dpt_stack_probe_available() {
+    cat /proc/self/stack >/dev/null 2>&1
+}
+
+# Echo the live pids of the watcher process tree rooted at $1, parents
+# before children, or nothing if the root is already gone.
+#
+# The pid a watcher is launched under is NOT necessarily the process that
+# blocks in the kernel. A stock install ships /opt/xilinx/xrt/bin/xrt-smi
+# as a POSIX shell wrapper that forks bin/unwrapped/xrt-smi and then sits
+# in wait4(), so $! names a /bin/sh: its state is S, but its stack is
+# do_wait and can never hold a DPT frame, and a signal delivered to it
+# does not reach the reader. Other installs -- and possibly future ones --
+# exec the binary directly, with no wrapper layer at all.
+#
+# Walking the subtree covers both without assuming either shape: with no
+# children the root is the only pid returned, which is exactly the
+# no-wrapper case. Callers re-walk on every sample rather than resolving
+# once, so a wrapper that has not forked yet at launch is simply picked up
+# by the next sample instead of being latched onto by a fixed sleep.
+dpt_watcher_tree() {
+    local pid="$1" kid
+    [[ -z "${pid}" ]] && return 0
+    kill -0 "${pid}" 2>/dev/null || return 0
+    printf '%s\n' "${pid}"
+    while read -r kid; do
+        [[ -n "${kid}" ]] || continue
+        dpt_watcher_tree "${kid}"
+    done < <(pgrep -P "${pid}" 2>/dev/null || true)
+    return 0
+}
+
+# Regex matching a kernel stack frame that means "parked in the amdxdna
+# DPT watch path". Matched as a SET rather than as amdxdna_dpt_get_data
+# exactly, because that function is static and the compiler is free to
+# inline it into amdxdna_get_fw_log / amdxdna_get_fw_trace, in which case
+# the sleeping frame carries the caller's name instead. It was observed
+# un-inlined on the npu4 build this group was validated against, but that
+# is one kernel built by one compiler and the set costs nothing.
+#
+# Shared by the park proof (dpt_parked_stack) and the recovery lever
+# (dpt_release_dpt_parked_readers) on purpose: the lever must recognise
+# exactly the state the proof calls "parked", or it would fail to release
+# readers the proof would have accepted.
+DPT_PARK_FRAME_RE='amdxdna_(dpt_get_data|get_fw_log|get_fw_trace)'
+
+# Echo "pid=<pid> tid=<tid> state=<S>" plus the kernel stack of the first
+# thread anywhere in the watcher tree rooted at $1 that is parked in the
+# DPT watch path, or nothing if no thread is.
+#
+# A park is two independent facts, and both are required: the thread is in
+# interruptible sleep (state S in /proc/<tid>/stat) and its kernel stack is
+# inside the amdxdna DPT get-data ioctl. State alone is far too weak --
+# xrt-smi sleeps in plenty of other places, and the shell wrapper that
+# dpt_watcher_tree exists to see past sits in wait4() in state S for its
+# whole life -- while the stack alone does not prove the thread is asleep
+# rather than passing through.
+dpt_parked_stack() {
+    local root="$1" pid tdir tid stat_line state stack
+    [[ -z "${root}" ]] && return 0
+    while read -r pid; do
+        for tdir in /proc/"${pid}"/task/*; do
+            [[ -r "${tdir}/stack" ]] || continue
+            stat_line=$(cat "${tdir}/stat" 2>/dev/null) || continue
+            # "pid (comm) state ...", and comm may itself contain spaces
+            # and parentheses, so split after the LAST ") ".
+            state="${stat_line##*') '}"
+            state="${state%% *}"
+            [[ "${state}" == "S" ]] || continue
+            stack=$(cat "${tdir}/stack" 2>/dev/null) || continue
+            grep -qE "${DPT_PARK_FRAME_RE}" <<<"${stack}" || continue
+            tid=$(basename "${tdir}")
+            printf 'pid=%s tid=%s state=%s\n%s' \
+                "${pid}" "${tid}" "${state}" "${stack}"
+            return 0
+        done
+    done < <(dpt_watcher_tree "${root}")
+    return 0
+}
+
+# Launch an --event-trace --watch consumer and wait for it to park stably
+# inside the driver's wait_event_interruptible. Sets
+# DPT_PARKED_WATCHER_PID as soon as the process exists, so the trap can
+# release it even if parking never completes, and writes the proving
+# evidence to the file $3.
+#
+# MUST be called directly, never through $( ): the watcher has to be a
+# child of the calling shell so that DPT_PARKED_WATCHER_PID is visible to
+# the trap and so dpt_release_parked_watcher can wait on it. That is why
+# the evidence goes to a file instead of stdout.
+#
+# Returns: 0 parked stably, 1 never parked, 2 exited before parking,
+#          3 no stack evidence available on this kernel.
+dpt_park_trace_watcher() {
+    local out="$1" err="$2" evidence="$3"
+    local pid stack samples stable=0 i
+
+    : >"${out}"; : >"${err}"; : >"${evidence}"
+    xrt_smi --advanced examine -d "${BDF}" --event-trace --watch \
+        >"${out}" 2>"${err}" &
+    pid=$!
+    DPT_PARKED_WATCHER_PID="${pid}"
+
+    dpt_stack_probe_available || return 3
+
+    # The park is looked for anywhere in the watcher's process tree, not
+    # just in ${pid}, because ${pid} may be a shell wrapper -- see
+    # dpt_watcher_tree. ${pid} is still the right liveness check: it is the
+    # process this shell spawned, so its exit means the watcher run is
+    # over however many layers it had.
+    samples=$(( DPT_PARK_BUDGET_MS / 250 ))
+    for (( i = 0; i < samples; i++ )); do
+        kill -0 "${pid}" 2>/dev/null || return 2
+        stack=$(dpt_parked_stack "${pid}")
+        if [[ -n "${stack}" ]]; then
+            stable=$((stable + 1))
+            if (( stable >= DPT_PARK_STABLE_SAMPLES )); then
+                printf '%s' "${stack}" >"${evidence}"
+                return 0
+            fi
+        else
+            # Woke up: the ring is still advancing. Restart the streak so
+            # only a genuinely quiet, continuously parked watcher counts.
+            stable=0
+        fi
+        sleep 0.25
+    done
+    return 1
+}
+
+# Release the deliberately-parked watcher. This is the recovery lever for
+# the wedge scenario: a blocked amdxdna_dpt_fini_chan() cannot make
+# progress until this reader drops its SRCU read lock. Idempotent, safe to
+# call from the trap, and safe to call when nothing was ever parked.
+#
+# It signals the whole watcher tree, not just the pid the watcher was
+# launched under, and that is the safety-critical part rather than a
+# tidiness one: measured on npu4, a SIGTERM delivered to the shell wrapper
+# alone left the reader parked in wait_event_interruptible, so on an
+# unfixed driver this "recovery" would have stranded the board instead of
+# freeing it.
+#
+# The tree is snapshotted BEFORE the first signal. Killing the wrapper
+# reparents the reader to init, after which pgrep -P cannot find it and
+# the reader we most need to reach becomes invisible.
+dpt_release_parked_watcher() {
+    local root="${DPT_PARKED_WATCHER_PID}"
+    local pids=()
+    local pid i
+
+    [[ -z "${root}" ]] && return 0
+    DPT_PARKED_WATCHER_PID=""
+
+    while read -r pid; do
+        [[ -n "${pid}" ]] && pids+=("${pid}")
+    done < <(dpt_watcher_tree "${root}")
+
+    # Deepest first: the reader is what holds the SRCU read lock, and
+    # reaching it before the shell that reaps it keeps the wrapper around
+    # to be waited on rather than leaving an orphan behind.
+    for (( i = ${#pids[@]} - 1; i >= 0; i-- )); do
+        kill -TERM "${pids[i]}" 2>/dev/null || true
+    done
+    for (( i = ${#pids[@]} - 1; i >= 0; i-- )); do
+        if ! dpt_wait_pid_ms "${pids[i]}" 3000; then
+            kill -KILL "${pids[i]}" 2>/dev/null || true
+            dpt_wait_pid_ms "${pids[i]}" 3000 || true
+        fi
+    done
+    wait "${root}" 2>/dev/null || true
+}
+
+# Hard bound on how many ancestors dpt_proc_depth will walk. The walk is
+# for ORDERING only -- no ancestor is ever signalled -- but it still needs
+# a bound: an earlier version of this lever walked the parent chain until
+# it reached pid 1 and killed this script's own harness shell on the way.
+# Nothing legitimate in an xrt-smi launch is more than a handful of levels
+# deep, so a walk that exceeds this is a bug or a pid-reuse race, and the
+# right answer is to stop rather than to keep climbing.
+DPT_PROC_DEPTH_MAX=16
+
+# Echo how many ancestors pid $1 has, stopping at DPT_PROC_DEPTH_MAX, at
+# pid 1, or at the first unreadable /proc entry. Used only to sort kill
+# candidates deepest-first; the ancestors themselves are never touched.
+dpt_proc_depth() {
+    local pid="$1" depth=0 stat_line rest ppid
+    while (( depth < DPT_PROC_DEPTH_MAX )); do
+        [[ -n "${pid}" && "${pid}" != "0" && "${pid}" != "1" ]] || break
+        stat_line=$(cat "/proc/${pid}/stat" 2>/dev/null) || break
+        # "pid (comm) state ppid ...", and comm may contain spaces and
+        # parentheses, so split after the LAST ") ".
+        rest="${stat_line##*') '}"
+        read -r _ ppid _ <<<"${rest}"
+        [[ -n "${ppid}" ]] || break
+        pid="${ppid}"
+        depth=$((depth + 1))
+    done
+    printf '%s' "${depth}"
+}
+
+# Echo the tid of the first thread of pid $1 that is parked in the DPT
+# watch path (interruptible sleep plus a DPT_PARK_FRAME_RE frame), or
+# nothing. Same two-fact test as dpt_parked_stack, applied to one process
+# rather than to a process tree.
+dpt_parked_tid() {
+    local pid="$1" tdir stat_line state
+    [[ -n "${pid}" ]] || return 0
+    for tdir in /proc/"${pid}"/task/*; do
+        [[ -r "${tdir}/stack" ]] || continue
+        stat_line=$(cat "${tdir}/stat" 2>/dev/null) || continue
+        state="${stat_line##*') '}"
+        state="${state%% *}"
+        [[ "${state}" == "S" ]] || continue
+        grep -qE "${DPT_PARK_FRAME_RE}" "${tdir}/stack" 2>/dev/null || continue
+        basename "${tdir}"
+        return 0
+    done
+    return 0
+}
+
+# Release EVERY reader parked in this device's DPT watch path, not just the
+# one this group tracked, and echo how many were signalled.
+#
+# dpt_release_parked_watcher alone is not a recovery lever for a full-script
+# run. By the time this group runs, the earlier groups have left on the
+# order of twenty other --watch consumers parked in the DPT wait path, and
+# on a driver with the shared SRCU domain every one of them keeps that
+# domain occupied. Killing only the pid this group happens to have
+# bookkeeping for leaves the teardown blocked on all the others, so the
+# group would report a wedged device it could in fact have recovered.
+#
+# Readers are identified by their KERNEL STACK rather than by pid
+# bookkeeping. That is what makes this work at all here: these readers were
+# launched by earlier groups that kept no record of them, and stack identity
+# also survives the reparenting that defeats pgrep -P walking.
+#
+# SCOPE -- this runs on shared lab hosts, so a process is signalled only if
+# BOTH hold:
+#
+#   1. its command line matches dpt_consumer_pattern, i.e. it is an xrt-smi
+#      --firmware-log/--event-trace consumer aimed at THIS BDF. This is the
+#      same bar teardown()'s pkill already uses, and the candidate set comes
+#      from pgrep against that pattern rather than from a sweep of all of
+#      /proc, so a process that does not match is never even examined.
+#   2. it has a thread parked in DPT_PARK_FRAME_RE, the same frame set the
+#      park proof uses.
+#
+# The intersection is strictly narrower than the existing pkill: every
+# process this can kill, teardown()'s pkill would already have killed.
+# Notably the disable under measurement cannot be caught by it even though
+# its command line does match (1): it is blocked in synchronize_srcu, which
+# is an uninterruptible D-state wait under amdxdna_dpt_fini_chan, so it
+# fails both the state and the frame half of (2). It is excluded by pid as
+# well, so that guarantee does not rest on reading stacks correctly.
+dpt_release_dpt_parked_readers() {
+    local pat cand tid depth
+    local -a ordered=()
+    local entry pid i signalled=0
+
+    pat=$(dpt_consumer_pattern)
+
+    while read -r cand; do
+        [[ -n "${cand}" ]] || continue
+        # Never signal this script, the shell it runs in, or the very
+        # disable whose duration is being measured.
+        [[ "${cand}" == "$$" || "${cand}" == "${BASHPID}" ]] && continue
+        [[ -n "${DPT_DISABLE_PID}" && "${cand}" == "${DPT_DISABLE_PID}" ]] && continue
+        tid=$(dpt_parked_tid "${cand}")
+        [[ -n "${tid}" ]] || continue
+        depth=$(dpt_proc_depth "${cand}")
+        ordered+=("${depth} ${cand}")
+    done < <(pgrep -f "${pat}" 2>/dev/null || true)
+
+    (( ${#ordered[@]} == 0 )) && { printf '0'; return 0; }
+
+    # Deepest first, for the same reason dpt_release_parked_watcher does
+    # it: reach the reader that holds the SRCU read lock before any shell
+    # that would reap it.
+    local -a pids=()
+    while read -r entry; do
+        [[ -n "${entry}" ]] && pids+=("${entry#* }")
+    done < <(printf '%s\n' "${ordered[@]}" | sort -k1,1nr -k2,2n)
+
+    for pid in "${pids[@]}"; do
+        kill -TERM "${pid}" 2>/dev/null && signalled=$((signalled + 1))
+    done
+    for (( i = 0; i < ${#pids[@]}; i++ )); do
+        if ! dpt_wait_pid_ms "${pids[i]}" 3000; then
+            kill -KILL "${pids[i]}" 2>/dev/null || true
+            dpt_wait_pid_ms "${pids[i]}" 3000 || true
+        fi
+    done
+
+    printf '%s' "${signalled}"
+}
+
+# Quiesce the --watch consumers earlier groups left parked on this device,
+# using the same BDF-scoped pattern teardown() and pre_flight() use, and
+# wait a bounded time for them to go.
+#
+# This is a precondition for the cross-channel group rather than part of its
+# measurement: see the comment in test_fw_dpt_cross_channel_teardown for why
+# leftover readers have to be gone before the control runs.
+dpt_quiesce_leftover_readers() {
+    local pat pid
+    local -a leftover=()
+
+    pat=$(dpt_consumer_pattern)
+    while read -r pid; do
+        [[ -n "${pid}" ]] && leftover+=("${pid}")
+    done < <(pgrep -f "${pat}" 2>/dev/null || true)
+
+    (( ${#leftover[@]} == 0 )) && return 0
+
+    info "quiescing ${#leftover[@]} leftover DPT consumer(s) from earlier groups (BDF-scoped)"
+    pkill -TERM -f "${pat}" 2>/dev/null || true
+    for pid in "${leftover[@]}"; do
+        dpt_wait_pid_ms "${pid}" 3000 || true
+    done
+    pkill -KILL -f "${pat}" 2>/dev/null || true
+    for pid in "${leftover[@]}"; do
+        dpt_wait_pid_ms "${pid}" 3000 || true
+    done
+}
+
+# Bounded probe of whether the device still answers an ordinary xrt-smi
+# query. Used after cleanup to report what actually happened to the device
+# instead of guessing, and to decide whether restoring the captured DPT
+# state can be attempted at all. Returns 0 only if the device answered.
+#
+# Deliberately NOT timeout(1). The state this probe exists to detect is a
+# teardown still holding xdna->dev_lock, and everything behind that lock
+# blocks in mutex_lock(), which is TASK_UNINTERRUPTIBLE --
+# amdxdna_drm_get_info_ioctl() takes dev_lock unconditionally, so the
+# examine below is exactly such a caller. A child in D state is reaped by
+# no signal, and timeout(1) waits for the child it signalled, so it would
+# hang precisely in the case this probe has to answer. The measurement
+# path avoids timeout(1) for the same reason.
+#
+# So the examine runs as a background job watched by the same bounded
+# poll. A probe still running at the deadline is reported as "did not
+# respond": the process is left behind, because nothing can reap it until
+# the lock is released, but this function returns and the trap goes on to
+# print a summary and exit.
+#
+# The xrt_smi() wrapper is not used here: backgrounding a shell function
+# makes $! the pid of a subshell rather than of the examine itself.
+dpt_device_responds() {
+    local pid rc=0
+
+    [[ -n "${XRT_SMI_BIN}" && -n "${BDF}" ]] || return 1
+
+    LD_LIBRARY_PATH="$(xrt_smi_ld_path)" \
+        "${XRT_SMI_BIN}" examine -d "${BDF}" >/dev/null 2>&1 &
+    pid=$!
+
+    if ! dpt_wait_pid_ms "${pid}" "${DPT_PROBE_BUDGET_MS}"; then
+        # Best effort only: a task blocked on dev_lock will not take it.
+        kill -TERM "${pid}" 2>/dev/null || true
+        return 1
+    fi
+
+    # Collects the status of a pid already observed to have exited, so
+    # this cannot block.
+    wait "${pid}" || rc=$?
+    return "${rc}"
+}
+
+# Run "configure --<$1> --disable" in the background, recording its own
+# wall-clock duration in milliseconds into the file $2. Sets
+# DPT_DISABLE_PID to the background pid.
+#
+# The background job exits with the disable's own exit status, so the
+# caller can require the command to have SUCCEEDED and not merely to have
+# returned. Timing alone cannot tell a disable that failed fast from one
+# that succeeded fast, and only the latter says anything about teardown.
+# The duration is still stamped on the failing path, so a failure can be
+# reported with the measurement that produced it.
+#
+# Backgrounded on purpose rather than wrapped in timeout(1): on an unfixed
+# driver this command never returns until the parked watcher dies, and
+# timeout would be no help because it waits for a child that is stuck in
+# uninterruptible D state inside synchronize_srcu(). The caller polls with
+# dpt_wait_pid_ms and kills the watcher to recover.
+#
+# Like dpt_park_trace_watcher, this must be called directly rather than
+# through $( ), so the job stays a child of the calling shell and
+# DPT_DISABLE_PID survives for both the poll and the later wait.
+dpt_disable_timed_bg() {
+    local opt="$1" stamp="$2"
+    : >"${stamp}"
+    (
+        drc=0
+        t0=$(date +%s%N)
+        LD_LIBRARY_PATH="$(xrt_smi_ld_path)" \
+            "${XRT_SMI_BIN}" --advanced configure -d "${BDF}" \
+                "--${opt}" --disable >/dev/null 2>&1 || drc=$?
+        printf '%s' "$(( ($(date +%s%N) - t0) / 1000000 ))" >"${stamp}"
+        exit "${drc}"
+    ) &
+    DPT_DISABLE_PID=$!
+}
+
+# Park a trace watcher, then time a disable of the channel named by the
+# xrt-smi option $2 while that watcher is parked.
+#
+#   $1 case_label : label for the assertion text
+#   $2 opt        : "firmware-log" (cross-channel) or "event-trace"
+#                   (same-channel)
+dpt_measure_teardown() {
+    local case_label="$1" opt="$2"
+    local out="${TMPDIR_}/dpt_park_${opt}.out"
+    local err="${TMPDIR_}/dpt_park_${opt}.err"
+    local evidence="${TMPDIR_}/dpt_park_${opt}.stack"
+    local stamp="${TMPDIR_}/dpt_disable_${opt}.ms"
+    local rc dpid drc elapsed released
+
+    # Two jobs at once. Level 1 (ERR) is the quietest level the driver
+    # accepts, which keeps the firmware from writing while the watcher is
+    # trying to stay parked. Enabling also guarantees fw_log is ACTIVE, so
+    # that the cross-channel case really does tear a live handle down: on an
+    # already-disabled channel amdxdna_dpt_fini_chan() returns immediately
+    # without ever reaching synchronize_srcu, and the measurement would be
+    # fast for entirely the wrong reason.
+    if ! fw_log_set_level 1; then
+        fail "[${case_label}] configure --firmware-log --enable --log-level 1 failed"
+        return
+    fi
+
+    trace_force_disable
+    if ! xrt_smi --advanced configure -d "${BDF}" --event-trace --enable \
+            --categories all >/dev/null 2>&1; then
+        fail "[${case_label}] configure --event-trace --enable failed; cannot park a watcher"
+        return
+    fi
+
+    # Called directly, not through $( ), so DPT_PARKED_WATCHER_PID lands in
+    # this shell and the trap can always release the watcher.
+    rc=0
+    dpt_park_trace_watcher "${out}" "${err}" "${evidence}" || rc=$?
+    case "${rc}" in
+    0)  ;;
+    2)  dpt_release_parked_watcher
+        fail "[${case_label}] trace watcher exited before parking." \
+             "stderr: $(head -c 256 "${err}")"
+        return ;;
+    3)  dpt_release_parked_watcher
+        skip "[${case_label}] /proc/<tid>/stack unreadable (kernel without" \
+             "CONFIG_STACKTRACE?); the park cannot be proven, so the timing" \
+             "assertion below would be vacuous"
+        return ;;
+    *)  dpt_release_parked_watcher
+        fail "[${case_label}] trace watcher never parked in the DPT watch path;" \
+             "a teardown measured now would complete quickly for the wrong reason"
+        return ;;
+    esac
+
+    pass "[${case_label}] trace watcher parked in the DPT watch path (SRCU read lock held)"
+    emit_snippet "[${case_label}] parked watcher evidence:" "$(cat "${evidence}")" 4
+
+    dpt_disable_timed_bg "${opt}" "${stamp}"
+    dpid="${DPT_DISABLE_PID}"
+    info "[${case_label}] disabling --${opt} (pid=${dpid}) with the trace watcher parked"
+
+    if ! dpt_wait_pid_ms "${dpid}" "${DPT_TEARDOWN_WEDGE_MS}"; then
+        # The unfixed-driver signature: the teardown is blocked in
+        # synchronize_srcu holding dev_lock, and only a parked reader
+        # dropping its SRCU read lock can let it finish.
+        info "[${case_label}] disable still outstanding after ${DPT_TEARDOWN_WEDGE_MS}ms;" \
+             "releasing the parked watcher to try to unwedge the device"
+        dpt_release_parked_watcher
+        if dpt_wait_pid_ms "${dpid}" 10000; then
+            fail "[${case_label}] disable of --${opt} blocked for more than" \
+                 "${DPT_TEARDOWN_WEDGE_MS}ms and completed only once the parked watcher" \
+                 "was killed: the teardown waited on a reader it never woke"
+            return
+        fi
+
+        # The watcher this group tracked is not necessarily the only reader
+        # holding the domain: on a shared SRCU domain every reader parked by
+        # an earlier group counts too, and this group kept no pids for those.
+        info "[${case_label}] still outstanding after releasing this group's watcher;" \
+             "releasing every reader parked in this device's DPT watch path"
+        released=$(dpt_release_dpt_parked_readers)
+        info "[${case_label}] released ${released} parked DPT reader(s)"
+        if dpt_wait_pid_ms "${dpid}" 10000; then
+            fail "[${case_label}] disable of --${opt} blocked for more than" \
+                 "${DPT_TEARDOWN_WEDGE_MS}ms and completed only after releasing" \
+                 "${released} reader(s) parked in the DPT watch path: the teardown" \
+                 "waited on readers it never woke"
+            return
+        fi
+
+        # Say only what is known here. The teardown did not return inside
+        # the budget, so it may still hold dev_lock -- but cleanup has not
+        # run yet, and on hardware the ordinary teardown() has recovered
+        # this every time, so a verdict on the host belongs after cleanup
+        # and not in this message.
+        DPT_DEVICE_WEDGED=1
+        fail "[${case_label}] disable of --${opt} did not complete within" \
+             "${DPT_TEARDOWN_WEDGE_MS}ms, nor after releasing this group's watcher and" \
+             "${released} other reader(s) parked in the DPT watch path. The teardown may" \
+             "still hold dev_lock, in which case amdxdna ioctls will block. Cleanup will" \
+             "now try to recover the device and will report whether it responds" \
+             "afterwards -- read that result before concluding anything about this host"
+        return
+    fi
+
+    dpt_release_parked_watcher
+
+    elapsed=$(cat "${stamp}" 2>/dev/null || true)
+    if [[ -z "${elapsed}" ]]; then
+        fail "[${case_label}] disable of --${opt} returned but recorded no duration"
+        return
+    fi
+
+    # The job is already gone, so this only collects its status; it never
+    # blocks, and the wedge path above returns before reaching here. The
+    # status has to be checked before the timing is trusted: a disable
+    # that errored out in a few milliseconds is fast for a reason that
+    # says nothing at all about teardown, and on time alone it is
+    # indistinguishable from one that really did tear a live handle down.
+    drc=0
+    wait "${dpid}" || drc=$?
+    if (( drc != 0 )); then
+        fail "[${case_label}] disable of --${opt} FAILED with exit status ${drc}" \
+             "after ${elapsed}ms. The command errored out instead of tearing the" \
+             "channel down, so this run measured nothing about teardown -- note that" \
+             "this is NOT the deadlock signature, which is a disable that never" \
+             "returns at all"
+        return
+    fi
+
+    if (( elapsed <= DPT_TEARDOWN_BUDGET_MS )); then
+        pass "[${case_label}] disable of --${opt} succeeded in ${elapsed}ms" \
+             "(<=${DPT_TEARDOWN_BUDGET_MS}ms)"
+    else
+        fail "[${case_label}] disable of --${opt} took ${elapsed}ms," \
+             "over the ${DPT_TEARDOWN_BUDGET_MS}ms budget"
+    fi
+}
+
+test_fw_dpt_cross_channel_teardown() {
+    group "fw_dpt: cross-channel teardown with a watcher parked"
+
+    # Quiesce the readers earlier groups left parked BEFORE measuring
+    # anything. This is a precondition, not tidiness: the earlier watch
+    # groups leave on the order of twenty --watch consumers parked in the
+    # DPT wait path, and on a driver with the shared SRCU domain every one
+    # of them holds that domain open. Measured on hardware that is what
+    # made the same-channel case below -- which cannot deadlock on its own --
+    # block and wedge the device, and because a failure is fatal the
+    # cross-channel assertion this group exists for never ran at all.
+    #
+    # It cannot mask the wedge the group looks for, because the group
+    # recreates that condition itself immediately afterwards with a watcher
+    # of its own. What is removed is unrelated leftover readers, never the
+    # parked reader whose presence is the entire point. It does not weaken
+    # the anti-vacuous-pass guarantees either: those rest on proving this
+    # group's own park (a stable stack matching DPT_PARK_FRAME_RE) and on
+    # requiring the disable to have exited 0, and neither involves any
+    # other process.
+    dpt_quiesce_leftover_readers
+
+    # The same-channel control runs FIRST, deliberately. It drives the exact
+    # same park-then-measure machinery over the path that cannot deadlock
+    # by construction -- fini_chan wakes the very waitqueue its watcher
+    # sleeps on -- so it proves the harness can park a watcher and time a
+    # teardown at all. Without it a fast cross-channel result is
+    # indistinguishable from a reproducer that quietly never parked
+    # anything.
+    #
+    # Structurally sound is not the same as safe to run, though. With
+    # readers left parked in a shared domain by earlier groups, this
+    # same-channel case is the one that blocked and wedged the device on
+    # hardware; it is only the harmless case once the quiesce above has
+    # happened.
+    dpt_measure_teardown "same-channel control" "event-trace"
+
+    # THE DIRECTION IS DELIBERATE: park a TRACE watcher, tear down the LOG.
+    # Do not "simplify" this by swapping the channels. The reverse direction
+    # is not a detector at all: on an unfixed driver, park-trace then
+    # disable-log wedges reproducibly (~515ms to wedge), while park-log
+    # then disable-trace returned in ~503ms with status 0 on every attempt
+    # and never wedged.
+    #
+    # That asymmetry is understood, not luck. Tearing down event-trace
+    # makes the firmware log its own shutdown -- a parked watcher captured
+    # exactly these entries:
+    #
+    #     [0] I: Got stop event trace command
+    #     [H] I: Stopping event trace
+    #     [H] I: Event trace stopped successfully
+    #
+    # Those writes advance the log tail, which wakes the parked log reader,
+    # which drops its SRCU read lock, which lets the very teardown it was
+    # meant to block run to completion. Flipping the channels would turn this
+    # group into one that passes on the buggy driver it exists to catch.
+    dpt_measure_teardown "cross-channel" "firmware-log"
+
+    # Leave the device the way the other groups expect to find it.
+    trace_force_disable
+    fw_log_set_level 3 || true
+}
+
+# ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------
 
@@ -1838,6 +2624,13 @@ main() {
         test_fw_trace_examine_oneshot
         test_fw_trace_examine_watch
         test_fw_trace_multi_watcher
+    fi
+
+    # Needs fw_log and fw_trace active at the same time to tear one down
+    # while a watcher is parked on the other, so it has no meaning in the
+    # single-channel modes.
+    if [[ "${MODE}" == "both" ]]; then
+        test_fw_dpt_cross_channel_teardown
     fi
 }
 

--- a/test/scripts/test_fw_dpt_xrt_smi.sh
+++ b/test/scripts/test_fw_dpt_xrt_smi.sh
@@ -231,6 +231,19 @@ DPT_PARK_BUDGET_MS=10000
 # than misreporting as wedged.
 DPT_PROBE_BUDGET_MS=20000
 
+# How long a parked watcher is watched for CPU consumption, and how much
+# CPU it is allowed to spend in that window.
+#
+# A watcher that is caught up is supposed to be blocked in the driver's
+# wait_event_interruptible, so its correct consumption is zero and any
+# nonzero figure is either a chatty ring or a spin. 250ms out of 5000ms is
+# 5% of one core: orders of magnitude above what waking for a few log
+# lines costs, and orders of magnitude below the ~100% of a core that a
+# reader retrying a failing ioctl with no delay actually burned on
+# hardware. The gap is wide enough that this needs no tuning per board.
+DPT_IDLE_WINDOW_MS=5000
+DPT_IDLE_CPU_BUDGET_MS=250
+
 # ---------------------------------------------------------------------------
 # Pretty-print helpers
 # ---------------------------------------------------------------------------
@@ -1971,6 +1984,43 @@ dpt_watcher_tree() {
     return 0
 }
 
+# Clock ticks per second, for turning the /proc CPU counters into
+# milliseconds. getconf is in coreutils on every host this runs on; the
+# fallback is the value Linux has used on x86 for its whole history and
+# only matters if getconf is missing entirely.
+DPT_CLK_TCK="$(getconf CLK_TCK 2>/dev/null || echo 100)"
+
+# Echo the CPU time in milliseconds consumed so far by every live thread
+# in the watcher tree rooted at $1, or 0 if nothing is readable.
+#
+# Threads are summed rather than sampling the root process, for the same
+# reason dpt_watcher_tree exists: the pid a watcher was launched under may
+# be a shell wrapper that consumes nothing while the reader underneath it
+# spins. Both utime and stime count, because a reader retrying a failing
+# ioctl in a tight loop spends most of its time in the kernel and would
+# barely register on utime alone.
+#
+# A thread that exits between the walk and the read simply drops out of
+# the sum; callers that need a total across an exit keep the largest
+# reading they saw rather than the last.
+dpt_tree_cpu_ms() {
+    local root="$1" pid tdir stat_line rest utime stime total=0
+    [[ -n "${root}" ]] || { printf '0'; return 0; }
+    while read -r pid; do
+        for tdir in /proc/"${pid}"/task/*; do
+            stat_line=$(cat "${tdir}/stat" 2>/dev/null) || continue
+            # "pid (comm) state ...", and comm may contain spaces and
+            # parentheses, so split after the LAST ") ". utime and stime
+            # are then the 12th and 13th fields of what remains.
+            rest="${stat_line##*') '}"
+            read -r _ _ _ _ _ _ _ _ _ _ _ utime stime _ <<<"${rest}"
+            [[ "${utime}" =~ ^[0-9]+$ && "${stime}" =~ ^[0-9]+$ ]] || continue
+            total=$(( total + utime + stime ))
+        done
+    done < <(dpt_watcher_tree "${root}")
+    printf '%s' "$(( total * 1000 / DPT_CLK_TCK ))"
+}
+
 # Regex matching a kernel stack frame that means "parked in the amdxdna
 # DPT watch path". Matched as a SET rather than as amdxdna_dpt_get_data
 # exactly, because that function is static and the compiler is free to
@@ -2019,11 +2069,12 @@ dpt_parked_stack() {
     return 0
 }
 
-# Launch an --event-trace --watch consumer and wait for it to park stably
-# inside the driver's wait_event_interruptible. Sets
+# Launch a --watch consumer on the DPT channel named by $1 (as the
+# xrt-smi flag, i.e. --firmware-log or --event-trace) and wait for it to
+# park stably inside the driver's wait_event_interruptible. Sets
 # DPT_PARKED_WATCHER_PID as soon as the process exists, so the trap can
 # release it even if parking never completes, and writes the proving
-# evidence to the file $3.
+# evidence to the file $4.
 #
 # MUST be called directly, never through $( ): the watcher has to be a
 # child of the calling shell so that DPT_PARKED_WATCHER_PID is visible to
@@ -2032,12 +2083,12 @@ dpt_parked_stack() {
 #
 # Returns: 0 parked stably, 1 never parked, 2 exited before parking,
 #          3 no stack evidence available on this kernel.
-dpt_park_trace_watcher() {
-    local out="$1" err="$2" evidence="$3"
+dpt_park_watcher() {
+    local feature="$1" out="$2" err="$3" evidence="$4"
     local pid stack samples stable=0 i
 
     : >"${out}"; : >"${err}"; : >"${evidence}"
-    xrt_smi --advanced examine -d "${BDF}" --event-trace --watch \
+    xrt_smi --advanced examine -d "${BDF}" "${feature}" --watch \
         >"${out}" 2>"${err}" &
     pid=$!
     DPT_PARKED_WATCHER_PID="${pid}"
@@ -2067,6 +2118,16 @@ dpt_park_trace_watcher() {
         sleep 0.25
     done
     return 1
+}
+
+# Park an --event-trace watcher. Kept as its own name because the
+# cross-channel teardown group's whole point is which channel is parked
+# and which is torn down, and a bare flag argument at those call sites
+# would make that direction easy to "simplify" by accident.
+#
+# Same call-site rule as dpt_park_watcher: never through $( ).
+dpt_park_trace_watcher() {
+    dpt_park_watcher "--event-trace" "$@"
 }
 
 # Release the deliberately-parked watcher. This is the recovery lever for
@@ -2545,6 +2606,125 @@ test_fw_dpt_cross_channel_teardown() {
 }
 
 # ---------------------------------------------------------------------------
+# Group: a watcher must sleep, not spin
+# ---------------------------------------------------------------------------
+
+# Require the watcher parked on the channel named by $1 (an xrt-smi flag)
+# to spend almost no CPU while it is caught up, and to still be parked at
+# the end of the window.
+dpt_assert_parked_watcher_idle() {
+    local feature="$1"
+    local tag="${feature#--}"
+    local out="${TMPDIR_}/idle_${tag}.out"
+    local err="${TMPDIR_}/idle_${tag}.err"
+    local evidence="${TMPDIR_}/idle_${tag}.stack"
+    local rc before after used stack
+
+    # Called directly, not through $( ), so DPT_PARKED_WATCHER_PID lands
+    # in this shell and the trap can always release the watcher.
+    rc=0
+    dpt_park_watcher "${feature}" "${out}" "${err}" "${evidence}" || rc=$?
+    case "${rc}" in
+    0)  ;;
+    2)  dpt_release_parked_watcher
+        fail "[${tag}] watcher exited before parking, so there is nothing" \
+             "to measure. stderr: $(head -c 256 "${err}")"
+        return ;;
+    3)  dpt_release_parked_watcher
+        skip "[${tag}] /proc/<tid>/stack unreadable; a CPU figure alone" \
+             "cannot distinguish a sleeping reader from a lucky one"
+        return ;;
+    *)  dpt_release_parked_watcher
+        fail "[${tag}] watcher never parked in the DPT watch path within" \
+             "${DPT_PARK_BUDGET_MS}ms"
+        return ;;
+    esac
+
+    before=$(dpt_tree_cpu_ms "${DPT_PARKED_WATCHER_PID}")
+    sleep $(( DPT_IDLE_WINDOW_MS / 1000 ))
+    after=$(dpt_tree_cpu_ms "${DPT_PARKED_WATCHER_PID}")
+    used=$(( after - before ))
+
+    # Re-prove the park at the END of the window. A reader that woke and
+    # started retrying would still be alive and could still show a low CPU
+    # figure if it had only just started, so the state matters as much as
+    # the number.
+    stack=$(dpt_parked_stack "${DPT_PARKED_WATCHER_PID}")
+    dpt_release_parked_watcher
+
+    if [[ -z "${stack}" ]]; then
+        emit_snippet "[${tag}] watcher output over the idle window:" \
+                     "$(cat "${out}")"
+        fail "[${tag}] watcher left the DPT wait path during a" \
+             "${DPT_IDLE_WINDOW_MS}ms idle window (${used}ms CPU used);" \
+             "a caught-up reader is supposed to stay blocked in the ioctl"
+        return
+    fi
+
+    if (( used > DPT_IDLE_CPU_BUDGET_MS )); then
+        emit_snippet "[${tag}] watcher output over the idle window:" \
+                     "$(cat "${out}")"
+        fail "[${tag}] watcher burned ${used}ms CPU over a" \
+             "${DPT_IDLE_WINDOW_MS}ms idle window (budget" \
+             "${DPT_IDLE_CPU_BUDGET_MS}ms) while parked: it is retrying" \
+             "the read rather than sleeping in it"
+        return
+    fi
+
+    pass "[${tag}] parked watcher stayed asleep: ${used}ms CPU over" \
+         "${DPT_IDLE_WINDOW_MS}ms, still in the DPT wait path afterwards"
+}
+
+# Every other watch assertion in this file is about output or about
+# teardown, so a reader that printed the right lines while retrying a
+# failing ioctl as fast as the CPU allowed passed all of them. That is
+# what shipped: a watcher spinning at ~100% of a core was found by hand,
+# not by this suite.
+#
+# The park proof cannot catch it on its own either. It only ever examines a
+# freshly started watcher on a live, quiet ring, which is precisely the
+# situation in which even a broken reader does sleep, and it reads state at
+# one moment rather than over an interval. What was missing is a CPU
+# budget, so that "asleep" is asserted as consumption rather than inferred
+# from a single well-chosen instant. Any spin that keeps a reader alive --
+# whichever error it is retrying -- shows up here as consumption.
+#
+# Only the firmware-log channel is exercised. Parking on the trace channel
+# needs shim_test traffic to park against, and "a parked reader must not
+# spend CPU" is shared code, so a second channel would buy a dependency
+# rather than coverage.
+test_fw_dpt_watcher_sleeps() {
+    group "fw_dpt: a parked watcher must sleep, not spin"
+
+    if ! dpt_stack_probe_available; then
+        skip "watcher sleep check: /proc/<tid>/stack unreadable (kernel" \
+             "without CONFIG_STACKTRACE?), so a park cannot be proven and" \
+             "a CPU budget alone would not say why"
+        return
+    fi
+
+    if [[ "${MODE}" == "trace-only" ]]; then
+        skip "watcher sleep check: needs the firmware-log channel"
+        return
+    fi
+
+    # Level 1 (ERR) is the quietest level the driver accepts, which keeps
+    # the firmware from writing while the watcher is supposed to be
+    # holding still. A chatty ring would spend real CPU legitimately and
+    # blunt the budget.
+    if ! fw_log_set_level 1; then
+        fail "configure --firmware-log --enable --log-level 1 failed;" \
+             "cannot park a watcher on a live channel"
+        return
+    fi
+
+    dpt_assert_parked_watcher_idle "--firmware-log"
+
+    # Leave the device the way the other groups expect to find it.
+    fw_log_set_level 3 || true
+}
+
+# ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------
 
@@ -2632,6 +2812,10 @@ main() {
     if [[ "${MODE}" == "both" ]]; then
         test_fw_dpt_cross_channel_teardown
     fi
+
+    # Last: it needs a quiet ring to measure against, which means dropping
+    # the log level under the other groups' feet.
+    test_fw_dpt_watcher_sleeps
 }
 
 main "$@"


### PR DESCRIPTION
A device-wide dpt_srcu was shared by both firmware Debug/Profile/Trace kinds,
AMDXDNA_DPT_FW_LOG and AMDXDNA_DPT_FW_TRACE. A watcher parks in
wait_event_interruptible() from amdxdna_dpt_get_data() while still inside its
SRCU read-side critical section, and only its own kind's teardown wakes it.
Tearing down either kind therefore called synchronize_srcu() on a domain whose
readers included the other kind's parked watcher, which nothing in that path
wakes, so the teardown blocked forever holding dev_lock and every later ioctl
piled up behind it. CI hit this as an xrt-smi task stuck in D state inside
amdxdna_dpt_fini_kind() -> synchronize_srcu(), reported by khungtaskd as
blocked for more than 120 seconds.

The fix is per-kind SRCU domains, so a kind's synchronize_srcu() waits only for
readers its own wake_up_all() can release. Two neighbouring defects in the same
paths come with it: a reader holding a cursor from before a disable/enable cycle
could never be satisfied and spun in an unbounded error loop, and a watcher
parked across a PCI FLR was never released at all, because no wake site runs
during a reset and nothing re-attaches the rings afterwards. The last patch
zeroes two message buffers that were handed to firmware still holding whatever
the page allocator left behind.

 1/5 accel/amdxdna: give each DPT kind its own SRCU domain
 Splits dpt_srcu into a per-kind array. enum amdxdna_dpt_kind moves to
 amdxdna_pci_drv.h because struct amdxdna_dev now sizes an array with it.

 2/5 accel/amdxdna: resync stale DPT reader cursors instead of failing
 A stale cursor returns success with offset 0 and size 0 rather than
 -EINVAL, so the reset offset is written back; the footer writeback is
 gated on success and user space discards the footer when the ioctl fails.

 3/5 test/scripts: cover cross-kind DPT teardown with a watcher parked
 Adds a "fw_dpt: cross-kind teardown" group that parks a trace watcher,
 proves it parked, then times a firmware-log disable against a same-kind
 control. Which kind is torn down is load-bearing, and the comment says so.

 4/5 accel/amdxdna: quiesce and restart DPT across an FLR
 reset_prepare quiesces DPT first, reusing the PM suspend path, which sends
 no mailbox traffic and is safe against dead firmware. reset_done restarts
 rather than resumes, from a zeroed buffer, because PMFW resets the firmware
 without any driver message while the footer cursors survive. Patch 1 is a
 prerequisite, not an ordering nicety.

 5/5 accel/amdxdna: zero message buffers before firmware attaches them
 The aie4 work buffer (also re-zeroed on the FLR path, not on every attach)
 and the async event buffer.
