### PR TITLE
shim: classify terminal command states instead of comparing values

### DIFF
--- a/src/shim/hwq.cpp
+++ b/src/shim/hwq.cpp
@@ -99,7 +99,7 @@ poll_command(xrt_core::buffer_handle *cmd) const
 {
   auto boh = static_cast<cmd_buffer*>(cmd);
   auto cmdpkt = reinterpret_cast<volatile ert_packet *>(boh->vaddr());
-  if (cmdpkt->state >= ERT_CMD_STATE_COMPLETED) {
+  if (ert_cmd_state_is_terminal(cmdpkt->state)) {
     XRT_TRACE_POINT_LOG(poll_command_done);
     return 1;
   }

--- a/src/shim/hwq.h
+++ b/src/shim/hwq.h
@@ -12,6 +12,35 @@
 
 namespace shim_xdna {
 
+// Not a >= comparison against ERT_CMD_STATE_COMPLETED: the enum grows by
+// appending, so an in-flight state can sort above the terminal ones, as
+// ERT_CMD_STATE_SUBMITTED already does. Enumerating lets -Wswitch catch a
+// new state nobody has classified.
+inline bool
+ert_cmd_state_is_terminal(uint32_t state)
+{
+  switch (static_cast<ert_cmd_state>(state)) {
+  case ERT_CMD_STATE_NEW:
+  case ERT_CMD_STATE_QUEUED:
+  case ERT_CMD_STATE_RUNNING:
+  case ERT_CMD_STATE_SUBMITTED:
+    return false;
+  case ERT_CMD_STATE_COMPLETED:
+  case ERT_CMD_STATE_ERROR:
+  case ERT_CMD_STATE_ABORT:
+  case ERT_CMD_STATE_TIMEOUT:
+  case ERT_CMD_STATE_NORESPONSE:
+  case ERT_CMD_STATE_SKERROR:
+  case ERT_CMD_STATE_SKCRASHED:
+    return true;
+  case ERT_CMD_STATE_MAX:
+    break;
+  }
+  // The packet carries the state in 4 bits, so it need not be an enumerator.
+  // Treat anything else as terminal rather than wait on it forever.
+  return true;
+}
+
 class hwq : public xrt_core::hwqueue_handle
 {
 public:

--- a/src/shim/umq/hwq.cpp
+++ b/src/shim/umq/hwq.cpp
@@ -394,7 +394,7 @@ complete_command(xrt_core::buffer_handle *cmd) const
   // Single cmd completion, cmd state maybe updated by CERT (normal case), or by
   // driver (KMS + timeout), or by nobody (UMS + timeout).
   if (cmdpkt->opcode != ERT_CMD_CHAIN) {
-    if (cmdpkt->state < ERT_CMD_STATE_COMPLETED) {
+    if (!ert_cmd_state_is_terminal(cmdpkt->state)) {
       // CERT failed to set error state properly.
       if (is_kernel_mode_submission()) {
         // In KMS, it is not expected.
@@ -456,7 +456,7 @@ complete_command(xrt_core::buffer_handle *cmd) const
     }
   }
 
-  if (cmdpkt->state < ERT_CMD_STATE_COMPLETED) {
+  if (!ert_cmd_state_is_terminal(cmdpkt->state)) {
     // CERT failed to set error state properly.
     if (is_kernel_mode_submission()) {
       // In KMS, it is not expected.


### PR DESCRIPTION
`poll_command()` decides a command is done with `state >= ERT_CMD_STATE_COMPLETED`, which assumes every in-flight state sorts below it.

`ert.h` documents `ERT_CMD_STATE_QUEUED`, `ERT_CMD_STATE_SUBMITTED` and `ERT_CMD_STATE_RUNNING` as internal scheduler states, i.e. in flight. But `SUBMITTED = 7` was appended after `ABORT = 6` to keep the ABI, so it sorts on the terminal side. A producer for it would make `poll_command()` report a running command as finished.

Nothing writes `SUBMITTED` today, so this is a trap rather than a live bug. Replace the comparison with an explicit switch, so `-Wswitch` flags the next state nobody has classified.

Verified: the helper compiles clean against `ert.h` with `-Wswitch -Wswitch-enum -Werror`, and deleting one `case` fails the build with `enumeration value 'ERT_CMD_STATE_NORESPONSE' not handled in switch`.
