### PR TITLE
accel/amdxdna: use min() for copy_from_user with amdxdna_drm_attribut…

### DIFF
--- a/drivers/accel/amdxdna/aie2_pci.c
+++ b/drivers/accel/amdxdna/aie2_pci.c
@@ -994,9 +994,11 @@ static int aie2_set_force_preempt(struct amdxdna_client *client,
 				  struct amdxdna_drm_set_state *args)
 {
 	struct amdxdna_dev_hdl *ndev = client->xdna->dev_handle;
-	struct amdxdna_drm_attribute_state state;
+	struct amdxdna_drm_attribute_state state = {};
+	u32 buf_sz;
 
-	if (copy_from_user(&state, u64_to_user_ptr(args->buffer), sizeof(state)))
+	buf_sz = min(args->buffer_size, sizeof(state));
+	if (copy_from_user(&state, u64_to_user_ptr(args->buffer), buf_sz))
 		return -EFAULT;
 
 	if (state.state > 1)
@@ -1014,11 +1016,13 @@ static int aie2_set_frame_boundary_preempt(struct amdxdna_client *client,
 					   struct amdxdna_drm_set_state *args)
 {
 	struct amdxdna_dev_hdl *ndev = client->xdna->dev_handle;
-	struct amdxdna_drm_attribute_state state;
+	struct amdxdna_drm_attribute_state state = {};
+	u32 buf_sz;
 	u32 val;
 	int ret;
 
-	if (copy_from_user(&state, u64_to_user_ptr(args->buffer), sizeof(state)))
+	buf_sz = min(args->buffer_size, sizeof(state));
+	if (copy_from_user(&state, u64_to_user_ptr(args->buffer), buf_sz))
 		return -EFAULT;
 
 	if (state.state > 1)

--- a/drivers/accel/amdxdna/aie4_pci.c
+++ b/drivers/accel/amdxdna/aie4_pci.c
@@ -2017,10 +2017,12 @@ static int aie4_set_force_preempt_state(struct amdxdna_client *client,
 					struct amdxdna_drm_set_state *args)
 {
 	struct amdxdna_dev_hdl *ndev = client->xdna->dev_handle;
-	struct amdxdna_drm_attribute_state state;
+	struct amdxdna_drm_attribute_state state = {};
+	u32 buf_sz;
 	int ret;
 
-	if (copy_from_user(&state, u64_to_user_ptr(args->buffer), sizeof(state)))
+	buf_sz = min(args->buffer_size, sizeof(state));
+	if (copy_from_user(&state, u64_to_user_ptr(args->buffer), buf_sz))
 		return -EFAULT;
 
 	if (state.state > 1)

--- a/drivers/accel/amdxdna/amdxdna_coredump.c
+++ b/drivers/accel/amdxdna/amdxdna_coredump.c
@@ -243,12 +243,12 @@ amdxdna_set_auto_coredump_mode(struct amdxdna_client *client,
 	struct amdxdna_drm_attribute_state state = {};
 	struct amdxdna_dev *xdna = client->xdna;
 	struct amdxdna_client *tmp_client;
+	u32 buf_sz;
 
 	drm_WARN_ON(&xdna->ddev, !mutex_is_locked(&xdna->dev_lock));
 
-	if (args->buffer_size < sizeof(state))
-		return -EINVAL;
-	if (copy_from_user(&state, u64_to_user_ptr(args->buffer), sizeof(state)))
+	buf_sz = min(args->buffer_size, sizeof(state));
+	if (copy_from_user(&state, u64_to_user_ptr(args->buffer), buf_sz))
 		return -EFAULT;
 
 	if (state.state > 1)


### PR DESCRIPTION
…e_state

Use min(buffer_size, sizeof(state)) instead of sizeof(state) directly when copying amdxdna_drm_attribute_state from userspace in SET handlers, for ABI forward compatibility if the struct is extended in the future. Initialize state to zero so uncopied fields default to 0.