### PR TITLE
accel/amdxdna: fix buffer_size writeback in amdxdna_get_hwctx_status()

### DIFF
--- a/drivers/accel/amdxdna/amdxdna_ctx_status.c
+++ b/drivers/accel/amdxdna/amdxdna_ctx_status.c
@@ -127,7 +127,7 @@ int amdxdna_get_hwctx_status(struct aie_device *aie,
 	if (ret && ret != -ENOSPC)
 		return ret;
 
-	args->buffer_size -= (u32)(array_args.buffer - args->buffer);
+	args->buffer_size = (u32)(array_args.buffer - args->buffer);
 	return 0;
 }
 


### PR DESCRIPTION
Report bytes written instead of bytes remaining, consistent with other get_info handlers (e.g. amdxdna_query_sensors()).