### PR TITLE
accel/amdxdna: name the firmware when the alive handshake times out

### DIFF
--- a/drivers/accel/amdxdna/aie2_pci.c
+++ b/drivers/accel/amdxdna/aie2_pci.c
@@ -92,8 +92,12 @@ static int aie2_get_mgmt_chann_info(struct amdxdna_dev_hdl *ndev)
 	 */
 	ret = readx_poll_timeout(readl, SRAM_GET_ADDR(ndev, FW_ALIVE_OFF),
 				 addr, addr, AIE_INTERVAL, AIE_TIMEOUT);
-	if (ret || !addr)
+	if (ret || !addr) {
+		XDNA_ERR(ndev->aie.xdna,
+			 "Firmware from %s did not report alive within %d us",
+			 ndev->priv->fw_path, AIE_TIMEOUT);
 		return -ETIME;
+	}
 
 	off = AIE2_SRAM_OFF(ndev, addr);
 	reg = (u32 *)&info_regs;


### PR DESCRIPTION
## Problem

When the firmware never reports alive, `aie2_get_mgmt_chann_info()` returns `-ETIME` silently. Nothing in the log says which firmware was loaded or how long the driver waited, so the failure is indistinguishable from any other `-ETIME` on the probe path.

That matters most in exactly the case where it fires: a firmware/hardware mismatch, where the loaded path is the single most useful fact.

## Fix

Log the firmware path and the timeout before returning, using the same `XDNA_ERR(ndev->aie.xdna, ...)` idiom as the neighbouring failure branches in this function.

## Test

Compile-gated. `ndev->aie.xdna` (17 other uses in this file), `ndev->priv->fw_path` (4 others) and `AIE_TIMEOUT` (`aie.h`) are all pre-existing; the message follows the form of the `Invalid mbox magic` branch a few lines below.

No behaviour change on the success path -- the error return is unchanged, only the diagnostic is added.