### PR TITLE
shim_test: suppress verbose prints in release builds

### DIFF
--- a/test/shim_test/hwctx.h
+++ b/test/shim_test/hwctx.h
@@ -65,7 +65,9 @@ private:
       m_handle = dev->create_hw_context(xclbin_uuid, qos, mode);
     }
 
+#ifndef NDEBUG
     std::cout << "loaded " << path << std::endl;
+#endif
   }
 };
 

--- a/test/shim_test/multi_threads.h
+++ b/test/shim_test/multi_threads.h
@@ -35,7 +35,9 @@ public:
     for (int i = 0; i < m_total_threads; i++) {
       m_threads.push_back(
         std::thread([&](int i) {
+#ifndef NDEBUG
           std::cout << "Thread " << i << " started" << std::endl;
+#endif
           try {
             m_test(id, dev ,arg);
           } catch (const std::exception& ex) {

--- a/test/shim_test/multi_threads.h
+++ b/test/shim_test/multi_threads.h
@@ -29,8 +29,10 @@ public:
 
   void run_test(xrt_core::device::id_type id, std::shared_ptr<device> dev, arg_type& arg)
   {
+    m_threads.clear();
+    m_failed.assign(m_total_threads, 0);
+    m_threads.reserve(m_total_threads);
     for (int i = 0; i < m_total_threads; i++) {
-      m_failed.push_back(false);
       m_threads.push_back(
         std::thread([&](int i) {
           std::cout << "Thread " << i << " started" << std::endl;
@@ -56,7 +58,7 @@ public:
 private:
   int m_total_threads;
   std::vector<std::thread> m_threads;
-  std::vector<bool> m_failed;
+  std::vector<uint8_t> m_failed;
   func m_test;
 };
 


### PR DESCRIPTION
Guard "loaded <path>" in hwctx.h and "Thread N started" in multi_threads.h with #ifndef NDEBUG so they are silent in release builds where NDEBUG is defined by CMake.