### PR TITLE
accel/amdxdna/ve2: fail submit with -ENOTRECOVERABLE after firmware MISC

### DIFF
--- a/drivers/accel/amdxdna/ve2_hwctx.c
+++ b/drivers/accel/amdxdna/ve2_hwctx.c
@@ -1185,7 +1185,7 @@ void ve2_hwctx_fini(struct amdxdna_hwctx *hwctx)
 	if (enable_debug_queue && vp && vp->dbg_queue.dbg_queue_p) {
 		timer_delete_sync(&vp->dbg_q_timer);
 		ve2_free_dbg_queue(hwctx);
-	}	
+	}
 
 	if (vp) {
 		u32 submitted = vp->submitted;
@@ -1291,6 +1291,21 @@ int ve2_cmd_submit(struct amdxdna_hwctx *hwctx, struct amdxdna_sched_job *job, u
 	if (op != ERT_START_DPU && op != ERT_CMD_CHAIN) {
 		XDNA_WARN(xdna, "Unsupported ERT opcode %u", op);
 		return -EINVAL;
+	}
+
+	/*
+	 * The context latched a firmware MISC/exception condition. It stays
+	 * unusable until the partition is re-initialized for it (see
+	 * ve2_mgmt_handshake_init()), which in practice means the application
+	 * must destroy and recreate the hwctx. Report -ENOTRECOVERABLE rather
+	 * than -EINVAL so userspace does not misdiagnose this as a malformed
+	 * command buffer.
+	 */
+	if (vp && vp->misc_intrpt_flag) {
+		XDNA_ERR(xdna,
+			 "Cannot submit: hwctx %u (pid %d) is unusable after a firmware MISC interrupt (misc_status 0x%x); recreate the context",
+			 hwctx->id, hwctx->client->pid, vp->misc_status_latched);
+		return -ENOTRECOVERABLE;
 	}
 
 	trace_xdna_cmd_submit_start(hwctx->name, hwctx->id, hwctx->start_col);

--- a/drivers/accel/amdxdna/ve2_hwctx.h
+++ b/drivers/accel/amdxdna/ve2_hwctx.h
@@ -77,6 +77,12 @@ struct amdxdna_ctx_priv {
 	u32				mem_bitmap;
 	u32				partition_id;
 	bool				misc_intrpt_flag;
+	/*
+	 * Firmware misc_status as read when misc_intrpt_flag was first set for
+	 * this context. Reported by ve2_cmd_submit() on a poisoned context.
+	 * Cleared with misc_intrpt_flag; valid only while that flag is set.
+	 */
+	u32				misc_status_latched;
 	bool				handshake_initialized;	/* CERT handshake done */
 	struct amdxdna_sched_job	*pending[HWCTX_MAX_CMDS];
 

--- a/drivers/accel/amdxdna/ve2_mgmt.c
+++ b/drivers/accel/amdxdna/ve2_mgmt.c
@@ -465,6 +465,18 @@ static int ve2_mgmt_handshake_init(struct amdxdna_mgmtctx *mgmtctx,
 		goto release_hs_data;
 
 	vp->handshake_initialized = true;
+	/*
+	 * The partition has been re-initialized and CERT restarted for this
+	 * context, so a previously latched MISC/exception condition no longer
+	 * describes the hardware. A poisoned context will not normally reach
+	 * here: ve2_cmd_submit() rejects with -ENOTRECOVERABLE first.
+	 */
+	if (vp->misc_intrpt_flag) {
+		XDNA_DBG(xdna, "Clearing misc_intrpt_flag after partition re-init hwctx=%p",
+			 hwctx);
+		vp->misc_intrpt_flag = false;
+		vp->misc_status_latched = 0;
+	}
 	ret = 0;
 
 release_hs_data:
@@ -681,8 +693,27 @@ static bool ve2_check_misc_interrupt(struct amdxdna_mgmtctx *mgmtctx)
 
 	if (mgmtctx->active_ctx) {
 		vp = ve2_hw_priv(mgmtctx->active_ctx);
-		if (vp)
-			vp->misc_intrpt_flag = true;
+		if (vp) {
+			/*
+			 * misc_status is level state: it stays set until
+			 * firmware/partition re-init clears it, so this helper
+			 * re-reads the same non-zero value on every later IRQ.
+			 * Only attribute it to a context once - otherwise a later,
+			 * innocent context that happens to be active gets
+			 * poisoned by a fault it did not cause.
+			 *
+			 * Caller (IRQ / scheduler) already holds ctx_lock.
+			 */
+			if (!vp->misc_intrpt_flag) {
+				vp->misc_status_latched = misc_status;
+				vp->misc_intrpt_flag = true;
+				XDNA_ERR(mgmtctx->xdna,
+					 "misc_status 0x%x on col %u: marking hwctx %u (pid %d) unusable\n",
+					 misc_status, mgmtctx->start_col,
+					 mgmtctx->active_ctx->id,
+					 mgmtctx->active_ctx->client->pid);
+			}
+		}
 	}
 
 	return true;
@@ -751,7 +782,15 @@ static void ve2_scheduler_work(struct work_struct *work)
 	ve2_check_context_req(mgmtctx);
 
 	if (vp->misc_intrpt_flag) {
-		XDNA_ERR(mgmtctx->xdna, "MISC interrupt from firmware");
+		/*
+		 * This branch neither recovers the faulted context nor yields
+		 * the partition. Switching away needs CERT context-switch
+		 * semantics for a faulted partition confirmed first.
+		 */
+		XDNA_ERR(mgmtctx->xdna,
+			 "MISC interrupt from firmware, hwctx %u (pid %d) on col %u is unusable (misc_status 0x%x)\n",
+			 hwctx->id, hwctx->client->pid, mgmtctx->start_col,
+			 vp->misc_status_latched);
 	} else if (ve2_check_queue_not_empty(mgmtctx)) {
 		/*
 		 * The firmware acked the switch but the active context still has
@@ -1177,7 +1216,8 @@ static void ve2_aie_error_cb(void *arg)
 		struct amdxdna_ctx_priv *vp = ve2_hw_priv(mgmtctx->active_ctx);
 
 		if (vp) {
-			vp->misc_intrpt_flag = true;
+			if (!vp->misc_intrpt_flag)
+				vp->misc_intrpt_flag = true;
 			wake_up_interruptible_all(&vp->waitq);
 			XDNA_ERR(xdna, "AIE error detected, waking up waiting threads\n");
 		}

--- a/src/shim_ve2/xdna_hwq.cpp
+++ b/src/shim_ve2/xdna_hwq.cpp
@@ -78,7 +78,11 @@ submit_command(xrt_core::buffer_handle *cmd_bo)
   } catch (const xrt_core::system_error& ex) {
     int err_code = ex.get_code();
 
-    if (err_code == EINVAL) {
+    if (err_code == ENOTRECOVERABLE) {
+      shim_err(err_code, "Command submission failed: hwctx %u is unusable after a firmware "
+               "MISC interrupt. Destroy and recreate the hwctx. cmd_bo=%u",
+               hwctx_id, cmd_bo_hdl);
+    } else if (err_code == EINVAL) {
       shim_err(err_code, "Command submission failed: Invalid command or arguments. "
                "hwctx=%u, cmd_bo=%u. Check command buffer format and arguments.",
                hwctx_id, cmd_bo_hdl);


### PR DESCRIPTION
Firmware misc_status is level-triggered, so a poisoned hwctx must not look like a malformed command. Latch the first MISC, reject later submits, and have the shim tell userspace to destroy/recreate the context.