### PR TITLE
accel/amdxdna: report the memory region backing a BO in GET_BO_INFO

### DIFF
--- a/drivers/accel/amdxdna/amdxdna_cma_buf.c
+++ b/drivers/accel/amdxdna/amdxdna_cma_buf.c
@@ -169,8 +169,8 @@ struct dma_buf *amdxdna_get_cma_buf(struct drm_device *dev, size_t size)
  * amdxdna_get_cma_buf_with_fallback - Allocate CMA buffer from a specific bank
  * with fallback to default CMA.
  *
- * @region_devs: Array of per-bank child devices (NULL entries = not initialized)
- * @max_regions: Size of region_devs array
+ * @regions: Array of per-bank regions (dev == NULL = not initialized)
+ * @max_regions: Size of regions array
  * @fallback_dev: DRM device to fall back to if no bank device matched
  * @size: Allocation size in bytes
  * @flags: Low 8 bits are the mem_bitmap (one bit per bank)
@@ -178,7 +178,7 @@ struct dma_buf *amdxdna_get_cma_buf(struct drm_device *dev, size_t size)
  * Tries each set bit in the bitmap in order; on first success returns the buf.
  * Falls back to the default DRM device CMA if no bank device is available.
  */
-struct dma_buf *amdxdna_get_cma_buf_with_fallback(struct device *const *region_devs,
+struct dma_buf *amdxdna_get_cma_buf_with_fallback(const struct amdxdna_cma_region *regions,
 						  int max_regions,
 						  struct drm_device *fallback_dev,
 						  size_t size, u64 flags)
@@ -188,12 +188,40 @@ struct dma_buf *amdxdna_get_cma_buf_with_fallback(struct device *const *region_d
 	int i;
 
 	for (i = 0; i < max_regions; i++) {
-		if ((mem_bitmap & (1U << i)) && region_devs[i]) {
-			dbuf = amdxdna_alloc_cma_buf_from_dev(region_devs[i], size);
+		if ((mem_bitmap & (1U << i)) && regions[i].dev) {
+			dbuf = amdxdna_alloc_cma_buf_from_dev(regions[i].dev, size);
 			if (!IS_ERR(dbuf))
 				return dbuf;
 		}
 	}
 
 	return amdxdna_alloc_cma_buf_from_dev(fallback_dev->dev, size);
+}
+
+/**
+ * amdxdna_mem_region_from_addr - Find the bank backing a device address.
+ *
+ * @regions: Array of per-bank regions (dev == NULL = not initialized)
+ * @max_regions: Size of regions array
+ * @addr: Device address to look up
+ *
+ * Returns the bank index owning @addr, or 0 when no bank matches. Index 0 is
+ * deliberately both a valid answer and the fallback: buffers allocated from
+ * the default CMA pool belong to no declared region, and platforms that
+ * declare none must keep reporting 0.
+ */
+u32 amdxdna_mem_region_from_addr(const struct amdxdna_cma_region *regions,
+				 int max_regions, u64 addr)
+{
+	int i;
+
+	for (i = 0; i < max_regions; i++) {
+		const struct amdxdna_cma_region *region = &regions[i];
+
+		if (region->dev && addr >= region->base &&
+		    addr < region->base + region->size)
+			return i;
+	}
+
+	return 0;
 }

--- a/drivers/accel/amdxdna/amdxdna_cma_buf.h
+++ b/drivers/accel/amdxdna/amdxdna_cma_buf.h
@@ -9,10 +9,14 @@
 #include <drm/drm_device.h>
 #include <linux/dma-buf.h>
 
+struct amdxdna_cma_region;
+
 struct dma_buf *amdxdna_get_cma_buf(struct drm_device *dev, size_t size);
-struct dma_buf *amdxdna_get_cma_buf_with_fallback(struct device *const *region_devs,
+struct dma_buf *amdxdna_get_cma_buf_with_fallback(const struct amdxdna_cma_region *regions,
 						  int max_regions,
 						  struct drm_device *fallback_dev,
 						  size_t size, u64 flags);
+u32 amdxdna_mem_region_from_addr(const struct amdxdna_cma_region *regions,
+				 int max_regions, u64 addr);
 
 #endif /* _AMDXDNA_CMA_BUF_H_ */

--- a/drivers/accel/amdxdna/amdxdna_gem.c
+++ b/drivers/accel/amdxdna/amdxdna_gem.c
@@ -986,7 +986,7 @@ amdxdna_gem_create_cma_object(struct drm_device *dev, struct amdxdna_drm_create_
 		return ERR_PTR(-EINVAL);
 	}
 
-	dma_buf = amdxdna_get_cma_buf_with_fallback(xdna->cma_region_devs,
+	dma_buf = amdxdna_get_cma_buf_with_fallback(xdna->cma_regions,
 						    MAX_MEM_REGIONS,
 						    dev, size, args->flags);
 	if (IS_ERR(dma_buf))
@@ -1405,7 +1405,7 @@ int amdxdna_drm_get_bo_info_ioctl(struct drm_device *dev, void *data, struct drm
 	struct drm_gem_object *gobj;
 	int ret = 0;
 
-	if (args->ext || args->ext_flags || args->pad)
+	if (args->ext || args->ext_flags || args->mem_region)
 		return -EINVAL;
 
 	gobj = drm_gem_object_lookup(filp, args->handle);
@@ -1418,13 +1418,27 @@ int amdxdna_drm_get_bo_info_ioctl(struct drm_device *dev, void *data, struct drm
 	args->vaddr = amdxdna_gem_uva(abo);
 	args->xdna_addr = amdxdna_gem_dev_addr(abo);
 
+#if defined(AMDXDNA_NPU3A) || defined(AMDXDNA_AUX)
+	/*
+	 * Only a SHARE BO is backed by CMA and addressed physically. For a DEV
+	 * BO amdxdna_gem_dev_addr() is a heap-relative offset and for a DEV_HEAP
+	 * BO it is dev_addr, so a region index would be meaningless there.
+	 * Elsewhere mem_region stays 0, which the MBZ check above guarantees.
+	 */
+	if (abo->type == AMDXDNA_BO_SHARE)
+		args->mem_region = amdxdna_mem_region_from_addr(xdna->cma_regions,
+								MAX_MEM_REGIONS,
+								args->xdna_addr);
+#endif
+
 	if (abo->type != AMDXDNA_BO_DEV)
 		args->map_offset = drm_vma_node_offset_addr(&gobj->vma_node);
 	else
 		args->map_offset = AMDXDNA_INVALID_ADDR;
 
-	XDNA_DBG(xdna, "BO hdl %d map_offset 0x%llx vaddr 0x%llx xdna_addr 0x%llx",
-		 args->handle, args->map_offset, args->vaddr, args->xdna_addr);
+	XDNA_DBG(xdna, "BO hdl %d map_offset 0x%llx vaddr 0x%llx xdna_addr 0x%llx mem_region %u",
+		 args->handle, args->map_offset, args->vaddr, args->xdna_addr,
+		 args->mem_region);
 
 	drm_gem_object_put(gobj);
 	return ret;

--- a/drivers/accel/amdxdna/amdxdna_pci_drv.h
+++ b/drivers/accel/amdxdna/amdxdna_pci_drv.h
@@ -157,6 +157,18 @@ struct amdxdna_dpt_chan {
 	const struct amdxdna_dpt_desc	*desc;
 };
 
+/*
+ * One CMA bank: the child device buffers are allocated from, plus the extent of
+ * the DT reserved-memory region behind it so a device address can be mapped
+ * back to the bank index. @base and @size are 0 when the region could not be
+ * resolved, which only disables the reverse lookup.
+ */
+struct amdxdna_cma_region {
+	struct device	*dev;
+	u64		base;
+	u64		size;
+};
+
 struct amdxdna_dev {
 	struct drm_device		ddev;
 	struct amdxdna_dev_hdl		*dev_handle;
@@ -203,8 +215,10 @@ struct amdxdna_dev {
 	 */
 	struct aie_device		*dpt_aie;
 
-	/* Per-bank CMA region devices, initialized from DT memory-region nodes. */
-	struct device			*cma_region_devs[MAX_MEM_REGIONS];
+	/* Per-bank CMA regions, initialized from DT memory-region nodes.
+	 * dev == NULL means the bank was not declared.
+	 */
+	struct amdxdna_cma_region	cma_regions[MAX_MEM_REGIONS];
 };
 
 /*

--- a/drivers/accel/amdxdna/ve2_aux.c
+++ b/drivers/accel/amdxdna/ve2_aux.c
@@ -228,12 +228,12 @@ static void ve2_cma_mem_region_remove(struct amdxdna_dev *xdna)
 	int i;
 
 	for (i = 0; i < MAX_MEM_REGIONS; i++) {
-		struct device *dev = xdna->cma_region_devs[i];
+		struct device *dev = xdna->cma_regions[i].dev;
 
 		if (dev) {
 			of_reserved_mem_device_release(dev);
 			put_device(dev);
-			xdna->cma_region_devs[i] = NULL;
+			memset(&xdna->cma_regions[i], 0, sizeof(xdna->cma_regions[i]));
 		}
 	}
 }
@@ -241,6 +241,8 @@ static void ve2_cma_mem_region_remove(struct amdxdna_dev *xdna)
 static int ve2_cma_mem_region_init(struct amdxdna_dev *xdna, struct device_node *aie_np)
 {
 	struct device *parent_dev = xdna->ddev.dev;
+	struct reserved_mem *rmem;
+	struct device_node *np;
 	struct device *child_dev;
 	int num_regions;
 	int ret;
@@ -279,8 +281,26 @@ static int ve2_cma_mem_region_init(struct amdxdna_dev *xdna, struct device_node 
 			goto put_dev;
 		}
 
-		xdna->cma_region_devs[i] = child_dev;
-		XDNA_INFO(xdna, "CMA region %d initialized", i);
+		/*
+		 * Record the region extent so a device address can be mapped
+		 * back to this index later. of_reserved_mem_device_init_by_idx()
+		 * resolves the same phandle but does not hand the descriptor
+		 * back. The descriptor lives in the OF core's own table and does
+		 * not borrow the node's refcount, so drop the node right away.
+		 */
+		np = of_parse_phandle(aie_np, "memory-region", i);
+		rmem = np ? of_reserved_mem_lookup(np) : NULL;
+		of_node_put(np);
+
+		xdna->cma_regions[i].dev = child_dev;
+		if (rmem) {
+			xdna->cma_regions[i].base = rmem->base;
+			xdna->cma_regions[i].size = rmem->size;
+		}
+
+		XDNA_INFO(xdna, "CMA region %d (%s) initialized: base 0x%llx size 0x%llx",
+			  i, rmem ? rmem->name : "unresolved",
+			  xdna->cma_regions[i].base, xdna->cma_regions[i].size);
 	}
 
 	return 0;

--- a/include/uapi/drm/amdxdna_accel.h
+++ b/include/uapi/drm/amdxdna_accel.h
@@ -273,7 +273,11 @@ struct amdxdna_drm_create_bo {
  * @ext: MBZ.
  * @ext_flags: MBZ.
  * @handle: DRM buffer object handle.
- * @pad: MBZ.
+ * @mem_region: MBZ on input. Returned index of the memory region backing the
+ *		buffer. The index is device local and uses the same numbering as
+ *		the DRM_AMDXDNA_HWCTX_MEM_BITMAP bit positions. 0 is also
+ *		returned when the buffer matches no declared region and on
+ *		devices that do not partition device memory into regions.
  * @map_offset: Returned DRM fake offset for mmap().
  * @vaddr: Returned user VA of buffer. 0 in case user needs mmap().
  * @xdna_addr: Returned XDNA device virtual address.
@@ -282,7 +286,7 @@ struct amdxdna_drm_get_bo_info {
 	__u64 ext;
 	__u64 ext_flags;
 	__u32 handle;
-	__u32 pad;
+	__u32 mem_region;
 	__u64 map_offset;
 	__u64 vaddr;
 	__u64 xdna_addr;

--- a/src/include/uapi/drm_local/amdxdna_accel.h
+++ b/src/include/uapi/drm_local/amdxdna_accel.h
@@ -278,7 +278,9 @@ struct amdxdna_drm_create_bo {
  * @ext: MBZ.
  * @ext_flags: MBZ.
  * @handle: DRM buffer object handle.
- * @pad: Structure padding.
+ * @mem_region: MBZ on input. Returned device local index of the memory region
+ *		backing the buffer, numbered as the DRM_AMDXDNA_HWCTX_MEM_BITMAP
+ *		bit positions. 0 when unmatched or untracked.
  * @map_offset: Returned DRM fake offset for mmap().
  * @vaddr: Returned user VA of buffer. 0 in case user needs mmap().
  * @xdna_addr: Returned XDNA device virtual address.
@@ -287,7 +289,7 @@ struct amdxdna_drm_get_bo_info {
 	__u64 ext;
 	__u64 ext_flags;
 	__u32 handle;
-	__u32 pad;
+	__u32 mem_region;
 	__u64 map_offset;
 	__u64 vaddr;
 	__u64 xdna_addr;

--- a/src/shim_ve2/xdna_bo.cpp
+++ b/src/shim_ve2/xdna_bo.cpp
@@ -181,11 +181,19 @@ xdna_bo(const device_xdna& device, xrt_core::hwctx_handle::slot_id ctx_id,
 
 xdna_bo::
 xdna_bo(const device_xdna& device, xrt_core::shared_handle::export_handle ehdl)
-  : m_edev(device.get_edev())
+  : m_core_device(&device)
+  , m_edev(device.get_edev())
 {
   uint32_t boh = import_drm_bo(ehdl, &m_type, &m_aligned_size);
   m_edev->bo_handle_ref_inc(boh);
   get_drm_bo_info(boh);
+
+  // The exporting device's bank numbering means nothing on this device, and
+  // there is no requested bank on an import. Report the region the driver
+  // found for this buffer so get_memory_group() is meaningful.
+  xcl_bo_flags xflags{ m_flags };
+  xflags.bank = static_cast<uint16_t>(m_mem_region);
+  m_flags = xflags.all;
 }
 
 xdna_bo::
@@ -390,6 +398,7 @@ get_drm_bo_info(uint32_t boh)
   m_map_offset = bo_info.map_offset;
   m_vaddr = bo_info.vaddr;
   m_xdna_addr = bo_info.xdna_addr;
+  m_mem_region = bo_info.mem_region;
 }
 
 void

--- a/src/shim_ve2/xdna_bo.h
+++ b/src/shim_ve2/xdna_bo.h
@@ -149,6 +149,8 @@ public:
   uint32_t m_handle = AMDXDNA_INVALID_BO_HANDLE;
   off_t m_map_offset = AMDXDNA_INVALID_ADDR;
   uint64_t m_xdna_addr = AMDXDNA_INVALID_ADDR;
+  // Index of the CMA memory region backing this BO, as reported by the driver.
+  uint32_t m_mem_region = 0;
   uint64_t m_vaddr = AMDXDNA_INVALID_ADDR;
   void *m_uptr = nullptr;
 


### PR DESCRIPTION
xrt::bo::get_memory_group() returns 0 for a BO allocated on zocl and imported onto amdxdna. XRT derives the group from the importing device's MEM_TOPOLOGY, which VE2 does not expose, so it falls back to the bank in the BO flags, and the VE2 import path never set one.

Repurpose the spare pad in struct amdxdna_drm_get_bo_info as mem_region and return the CMA bank owning the BO's device address. The field was already validated MBZ, so the struct layout and existing userspace are unaffected. To make an address reverse-mappable, replace cma_region_devs[] with struct amdxdna_cma_region, pairing each bank's device with the extent of its DT reserved-memory region.

The VE2 shim applies the reported index as the BO's bank, giving XRT a correct fallback. Devices that do not partition memory into regions keep reporting 0.