### PR TITLE
accel/amdxdna: allocate CERT buffers from a reachable DDR bank

### DIFF
--- a/drivers/accel/amdxdna/ve2_aux.c
+++ b/drivers/accel/amdxdna/ve2_aux.c
@@ -457,6 +457,51 @@ void ve2_auto_select_mem_bitmap(struct amdxdna_dev *xdna, struct amdxdna_hwctx *
 	vp->mem_bitmap = 0;
 }
 
+/*
+ * Allocate DMA-coherent memory for a buffer that CERT dereferences itself.
+ *
+ * Such buffers must sit in a DDR bank the context's columns can actually
+ * reach, so only the banks named by @mem_bitmap are eligible; each is tried in
+ * turn and the device that served the allocation is returned in @alloc_dev for
+ * the caller's later sync and free. The default CMA pool is used only when the
+ * context named no bank at all, which is the case on platforms without an
+ * aie-mem-topology. Falling back to it for a context that did name banks would
+ * hand CERT an address it cannot route, surfacing as a NoC error at submit
+ * instead of an error here.
+ */
+void *ve2_alloc_cert_coherent(struct amdxdna_dev *xdna, u32 mem_bitmap, size_t size,
+			      dma_addr_t *dma_addr, struct device **alloc_dev)
+{
+	void *va = NULL;
+	int i;
+
+	*alloc_dev = NULL;
+
+	if (mem_bitmap) {
+		for (i = 0; i < MAX_MEM_REGIONS; i++) {
+			struct device *dev = xdna->cma_regions[i].dev;
+
+			if (!(mem_bitmap & (1U << i)) || !dev)
+				continue;
+
+			va = dma_alloc_coherent(dev, size, dma_addr, GFP_KERNEL);
+			if (va) {
+				*alloc_dev = dev;
+				break;
+			}
+		}
+	} else {
+		va = dma_alloc_coherent(xdna->ddev.dev, size, dma_addr, GFP_KERNEL);
+		if (va)
+			*alloc_dev = xdna->ddev.dev;
+	}
+
+	if (!va)
+		XDNA_ERR(xdna, "Coherent alloc failed: size=%zu mem_bitmap=0x%x", size, mem_bitmap);
+
+	return va;
+}
+
 int ve2_probe(struct amdxdna_dev *xdna, struct amdxdna_dev_hdl *hdl)
 {
 	struct init_config xrs_cfg = { };
@@ -582,14 +627,22 @@ static int ve2_aux_init(struct amdxdna_dev *xdna)
 	aie_np = dev->parent ? dev->parent->of_node : NULL;
 	if (aie_np) {
 		ret = ve2_cma_mem_region_init(xdna, aie_np);
-		if (ret)
+		if (ret) {
+			/*
+			 * Bank setup is all-or-nothing, so skip the topology
+			 * parse: it resolves DT phandles by index and would
+			 * otherwise hand contexts a mem_bitmap naming banks
+			 * that have no device behind them.
+			 */
 			XDNA_INFO(xdna, "CMA mem region init failed (%d), using default CMA", ret);
-
-		ret = ve2_parse_mem_topology(xdna, aie_np);
-		if (ret == -ENOENT)
-			XDNA_INFO(xdna, "No aie-mem-topology in DT, using default CMA");
-		else if (ret)
-			XDNA_INFO(xdna, "mem topology parse failed (%d), using default CMA", ret);
+		} else {
+			ret = ve2_parse_mem_topology(xdna, aie_np);
+			if (ret == -ENOENT)
+				XDNA_INFO(xdna, "No aie-mem-topology in DT, using default CMA");
+			else if (ret)
+				XDNA_INFO(xdna, "mem topology parse failed (%d), using default CMA",
+					  ret);
+		}
 	} else {
 		XDNA_WARN(xdna, "No parent DT node, skipping CMA region and topology init");
 	}

--- a/drivers/accel/amdxdna/ve2_aux.h
+++ b/drivers/accel/amdxdna/ve2_aux.h
@@ -85,6 +85,8 @@ static inline struct amdxdna_dev_hdl *ve2_dev_hdl(struct amdxdna_dev *xdna)
 
 int ve2_probe(struct amdxdna_dev *xdna, struct amdxdna_dev_hdl *hdl);
 void ve2_auto_select_mem_bitmap(struct amdxdna_dev *xdna, struct amdxdna_hwctx *hwctx);
+void *ve2_alloc_cert_coherent(struct amdxdna_dev *xdna, u32 mem_bitmap, size_t size,
+			      dma_addr_t *dma_addr, struct device **alloc_dev);
 
 /* Capture the per-column CERT firmware status for @hwctx's partition. */
 int ve2_get_firmware_status(struct amdxdna_hwctx *hwctx);

--- a/drivers/accel/amdxdna/ve2_debug.c
+++ b/drivers/accel/amdxdna/ve2_debug.c
@@ -142,6 +142,8 @@ static int ve2_dbg_queue_data_rw(struct amdxdna_dev *xdna, struct amdxdna_hwctx 
 				 u32 col, u32 row, u32 addr, void *data, size_t size,
 				 int cmd_type)
 {
+	struct amdxdna_ctx_priv *vp = ve2_hw_priv(hwctx);
+	struct device *alloc_dev;
 	dma_addr_t dma_handle;
 	void *virt_ptr = NULL;
 	int ret = 0;
@@ -151,11 +153,13 @@ static int ve2_dbg_queue_data_rw(struct amdxdna_dev *xdna, struct amdxdna_hwctx 
 		return -EINVAL;
 	}
 
-	virt_ptr = dma_alloc_coherent(xdna->ddev.dev, size, &dma_handle, GFP_KERNEL);
-	if (!virt_ptr) {
-		XDNA_ERR(xdna, "Failed to allocate DMA buffer");
+	if (!vp)
+		return -EINVAL;
+
+	/* CERT dereferences this buffer, so it must come from a bank it can reach. */
+	virt_ptr = ve2_alloc_cert_coherent(xdna, vp->mem_bitmap, size, &dma_handle, &alloc_dev);
+	if (!virt_ptr)
 		return -ENOMEM;
-	}
 
 	addr = addr + ((col << VE2_COL_SHIFT) + (row << VE2_ROW_SHIFT));
 
@@ -181,7 +185,7 @@ static int ve2_dbg_queue_data_rw(struct amdxdna_dev *xdna, struct amdxdna_hwctx 
 		break;
 	}
 
-	dma_free_coherent(xdna->ddev.dev, size, virt_ptr, dma_handle);
+	dma_free_coherent(alloc_dev, size, virt_ptr, dma_handle);
 	return ret;
 }
 

--- a/drivers/accel/amdxdna/ve2_hwctx.c
+++ b/drivers/accel/amdxdna/ve2_hwctx.c
@@ -622,11 +622,10 @@ static int ve2_create_host_queue(struct amdxdna_hwctx *hwctx)
 	queue = &vp->hsa_queue;
 	alloc_size = sizeof(struct hsa_queue) + sizeof(u64) * HOST_QUEUE_ENTRY;
 
-	queue->hsa_queue_p = dma_alloc_coherent(xdna->ddev.dev, alloc_size,
-						&dma_handle, GFP_KERNEL);
+	queue->hsa_queue_p = ve2_alloc_cert_coherent(xdna, vp->mem_bitmap, alloc_size,
+						     &dma_handle, &queue->alloc_dev);
 	if (!queue->hsa_queue_p)
 		return -ENOMEM;
-	queue->alloc_dev = xdna->ddev.dev;
 
 	mutex_init(&queue->hq_lock);
 	queue->reserved_write_index = 0;
@@ -672,8 +671,8 @@ static int ve2_create_host_queue(struct amdxdna_hwctx *hwctx)
 	dma_sync_single_for_device(queue->alloc_dev, dma_handle, alloc_size,
 				   DMA_TO_DEVICE);
 
-	XDNA_DBG(xdna, "Host queue alloc dma=0x%llx capacity=%u", (u64)dma_handle,
-		 HOST_QUEUE_ENTRY);
+	XDNA_DBG(xdna, "Host queue alloc dma=0x%llx capacity=%u bank=%s", (u64)dma_handle,
+		 HOST_QUEUE_ENTRY, dev_name(queue->alloc_dev));
 
 	return 0;
 }
@@ -876,14 +875,10 @@ static int ve2_create_dbg_queue(struct amdxdna_hwctx *hwctx)
 	queue = &vp->dbg_queue;
 	alloc_size = sizeof(struct dbg_queue) + sizeof(u64) * HOST_QUEUE_ENTRY;
 
-	queue->dbg_queue_p = dma_alloc_coherent(xdna->ddev.dev, alloc_size,
-						&dma_handle, GFP_KERNEL);
-	if (!queue->dbg_queue_p) {
-		XDNA_ERR(xdna, "DBG queue alloc failed: hwctx=%u ret=%d",
-			 hwctx->id, -ENOMEM);
+	queue->dbg_queue_p = ve2_alloc_cert_coherent(xdna, vp->mem_bitmap, alloc_size,
+						     &dma_handle, &queue->alloc_dev);
+	if (!queue->dbg_queue_p)
 		return -ENOMEM;
-	}
-	queue->alloc_dev = xdna->ddev.dev;
 
 	mutex_init(&queue->hq_lock);
 	queue->reserved_write_index = 0;
@@ -906,8 +901,8 @@ static int ve2_create_dbg_queue(struct amdxdna_hwctx *hwctx)
 
 	dma_sync_single_for_device(queue->alloc_dev, dma_handle, alloc_size, DMA_TO_DEVICE);
 
-	XDNA_DBG(xdna, "DBG queue alloc: hwctx=%u dma_addr=0x%llx capacity=%u",
-		 hwctx->id, (u64)dma_handle, HOST_QUEUE_ENTRY);
+	XDNA_DBG(xdna, "DBG queue alloc: hwctx=%u dma_addr=0x%llx capacity=%u bank=%s",
+		 hwctx->id, (u64)dma_handle, HOST_QUEUE_ENTRY, dev_name(queue->alloc_dev));
 
 	return 0;
 }


### PR DESCRIPTION
The host queue, the debug queue and the debug read/write payload are allocated by the driver but dereferenced by CERT, yet all three came from the default CMA pool, which a partition's columns need not be able to reach. On platforms that split DDR per column group this surfaced as a NoC error at submit instead of a diagnosable failure at allocation.

Add ve2_alloc_cert_coherent() to allocate these buffers from the banks named by the context's mem_bitmap, and record the owning device so the matching sync and free use it. Contexts that name no bank, i.e. platforms without an aie-mem-topology, keep using the default pool as before.

Also skip the memory topology parse when CMA bank setup fails. Bank setup is all-or-nothing, so parsing it anyway could hand a context a mem_bitmap naming banks with no device behind them.