### PR TITLE
Clean up context after failed `set_dpm_level`

### DIFF
--- a/drivers/accel/amdxdna/aie2_message.c
+++ b/drivers/accel/amdxdna/aie2_message.c
@@ -385,6 +385,7 @@ int aie2_create_context(struct amdxdna_dev_hdl *ndev, struct amdxdna_hwctx *hwct
 
 free_channel:
 	xdna_mailbox_free_channel(hwctx->priv->mbox_chann);
+	hwctx->priv->mbox_chann = NULL;
 del_ctx_req:
 	aie2_destroy_context_req(ndev, hwctx->fw_ctx_id);
 	return ret;

--- a/drivers/accel/amdxdna/aie2_solver.c
+++ b/drivers/accel/amdxdna/aie2_solver.c
@@ -339,7 +339,7 @@ int xrs_allocate_resource(void *hdl, struct alloc_requests *req, void *cb_arg)
 
 	ret = set_dpm_level(xrs, req, &dpm_level);
 	if (ret)
-		goto free_node;
+		goto unload;
 
 	snode->dpm_level = dpm_level;
 	snode->cb_arg = cb_arg;
@@ -349,6 +349,8 @@ int xrs_allocate_resource(void *hdl, struct alloc_requests *req, void *cb_arg)
 
 	return 0;
 
+unload:
+	xrs->cfg.actions->unload(cb_arg);
 free_node:
 	remove_solver_node(&xrs->rgp, snode);
 


### PR DESCRIPTION
xrs_allocate_resource() calls actions->load() to create the hardware context. That asks the firmware for a context and registers an interrupt named in the firmware reply. It then calls `set_dpm_level`.

When `set_dpm_level` fails -- which is something we have observed happening in our MLIR-AIE CI -- the error path never calls actions->unload().

This breaks every later attempted context allocation that would use the same interrupt index:

```
  [drm] *ERROR* Set hclock to 1600 failed, ret -110
  genirq: Flags mismatch irq 95. 00200000 (xdna_mailbox) vs. 00200000 (xdna_mailbox)
  xdna_mailbox.95: Failed to request irq 95 ret -16
```