### PR TITLE
accel/amdxdna: check the ring buffer before failing a mailbox timeout

### DIFF
--- a/drivers/accel/amdxdna/amdxdna_mailbox.c
+++ b/drivers/accel/amdxdna/amdxdna_mailbox.c
@@ -438,6 +438,24 @@ again:
 		goto again;
 }
 
+void xdna_mailbox_drain_channel(struct mailbox_channel *mb_chann)
+{
+	if (!mb_chann)
+		return;
+
+	/*
+	 * Run the receive path through the channel workqueue rather than
+	 * inline. i2x_head and the ring buffer are owned by the single
+	 * mailbox_rx_worker context and are not otherwise serialised, so
+	 * reading the ring from the caller would race a worker started by an
+	 * interrupt. queue_work() re-arms the work even if it is running, and
+	 * flush_work() waits for the queued run, so the drain always observes
+	 * the ring as of at least this call.
+	 */
+	queue_work(mb_chann->work_q, &mb_chann->rx_work);
+	flush_work(&mb_chann->rx_work);
+}
+
 int xdna_mailbox_send_msg(struct mailbox_channel *mb_chann,
 			  const struct xdna_mailbox_msg *msg, u64 tx_timeout)
 {

--- a/drivers/accel/amdxdna/amdxdna_mailbox.h
+++ b/drivers/accel/amdxdna/amdxdna_mailbox.h
@@ -128,6 +128,18 @@ void xdna_mailbox_free_channel(struct mailbox_channel *mailbox_chann);
 void xdna_mailbox_stop_channel(struct mailbox_channel *mailbox_chann);
 
 /*
+ * xdna_mailbox_drain_channel() -- consume responses already in the ring buffer
+ *
+ * @mailbox_chann: the handle return from xdna_mailbox_alloc_channel()
+ *
+ * Run the receive path once and wait for it, for callers that cannot assume a
+ * response was announced by an interrupt. Does nothing if the channel is in
+ * bad state, since the receive path refuses to run there. Safe to call with a
+ * NULL channel.
+ */
+void xdna_mailbox_drain_channel(struct mailbox_channel *mailbox_chann);
+
+/*
  * xdna_mailbox_send_msg() -- Send a message
  *
  * @mailbox_chann: Mailbox channel handle

--- a/drivers/accel/amdxdna/amdxdna_mailbox_helper.c
+++ b/drivers/accel/amdxdna/amdxdna_mailbox_helper.c
@@ -68,8 +68,23 @@ int xdna_send_msg_wait(struct amdxdna_dev *xdna, struct mailbox_channel *chann,
 	ret = wait_for_completion_timeout(&hdl->comp,
 					  msecs_to_jiffies(RX_TIMEOUT));
 	if (!ret) {
-		XDNA_ERR(xdna, "Wait for completion timeout");
-		return -ETIME;
+		/*
+		 * Firmware is reported to complete some commands, SUSPEND in
+		 * particular, by writing the response into the ring buffer
+		 * without raising the completion interrupt, so nothing wakes
+		 * the receive path and the wait above expires on a command that
+		 * did finish. Drain the ring by hand before declaring the
+		 * command lost; this also picks up a response that landed in
+		 * the instant the wait was timing out.
+		 */
+		xdna_mailbox_drain_channel(chann);
+		if (!try_wait_for_completion(&hdl->comp)) {
+			XDNA_ERR(xdna, "Wait for completion timeout");
+			return -ETIME;
+		}
+		XDNA_DBG(xdna,
+			 "Opcode 0x%x completed without an interrupt, response taken from the ring buffer",
+			 msg->opcode);
 	}
 
 	return hdl->error;


### PR DESCRIPTION
xdna_send_msg_wait() treats the completion interrupt as the only way a response can arrive. When wait_for_completion_timeout() expires it returns -ETIME without ever looking at the ring buffer, so a response that was written but never announced is never seen.

The -ETIME is not a cosmetic misreport. aie_send_mgmt_msg_wait() responds to it by calling aie_destroy_chann(), so one missed interrupt on a command that actually completed tears down the management mailbox and leaves aie->mgmt_chann NULL, after which every management message returns -ENODEV until something restarts the channel. Both aie2 and aie4 reach this through the same shared helper.

Drain the ring once by hand before declaring the command lost. The drain goes through the channel workqueue rather than reading the ring inline: i2x_head and the ring are owned by the single mailbox_rx_worker context and are not otherwise serialised, so polling from the caller would race a worker an interrupt had already started. queue_work() re-arms the work even while it is running and flush_work() waits for that run, so the drain always sees the ring as of at least the call.