### PR TITLE
test/shim_test: move vf shared_ptr instead of copying

### DIFF
--- a/test/shim_test/io_test.cpp
+++ b/test/shim_test/io_test.cpp
@@ -1290,7 +1290,7 @@ TEST_aie4_pf_flr(device::id_type id, std::shared_ptr<device>& sdev,
       continue;
     }
     std::cout << "starting in-flight VF workload on userpf[" << i << "]" << std::endl;
-    loads.push_back(prepare_flr_workload(vf));
+    loads.push_back(prepare_flr_workload(std::move(vf)));
   }
   for (auto& w : loads)
     submit_flr_workload(w);


### PR DESCRIPTION
Fixes Coverity CID 913366: vf is not used after prepare_flr_workload(), so move it to avoid an unnecessary refcount bump.