### PR TITLE
test/shim_test: Decouple flow and device type filtering

### DIFF
--- a/test/shim_test/df_bw_test.cpp
+++ b/test/shim_test/df_bw_test.cpp
@@ -3,7 +3,6 @@
 
 #include "io.h"
 #include "dev_info.h"
-#include "dev_filter.h"
 #include "exec_buf.h"
 
 #include "core/common/device.h"
@@ -157,14 +156,14 @@ void
 TEST_df_bw(device::id_type id, std::shared_ptr<device>& sdev, arg_type& arg)
 {
   auto dev = sdev.get();
-  const bool is_aie4 = dev_filter_is_aie4(id, dev);
-  const flow_type flow = is_aie4 ? FULL_ELF : PARTIAL_ELF;
+
+  const auto& info = get_binary_info(dev, df_bw_tag, nullptr);
 
   std::unique_ptr<io_test_bo_set_base> bo_set;
-  if (is_aie4)
-    bo_set = std::make_unique<df_bw_elf_io_test_bo_set>(dev);
-  else
+  if (info.flow == PARTIAL_ELF)
     bo_set = std::make_unique<df_bw_io_test_bo_set>(dev);
+  else
+    bo_set = std::make_unique<df_bw_elf_io_test_bo_set>(dev);
 
   auto& bos   = bo_set->get_bos();
   auto* in_p  = reinterpret_cast<uint32_t*>(bos[IO_TEST_BO_INPUT].tbo->map());
@@ -176,7 +175,7 @@ TEST_df_bw(device::id_type id, std::shared_ptr<device>& sdev, arg_type& arg)
 
   constexpr int iterations = 10;
   /* Run loop — create hwctx and iterate iterations times */
-  hw_ctx hwctx{dev, df_bw_tag, &flow};
+  hw_ctx hwctx{dev, df_bw_tag, &info.flow};
   auto hwq = hwctx.get()->get_hw_queue();
   auto cbo = bos[IO_TEST_BO_CMD].tbo.get();
 

--- a/test/shim_test/io.cpp
+++ b/test/shim_test/io.cpp
@@ -715,7 +715,7 @@ elf_io_negative_test_bo_set(device* dev, const std::string& tag)
   }
 
   m_is_aie4 = dev_filter_is_aie4(0, dev);
-  m_is_full_elf = m_is_aie4;
+  m_is_full_elf = (info.flow == FULL_ELF);
 
   // Expected code for the driver-synthesized AIE async error on an aie4 fault.
   uint64_t err_num = XRT_ERROR_NUM_KDS_EXEC;
@@ -726,7 +726,6 @@ elf_io_negative_test_bo_set(device* dev, const std::string& tag)
   m_expect_err_code = XRT_ERROR_CODE_BUILD(err_num, err_drv, err_severity, err_module, err_class);
 
   if (m_is_full_elf) {
-    m_is_full_elf = true;
     m_elf = xrt::elf(get_binary_path(dev, tag.empty() ? nullptr : tag.c_str(), nullptr));
     auto kernel_name = get_kernel_name(dev, tag.empty() ? nullptr : tag.c_str(), nullptr);
     try {
@@ -777,15 +776,14 @@ elf_io_gemm_test_bo_set(device* dev, const std::string& tag)
   : io_test_bo_set_base(dev, tag, nullptr)
 {
   const char* tag_c = tag.empty() ? nullptr : tag.c_str();
-  // npu3/npu3a: full-ELF gemm.elf; npu4: xclbin + sidecar gemm_int8.elf
-  m_is_full_elf = dev_filter_is_aie4(0, dev);
+  const auto& info = get_binary_info(dev, tag_c, nullptr);
+  m_is_full_elf = (info.flow == FULL_ELF);
+  m_is_aie4 = dev_filter_is_aie4(0, dev);
   std::string elf_path;
-  if (m_is_full_elf) {
+  if (m_is_full_elf)
     elf_path = get_binary_path(dev, tag_c, nullptr);
-  } else {
-    const auto& info = get_binary_info(dev, tag_c, nullptr);
+  else
     elf_path = m_local_data_path + info.extra.at("elf_name");
-  }
   m_elf = xrt::elf(elf_path);
 
   try {
@@ -1078,16 +1076,16 @@ init_cmd(hw_ctx& hwctx, bool dump)
       elf_patcher::buf_type::ctrltext, m_elf, patch_id);
   }
 
-  // Get a debug BO (full-ELF: uc_debug with fixed layout; else legacy size)
-  const size_t dbo_size = m_is_full_elf ? m_gemm_uc_debug_size : 4096;
+  // Get a debug BO (AIE4: uc_debug with fixed layout; else legacy size)
+  const size_t dbo_size = m_is_aie4 ? m_gemm_uc_debug_size : 4096;
   auto boflags = XRT_BO_FLAGS_CACHEABLE;
-  auto ext_boflags = m_is_full_elf ? (XRT_BO_USE_UC_DEBUG << 4) : (XRT_BO_USE_DEBUG << 4);
+  auto ext_boflags = m_is_aie4 ? (XRT_BO_USE_UC_DEBUG << 4) : (XRT_BO_USE_DEBUG << 4);
   m_dbo = hwctx.get()->alloc_bo(dbo_size, get_bo_flags(boflags, ext_boflags));
   auto dbo_p = static_cast<int32_t *>(m_dbo->map(buffer_handle::map_type::write));
   std::memset(dbo_p, 0xff, dbo_size);
   m_dbo->sync(buffer_handle::direction::host2device, dbo_size, 0);
 
-  if (m_is_full_elf) {
+  if (m_is_aie4) {
     std::map<uint32_t, size_t> buf_map{{0, m_gemm_uc_debug_size}};
     m_dbo->config(hwctx.get(), buf_map);
   }
@@ -1228,7 +1226,7 @@ verify_result()
   m_dbo.get()->sync(buffer_handle::direction::device2host, m_dbo->get_properties().size, 0);
   auto dbo_p = static_cast<int32_t *>(m_dbo->map(buffer_handle::map_type::write));
 
-  if (m_is_full_elf) {
+  if (m_is_aie4) {
     const uint32_t* words = reinterpret_cast<const uint32_t*>(dbo_p);
 
     // The debug BO holds one (core_idx, cycle_count) pair per SAVE_REGISTER in
@@ -1347,7 +1345,7 @@ void
 elf_io_gemm_test_bo_set::
 teardown(hw_ctx& hwctx)
 {
-  if (m_is_full_elf && m_dbo)
+  if (m_is_aie4 && m_dbo)
     m_dbo->unconfig(hwctx.get());
 }
 

--- a/test/shim_test/io.h
+++ b/test/shim_test/io.h
@@ -254,6 +254,7 @@ private:
 
   std::unique_ptr<xrt_core::buffer_handle> m_dbo;
   bool m_is_full_elf = false;
+  bool m_is_aie4 = false;
 };
 
 class elf_io_aie_debug_test_bo_set : public io_test_bo_set_base

--- a/test/shim_test/io_test.cpp
+++ b/test/shim_test/io_test.cpp
@@ -843,9 +843,15 @@ TEST_app_health_query_multi_ctx(device::id_type id, std::shared_ptr<device>& sde
 {
   auto dev = sdev.get();
   const int64_t pid = static_cast<int64_t>(::getpid());
-  /* npu4 (AIE2): preemptible partial-ELF; npu3 (AIE4): preemptible full-ELF. */
-  const flow_type flow = dev_filter_is_aie4(id, dev) ?
-    PREEMPT_FULL_ELF : PREEMPT_PARTIAL_ELF;
+  static const flow_type flow_preempt_partial = PREEMPT_PARTIAL_ELF;
+  static const flow_type flow_full = PREEMPT_FULL_ELF;
+  const flow_type flow = [&]() -> flow_type {
+    try {
+      return get_binary_info(dev, "good", &flow_preempt_partial).flow;
+    } catch (const std::runtime_error&) {
+      return get_binary_info(dev, "good", &flow_full).flow;
+    }
+  }();
 
   io_test_parameter_init(IO_TEST_NO_PERF, IO_TEST_NORMAL_RUN, IO_TEST_IOCTL_WAIT);
 
@@ -1349,9 +1355,16 @@ TEST_instr_invalid_addr_io(device::id_type id, std::shared_ptr<device>& sdev, ar
   bo_set.run();
 
   std::vector<uint64_t> params = {IO_TEST_NORMAL_RUN, 1};
-  /* NPU4-class (AIE2): partial-ELF; NPU3 (AIE4): FULL_ELF */
-  const flow_type good_flow = dev_filter_is_aie4(id, sdev.get()) ?
-    FULL_ELF : PARTIAL_ELF;
+  /* Prefer partial-ELF when the catalog has it; else FULL_ELF. */
+  static const flow_type flow_partial = PARTIAL_ELF;
+  static const flow_type flow_full = FULL_ELF;
+  const flow_type good_flow = [&]() -> flow_type {
+    try {
+      return get_binary_info(sdev.get(), "good", &flow_partial).flow;
+    } catch (const std::runtime_error&) {
+      return get_binary_info(sdev.get(), "good", &flow_full).flow;
+    }
+  }();
   elf_io(id, sdev, params, "good", &good_flow);
 }
 
@@ -1369,9 +1382,17 @@ TEST_io_runlist_bad_cmd(device::id_type id, std::shared_ptr<device>& sdev, arg_t
   device* dev = sdev.get();
   const char *good_tag = "good";
 
-  /* NPU4-class: partial-ELF; NPU3: FULL_ELF */
-  const flow_type good_flow = dev_filter_is_aie4(id, dev) ?
-    FULL_ELF : PARTIAL_ELF;
+  /* Prefer partial-ELF when the catalog has it; else FULL_ELF. */
+  static const flow_type flow_partial = PARTIAL_ELF;
+  static const flow_type flow_full = FULL_ELF;
+  const binary_info& good_info = [&]() -> const binary_info& {
+    try {
+      return get_binary_info(dev, good_tag, &flow_partial);
+    } catch (const std::runtime_error&) {
+      return get_binary_info(dev, good_tag, &flow_full);
+    }
+  }();
+  flow_type good_flow = good_info.flow;
 
   // Two good ones
   auto good_bo_set1 = create_bo_set_for_device(dev, false, good_tag, &good_flow);


### PR DESCRIPTION
Filter test mechanics through flow when appropriate, through device ID or type when appropriate, and sometimes both. Don't assume full elf flow == AIE4 or partial == AIE2. Examples of both being needed: gemm and preempt tests both can take partial or full elf flow, but then need device type to decide the type of debug bo needed (gemm) and how to use the telemetry data (preempt).