### PR TITLE
accel/amdxdna: add to_aie_dev() macro and drop redundant aie argument

### DIFF
--- a/drivers/accel/amdxdna/aie.c
+++ b/drivers/accel/amdxdna/aie.c
@@ -207,10 +207,9 @@ int amdxdna_get_firmware_version(struct amdxdna_client *client,
 	return ret;
 }
 
-int amdxdna_get_metadata(struct aie_device *aie,
-			 struct amdxdna_client *client,
-			 struct amdxdna_drm_get_info *args)
+int amdxdna_get_metadata(struct amdxdna_client *client, struct amdxdna_drm_get_info *args)
 {
+	struct aie_device *aie = to_aie_dev(client->xdna);
 	int ret = 0;
 	u32 buf_sz;
 
@@ -221,12 +220,11 @@ int amdxdna_get_metadata(struct aie_device *aie,
 	return ret;
 }
 
-int amdxdna_get_aie_status(struct aie_device *aie,
-			   struct amdxdna_client *client,
-			   struct amdxdna_drm_get_info *args)
+int amdxdna_get_aie_status(struct amdxdna_client *client, struct amdxdna_drm_get_info *args)
 {
 	struct amdxdna_drm_query_aie_status status = {};
 	struct amdxdna_dev *xdna = client->xdna;
+	struct aie_device *aie = to_aie_dev(xdna);
 	struct amdxdna_msg_buf_hdl *buf_hdl;
 	u32 cols_filled = 0;
 	u32 resp_size = 0;
@@ -254,7 +252,7 @@ int amdxdna_get_aie_status(struct aie_device *aie,
 	memset(to_cpu_addr(buf_hdl, 0), 0, to_buf_size(buf_hdl));
 	drm_clflush_virt_range(to_cpu_addr(buf_hdl, 0), to_buf_size(buf_hdl));
 
-	ret = aie->msg_ops.query_status(aie, buf_hdl, &cols_filled, &resp_size);
+	ret = aie->msg_ops.query_status(buf_hdl, &cols_filled, &resp_size);
 	if (ret) {
 		XDNA_ERR(xdna, "Failed to get AIE status info, ret %d", ret);
 		goto out_free;
@@ -340,13 +338,12 @@ static int amdxdna_fill_hwctx_map(struct aie_device *aie, u32 *map)
 	return 0;
 }
 
-int amdxdna_get_telemetry(struct aie_device *aie,
-			  struct amdxdna_client *client,
-			  struct amdxdna_drm_get_info *args)
+int amdxdna_get_telemetry(struct amdxdna_client *client, struct amdxdna_drm_get_info *args)
 {
 	struct amdxdna_drm_query_telemetry_header *header __free(kfree) = NULL;
 	u32 telemetry_data_sz, header_sz, elem_num;
 	struct amdxdna_dev *xdna = client->xdna;
+	struct aie_device *aie = to_aie_dev(xdna);
 	u64 payload;
 	int ret;
 

--- a/drivers/accel/amdxdna/aie.h
+++ b/drivers/accel/amdxdna/aie.h
@@ -28,15 +28,13 @@ struct aie_msg_ops {
 		      u8 row, u8 col, u32 aie_addr,
 		      dma_addr_t dram_addr, u32 size);
 
-	int (*query_status)(struct aie_device *aie,
-			    struct amdxdna_msg_buf_hdl *buf_hdl,
+	int (*query_status)(struct amdxdna_msg_buf_hdl *buf_hdl,
 			    u32 *cols_filled, u32 *resp_size);
 
 	int (*query_telemetry)(struct aie_device *aie, char __user *buf, u32 size,
 			       struct amdxdna_drm_query_telemetry_header *header);
 	/* Optional per-arch FW health hook; leave NULL when unsupported. */
-	int (*fill_hwctx_health)(struct aie_device *aie,
-				 struct amdxdna_hwctx *hwctx,
+	int (*fill_hwctx_health)(struct amdxdna_hwctx *hwctx,
 				 struct amdxdna_drm_hwctx_entry *entry);
 
 	int  (*fw_log_init)(struct amdxdna_dev *xdna, size_t size, u32 level);
@@ -167,19 +165,15 @@ int aie_send_mgmt_msg_wait(struct aie_device *aie, struct xdna_mailbox_msg *msg)
 int aie_check_protocol(struct aie_device *aie, u32 fw_major, u32 fw_minor);
 int aie_check_cert_protocol(struct aie_device *aie, u32 cert_major, u32 cert_minor);
 void amdxdna_vbnv_init(struct amdxdna_dev *xdna);
-int amdxdna_get_metadata(struct aie_device *aie, struct amdxdna_client *client,
-			 struct amdxdna_drm_get_info *args);
+int amdxdna_get_metadata(struct amdxdna_client *client, struct amdxdna_drm_get_info *args);
 int amdxdna_get_aie_version(struct amdxdna_client *client,
 			    struct amdxdna_drm_get_info *args,
 			    struct amdxdna_drm_query_aie_version *version);
 int amdxdna_get_firmware_version(struct amdxdna_client *client,
 				 struct amdxdna_drm_get_info *args,
 				 struct amdxdna_drm_query_firmware_version *version);
-int amdxdna_get_aie_status(struct aie_device *aie,
-			   struct amdxdna_client *client,
-			   struct amdxdna_drm_get_info *args);
-int amdxdna_get_telemetry(struct aie_device *aie, struct amdxdna_client *client,
-			  struct amdxdna_drm_get_info *args);
+int amdxdna_get_aie_status(struct amdxdna_client *client, struct amdxdna_drm_get_info *args);
+int amdxdna_get_telemetry(struct amdxdna_client *client, struct amdxdna_drm_get_info *args);
 int amdxdna_get_force_preempt_state(struct aie_device *aie, struct amdxdna_drm_get_info *args);
 int amdxdna_get_frame_boundary_preempt_state(struct aie_device *aie,
 					     struct amdxdna_drm_get_info *args);

--- a/drivers/accel/amdxdna/aie2_ctx.c
+++ b/drivers/accel/amdxdna/aie2_ctx.c
@@ -527,14 +527,12 @@ aie2_sched_job_timedout(struct drm_sched_job *sched_job)
 	struct app_health_report *report;
 	struct amdxdna_dev_hdl *ndev;
 	struct amdxdna_dev *xdna;
-	struct aie_device *aie;
 	bool fw_dead = false;
 	bool fw_fatal = false;
 	int ret;
 
 	xdna = hwctx->client->xdna;
 	ndev = xdna->dev_handle;
-	aie = &ndev->aie;
 
 	guard(mutex)(&xdna->dev_lock);
 
@@ -565,7 +563,7 @@ aie2_sched_job_timedout(struct drm_sched_job *sched_job)
 
 	if (xdna->auto_coredump) {
 		kvfree(hwctx->coredump);
-		hwctx->coredump = amdxdna_get_hwctx_coredump(aie, hwctx);
+		hwctx->coredump = amdxdna_get_hwctx_coredump(hwctx);
 		if (IS_ERR(hwctx->coredump)) {
 			XDNA_ERR(xdna, "Failed to get core dump on job timing out: %ld",
 				 PTR_ERR(hwctx->coredump));

--- a/drivers/accel/amdxdna/aie2_message.c
+++ b/drivers/accel/amdxdna/aie2_message.c
@@ -472,11 +472,11 @@ static int amdxdna_hwctx_col_map(struct amdxdna_hwctx *hwctx, void *arg)
 	return 0;
 }
 
-int aie2_query_status(struct aie_device *aie, struct amdxdna_msg_buf_hdl *buf_hdl,
-		      u32 *cols_filled, u32 *resp_size)
+int aie2_query_status(struct amdxdna_msg_buf_hdl *buf_hdl, u32 *cols_filled, u32 *resp_size)
 {
 	DECLARE_AIE_MSG(aie_column_info, MSG_OP_QUERY_COL_STATUS);
-	struct amdxdna_dev *xdna = aie->xdna;
+	struct amdxdna_dev *xdna = buf_hdl->xdna;
+	struct aie_device *aie = to_aie_dev(xdna);
 	struct amdxdna_client *client;
 	u32 aie_bitmap = 0;
 	int ret;

--- a/drivers/accel/amdxdna/aie2_pci.c
+++ b/drivers/accel/amdxdna/aie2_pci.c
@@ -768,10 +768,9 @@ static int aie2_get_clock_metadata(struct amdxdna_client *client,
 	return ret;
 }
 
-int aie2_fill_hwctx_health(struct aie_device *aie, struct amdxdna_hwctx *hwctx,
-			   struct amdxdna_drm_hwctx_entry *entry)
+int aie2_fill_hwctx_health(struct amdxdna_hwctx *hwctx, struct amdxdna_drm_hwctx_entry *entry)
 {
-	struct amdxdna_dev_hdl *ndev = container_of(aie, struct amdxdna_dev_hdl, aie);
+	struct amdxdna_dev_hdl *ndev = hwctx->client->xdna->dev_handle;
 	struct app_health_report report;
 	int ret;
 
@@ -831,10 +830,10 @@ static int aie2_get_info(struct amdxdna_client *client, struct amdxdna_drm_get_i
 
 	switch (args->param) {
 	case DRM_AMDXDNA_QUERY_AIE_STATUS:
-		ret = amdxdna_get_aie_status(&ndev->aie, client, args);
+		ret = amdxdna_get_aie_status(client, args);
 		break;
 	case DRM_AMDXDNA_QUERY_AIE_METADATA:
-		ret = amdxdna_get_metadata(&ndev->aie, client, args);
+		ret = amdxdna_get_metadata(client, args);
 		break;
 	case DRM_AMDXDNA_QUERY_AIE_VERSION:
 		ret = amdxdna_get_aie_version(client, args, &ndev->aie.version);
@@ -846,7 +845,7 @@ static int aie2_get_info(struct amdxdna_client *client, struct amdxdna_drm_get_i
 		ret = amdxdna_query_sensors(args, ndev->total_col);
 		break;
 	case DRM_AMDXDNA_QUERY_HW_CONTEXTS:
-		ret = amdxdna_get_hwctx_status(&ndev->aie, client, args);
+		ret = amdxdna_get_hwctx_status(client, args);
 		break;
 	case DRM_AMDXDNA_QUERY_FIRMWARE_VERSION:
 		ret = amdxdna_get_firmware_version(client, args, &xdna->fw_ver);
@@ -855,7 +854,7 @@ static int aie2_get_info(struct amdxdna_client *client, struct amdxdna_drm_get_i
 		ret = aie2_get_power_mode(client, args);
 		break;
 	case DRM_AMDXDNA_QUERY_TELEMETRY:
-		ret = amdxdna_get_telemetry(&ndev->aie, client, args);
+		ret = amdxdna_get_telemetry(client, args);
 		break;
 	case DRM_AMDXDNA_QUERY_RESOURCE_INFO:
 		ret = aie2_query_resource_info(client, args);
@@ -919,22 +918,22 @@ static int aie2_get_array(struct amdxdna_client *client,
 
 	switch (args->param) {
 	case DRM_AMDXDNA_HW_CONTEXT_ALL:
-		ret = amdxdna_query_ctx_status_array(&ndev->aie, client, args);
+		ret = amdxdna_query_ctx_status_array(client, args);
 		break;
 	case DRM_AMDXDNA_HW_CONTEXT_BY_ID:
-		ret = amdxdna_query_ctx_status_by_id(&ndev->aie, client, args);
+		ret = amdxdna_query_ctx_status_by_id(client, args);
 		break;
 	case DRM_AMDXDNA_HW_LAST_ASYNC_ERR:
 		ret = aie2_get_array_async_error(xdna->dev_handle, args);
 		break;
 	case DRM_AMDXDNA_AIE_COREDUMP:
-		ret = amdxdna_get_coredump(&ndev->aie, client, args);
+		ret = amdxdna_get_coredump(client, args);
 		break;
 	case DRM_AMDXDNA_BO_USAGE:
 		ret = amdxdna_drm_get_bo_usage(&xdna->ddev, args);
 		break;
 	case DRM_AMDXDNA_AIE_TILE_READ:
-		ret = amdxdna_aie_tile_read(&ndev->aie, client, args);
+		ret = amdxdna_aie_tile_read(client, args);
 		break;
 	case DRM_AMDXDNA_FW_LOG:
 		ret = amdxdna_get_fw_log(&ndev->aie, args);
@@ -1072,7 +1071,7 @@ static int aie2_set_state(struct amdxdna_client *client,
 		ret = aie2_set_frame_boundary_preempt(client, args);
 		break;
 	case DRM_AMDXDNA_AIE_TILE_WRITE:
-		ret = amdxdna_aie_tile_write(&ndev->aie, client, args);
+		ret = amdxdna_aie_tile_write(client, args);
 		break;
 	case DRM_AMDXDNA_SET_FW_LOG_STATE:
 		ret = amdxdna_set_fw_log_state(&ndev->aie, args);

--- a/drivers/accel/amdxdna/aie2_pci.h
+++ b/drivers/accel/amdxdna/aie2_pci.h
@@ -139,7 +139,7 @@ struct aie2_tdr {
 };
 
 struct amdxdna_dev_hdl {
-	struct aie_device		aie;
+	struct aie_device		aie; /* must be the first member, see to_aie_dev() */
 	const struct amdxdna_dev_priv	*priv;
 	void			__iomem *sram_base;
 	void			__iomem *mbox_base;
@@ -286,13 +286,11 @@ int aie2_create_context(struct amdxdna_dev_hdl *ndev, struct amdxdna_hwctx *hwct
 int aie2_destroy_context(struct amdxdna_dev_hdl *ndev, struct amdxdna_hwctx *hwctx);
 int aie2_map_host_buf(struct amdxdna_dev_hdl *ndev, u32 context_id, u64 addr, u64 size);
 int aie2_add_host_buf(struct amdxdna_dev_hdl *ndev, u32 context_id, u64 addr, u64 size);
-int aie2_query_status(struct aie_device *aie, struct amdxdna_msg_buf_hdl *buf_hdl,
-		      u32 *cols_filled, u32 *resp_size);
+int aie2_query_status(struct amdxdna_msg_buf_hdl *buf_hdl, u32 *cols_filled, u32 *resp_size);
 int aie2_query_telemetry(struct amdxdna_dev_hdl *ndev,
 			 char __user *buf, u32 size,
 			 struct amdxdna_drm_query_telemetry_header *header);
-int aie2_fill_hwctx_health(struct aie_device *aie, struct amdxdna_hwctx *hwctx,
-			   struct amdxdna_drm_hwctx_entry *entry);
+int aie2_fill_hwctx_health(struct amdxdna_hwctx *hwctx, struct amdxdna_drm_hwctx_entry *entry);
 int aie2_register_asyn_event_msg(struct amdxdna_dev_hdl *ndev, dma_addr_t addr, u32 size,
 				 void *handle, int (*cb)(void*, void __iomem *, size_t));
 int aie2_config_cu(struct amdxdna_hwctx *hwctx,

--- a/drivers/accel/amdxdna/aie2_tdr.c
+++ b/drivers/accel/amdxdna/aie2_tdr.c
@@ -80,7 +80,6 @@ static int aie2_tdr_stop_hwctx(struct amdxdna_hwctx *hwctx, void *arg)
 	struct amdxdna_dev *xdna = hwctx->client->xdna;
 	struct amdxdna_dev_hdl *ndev = xdna->dev_handle;
 	struct app_health_report *report = NULL;
-	struct aie_device *aie = &ndev->aie;
 	struct drm_gpu_scheduler *sched;
 	struct drm_sched_job *s_job;
 	int ret;
@@ -96,7 +95,7 @@ static int aie2_tdr_stop_hwctx(struct amdxdna_hwctx *hwctx, void *arg)
 
 	if (xdna->auto_coredump) {
 		kvfree(hwctx->coredump);
-		hwctx->coredump = amdxdna_get_hwctx_coredump(aie, hwctx);
+		hwctx->coredump = amdxdna_get_hwctx_coredump(hwctx);
 		if (IS_ERR(hwctx->coredump)) {
 			XDNA_ERR(xdna, "Failed to get core dump on hwctx timing out: %ld",
 				 PTR_ERR(hwctx->coredump));

--- a/drivers/accel/amdxdna/aie4.c
+++ b/drivers/accel/amdxdna/aie4.c
@@ -242,10 +242,10 @@ int aie4_get_info(struct amdxdna_client *client, struct amdxdna_drm_get_info *ar
 
 	switch (args->param) {
 	case DRM_AMDXDNA_QUERY_AIE_STATUS:
-		ret = amdxdna_get_aie_status(&ndev->aie, client, args);
+		ret = amdxdna_get_aie_status(client, args);
 		break;
 	case DRM_AMDXDNA_QUERY_AIE_METADATA:
-		ret = amdxdna_get_metadata(&ndev->aie, client, args);
+		ret = amdxdna_get_metadata(client, args);
 		break;
 	case DRM_AMDXDNA_QUERY_AIE_VERSION:
 		ret = amdxdna_get_aie_version(client, args, &ndev->aie.version);
@@ -269,10 +269,10 @@ int aie4_get_info(struct amdxdna_client *client, struct amdxdna_drm_get_info *ar
 		ret = aie4_query_resource_info(client, args);
 		break;
 	case DRM_AMDXDNA_QUERY_HW_CONTEXTS:
-		ret = amdxdna_get_hwctx_status(&ndev->aie, client, args);
+		ret = amdxdna_get_hwctx_status(client, args);
 		break;
 	case DRM_AMDXDNA_QUERY_TELEMETRY:
-		ret = amdxdna_get_telemetry(&ndev->aie, client, args);
+		ret = amdxdna_get_telemetry(client, args);
 		break;
 	case DRM_AMDXDNA_GET_FORCE_PREEMPT_STATE:
 		ret = amdxdna_get_force_preempt_state(&ndev->aie, args);
@@ -385,16 +385,16 @@ int aie4_get_array(struct amdxdna_client *client,
 
 	switch (args->param) {
 	case DRM_AMDXDNA_HW_CONTEXT_ALL:
-		ret = amdxdna_query_ctx_status_array(&ndev->aie, client, args);
+		ret = amdxdna_query_ctx_status_array(client, args);
 		break;
 	case DRM_AMDXDNA_HW_CONTEXT_BY_ID:
-		ret = amdxdna_query_ctx_status_by_id(&ndev->aie, client, args);
+		ret = amdxdna_query_ctx_status_by_id(client, args);
 		break;
 	case DRM_AMDXDNA_AIE_COREDUMP:
-		ret = amdxdna_get_coredump(&ndev->aie, client, args);
+		ret = amdxdna_get_coredump(client, args);
 		break;
 	case DRM_AMDXDNA_AIE_TILE_READ:
-		ret = amdxdna_aie_tile_read(&ndev->aie, client, args);
+		ret = amdxdna_aie_tile_read(client, args);
 		break;
 	case DRM_AMDXDNA_HW_LAST_ASYNC_ERR:
 		ret = aie4_get_array_async_error(ndev, args);
@@ -644,7 +644,7 @@ int aie4_set_state(struct amdxdna_client *client,
 		ret = aie4_set_force_preempt_state(client, args);
 		break;
 	case DRM_AMDXDNA_AIE_TILE_WRITE:
-		ret = amdxdna_aie_tile_write(&ndev->aie, client, args);
+		ret = amdxdna_aie_tile_write(client, args);
 		break;
 	case DRM_AMDXDNA_SET_FW_LOG_STATE:
 		ret = amdxdna_set_fw_log_state(&ndev->aie, args);

--- a/drivers/accel/amdxdna/aie4.h
+++ b/drivers/accel/amdxdna/aie4.h
@@ -106,7 +106,7 @@ struct amdxdna_hwctx_priv {
 };
 
 struct amdxdna_dev_hdl {
-	struct aie_device		aie;
+	struct aie_device		aie; /* must be the first member, see to_aie_dev() */
 	const struct amdxdna_dev_priv	*priv;
 	void			__iomem *mbox_base;
 	void			__iomem *rbuf_base;
@@ -189,8 +189,7 @@ int aie4_query_dpm_level(struct amdxdna_dev_hdl *ndev,
 			 u32 *aieclk_dpm_level, u32 *npuhclk_dpm_level);
 int aie4_query_app_health(struct amdxdna_dev_hdl *ndev, u32 context_id,
 			  struct aie4_msg_app_health_report *report);
-int aie4_fill_hwctx_health(struct aie_device *aie, struct amdxdna_hwctx *hwctx,
-			   struct amdxdna_drm_hwctx_entry *entry);
+int aie4_fill_hwctx_health(struct amdxdna_hwctx *hwctx, struct amdxdna_drm_hwctx_entry *entry);
 int aie4_init_dpm_freq_table(struct amdxdna_dev_hdl *ndev);
 int aie4_query_cert_firmware_version(struct amdxdna_dev_hdl *ndev,
 				     struct amdxdna_drm_query_firmware_version *cert_version);

--- a/drivers/accel/amdxdna/aie4_message.c
+++ b/drivers/accel/amdxdna/aie4_message.c
@@ -614,12 +614,11 @@ int aie4_start_fw_trace(struct amdxdna_dev_hdl *ndev,
 	return 0;
 }
 
-static int aie4_query_status(struct aie_device *aie,
-			     struct amdxdna_msg_buf_hdl *buf_hdl,
-			     u32 *cols_filled, u32 *resp_size)
+static int aie4_query_status(struct amdxdna_msg_buf_hdl *buf_hdl, u32 *cols_filled, u32 *resp_size)
 {
 	DECLARE_AIE_MSG(aie4_msg_aie_column_info, AIE4_MSG_OP_AIE_COLUMN_INFO);
-	struct amdxdna_dev *xdna = aie->xdna;
+	struct amdxdna_dev *xdna = buf_hdl->xdna;
+	struct aie_device *aie = to_aie_dev(xdna);
 	u32 aie_bitmap;
 	int ret;
 
@@ -709,10 +708,9 @@ free_buf:
 	return ret;
 }
 
-int aie4_fill_hwctx_health(struct aie_device *aie, struct amdxdna_hwctx *hwctx,
-			   struct amdxdna_drm_hwctx_entry *entry)
+int aie4_fill_hwctx_health(struct amdxdna_hwctx *hwctx, struct amdxdna_drm_hwctx_entry *entry)
 {
-	struct amdxdna_dev_hdl *ndev = container_of(aie, struct amdxdna_dev_hdl, aie);
+	struct amdxdna_dev_hdl *ndev = hwctx->client->xdna->dev_handle;
 	struct aie4_msg_app_health_report report;
 	u32 num_uc;
 	int ret;

--- a/drivers/accel/amdxdna/aie4_pci.c
+++ b/drivers/accel/amdxdna/aie4_pci.c
@@ -1186,10 +1186,10 @@ int aie4_get_info(struct amdxdna_client *client, struct amdxdna_drm_get_info *ar
 
 	switch (args->param) {
 	case DRM_AMDXDNA_QUERY_AIE_STATUS:
-		ret = amdxdna_get_aie_status(&ndev->aie, client, args);
+		ret = amdxdna_get_aie_status(client, args);
 		break;
 	case DRM_AMDXDNA_QUERY_AIE_METADATA:
-		ret = amdxdna_get_metadata(&ndev->aie, client, args);
+		ret = amdxdna_get_metadata(client, args);
 		break;
 	case DRM_AMDXDNA_QUERY_AIE_VERSION:
 		ret = amdxdna_get_aie_version(client, args, &ndev->aie.version);
@@ -1213,10 +1213,10 @@ int aie4_get_info(struct amdxdna_client *client, struct amdxdna_drm_get_info *ar
 		ret = aie4_query_resource_info(client, args);
 		break;
 	case DRM_AMDXDNA_QUERY_HW_CONTEXTS:
-		ret = amdxdna_get_hwctx_status(&ndev->aie, client, args);
+		ret = amdxdna_get_hwctx_status(client, args);
 		break;
 	case DRM_AMDXDNA_QUERY_TELEMETRY:
-		ret = amdxdna_get_telemetry(&ndev->aie, client, args);
+		ret = amdxdna_get_telemetry(client, args);
 		break;
 	case DRM_AMDXDNA_GET_FORCE_PREEMPT_STATE:
 		ret = amdxdna_get_force_preempt_state(&ndev->aie, args);
@@ -1332,16 +1332,16 @@ int aie4_get_array(struct amdxdna_client *client,
 
 	switch (args->param) {
 	case DRM_AMDXDNA_HW_CONTEXT_ALL:
-		ret = amdxdna_query_ctx_status_array(&ndev->aie, client, args);
+		ret = amdxdna_query_ctx_status_array(client, args);
 		break;
 	case DRM_AMDXDNA_HW_CONTEXT_BY_ID:
-		ret = amdxdna_query_ctx_status_by_id(&ndev->aie, client, args);
+		ret = amdxdna_query_ctx_status_by_id(client, args);
 		break;
 	case DRM_AMDXDNA_AIE_COREDUMP:
-		ret = amdxdna_get_coredump(&ndev->aie, client, args);
+		ret = amdxdna_get_coredump(client, args);
 		break;
 	case DRM_AMDXDNA_AIE_TILE_READ:
-		ret = amdxdna_aie_tile_read(&ndev->aie, client, args);
+		ret = amdxdna_aie_tile_read(client, args);
 		break;
 	case DRM_AMDXDNA_HW_LAST_ASYNC_ERR:
 		ret = aie4_get_array_async_error(ndev, args);
@@ -2301,7 +2301,7 @@ int aie4_set_state(struct amdxdna_client *client,
 		ret = aie4_set_force_preempt_state(client, args);
 		break;
 	case DRM_AMDXDNA_AIE_TILE_WRITE:
-		ret = amdxdna_aie_tile_write(&ndev->aie, client, args);
+		ret = amdxdna_aie_tile_write(client, args);
 		break;
 	case DRM_AMDXDNA_SET_FW_LOG_STATE:
 		ret = amdxdna_set_fw_log_state(&ndev->aie, args);

--- a/drivers/accel/amdxdna/amdxdna_coredump.c
+++ b/drivers/accel/amdxdna/amdxdna_coredump.c
@@ -21,7 +21,6 @@ static const size_t coredump_data_chunk_size = SZ_1M;
 struct amdxdna_coredump_walk_arg {
 	struct amdxdna_hwctx_key	key;
 
-	struct aie_device		*aie;
 	struct amdxdna_drm_get_array	*args;
 	u8 __user			*buf;
 	size_t				buf_size;
@@ -31,20 +30,22 @@ struct amdxdna_coredump_walk_arg {
 static_assert(offsetof(struct amdxdna_coredump_walk_arg, key) == 0,
 	      "key must be the first member for amdxdna_hwctx_match()");
 
-static size_t amdxdna_coredump_total_buf_size(struct aie_device *aie, struct amdxdna_hwctx *hwctx)
+static size_t amdxdna_coredump_total_buf_size(struct amdxdna_hwctx *hwctx)
 {
+	struct aie_device *aie = to_aie_dev(hwctx->client->xdna);
 	u32 orig_col = hwctx->num_col - hwctx->num_unused_col;
 	u32 num_bufs = aie->metadata.rows * orig_col;
 
 	return num_bufs * coredump_data_chunk_size;
 }
 
-char *amdxdna_get_hwctx_coredump(struct aie_device *aie, struct amdxdna_hwctx *hwctx)
+char *amdxdna_get_hwctx_coredump(struct amdxdna_hwctx *hwctx)
 {
 	struct amdxdna_dev *xdna = hwctx->client->xdna;
 	struct amdxdna_msg_buf_hdl **data_hdls = NULL;
 	struct amdxdna_msg_buf_hdl *list_hdl = NULL;
 	struct amdxdna_coredump_buf_entry *buf_list;
+	struct aie_device *aie = to_aie_dev(xdna);
 	size_t total_size;
 	size_t offset;
 	u32 num_bufs;
@@ -55,7 +56,7 @@ char *amdxdna_get_hwctx_coredump(struct aie_device *aie, struct amdxdna_hwctx *h
 	if (!aie->msg_ops.get_coredump)
 		return ERR_PTR(-EOPNOTSUPP);
 
-	total_size = amdxdna_coredump_total_buf_size(aie, hwctx);
+	total_size = amdxdna_coredump_total_buf_size(hwctx);
 	buf = kvmalloc(total_size, GFP_KERNEL);
 	if (!buf)
 		return ERR_PTR(-ENOMEM);
@@ -132,7 +133,7 @@ static int amdxdna_get_coredump_cb(struct amdxdna_hwctx *hwctx, void *arg)
 		return -EPERM;
 	}
 
-	total_size = amdxdna_coredump_total_buf_size(wa->aie, hwctx);
+	total_size = amdxdna_coredump_total_buf_size(hwctx);
 	if (wa->buf_size < total_size) {
 		XDNA_DBG(xdna, "Insufficient buffer size %zu, need %zu",
 			 wa->buf_size, total_size);
@@ -144,7 +145,7 @@ static int amdxdna_get_coredump_cb(struct amdxdna_hwctx *hwctx, void *arg)
 		buf = hwctx->coredump;
 		hwctx->coredump = NULL;
 	} else {
-		buf = amdxdna_get_hwctx_coredump(wa->aie, hwctx);
+		buf = amdxdna_get_hwctx_coredump(hwctx);
 	}
 	if (IS_ERR(buf))
 		return PTR_ERR(buf);
@@ -156,12 +157,11 @@ static int amdxdna_get_coredump_cb(struct amdxdna_hwctx *hwctx, void *arg)
 	return 0;
 }
 
-int amdxdna_get_coredump(struct aie_device *aie,
-			 struct amdxdna_client *client,
-			 struct amdxdna_drm_get_array *args)
+int amdxdna_get_coredump(struct amdxdna_client *client, struct amdxdna_drm_get_array *args)
 {
 	struct amdxdna_drm_aie_coredump config = {};
 	struct amdxdna_dev *xdna = client->xdna;
+	struct aie_device *aie = to_aie_dev(xdna);
 	struct amdxdna_coredump_walk_arg wa;
 	struct amdxdna_client *tmp_client;
 	int ret = -ENOENT;
@@ -208,7 +208,6 @@ int amdxdna_get_coredump(struct aie_device *aie,
 	wa.key.pid = config.pid;
 	wa.buf_size = buf_size;
 	wa.args = args;
-	wa.aie = aie;
 	wa.buf = buf;
 
 	amdxdna_for_each_client(xdna, tmp_client) {

--- a/drivers/accel/amdxdna/amdxdna_coredump.h
+++ b/drivers/accel/amdxdna/amdxdna_coredump.h
@@ -7,7 +7,6 @@
 
 #include <linux/types.h>
 
-struct aie_device;
 struct amdxdna_client;
 struct amdxdna_hwctx;
 struct amdxdna_drm_get_array;
@@ -23,11 +22,8 @@ struct amdxdna_coredump_buf_entry {
 	u32				reserved;
 } __packed;
 
-int amdxdna_get_coredump(struct aie_device *aie,
-			 struct amdxdna_client *client,
-			 struct amdxdna_drm_get_array *args);
-char *amdxdna_get_hwctx_coredump(struct aie_device *aie,
-				 struct amdxdna_hwctx *hwctx);
+int amdxdna_get_coredump(struct amdxdna_client *client, struct amdxdna_drm_get_array *args);
+char *amdxdna_get_hwctx_coredump(struct amdxdna_hwctx *hwctx);
 int amdxdna_get_auto_coredump_mode(struct amdxdna_client *client,
 				   struct amdxdna_drm_get_info *args);
 int amdxdna_set_auto_coredump_mode(struct amdxdna_client *client,

--- a/drivers/accel/amdxdna/amdxdna_ctx_status.c
+++ b/drivers/accel/amdxdna/amdxdna_ctx_status.c
@@ -19,7 +19,6 @@
 struct amdxdna_hwctx_status_ctx {
 	struct amdxdna_hwctx_key	key;
 
-	struct aie_device		*aie;
 	struct amdxdna_drm_get_array	*array_args;
 };
 
@@ -27,10 +26,10 @@ struct amdxdna_hwctx_status_ctx {
 static_assert(offsetof(struct amdxdna_hwctx_status_ctx, key) == 0,
 	      "key must be the first member for amdxdna_hwctx_match()");
 
-static int amdxdna_fill_hwctx_status_entry(struct aie_device *aie,
-					   struct amdxdna_hwctx *hwctx,
+static int amdxdna_fill_hwctx_status_entry(struct amdxdna_hwctx *hwctx,
 					   struct amdxdna_drm_get_array *array_args)
 {
+	struct aie_device *aie = to_aie_dev(hwctx->client->xdna);
 	struct amdxdna_drm_hwctx_entry *tmp __free(kfree) = NULL;
 	struct amdxdna_drm_hwctx_entry __user *buf;
 	u32 size;
@@ -66,7 +65,7 @@ static int amdxdna_fill_hwctx_status_entry(struct aie_device *aie,
 
 	/* Optional FW health is best-effort; ignore errors. */
 	if (aie->msg_ops.fill_hwctx_health)
-		aie->msg_ops.fill_hwctx_health(aie, hwctx, tmp);
+		aie->msg_ops.fill_hwctx_health(hwctx, tmp);
 
 	buf = u64_to_user_ptr(array_args->buffer);
 	size = min(sizeof(*tmp), array_args->element_size);
@@ -93,15 +92,13 @@ static int amdxdna_hwctx_status_cb(struct amdxdna_hwctx *hwctx, void *arg)
 	if (!amdxdna_client_visible(hwctx->client))
 		return 0;
 
-	return amdxdna_fill_hwctx_status_entry(ctx->aie, hwctx, ctx->array_args);
+	return amdxdna_fill_hwctx_status_entry(hwctx, ctx->array_args);
 }
 
-int amdxdna_get_hwctx_status(struct aie_device *aie,
-			     struct amdxdna_client *client,
-			     struct amdxdna_drm_get_info *args)
+int amdxdna_get_hwctx_status(struct amdxdna_client *client, struct amdxdna_drm_get_info *args)
 {
 	struct amdxdna_drm_get_array array_args = {};
-	struct amdxdna_hwctx_status_ctx ctx = { .aie = aie };
+	struct amdxdna_hwctx_status_ctx ctx = {};
 	struct amdxdna_dev *xdna = client->xdna;
 	struct amdxdna_client *tmp_client;
 	int ret = 0;
@@ -131,12 +128,11 @@ int amdxdna_get_hwctx_status(struct aie_device *aie,
 	return 0;
 }
 
-int amdxdna_query_ctx_status_array(struct aie_device *aie,
-				   struct amdxdna_client *client,
+int amdxdna_query_ctx_status_array(struct amdxdna_client *client,
 				   struct amdxdna_drm_get_array *args)
 {
 	struct amdxdna_drm_get_array array_args = {};
-	struct amdxdna_hwctx_status_ctx ctx = { .aie = aie };
+	struct amdxdna_hwctx_status_ctx ctx = {};
 	struct amdxdna_dev *xdna = client->xdna;
 	struct amdxdna_client *tmp_client;
 	int ret = 0;
@@ -178,13 +174,12 @@ int amdxdna_query_ctx_status_array(struct aie_device *aie,
 	return 0;
 }
 
-int amdxdna_query_ctx_status_by_id(struct aie_device *aie,
-				   struct amdxdna_client *client,
+int amdxdna_query_ctx_status_by_id(struct amdxdna_client *client,
 				   struct amdxdna_drm_get_array *args)
 {
-	struct amdxdna_drm_hwctx_entry input = {};
 	struct amdxdna_drm_get_array array_args = {};
-	struct amdxdna_hwctx_status_ctx ctx = { .aie = aie };
+	struct amdxdna_drm_hwctx_entry input = {};
+	struct amdxdna_hwctx_status_ctx ctx = {};
 	struct amdxdna_dev *xdna = client->xdna;
 	struct amdxdna_client *tmp_client;
 	int ret = -ENOENT;

--- a/drivers/accel/amdxdna/amdxdna_ctx_status.h
+++ b/drivers/accel/amdxdna/amdxdna_ctx_status.h
@@ -5,16 +5,14 @@
 #ifndef _AMDXDNA_CTX_STATUS_H_
 #define _AMDXDNA_CTX_STATUS_H_
 
-struct aie_device;
 struct amdxdna_client;
 struct amdxdna_drm_get_info;
 struct amdxdna_drm_get_array;
 
-int amdxdna_get_hwctx_status(struct aie_device *aie, struct amdxdna_client *client,
-			     struct amdxdna_drm_get_info *args);
-int amdxdna_query_ctx_status_array(struct aie_device *aie, struct amdxdna_client *client,
+int amdxdna_get_hwctx_status(struct amdxdna_client *client, struct amdxdna_drm_get_info *args);
+int amdxdna_query_ctx_status_array(struct amdxdna_client *client,
 				   struct amdxdna_drm_get_array *args);
-int amdxdna_query_ctx_status_by_id(struct aie_device *aie, struct amdxdna_client *client,
+int amdxdna_query_ctx_status_by_id(struct amdxdna_client *client,
 				   struct amdxdna_drm_get_array *args);
 
 #endif /* _AMDXDNA_CTX_STATUS_H_ */

--- a/drivers/accel/amdxdna/amdxdna_drv.h
+++ b/drivers/accel/amdxdna/amdxdna_drv.h
@@ -52,6 +52,9 @@
 #define to_xdna_dev(drm_dev) \
 	((struct amdxdna_dev *)container_of(drm_dev, struct amdxdna_dev, ddev))
 
+#define to_aie_dev(xdna_dev) \
+	((struct aie_device *)(xdna_dev)->dev_handle)
+
 extern const struct drm_driver amdxdna_drm_drv;
 
 struct amdxdna_client;

--- a/drivers/accel/amdxdna/amdxdna_tile_read_write.c
+++ b/drivers/accel/amdxdna/amdxdna_tile_read_write.c
@@ -121,12 +121,11 @@ static int amdxdna_aie_tile_read_cb(struct amdxdna_hwctx *hwctx, void *arg)
 	}
 }
 
-int amdxdna_aie_tile_read(struct aie_device *aie,
-			  struct amdxdna_client *client,
-			  struct amdxdna_drm_get_array *args)
+int amdxdna_aie_tile_read(struct amdxdna_client *client, struct amdxdna_drm_get_array *args)
 {
 	struct amdxdna_drm_aie_tile_access access = {};
 	struct amdxdna_dev *xdna = client->xdna;
+	struct aie_device *aie = to_aie_dev(xdna);
 	struct amdxdna_tile_rw_walk_arg wa;
 	struct amdxdna_client *tmp_client;
 	int ret = -ENOENT;
@@ -301,12 +300,11 @@ static int amdxdna_aie_tile_write_cb(struct amdxdna_hwctx *hwctx, void *arg)
 	}
 }
 
-int amdxdna_aie_tile_write(struct aie_device *aie,
-			   struct amdxdna_client *client,
-			   struct amdxdna_drm_set_state *args)
+int amdxdna_aie_tile_write(struct amdxdna_client *client, struct amdxdna_drm_set_state *args)
 {
 	struct amdxdna_drm_aie_tile_access access = {};
 	struct amdxdna_dev *xdna = client->xdna;
+	struct aie_device *aie = to_aie_dev(xdna);
 	struct amdxdna_tile_rw_walk_arg wa;
 	struct amdxdna_client *tmp_client;
 	int ret = -ENOENT;

--- a/drivers/accel/amdxdna/amdxdna_tile_read_write.h
+++ b/drivers/accel/amdxdna/amdxdna_tile_read_write.h
@@ -5,16 +5,11 @@
 #ifndef _AMDXDNA_TILE_READ_WRITE_H_
 #define _AMDXDNA_TILE_READ_WRITE_H_
 
-struct aie_device;
 struct amdxdna_client;
 struct amdxdna_drm_get_array;
 struct amdxdna_drm_set_state;
 
-int amdxdna_aie_tile_read(struct aie_device *aie,
-			  struct amdxdna_client *client,
-			  struct amdxdna_drm_get_array *args);
-int amdxdna_aie_tile_write(struct aie_device *aie,
-			   struct amdxdna_client *client,
-			   struct amdxdna_drm_set_state *args);
+int amdxdna_aie_tile_read(struct amdxdna_client *client, struct amdxdna_drm_get_array *args);
+int amdxdna_aie_tile_write(struct amdxdna_client *client, struct amdxdna_drm_set_state *args);
 
 #endif /* _AMDXDNA_TILE_READ_WRITE_H_ */


### PR DESCRIPTION
aie_device is always the first member of amdxdna_dev_hdl, so define to_aie_dev(xdna_dev) to cast dev_handle directly to struct aie_device *. Add a comment on the aie member in both aie2_pci.h and aie4.h to enforce the first-member constraint.

Use the macro to remove the redundant struct aie_device *aie parameter from all common functions that also take struct amdxdna_client *client or struct amdxdna_hwctx *hwctx, since aie is always derivable from those. Update all call sites and drop the now-unused local aie variables.